### PR TITLE
Add መጽሐፈ፡ አርድእት፡

### DIFF
--- a/LondonBritishLibrary/add/BLadd16204.xml
+++ b/LondonBritishLibrary/add/BLadd16204.xml
@@ -46,15 +46,24 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <summary/>
                         
                         <msItem xml:id="ms_i1">
-                            <locus from="1" to="25"/>
+                            <locus from="1" to="17"/>
                             <title type="complete" ref="LIT1758Lefafa"/>
                             <incipit xml:lang="gez">
                                 <locus target="#1"/>
-                                በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ጸሎት፡ መድኀኒት፡ መጽሐፈ፡ ሕይወት፡ ዘትሰመይ፡ ልፋፈ፡ ጽድቅ።
+                                በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ጸሎት፡ መድኀኒት፡ መጽሐፈ፡ ሕይወት፡ ዘትሰመይ፡ ልፋፈ፡ ጽድቅ፡
+                            </incipit>
+                        </msItem>
+                         
+                         <msItem xml:id="ms_i2">
+                                <locus from="18" to="25"/>
+                            <title type="incomplete" xml:lang="gez" ref="LIT3942ArdeetCh">መጽሐፈ፡ አርድእት፡</title>
+                              <incipit xml:lang="gez">
+                                <locus target="#18"/>
+                                በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡ መጽሐፈ፡ አርድእት፡
                             </incipit>
                         </msItem>
                             
-                        <msItem xml:id="ms_i2">
+                        <msItem xml:id="ms_i3">
                                 <locus from="27" to="30"/>
                             <title type="incomplete" xml:lang="am" ref="LIT4099MashafaT">ትርጓሜ፡ ፊደል፡</title>
                             <note>The same work as in <ref type="item" corresp="BLadd16223#ms_i4"/>
@@ -109,6 +118,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                         <bibl>
                                             <ptr target="bm:Dillmann1847BM"/>
                                             <citedRange unit="page">61b</citedRange>
+                                        </bibl>
+                                         <bibl>
+                                            <ptr target="bm:budge1929"/>
                                         </bibl>
                                     </listBibl>
                                 </source>


### PR DESCRIPTION
Budge includes a negative facsimile of ff. 1-25 in his book. As he notes in the introduction and as one can see in the facsimile, after the ጸሎት፡ ዘመንገደ፡ ሰማይ፡, a part of ልፋፈ፡ ጽድቅ፡, but before the ትርጓሜ፡ ፊደል፡ (? this is absent in the facsimile) is መጽሐፈ፡ አርድእት፡. There are three entries for this text in BM, but I can't tell which is which since they don't have the text, so I went with the most generic.