### PR TITLE
updated occurrences of @n in locus

### DIFF
--- a/EMIP/1-1000/EMIP00041.xml
+++ b/EMIP/1-1000/EMIP00041.xml
@@ -113,7 +113,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             </item>
                               <item xml:id="q6" n="6">
                                  <dim unit="leaf">8</dim>
-                                 <locus from="31" n="38" facs="031"/>
+                                 <locus from="31" to="38" facs="031"/>
                               Quire 6
                             </item>
                               <item xml:id="q7" n="7">

--- a/EMIP/1-1000/EMIP00079.xml
+++ b/EMIP/1-1000/EMIP00079.xml
@@ -140,7 +140,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             </item>
                               <item xml:id="q10" n="9">
                                  <dim unit="leaf">10</dim>
-                                 <locus from="81" n="90"/>
+                                 <locus from="81" to="90"/>
                               Quire 9
                             </item>
                               <item xml:id="q11" n="10">

--- a/EMIP/1-1000/EMIP00164.xml
+++ b/EMIP/1-1000/EMIP00164.xml
@@ -156,7 +156,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             </item>
                               <item xml:id="q3" n="2">
                                  <dim unit="leaf">8</dim>
-                                 <locus from="7" n="14"/>
+                                 <locus from="7" to="14"/>
                               Quire 2
                             </item>
                               <item xml:id="q4" n="3">

--- a/EMIP/3001-4000/EMIP03225.xml
+++ b/EMIP/3001-4000/EMIP03225.xml
@@ -154,7 +154,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
       <profileDesc>
          <langUsage>
            <language ident="en">English</language>
-           <language ident="am">Amharic</lanuage>
+           <language ident="am">Amharic</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/ES/ESagm005.xml
+++ b/ES/ESagm005.xml
@@ -274,7 +274,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            </desc>
                         </item>
                         <item xml:id="a2">
-                           <locus target="#87ra" n="#9">f. 87ra, l. 9</locus>
+                           <locus target="#87ra9">f. 87ra, l. 9</locus>
                            <desc type="Supplication">Supplication.<q xml:lang="gez"> ምደብረ፡ ሕሊና፡ ዕሙቅ፡
                                  እንዘ፡ ሩጸቶሙ፡ ድኩም፡ በእደ፡ ልሳን፡ ረቂቅ፡ ተውከፍ፡ ሊተ፡ እግዚየ፡ እስጢፋኖስ፡ ጻድቅ፡ ከመ፡
                                  ተወክፈ፡ እግዚእከ።</q>

--- a/ES/ESagm009.xml
+++ b/ES/ESagm009.xml
@@ -294,7 +294,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <additions><!--THIS element in domlib CONTAINS ESCAPED HTML, thus it is not possible to reliably extract the information about pages. Please watch out.-->
                      <list>
                         <item xml:id="a1">
-                           <locus target="#31r" n="#7">f. 31r, l.7</locus>
+                           <locus target="#31r7">f. 31r, l.7</locus>
                            <desc type="Unclear">: Unclear note (exhortation to the priests?)<q xml:lang="gez">
                                  <locus target="#31r">31r</locus>, l.7: [vac.] አጋምዮ፡[vac.] ልደ፡
                                  ጊዮ[vac.] ያ። ወ[vac.] አንትሙ[vac.]፡ ፩አቡነ፡ ዘማያ[vac.]። ፈዓዓ።</q>

--- a/ES/ESbgy002.xml
+++ b/ES/ESbgy002.xml
@@ -273,7 +273,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               "Canonical rules". </note>
                         </item>
                         <item xml:id="a2">
-                           <locus target="#229ra" n="#11">f. 229ra, l.11-15</locus>
+                           <locus from="229ra11" to="229ra15">f. 229ra, l.11-15</locus>
                            <desc>: Ownership note.</desc>
                            <quote xml:lang="gez">
                               <locus target="#229ra">229ra</locus>, l.11: ዝመጽሐፍ፡ ዘመምህር፡ ኪዳነ፡ ማርያም፡

--- a/ES/ESddm001.xml
+++ b/ES/ESddm001.xml
@@ -217,7 +217,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               daughters Walatta ʿAbiyä ʾƎgziʾ and Walatta Gabrǝʾel. </note>
                         </item>
                         <item xml:id="a4">
-                           <locus target="#5vb" n="#9">f. 5vb, l. 9</locus>
+                           <locus target="#5vb9">f. 5vb, l. 9</locus>
                            <desc>: Donation note.</desc>
                            <quote xml:lang="gez"/>
                            <quote xml:lang="en"/>

--- a/ES/ESdma001.xml
+++ b/ES/ESdma001.xml
@@ -160,10 +160,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <note> The names of the donors are erased or washed out. </note>
                         </item>
                         <item xml:id="a2">
-                           <locus target="#24vb" n="#16">f. 24vb, l. 16</locus>
+                           <locus target="#24vb16">f. 24vb, l. 16</locus>
                            <desc>: Unclear note.</desc>
                            <quote xml:lang="gez">
-                              <locus target="#24vb">24vb</locus>, l.16: በስመ፡ አብ፡ ወወልደ፡ ወመንፈስ፡ ቅዱስ።
+                              <locus target="#24vb16">24vb, l.16</locus>: በስመ፡ አብ፡ ወወልደ፡ ወመንፈስ፡ ቅዱስ።
                               አሐዱ፡ አምላክ። ኵሉ፡ ዘኢያ&lt;...&gt;፡ በእግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ ወዘኢ &lt;…&gt; ።
                               &lt;…&gt; ቶ፡ እማርያም፡ ያ &lt;…&gt; መንፈስ፡ ቅዱስ፡ እስከ፡ ም &lt;…&gt; ሐዲስ፡ በከመ፡
                               ይቤ፡ ጳውሎስ፡ ውጉዘ፡ ለአለመ፡ አለም።</quote>

--- a/ES/ESdma004.xml
+++ b/ES/ESdma004.xml
@@ -172,10 +172,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <additions><!--THIS element in domlib CONTAINS ESCAPED HTML, thus it is not possible to reliably extract the information about pages. Please watch out.-->
                      <list>
                         <item xml:id="a1">
-                           <locus target="#111vb" n="#2">f. 111vb, l.2</locus>
+                           <locus target="#111vb2">f. 111vb, l.2</locus>
                            <desc>. Blessing for the persons mentioned.</desc>
                            <quote xml:lang="gez">
-                              <locus target="#111vb">111vb</locus>, l.2: ወከማሁ፡ ይባርኮ፡ እግዚአብሔር፡ ለገብሩ፡
+                              <locus target="#111vb2">111vb, l.2</locus>: ወከማሁ፡ ይባርኮ፡ እግዚአብሔር፡ ለገብሩ፡
                               አቡነ፡ አስተአ፡ ድንግል፡ ወአቡሁ፡ አቡነ፡ አሥራተ</quote>
                            <quote xml:lang="en">
                               <locus target="#111vb">111vb</locus>: And likewise may God bless His

--- a/ES/ESdsm002.xml
+++ b/ES/ESdsm002.xml
@@ -275,10 +275,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <note> </note>
                         </item>
                         <item xml:id="a4">
-                           <locus target="#245vb" n="#3">f. 245vb, l. 3</locus>
+                           <locus target="#245vb3">f. 245vb, l. 3</locus>
                            <desc>: Ownership or purchase note (?).</desc>
                            <quote xml:lang="gez">
-                              <locus target="#245vb">245vb</locus>, l. 3: በንዋዩ። ሰርፀ፡ አርጋዊ። አመተ፡
+                              <locus target="#245vb3">245vb, l. 3</locus>: በንዋዩ። ሰርፀ፡ አርጋዊ። አመተ፡
                               ማርያም።</quote>
                            <quote xml:lang="en"/>
                            <note> </note>

--- a/ES/ESfbm008.xml
+++ b/ES/ESfbm008.xml
@@ -181,7 +181,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <additions>
                      <list>
                         <item xml:id="a1">
-                           <locus target="#60vb" n="#8">f. 60vb, l.8-19</locus>
+                           <locus from="60vb8" to="60vb19">f. 60vb, l.8-19</locus>
                            <desc>: Donation note.</desc>
                            <quote xml:lang="gez">
                               <locus target="#60vb">60vb</locus>, l. 8: ዝንቱ፡ መጽሐፍ፡ ዘደብረ፡ ማርያም፡ ፈቃዳ፡

--- a/ES/ESfbm020.xml
+++ b/ES/ESfbm020.xml
@@ -312,9 +312,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <additions><!--THIS element in domlib CONTAINS ESCAPED HTML, thus it is not possible to reliably extract the information about pages. Please watch out.-->
                      <list>
                         <item xml:id="a1">
-                           <locus target="#35ra" n="#13">ff. 35ra, l.13</locus>
-                           <desc>- rb, </desc>
-                           <locus target="#12">12</locus>: Additional personal names and invocation
+                           <locus from="35ra13" to="35rb12">ff. 35ra, l.13 - rb,12</locus>: Additional personal names and invocation
                            following the explicit.<quote xml:lang="gez">
                               <locus target="#35ra">35ra</locus>, l.13: ወለደቂቁ፡ ለኃብተ፡ ሥላሴ፡ ወለተ፡ ሥላሴ፡
                               መዝገበ፡ ሥላሴ፡ ወ[n.l.]። ዓመተ፡ ሥላሴ፡ ጽጌ፡ ሃይማኖት፡ ተወልደ፡ መድኀን፡ ጸዋሬ፡ መስቀል፡ ማርቆስ፡

--- a/ES/EShmm001.xml
+++ b/ES/EShmm001.xml
@@ -233,7 +233,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <additions><!--THIS element in domlib CONTAINS ESCAPED HTML, thus it is not possible to reliably extract the information about pages. Please watch out.-->
                      <list>
                         <item xml:id="a1">
-                           <locus target="#78vb" n="#8">f. 78vb, l. 8</locus>
+                           <locus target="#78vb8">f. 78vb, l. 8</locus>
                            <desc>: Purchase note.</desc>
                            <quote xml:lang="gez">
                               <locus target="#78vb">78vb</locus>, l. 8: ዛቲ፡ መጽሐፍ፡ ዘቅዱስ፡ ሚካኤል፡ ዘሐንጐዳ፡

--- a/ES/ESky023.xml
+++ b/ES/ESky023.xml
@@ -333,8 +333,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <note> Crudely written in a secondary hand. </note>
                         </item>
                         <item xml:id="a7">
-                           <locus target="#219va" n="#1">f. 219va, l.1</locus>
-                           <desc>-vb, l.21:  ʾAsmat-prayer.</desc>
+                           <locus from="219va1" to="219vb21">f. 219va, l.1-vb, l.21</locus>
+                           <desc>:  ʾAsmat-prayer.</desc>
                            <quote xml:lang="gez"/>
                            <quote xml:lang="en"/>
                            <note> Crudely written in a secondary hand. </note>

--- a/ES/ESmma008.xml
+++ b/ES/ESmma008.xml
@@ -244,8 +244,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <note> Incomplete, beginning missing. </note>
                         </item>
                         <item xml:id="a3">
-                           <locus target="#123ra" n="#7">f. 123ra, l.7</locus>
-                           <desc>-rb, l.2: Qǝne-poem (of the type ʿǝṭāna mogar?).</desc>
+                           <locus from="123ra7" to="123rb2">f. 123ra, l.7-rb, l.2</locus>
+                           <desc>: Qǝne-poem (of the type ʿǝṭāna mogar?).</desc>
                            <quote xml:lang="gez">
                               <locus target="#123ra">123ra</locus>, l.7-rb, l.2: ዕጣነ፡ ሞገር፡ ግዕዝ። ለእመ፡
                               ብንያም፡ ወዮሴፍ። አዕይንቲሃ፡ ኮከብ፡ በመዝአረ፡ ገጻ፡ ዘአሶንያ፡ መልአከ፡ ሞት፡ ጸዋግ፡ ዘአደመነ፡ ላህያ፡

--- a/ES/ESmqm012.xml
+++ b/ES/ESmqm012.xml
@@ -154,8 +154,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <note> Written in a secondary hand (?). </note>
                         </item>
                         <item xml:id="a2">
-                           <locus target="#42rb" n="#15">f. 42rb, l.15-42</locus>
-                           <desc>va, l.14: Supplication.</desc>
+                           <locus from="42rb15" to="42va14">f. 42rb, l.15-42va, l.14</locus>
+                           <desc>: Supplication.</desc>
                            <quote xml:lang="gez"/>
                            <quote xml:lang="en"/>
                            <note> Written in the same hand as that of the main text. Supplication
@@ -163,8 +163,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               3). </note>
                         </item>
                         <item xml:id="a3">
-                           <locus target="#42vb" n="#6">f. 42vb, l.6-43</locus>
-                           <desc>ra, l.4: Donation note.</desc>
+                           <locus from="42vb6" to="43ra4">f. 42vb, l.6-43ra, l.4</locus>
+                           <desc>: Donation note.</desc>
                            <quote xml:lang="gez">
                               <locus target="#42vb">42vb</locus>, l.6: ዛቲ፡ መጽሐፍ፡ ዘወይዘሮ፡ ወለተ፡ መስቀል፡
                               ኃይሉ፡ ዘአጥ{ረ}የታ፡ በንዋያ፡ ወወሀበቶ፡ ለአብነ፡ ገብረ፡ ገብረ[sic.]፡ መንፈስ፡ ቅዱ{ስ}፡ ዘአናማዕፃ፡

--- a/ES/ESmr013.xml
+++ b/ES/ESmr013.xml
@@ -211,8 +211,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <additions><!--THIS element in domlib CONTAINS ESCAPED HTML, thus it is not possible to reliably extract the information about pages. Please watch out.-->
                      <list>
                         <item xml:id="a1">
-                           <locus target="#124rb" n="#5">f. 124rb, l.5</locus>
-                           <desc>– 124va, l.5: ʾAnbǝro ʾǝd of the Anaphora of St Dioscorus.</desc>
+                           <locus from="124rb5" to="124va5">f. 124rb, l.5– 124va, l.5</locus>
+                           <desc>: ʾAnbǝro ʾǝd of the Anaphora of St Dioscorus.</desc>
                            <quote xml:lang="gez"/>
                            <quote xml:lang="en"/>
                            <note> </note>

--- a/ES/ESmr019.xml
+++ b/ES/ESmr019.xml
@@ -244,25 +244,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               supplications in Gǝʿǝz. </note>
                         </item>
                         <item xml:id="a3">
-                           <locus target="#2rb" n="#5">f. 2rb, l.5</locus>
-                           <desc>– 2vb: ʾAsmat-prayer.</desc>
+                           <locus from="2rb5" to="2vb">f. 2rb, l.5– 2vb</locus>
+                           <desc>: ʾAsmat-prayer.</desc>
                            <quote xml:lang="gez"/>
                            <quote xml:lang="en"/> In violet ink. Various ʾasmat are invoked, to
                            protect the cattle of ʾabuna<note> Walda Tǝnśāʾe. </note>
                         </item>
                         <item xml:id="a4">
-                           <locus target="#144vb" n="#4">ff. 144vb, l.4</locus>
-                           <desc>– 146ra, l.4.: Poem in praise of the Virgin Mary.</desc>
+                           <locus from="144vb4" to="146ra4">ff. 144vb, l.4– 146ra, l.4.</locus>
+                           <desc>: Poem in praise of the Virgin Mary.</desc>
                            <quote xml:lang="gez"/>
                            <quote xml:lang="en"/> A supplication for St Mary to intercede for Gabra
                            Ḥǝywat and other believers is added (<locus target="#146ra">146ra</locus>
                            <note>, ll.5-12). </note>
                         </item>
                         <item xml:id="a5">
-                           <locus target="#136vb" n="#4">f. 136vb, l.4</locus>
+                           <locus target="#136vb4">f. 136vb, l.4</locus>
                            <desc>: Donation note.</desc>
                            <quote xml:lang="gez"><!--[if gte mso 10]> <style> /* Style Definitions */ table.MsoNormalTable {mso-style-name:"Normale Tabelle"; mso-tstyle-rowband-size:0; mso-tstyle-colband-size:0; mso-style-noshow:yes; mso-style-priority:99; mso-style-qformat:yes; mso-style-parent:""; mso-padding-alt:0cm 5.4pt 0cm 5.4pt; mso-para-margin-top:0cm; mso-para-margin-right:0cm; mso-para-margin-bottom:10.0pt; mso-para-margin-left:0cm; line-height:115%; mso-pagination:widow-orphan; font-size:11.0pt; font-family:"Calibri","sans-serif"; mso-ascii-font-family:Calibri; mso-ascii-theme-font:minor-latin; mso-fareast-font-family:"Times New Roman"; mso-fareast-theme-font:minor-fareast; mso-hansi-font-family:Calibri; mso-hansi-theme-font:minor-latin;} </style> <![endif]-->
-                              <locus target="#136vb">136vb</locus>, l. 4: ዛቲ፡ መጽሐፍ፡ ዘወሀበት፡ ለታቦተ፡
+                              <locus target="#136vb4">136vb, l. 4</locus>: ዛቲ፡ መጽሐፍ፡ ዘወሀበት፡ ለታቦተ፡
                               ሥላሴ፡ ምድር፡ ሩባ፡ ከመ፡ ትኩና፡ መድኃኒተ፡ ነፍስ፡ ወሥጋ፡ ለመንግሥተ፡ ሰማያት፡ ወለተ፡ ሥላሴ፡ ዓመተ፡
                               እግዚአብሔር፡ ዘሠረቆ፡ ወዘፈሐቆ፡ በሥልጣነ፡ ጴጥሮስ፡ ወጳውሎስ። </quote>
                            <quote xml:lang="en">

--- a/ES/ESmr024.xml
+++ b/ES/ESmr024.xml
@@ -183,7 +183,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <additions>
                      <list>
                         <item xml:id="a1">
-                           <locus target="#32vb" n="#19">f. 32vb, l. 19</locus>
+                           <locus target="#32vb19">f. 32vb, l. 19</locus>
                            <desc>: Ownership note.</desc>
                            <quote xml:lang="gez">
                               <locus target="#32vb">32vb</locus>, <locus target="#19">19</locus>:
@@ -195,8 +195,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               of the name of the probable donor, Gabra Madḫǝn. </note>
                         </item>
                         <item xml:id="a2">
-                           <locus target="#33ra" n="#13">ff. 33ra, l.13-33</locus>
-                           <desc>vb: Excerpt from the Gospel of Matthew (Parable of the Ten Virgins,
+                           <locus from="33ra13" to="33vb">ff. 33ra, l.13-33vb</locus>
+                           <desc>: Excerpt from the Gospel of Matthew (Parable of the Ten Virgins,
                               Mt. 25:1-13).</desc>
                            <quote xml:lang="gez"/>
                            <quote xml:lang="en"/>

--- a/ES/ESqds011.xml
+++ b/ES/ESqds011.xml
@@ -147,11 +147,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <additions>
                      <list>
                         <item xml:id="a1">
-                           <locus target="#42rb" n="#21">ff. 42rb, l.21-42</locus>
-                           <desc>va, l.10: Monastic genealogy of the abbots of Dabra Qäwät from
+                           <locus from="42rb21" to="42va10">ff. 42rb, l.21-42va, l.10</locus>
+                           <desc>: Monastic genealogy of the abbots of Dabra Qäwät from
                               Takla Hāymānot to Gäbr Ḫer.</desc>
                            <quote xml:lang="gez">
-                              <locus target="#42rb">42rb</locus>, l.21: መጽሐፈ፡ ልደቶሙ፡ ለአበዊነ፡ ቀደምት፡
+                              <locus target="#42rb21">42rb, l.21</locus>: መጽሐፈ፡ ልደቶሙ፡ ለአበዊነ፡ ቀደምት፡
                               ቅዱሳን፡ መምህራነ፡ ሕግ፡ ዘደብረ፡ ቀወት፡ አባ፡ ተክለ፡ ሃይማኖት፡ ዘኢትዮጵያ፡ ወልዱ፡ ለዮሐንስ፡ ዮሐንስኒ፡
                               ወለዶ፡ ለአባ፡ ገብረ፡ ናዝራዊ፡ ወገብረ፡ ናዝራዊ፡ ወለዶ፡ ለአ[<locus target="#42va">42va</locus>]ባ፡ መርቆሬዎስ፡ ወአባ፡ መርቆሬዎስ፡ ወለዶ፡ ለአባ፡ ዘካርያስ፡ ወዘካርያስኒ፡
                               ወለዶ፡ ለፊቅጦር፡ ወፊቅጦር፡ ወለዶ፡ ለዮሐንስ፡ ከማ፡ ወዮሐንስ፡ ከማ፡ ወለዶ፡ ለገብረ፡ ማርያም፡ ወገብረ፡
@@ -164,8 +164,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            </note>
                         </item>
                         <item xml:id="a2">
-                           <locus target="#42va" n="#11">ff. 42va, l.11-42</locus>
-                           <desc>vb, l.6: List of spiritual sons of Gabra Nazrawi.</desc>
+                           <locus from="42va11" to="42vb6">ff. 42va, l.11-42vb, l.6</locus>
+                           <desc>: List of spiritual sons of Gabra Nazrawi.</desc>
                            <quote xml:lang="gez">
                               <locus target="#42va">42va</locus>, l.11: ወካልአን፡ ውሉዱ፡ ለአባ፡ ገብረ፡ ናዝራዊ፡
                               ቶማስ፡ ዘደብረ፡ ሐረይክዋ፡ ወመርቆረዎስ፡ ዘመንከናክስ፡ ወአብርሃም፡ ዘገረዓልታ፡ ማማስ፡ ዘጕንዳጕንዴ፡ አባ፡

--- a/ES/ESsm017.xml
+++ b/ES/ESsm017.xml
@@ -243,7 +243,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <note> Crudely written in a secondary hand in the outer margins. </note>
                         </item>
                         <item xml:id="a2">
-                           <locus target="#169v" n="#7">f. 169v, l.7-16</locus>
+                           <locus from="169v7" to="169v16">f. 169v, l.7-16</locus>
                            <desc>: Prayer against snake bite.</desc>
                            <quote xml:lang="gez"/>
                            <quote xml:lang="en"/>

--- a/ES/ESsmm003.xml
+++ b/ES/ESsmm003.xml
@@ -46,7 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <title ref="LIT1917Mashaf#year"/>
                      </msItem>
                      <colophon xml:id="coloph1" type="subscriptio">
-                        <locus target="#72ra">f. 72ra, l.6</locus> ተፈጸመ፡ መጽሐፈ፡ አሥልጢ፡ ዘወንጌለ፡ መንግሥቱ፡
+                        <locus target="#72ra6">f. 72ra, l.6</locus> ተፈጸመ፡ መጽሐፈ፡ አሥልጢ፡ ዘወንጌለ፡ መንግሥቱ፡
                         ዘጳውሎስ፡ ወሐዋርያ፡ ወግብር፡ በፈቃደ፡ እግዚአብሔር፡ ዘአጽሐፋ፡ ቀሲስ፡ ምኅጽንተ፡ ማርያም፡ በወርቁ፡ ለመቅደሰ፡
                         ሰማዝ፡ ወጸሐፊሃኒ፡ ኃጥእ፡ ዘወልደ፡ ማርያም፡ ይጽሐፍ፡ ስሞሙ፡ ኀበ፡ አምደ፡ ወርቅ፡ ለዓለመ፡ ዓለም፡ አሜን፡ ወአሜን፡
                         ለይኩን። <note> Scribe's note on completing the work. The title of the work,
@@ -178,7 +178,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                  Māryām</persName>.</note>
                         </item>
                         <item xml:id="a3">
-                           <locus target="#72rb" n="#11">f. 72rb, l.11-72va</locus>
+                           <locus target="72rb11" to="72va">f. 72rb, l.11-72va</locus>
                            <desc type="CommemorativeNote">Note on commemoration days of some saints
                               and individuals.</desc>
                            <q xml:lang="gez"/>
@@ -189,7 +189,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                  Dǝngǝl</persName>). </note>
                         </item>
                         <item xml:id="a4">
-                           <locus target="#72ra" n="#16">f. 72ra, l.16</locus>
+                           <locus target="#72ra16">f. 72ra, l.16</locus>
                            <desc type="RecordTransaction">Record concerning a donation of clothes
                               made by <persName ref="PRS8668SebhatA">Sǝbḥāt ʾAragāwi</persName> (ca.
                                  <date>1844-1914</date>), governor of ʿAgāma.</desc>

--- a/ES/ESthmr001.xml
+++ b/ES/ESthmr001.xml
@@ -266,14 +266,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <note> </note>
                         </item>
                         <item xml:id="a3">
-                           <locus target="#126va" n="#3">f. 126va, l. 3</locus>
+                           <locus target="#126va3">f. 126va, l. 3</locus>
                            <desc>: Record concerning land donation to the church.</desc>
                            <quote xml:lang="gez"/>
                            <quote xml:lang="en"/> The note mentions ʾato Gabra Dǝngǝl, qes
                               gabaz<note> Za-Rufāʾel. </note>
                         </item>
                         <item xml:id="a4">
-                           <locus target="#126va" n="#8">f. 126va, l. 8</locus>
+                           <locus target="#126va8">f. 126va, l. 8</locus>
                            <desc>: Note on genealogy mentioning at least one of the donors.</desc>
                            <quote xml:lang="gez"/>
                            <quote xml:lang="en"/>

--- a/Grottaferrata/GAet7.xml
+++ b/Grottaferrata/GAet7.xml
@@ -304,13 +304,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                           </item>
                           <item xml:id="a3">
                             <desc type="ProtectivePrayer"/>
-                            <locus target="#173v" n="5"/>
+                            <locus target="#173v5" n="5"/>
                             <q xml:lang="gez"/>
                             <q xml:lang="en">Protect me from Dawe's eye and from death, your servant Daqsǝyos.</q>
                           </item>
                           <item xml:id="a4">
                             <desc type="ProtectivePrayer"/>
-                            <locus target="#175v" n="6"/>
+                            <locus target="#175v6" n="6"/>
                             <q xml:lang="gez"/>
                           </item>
                           <item xml:id="a5">
@@ -333,17 +333,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                           </item>
                           <item xml:id="a8">
                             <desc type="ProtectivePrayer"/>
-                            <locus target="#222va" n="3"/>
+                            <locus target="#222va3" n="3"/>
                             <q xml:lang="gez"/>
                             <desc>Prayer against snake bites.</desc>
                           </item>
                           <item xml:id="a9">
                             <desc type="ProtectivePrayer"/>
-                            <locus target="#222va" n="12"/>
+                            <locus target="#222va12" n="12"/>
                             <q xml:lang="gez"/>
                           </item>
                           <item xml:id="e1">
-                            <locus target="#87v" n="13"/>
+                            <locus target="#87v13" n="13"/>
                             <p>In Ps. 77, after the word በደመና, the drawing of a cross in a circle indicates the midpoint of the psalter.</p>
                           </item>
                           <item xml:id="e2">

--- a/LondonBritishLibrary/orient/BLorient480.xml
+++ b/LondonBritishLibrary/orient/BLorient480.xml
@@ -135,10 +135,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <list>
                         
                            <item xml:id="a1" rend="marginal">
-                              <locus target="#2a" n="30"/>
-                              
-
-
+                              <locus target="#2a30"/>
                               <desc type="OwnershipNote">The note stating that the manuscript belongs to the church 
                                  of <placeName ref="INS0101MadhaneAlam">Madḫāne ʿAlam</placeName>  
                                  built, or rather intended to be built, by king <persName ref="PRS9430Tewodros">Theodore</persName> at 

--- a/LondonBritishLibrary/orient/BLorient686.xml
+++ b/LondonBritishLibrary/orient/BLorient686.xml
@@ -187,7 +187,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <list>
                         
                            <item xml:id="a1">
-                              <locus target="#1a" n="30"/>
+                              <locus target="#1a30"/>
                               <quote xml:lang="gez">ገድለ ፡ ሰማዕታት ፡ ዘቅ' ፡ መ' ፡ ዓለም። </quote>
                               <quote xml:lang="en">the Acts of Martyrs, belonging to the Holy Saviour of the World</quote>
                               

--- a/PrivateCollections/Germany/TreeskeFricke/TF001.xml
+++ b/PrivateCollections/Germany/TreeskeFricke/TF001.xml
@@ -31,8 +31,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   <summary/>
                   
                      <msItem xml:id="ms_i1">
-                        <locus from="1" n="1"/>
-                        <locus to="1" n="10"/>
+                        <locus from="1r1" to="1r10"/>
                         <title type="complete">Prayer against <foreign xml:lang="gez">bāryā</foreign> and <foreign xml:lang="gez">legewon</foreign>
                      </title> 
                         <textLang mainLang="gez"/>
@@ -44,8 +43,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                      </msItem>
                   
                   <msItem xml:id="ms_i2">
-                     <locus from="1r" n="11"/>
-                     <locus to="1r" n="18"/>
+                     <locus from="1r11"  to="1r18"/>
                      <title type="complete"/> 
                      <textLang mainLang="gez"/>
                      <incipit xml:lang="gez">
@@ -57,8 +55,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   </msItem>
                   
                   <msItem xml:id="ms_i3">
-                     <locus from="1r" n="19"/>
-                     <locus to="1r" n="24"/>                     
+                     <locus from="1r19"  to="1r24"/>                     
                      <title type="complete"/> 
                      <textLang mainLang="gez"/>
                      <incipit xml:lang="gez">ጸሎት፡ በእንተ፡ ሕማመ፡ ምትዓት፡ ይኤርር፡ ይኤርር፡ ይሽባኤርር፡</incipit>
@@ -67,8 +64,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   </msItem>
                   
                   <msItem xml:id="ms_i4">
-                     <locus from="1r" n="25"/>
-                     <locus to="1r" n="39"/>                     
+                     <locus from="1r25" to="1r39"/>                     
                      <title type="complete">Prayer against bāryā and legewon, containing the beginning of the Gospel of John</title> 
                      <textLang mainLang="gez"/>
                      <incipit xml:lang="gez">ጸሎት፡ በእንተ፡ ሕማመ፡ ባርያ፡ ወሌጌዎን፡ ወንጌል፡ ዘዮሐንስ፡ ቀዳሚሁ፡ ቃል፡ ውእቱ፡</incipit>
@@ -78,8 +74,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   </msItem>
                   
                   <msItem xml:id="ms_i5">
-                     <locus from="1r" n="40"/>
-                     <locus to="1r" n="49"/>                     
+                     <locus from="1r40" to="1r49"/>                     
                      <title type="complete"/> 
                      <textLang mainLang="gez"/>
                      <incipit xml:lang="gez">ጸሎት፡ በእንተ፡ ሕማመ፡ ዓይነ፡ ጽላ፡ ወማዕሠረ፡ አጋንንት፡ ወመርበብተ፡ ሰሎሞን፡ ዘሩበቦሙ፡ ለአጋንንት፡ ከመ፡ መርበብተ፡ ዓሣ፡</incipit>
@@ -89,8 +84,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   </msItem>
                   
                   <msItem xml:id="ms_i6">
-                     <locus from="1r" n="49"/>
-                     <locus to="1r" n="129"/>                     
+                     <locus from="1r49" to="1r129"/>                     
                      <title type="complete">Susǝnyos</title> 
                      <textLang mainLang="gez"/>
                      <incipit xml:lang="gez">ጸሎት፡ በእንተ፡ ሕማመ፡ ዓይነ፡ ጽላ፡ ዛር፡ ወፍሬራኛ፡ በስመ፡ እግዚአብሔር፡ ሕያው፡ ነባቢ፡ ወተናጋሪ፡ ለቅዱስ፡ ሱስንዮስ፡</incipit>
@@ -98,8 +92,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   </msItem>
                   
                   <msItem xml:id="ms_i7">
-                     <locus from="1r" n="129"/>
-                     <locus to="1r" n="201"/>                     
+                     <locus from="1r129" to="1r201"/>                     
                      <title type="complete"/> 
                      <textLang mainLang="gez"/>
                      <incipit xml:lang="gez">ጸሎት፡ በእንተ፡ ሕማመ፡ ደም፡</incipit>
@@ -107,8 +100,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   </msItem>
                   
                   <msItem xml:id="ms_i8">
-                     <locus from="1r" n="201"/>
-                     <locus to="1r" n="228"/>                     
+                     <locus from="1r201" to="1r228"/>                     
                      <title type="complete">Beginning of the first psalm and prayer</title> 
                      <textLang mainLang="gez"/>
                      <incipit xml:lang="gez"/>

--- a/PrivateCollections/Germany/TreeskeFricke/TF002.xml
+++ b/PrivateCollections/Germany/TreeskeFricke/TF002.xml
@@ -115,8 +115,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         
                         <layout columns="2" writtenLines="68" corresp="#strip1">
                            <!--1ra-->
-                           <locus from="#1r" n=""/>
-                           <locus to="#1r" n=""/>
+                           <locus from="1ra" />
                            <note corresp="#textarea1 #margin1">Data on text area and margin dimensions taken from <locus target="#1r" n=""/>.</note>
                            <note>Number of characters per line: .</note>
                            <dimensions unit="mm" xml:id="textarea1">
@@ -141,8 +140,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                      
                         <layout columns="2" writtenLines="68" corresp="#strip1">
                         <!--1va-->
-                           <locus from="#1v" n=""/>
-                           <locus to="#1v" n=""/>
+                           <locus from="#1va"
                            <note corresp="#textarea1 #margin1">Data on text area and margin dimensions taken from <locus target="#1v" n=""/>.</note>
                            <note>Number of characters per line: .</note>
                            <dimensions unit="mm" xml:id="textarea1">

--- a/StPetersburg/InEtn405510.xml
+++ b/StPetersburg/InEtn405510.xml
@@ -33,47 +33,40 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                   <summary>
                   </summary>
                   <msItem xml:id="ms_i1">
-                    <locus from="1ra" n="1"></locus>
-                    <locus to="1ra" n="20"></locus>
+                    <locus from="1ra1" to="1ra20"></locus>
                     <title type="complete" ref="LIT4702MagicPr"><certainty locus="value" match="../@ref" cert="medium"></certainty></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"></gap> ጸሎት፡ በእንተ፡ ማዕሠረ፡ አጋንንት፡</incipit>
                   </msItem>
                   <msItem xml:id="ms_i2">
-                    <locus from="1ra" n="21"></locus>
-                    <locus to="1ra" n="96"></locus>
+                    <locus from="1ra21"  to="1ra96"></locus>
                     <title type="complete" ref="LIT1878Marbab"></title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>
                   <msItem xml:id="ms_i3">
-                    <locus from="1rአ" n="97"></locus>
-                    <locus to="1rb" n="14"></locus>
+                    <locus from="1ra97" to="1rb14"></locus>
                     <title type="complete" ref="LIT2295Sayfam"><certainty locus="value" match="../@ref" cert="medium"></certainty></title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>
                   <msItem xml:id="ms_i4">
-                    <locus from="1rb" n="15"></locus>
-                    <locus from="1rb" n="95"></locus>
+                    <locus from="1rb15" to="1rb95"></locus>
                     <title type="complete" ref="LIT1763Legend"></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"></gap>
                     ጸሎት፡ በእንተ፡ አሰስሎ፡ ደዌ፡ እምሕፃናት፡</incipit>
                   </msItem>
                   <msItem xml:id="ms_i5">
-                    <locus from="1rb" n="96"></locus>
-                    <locus to="1rb" n="117"></locus>
+                    <locus from="1rb96" to="1rb117"></locus>
                     <title type="complete" ref="LIT2295Sayfam"><certainty locus="value" match="../@ref" cert="medium"></certainty></title>
                   </msItem>
                   <msItem xml:id="ms_i6">
-                    <locus from="1rb" n="118"></locus>
-                    <locus to="1rb" n="147"></locus>
+                    <locus from="1rb118" to="1rb147"></locus>
                     <title type="complete" ref="LIT2168PaterNa"></title>
                     <textLang mainLang="gez"></textLang>
                     <note>Magic names are added in each line.</note>
                   </msItem>
                   <msItem xml:id="ms_i7">
-                    <locus from="1rb" n="148"></locus>
-                    <locus to="1rb" n="188"></locus>
+                    <locus from="1rb148" to="1rb188"></locus>
                     <title type="complete" ref="LIT5882MagicPrayer"></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"></gap> ጸሎት፡ በእንተ፡ ማዕሰረ፡ ቡዳ፡ ወሠራቅያን፡</incipit>

--- a/StPetersburg/InEtn40558.xml
+++ b/StPetersburg/InEtn40558.xml
@@ -33,8 +33,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                   <summary>
                   </summary>
                   <msItem xml:id="ms_i1">
-                    <locus from="1r" n="1"></locus>
-                    <locus to="1r" n="34"></locus>
+                    <locus from="1r1" to="1r34"></locus>
                     <title type="complete" ref="LIT4599Salot"><certainty locus="value" match="../@ref" cert="medium"></certainty></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez">
@@ -42,22 +41,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     ለአጋንንት፡ ባርያ፡ ወሌጌዎን፡ ዘይሰልብ፡ ልበ፡ ሰብእ፡</incipit>
                   </msItem>
                   <msItem xml:id="ms_i2">
-                    <locus from="1r" n="35"></locus>
-                    <locus to="1r" n="69"></locus>
+                    <locus from="1r35" to="1r69"></locus>
                     <title type="incomplete" ref="LIT2709Matthew"></title>
                     <textLang mainLang="gez"></textLang>
                     <note>8.28-32</note>
                   </msItem>
                   <msItem xml:id="ms_i3">
-                    <locus from="1r" n="70"></locus>
-                    <locus to="1r" n="127"></locus>
+                    <locus from="1r70" to="1r127"></locus>
                     <title type="incomplete" ref="LIT2711Mark"></title>
                     <textLang mainLang="gez"></textLang>
                     <note>1.23-28</note>
                   </msItem>
                   <msItem xml:id="ms_i4">
-                    <locus from="1r" n="128"></locus>
-                    <locus to="1r" n="195"></locus>
+                    <locus from="1r128" to="1r195"></locus>
                     <title type="complete" ref="LIT4642MagicPr"></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"></gap> ጸሎት፡ በእንተ፡ ማዕሠሮሙ፡ ለአጋንንት፡ ባርያ፡ ወሌጌዎን፡
@@ -65,45 +61,39 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     </incipit>
                   </msItem>
                   <msItem xml:id="ms_i5">
-                    <locus from="1r" n="196"></locus>
-                    <locus to="1r" n="217"></locus>
+                    <locus from="1r196" to="1r217"></locus>
                     <title type="complete" ref="LIT5822MagicPrayer"></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"></gap> ጸሎት፡ በእንተ፡ ሕማመ፡ ደም፡</incipit>
                   </msItem>
                   <msItem xml:id="ms_i6">
-                    <locus from="1v" n="1"></locus>
-                    <locus to="1v" n="19"></locus>
+                    <locus from="1v1" to="1v19"></locus>
                     <title type="complete" ref="LIT4564Salot"></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"></gap> አብ፡ በል፡ ፩ አምላክ፡ ጽሎት፡
                     በእንተ፡ ደም፡</incipit>
                   </msItem>
                   <msItem xml:id="ms_i7">
-                    <locus from="1v" n="20"></locus>
-                    <locus to="1v" n="33"></locus>
+                    <locus from="1v20" to="1v33"></locus>
                     <title type="complete" ref="LIT2295Sayfam"><certainty locus="value" match="../@ref" cert="medium"></certainty></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez">በስመ፡ አብ፡ በል፡ ሻኤል፡ ጃሟኢኢል፡
                     ሻጂማዋል፡</incipit>
                   </msItem>
                   <msItem xml:id="ms_i8">
-                    <locus from="1v" n="34"></locus>
-                    <locus to="1v" n="52"></locus>
+                    <locus from="1v34" to="1v52"></locus>
                     <title type="complete" ref="LIT5696MagicPrayer"></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez"></incipit>
                   </msItem>
                   <msItem xml:id="ms_i9">
-                    <locus from="1v" n="53"></locus>
-                    <locus to="1v" n="74"></locus>
+                    <locus from="1v53" to="1v74"></locus>
                     <title type="complete" ref="LIT5696MagicPrayer"><certainty locus="value" match="../@ref" cert="medium"></certainty></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez"></incipit>
                   </msItem>
                   <msItem xml:id="ms_i10">
-                    <locus from="1v" n="75"></locus>
-                    <locus to="1v" n="100"></locus>
+                    <locus from="1v75" to="1v100"></locus>
                     <title type="complete" ref="LIT5696MagicPrayer"><certainty locus="value" match="../@ref" cert="medium"></certainty></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez"></incipit>

--- a/StPetersburg/InEtn40559.xml
+++ b/StPetersburg/InEtn40559.xml
@@ -33,10 +33,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                   <summary>
                   </summary>
                   <msItem xml:id="ms_i1">
-                    <locus from="1r" n="1"></locus>
-                    <locus to="1r" n="14"></locus>
-                    <locus from="1ra" n="1"></locus>
-                    <locus to="1ra" n="65"></locus>
+                    <locus from="1r1" to="1r14"></locus>
+                    <locus from="1ra1" to="1ra65"></locus>
                     <title type="complete" ref="LIT5875MagicPrayer"></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡
@@ -44,8 +42,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                   ወጥቁሮ፡</incipit>
                   </msItem>
                   <msItem xml:id="ms_i2">
-                    <locus from="1ra" n="66"></locus>
-                    <locus to="1ra" n="76"></locus>
+                    <locus from="1ra66" to="1ra76"></locus>
                     <title type="incomplete" ref="LIT4156Prayer"></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez">አሌፍ፡ ብሂል፡ ፩ እግዚአብሔር፡ አብ፡
@@ -54,30 +51,26 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     Bet, Gimel, Dalet, He, Vav.</note>
                   </msItem>
                   <msItem xml:id="ms_i3">
-                    <locus from="1rb" n="1"></locus>
-                    <locus to="1rb" n="35"></locus>
+                    <locus from="1rb1" to="1rb35"></locus>
                     <title type="complete" ref="LIT5847Asmat"><certainty locus="value" match="../@ref" cert="medium"></certainty></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡
                     ፩ አምላክ፡ ወትብል፡ ቃል፡ ጸሎተ፡ አስማተ፡ ዓስማተ፡</incipit>
                   </msItem>
                   <msItem xml:id="ms_i4">
-                    <locus from="1rb" n="36"></locus>
-                    <locus from="1rb" n="115"></locus>
+                    <locus from="1rb36" to="1rb115"></locus>
                     <title type="complete" ref="LIT2765RepCh49"></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez">ሰላም፡ ለከ፡ ሰዳዴ፡ ሰይጣናት፡ ፋኑኤል፡ ለእግዚአብሔር፡
                     እምጽርሑ፡ ከመ፡ ኢይስክዩ፡ ሰብአ፡ እለ፡ ይኔስሑ፡</incipit>
                   </msItem>
                   <msItem xml:id="ms_i5">
-                    <locus from="2r" n="1"></locus>
-                    <locus to="2r" n="68"></locus>
+                    <locus from="2r1" to="2r68"></locus>
                     <title type="complete" ref="LIT5876AsmatPrayer"></title>
                     <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"></gap> ኤኮስ፡ አስሌ፡ ኤፓ፡</incipit>
                   </msItem>
                   <msItem xml:id="ms_i6">
-                    <locus from="2r" n="69"></locus>
-                    <locus to="2r" n="85"></locus>
+                    <locus from="2r69" to="2r85"></locus>
                     <title type="incomplete" ref="LIT2452Tergwa"><certainty locus="value" match="../@ref" cert="medium"></certainty></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez">አሌፍ፡ ብፁዓን፡ እለ፡ ንፁሃን፡</incipit>

--- a/StPetersburg/InEtn46931.xml
+++ b/StPetersburg/InEtn46931.xml
@@ -33,44 +33,38 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                   <summary>
                   </summary>
                   <msItem xml:id="ms_i1">
-                    <locus from="1r" n="1"></locus>
-                    <locus to="1r" n="9"></locus>
+                    <locus from="1r1" to="1r9"></locus>
                     <title type="complete" ref="LIT4581MagicPr"><certainty locus="value" match="../@ref" cert="medium"></certainty></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"></gap> ጸሎት፡ በእንተ፡ ማዕሠረ፡
                   አጋንንት፡</incipit>
                   </msItem>
                   <msItem xml:id="ms_i2">
-                    <locus from="1r" n="10"></locus>
-                    <locus to="1r" n="94"></locus>
+                    <locus from="1r10" to="1r94"></locus>
                     <title type="complete" ref="LIT4642MagicPr"></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez">በስመ፡ እግዚአብሔር፡ ሕያው፡ ነባቢ፡ ወተናጋሪ፡ ጸሎቱ፡ ወበረከቱ፡ ለቅዱስ፡ ሱስንዮስ፡
                     </incipit>
                   </msItem>
                   <msItem xml:id="ms_i3">
-                    <locus from="1r" n="95"></locus>
-                    <locus to="1r" n="101"></locus>
+                    <locus from="1r95" to="1r101"></locus>
                     <title type="complete" ref="LIT4643Salam"></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez">ሰላም፡ ለሱስንዮስ፡ ወልደ፡ ጴጥሮስ፡ ሱሲ፡</incipit>
                   </msItem>
                   <msItem xml:id="ms_i4">
-                    <locus from="1r" n="102"></locus>
-                    <locus from="1r" n="115"></locus>
+                    <locus from="1r102" to="1r115"></locus>
                     <title type="complete" ref="LIT4578MagicPr"><certainty locus="value" match="../@ref" cert="medium"></certainty></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez">ኦአምላከ፡ ሱስንዮስ፡ ዕቀባ፡ ወአድኅና፡ እምሕማመ፡ ባርያ፡ ወሌጌዎን፡ ደም፡ ወመጋኛ፡</incipit>
                   </msItem>
                   <msItem xml:id="ms_i5">
-                    <locus from="1r" n="117"></locus>
-                    <locus to="1r" n="162"></locus>
+                    <locus from="1r117" n="1r162"></locus>
                     <title type="complete" ref="LIT4702MagicPr"><certainty locus="value" match="../@ref" cert="medium"></certainty></title>
                     <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"></gap> ጸሎት፡ በእንተ፡ ማዕሠረ፡ አጋንንት፡</incipit>
                   </msItem>
                   <msItem xml:id="ms_i6">
-                    <locus from="1r" n="163"></locus>
-                    <locus to="1r" n="183"></locus>
+                    <locus from="1r163" to="1r183"></locus>
                     <title type="complete" ref="LIT5691MagicPrayer"><certainty locus="value" match="../@ref" cert="medium"></certainty></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"></gap> ጸሎት፡ በእንተ፡ ሕማመ፡ ቡዳ፡ ወ<sic>ቀ</sic>ማኛ፡

--- a/StPetersburg/InEtn660714.xml
+++ b/StPetersburg/InEtn660714.xml
@@ -33,8 +33,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                   <summary>
                   </summary>
                   <msItem xml:id="ms_i1">
-                    <locus from="1ra" n="1"></locus>
-                    <locus to="1ra" n="22"></locus>
+                    <locus from="1ra1" to="1ra22"></locus>
                     <title type="complete" ref="LIT5887MagicPrayer"></title>
                     <textLang mainLang="gez"></textLang>
                     <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"></gap> ጸሎት፡ በእንተ፡ ሕማመ፡ ባርያ፡ ወሌጌዎን፡ ወሕማመ፡ አልጕም፡
@@ -42,57 +41,48 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                   </msItem>
 
                   <msItem xml:id="ms_i2">
-                    <locus from="1ra" n="23"></locus>
-                    <locus to="1ra" n="58"></locus>
+                    <locus from="1ra23" to="1ra58"></locus>
                     <title type="incomplete" ref="LIT2715John"></title>
                     <textLang mainLang="gez"></textLang>
                     <note>1.1-5. Contains magic introduction and conclusion.</note>
                   </msItem>
                   <msItem xml:id="ms_i3">
-                    <locus from="1ra" n="59"></locus>
-                    <locus to="1ra" next="146"></locus>
+                    <locus from="1ra59" to="1ra146"></locus>
                     <title type="complete" ref="LIT2295Sayfam"><certainty locus="value" match="../@ref" cert="medium"></certainty></title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>
                   <msItem xml:id="ms_i4">
-                    <locus from="1ra" n="147"></locus>
-                    <locus to="1ra" n="302"></locus>
+                    <locus from="1ra147" to="1ra302"></locus>
                     <title type="complete" ref="LIT5888AsmatPrayer" xml:lang="gez">አስማት፡</title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>
                   <msItem xml:id="ms_i5">
-                    <locus from="1rb" n="1"></locus>
-                    <locus to="1rb" n="47"></locus>
+                    <locus from="1rb1" to="1rb47"></locus>
                     <title type="complete" ref="LIT5889UndoingOfCharms"></title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>
                   <msItem xml:id="ms_i6">
-                    <locus from="1rb" n="48"></locus>
-                    <locus to="1rb" n="77"></locus>
+                    <locus from="1rb48" to="1rb77"></locus>
                     <title type="complete" ref="LIT5889UndoingOfCharms"></title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>
                   <msItem xml:id="ms_i7">
-                    <locus from="1rb" n="78"></locus>
-                    <locus to="1rb" n="144"></locus>
+                    <locus from="1rb78" to="1rb144"></locus>
                     <title type="complete" ref="LIT5889UndoingOfCharms"></title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>
                   <msItem xml:id="ms_i8">
-                    <locus from="1rb" n="145"></locus>
-                    <locus to="1rb" n="210"></locus>
+                    <locus from="1rb145" to="1rb210"></locus>
                     <title type="complete" ref="LIT5889UndoingOfCharms"></title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>
                   <msItem xml:id="ms_i9">
-                    <locus from="1rb" n="211"></locus>
-                    <locus to="1rb" n="267"></locus>
+                    <locus from="1rb211" to="1rb267"></locus>
                     <title type="complete" ref="LIT5888AsmatPrayer"></title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>
                   <msItem xml:id="ms_i10">
-                    <locus from="1rb" n="268"></locus>
-                    <locus to="1rb" n="309"></locus>
+                    <locus from="1rb268" to="1rb309"></locus>
                     <title type="complete" ref="LIT5888AsmatPrayer"></title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>

--- a/StPetersburg/InEtn660715.xml
+++ b/StPetersburg/InEtn660715.xml
@@ -33,94 +33,80 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                   <summary>
                   </summary>
                   <msItem xml:id="ms_i1">
-                    <locus from="1r" n="1"></locus>
-                    <locus to="1r" n="13"></locus>
+                    <locus from="1r1" to="1r13"></locus>
                     <title type="complete" ref="LIT5889UndoingOfCharms" xml:lang="gez">መፍትሔ፡ ሥራይ፡</title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>
                   <msItem xml:id="ms_i2">
-                    <locus from="1r" n="14"></locus>
-                    <locus to="1r" n="38"></locus>
-                    <title type="incomplete" ref="LIT2711Mark"></title>
+                    <locus from="1r14" to="1r38"></locus>
+                    <title type="incomplete" ref="LIT2711Mark">
+                      Excerpt from 
+                      <ref cRef="betmas:LIT2711Mark.1.23-28">Mark 1.23-28</ref>.
+                    </title>
                     <textLang mainLang="gez"></textLang>
-                    <note>1.23-28.</note>
                   </msItem>
                   <msItem xml:id="ms_i3">
-                    <locus from="1r" n="39"></locus>
-                    <locus to="1r" next="52"></locus>
+                    <locus from="1r39" to="1r52"></locus>
                     <title type="complete" ref="LIT5889UndoingOfCharms"></title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>
                   <msItem xml:id="ms_i4">
-                    <locus from="1r" n="53"></locus>
-                    <locus to="1r" n="59"></locus>
+                    <locus from="1r53" to="1r59"></locus>
                     <title type="complete" ref="LIT2295Sayfam"><certainty locus="value" match="../@ref" cert="medium"></certainty></title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>
                   <msItem xml:id="ms_i5">
-                    <locus from="1r" n="60"></locus>
-                    <locus to="1r" n="82"></locus>
+                    <locus from="1r60" n="1r82"></locus>
                     <title type="complete" ref="LIT5889UndoingOfCharms"></title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>
                   <msItem xml:id="ms_i6">
-                    <locus from="1r" n="83"></locus>
-                    <locus to="1r" n="120"></locus>
+                    <locus from="1r83" to="1r120"></locus>
                     <title type="complete" ref="LIT5889UndoingOfCharms"></title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>
                   <msItem xml:id="ms_i7">
-                    <locus from="1r" n="121"></locus>
-                    <locus to="1r" n="125"></locus>
+                    <locus from="1r121" to="1r125"></locus>
                     <title type="complete" ref="LIT5889UndoingOfCharms"></title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>
                   <msItem xml:id="ms_i8">
-                    <locus from="1r" n="126"></locus>
-                    <locus to="1r" n="135"></locus>
+                    <locus from="1r126" to="1r135"></locus>
                     <title type="complete" ref="LIT1878Marbab" xml:lang="gez">መርበብተ፡ ሰሎሞን፡</title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>
                   <msItem xml:id="ms_i9">
-                    <locus from="1r" n="136"></locus>
-                    <locus to="1r" n="154"></locus>
+                    <locus from="1r136" to="1r154"></locus>
                     <title type="complete" ref="LIT5889UndoingOfCharms"></title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>
                   <msItem xml:id="ms_i10">
-                    <locus from="1r" n="155"></locus>
-                    <locus to="1r" n="168"></locus>
+                    <locus from="1r155" to="1r168"></locus>
                     <title type="complete" ref="LIT5888AsmatPrayer" xml:lang="gez">አስማት፡</title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>
                   <msItem xml:id="ms_i11">
-                    <locus from="1r" n="169"></locus>
-                    <locus to="1r" n="183"></locus>
+                    <locus from="1r169" n="1r183"></locus>
                     <title type="complete" ref="LIT5889UndoingOfCharms"></title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>
                   <msItem xml:id="ms_i12">
-                    <locus from="1r" n="184"></locus>
-                    <locus to="1r" n="196"></locus>
+                    <locus from="1r184" to="1r196"></locus>
                     <title type="complete" ref="LIT2295Sayfam"><certainty locus="value" match="../@ref" cert="medium"></certainty></title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>
                   <msItem xml:id="ms_i13">
-                    <locus from="1r" n="197"></locus>
-                    <locus to="1r" n="211"></locus>
+                    <locus from="1r197" to="1r211"></locus>
                     <title type="complete" ref="LIT5889UndoingOfCharms"></title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>
                   <msItem xml:id="ms_i14">
-                    <locus from="1r" n="212"></locus>
-                    <locus to="1r" n="231"></locus>
-                    <title type="incomplete" ref="LIT2715John"></title>
+                    <locus from="1r212" to="1r231"></locus>
+                    <title type="incomplete" ref="LIT2715John">Excerpt from <ref cRef="betmas:LIT2715John.1.1-5">John 1.1-5</ref>.</title>
                     <textLang mainLang="gez"></textLang>
-                    <note>1.1-5.</note>
                   </msItem>
                   <msItem xml:id="ms_i15">
-                    <locus from="1r" n="232"></locus>
-                    <locus to="1r" n="244"></locus>
+                    <locus from="1r232" to="1r244"></locus>
                     <title type="complete" ref="LIT5696MagicPrayer" xml:lang="gez">ሐፁረ፡ መስቀል፡</title>
                     <textLang mainLang="gez"></textLang>
                   </msItem>

--- a/VaticanBAV/cerulli/BAVcerulli223.xml
+++ b/VaticanBAV/cerulli/BAVcerulli223.xml
@@ -500,7 +500,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <origin>
                      <origDate evidence="internal" notAfter="1974" notBefore="1930">Mention of <persName ref="PRS5226haylase">
                            <roleName type="title">ንጉሥነሂ፡</roleName> ኃይለ፡ ሥላሴ፡ </persName>
-     on <locus target="#5vb-6ra" n="1"/>
+     on <locus from="5vb" to="6ra1"/>
                      </origDate>
                   </origin>
                </history>

--- a/VaticanBAV/et/BAVet1.xml
+++ b/VaticanBAV/et/BAVet1.xml
@@ -407,16 +407,16 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <note/>
                      </msItem>
                      <msItem xml:id="ms_i6.7">
-                        <locus from="168r" to="169vb" n="13" facs="0170"/>
+                        <locus from="168r" to="169vb13" facs="0170"/>
                         <title type="incomplete" ref="LIT2651CanonsCouncils">Canons of Gangra, 20 in number</title>
                         <note>The text breaks off after Canon 18, on <locus target="#169vb" n="13"/>.</note>
                      </msItem>
                      <msItem xml:id="ms_i6.8">
-                        <locus from="169vb" n="13" to="173r" facs="0172"/>
+                        <locus from="169vb13" to="173r" facs="0172"/>
                         <title type="incomplete" ref="LIT2686CanonsLao">Canons of Laodicea, canons 19-59</title>
                         <note>It is the continuation of <ref target="#ms_i6.14"/>.</note>
                         <incipit xml:lang="gez">
-                           <locus target="#169vb" n="13" facs="0172"/>በእንተ፡ በዓል፡ ይጸውዖሙ፡ ለንኡስ፡ ክርስቲያን፡</incipit>
+                           <locus target="#169vb13"  facs="0172"/>በእንተ፡ በዓል፡ ይጸውዖሙ፡ ለንኡስ፡ ክርስቲያን፡</incipit>
                      </msItem>
                      <msItem xml:id="ms_i6.9">
                         <locus from="173r" to="176v" facs="0175"/>
@@ -586,7 +586,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                      <note>The text follows the text edited in: <bibl>
                            <ptr target="bm:Dillmann1866Chrestomathia"/>
                            <citedRange unit="page">51-56</citedRange>
-                        </bibl> up to <locus target="#216vb" n="4"/>, then few passages are added.</note>
+                        </bibl> up to <locus target="#216vb4"/>, then few passages are added.</note>
                      <explicit xml:lang="gez">
                         <locus target="#218r" facs="0221"/>
                         <choice>

--- a/VaticanBAV/et/BAVet104.xml
+++ b/VaticanBAV/et/BAVet104.xml
@@ -42,7 +42,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <locus from="1" to="10v"/>
                         <title type="complete" ref="LIT4707Salot#Sunday">Praises for Sunday</title>
                         <note>
-                           The scribe erroneously repeated the portion of text <locus from="3r" to="4v" n="3"/> (<q xml:lang="gez">ኦድንግል፡</q>).
+                           The scribe erroneously repeated the portion of text <locus from="3r3" to="4v"/> (<q xml:lang="gez">ኦድንግል፡</q>).
                         </note>
                      </msItem>
                      <msItem xml:id="ms_i1.2">
@@ -106,7 +106,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <measure unit="quire">11 (A + 10)</measure>
                            <measure unit="leaf" type="blank">7</measure>
                            <locus target="#1v"/>
-                           <locus from="IIv" to="IIIv"/>
+                           <locus from="iiv" to="iiiv"/>
                            <locus from="77v" to="78v"/>
                            <dimensions type="outer" unit="mm">
                               <height>120</height>
@@ -124,7 +124,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <list>
                               <item xml:id="q1">
                                  <dim unit="leaf">1</dim>
-                                 <locus from="IIr" to="6v"/>
+                                 <locus from="iir" to="6v"/>
                                  <note>
                                     <locus target="#I"/> has been glued to the first leaf of the first quire.</note>
                               </item>

--- a/VaticanBAV/et/BAVet29.xml
+++ b/VaticanBAV/et/BAVet29.xml
@@ -595,7 +595,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <locus from="30rb" to="33v" facs="0036"/>
                            <title type="complete" ref="LIT3129Prayer">Prayer for the time of the twilight</title>
                            <msItem xml:id="p6_i1.3.1">
-                              <locus from="31ra" n="21" to="33rb" facs="0037"/>
+                              <locus from="31ra21" to="33rb" facs="0037"/>
                               <title type="complete">Prayers of praise and thanksgiving</title>
                               <incipit xml:lang="gez">
                                  እግዚኦ፤ መሐረነ፤ ክርስቶስ፨ ፫ጊዜ፨ ጸጋ፤ ዘእግዚአብሔር፤ ይሃሉ፤ ምስሌክሙ፨ ይ፤ ሕ፤ ምስለ፡ መንፈስከ፨  ይ፡ ካ፤ <choice>
@@ -997,7 +997,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <note>
                            The same text is also found in <ref type="mss" corresp="BAVet66#i8"/>.
                         </note>
-                        <listBibl type="editions">
+                        <listBibl type="secondary">
                            <bibl>
                               <ptr target="bm:Chaine1911SanStefanodeiMori"/>
                               <citedRange>20-23</citedRange>

--- a/VaticanBAV/et/BAVet31.xml
+++ b/VaticanBAV/et/BAVet31.xml
@@ -267,7 +267,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <seg type="ink">Black, red</seg>
                         <desc>
                            Some paleographic features: 
-                           ሎ has the loop marking the 7th order of half-round shape and sometimes attached directly to the body of the letter, without the linking line (e.g., <locus target="#182vb" n="5"/>);   
+                           ሎ has the loop marking the 7th order of half-round shape and sometimes attached directly to the body of the letter, without the linking line (e.g., <locus target="#182vb5"/>);   
                            the left strokes of ሰ, በ, and ዘ are slightly slanted; 
                            the upper part of ቆ, ቶ, የ, ደ and ጸ has sometimes triangular shape; 
                            the crux ansata is used in the margins.

--- a/VaticanBAV/et/BAVet36.xml
+++ b/VaticanBAV/et/BAVet36.xml
@@ -454,10 +454,12 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   <msItem xml:id="ms_i10">
                      <locus from="71r" to="71v" facs="0087"/>
                      <title type="incomplete" ref="LIT1807Litonz">ሰዓታት፡ ዘነግህ፡ ዕዝል፡</title>
-                     <note>The text corresponds to the prayer contained in <ref type="mss" corresp="BAVet1"/>, <locus from="125ra" n="11"/> 
-                        <locus to="125rb" n="13"/> and 
-                        <locus from="125vb" n="6"/> 
-                        <locus to="126rb" n="14"/>.</note>
+                     <note>The text corresponds to the prayer contained in <ref type="mss" corresp="BAVet1"/>, 
+                        <!--                        loci in BAVet1 ? or here in BAVet36? -->
+                        <locus from="125ra11"/> 
+                        <locus to="125rb13" /> and 
+                        <locus from="125vb6"/> 
+                        <locus to="126rb14"/>.</note>
                   </msItem>
                   
                   <msItem xml:id="ms_i11">

--- a/VaticanBAV/et/BAVet4.xml
+++ b/VaticanBAV/et/BAVet4.xml
@@ -357,7 +357,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   </msItem>
 
                   <msItem xml:id="ms_i6">
-                     <locus from="156r" to="157v" n="10"/>
+                     <locus from="156r10" to="157v"/>
                      <title type="incomplete" ref="LIT2362Songof"/>
                   </msItem>
 

--- a/VaticanBAV/et/BAVet42.xml
+++ b/VaticanBAV/et/BAVet42.xml
@@ -247,7 +247,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            ዐ and sometimes መ and ሠ have angular shapes; 
                            the upper part of ቆ, ቶ, የ, ደ, and ጸ have an angular shape;
                            ሎ has the loop marking the 7th order attached directly to the body of the letter, without the linking line (it is written with the linking line on 
-                           <locus target="#52r" n="1"/>, cp. also <bibl>
+                           <locus target="#52r1"/>, cp. also <bibl>
                               <ptr target="bm:ContiRossini1896Vergine"/>
                               <citedRange unit="page">461 n. 1</citedRange>
                            </bibl> 

--- a/VaticanBAV/et/BAVet65.xml
+++ b/VaticanBAV/et/BAVet65.xml
@@ -266,10 +266,10 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <choice>
                                  <sic>الروحانية</sic>
                               </choice> اول السرائرجميعها هي المعمودية المقدسة لانها باب حياة</q>),
-                           the Confirmation (<locus from="19r" n="4"/>), the Eucharist 
-                           (<locus from="19v" n="11"/>), the Penance (<locus from="20r" n="24"/>), the Extreme Unction (<locus from="20v" n="18"/>), the 
-                           Orders (<locus from="21r" n="15"/>), the Matrimony (<locus from="21v" n="15"/>). The profession of faith continuates on 
-                           <locus from="22" n="16"/>.
+                           the Confirmation (<locus from="19r4"/>), the Eucharist 
+                           (<locus from="19v11"/>), the Penance (<locus from="20r24" />), the Extreme Unction (<locus from="20v18"/>), the 
+                           Orders (<locus from="21r15" />), the Matrimony (<locus from="21v15"/>). The profession of faith continuates on 
+                           <locus from="22"/>. <!--n=16?-->
                         </note>
                         <explicit xml:lang="ar">
                            ወእመ፡ አ<supplied reason="omitted">ን</supplied>ፋስ፡ ሀውልይከ፡ እለዲን፡ በኣድ፡ አኸድሆሙ፡ እምማእሙድየ፡ ማተደነሱ፡ በአውሰኸ፡ እል፡ ኸጥየ፡ ቀጥ፡

--- a/VaticanBAV/et/BAVet67.xml
+++ b/VaticanBAV/et/BAVet67.xml
@@ -181,7 +181,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                           the upper parts of ቆ, ቶ, የ, ደ, and ጸ are of triangular shape; 
                           ሎ has the loop marking the 7th order sometimes attached directly to the body of the letter, without the linking line; 
                           ዐ and ፀ are rounded; 
-                          ኖ has the loop marking the 7th order of angular shape (e.g., on <locus target="#29ra" n="4"/>, <locus target="#140ra" n="3"/>); 
+                          ኖ has the loop marking the 7th order of angular shape (e.g., on <locus target="#29ra4"/>, <locus target="#140ra3"/>); 
                           has a loop on the right side.
                       </desc>
                         <seg type="rubrication">Titles, nomina sacra.</seg>

--- a/VaticanBAV/et/BAVet8.xml
+++ b/VaticanBAV/et/BAVet8.xml
@@ -206,7 +206,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               </choice>
                            </incipit>
                            <explicit xml:lang="gez">ወኵሎሙ፡ እለ፡ ርእዩ፡ ወሰምኡ፡ አንከርዎ፡ ለእግዚአብሔር፡ ወለወላዲቱ፡ ድንግል፡ ዘይፈቅድ፡ ምክንያተ፡ ለድሒን፡ ወለጸሎተ፡ እግዝእትነ፡ ማርያም፡ ጸሎትኪ፡ ...</explicit>
-                           <listBibl type="editions">
+                           <listBibl type="secondary">
                               <bibl>
                                  <ptr target="bm:Cerulli1943Maria"/>
                                  <citedRange unit="page">393-395</citedRange>
@@ -710,7 +710,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                     </objectDesc>
                     <handDesc>
                        <handNote xml:id="h1" script="Ethiopic">
-                          <locus from="1r" to="76vb" n="13" facs="0004"/>
+                          <locus from="1r" to="76vb13" facs="0004"/>
                           <locus from="78" to="101" facs="0083"/>
                           <locus from="127" to="164v" facs="0133"/>
                           <seg type="script">Written in a mediocre handwriting.</seg>
@@ -730,7 +730,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                        </handNote>
                        <handNote xml:id="h2" script="Ethiopic">
                           <seg type="script">Written in a mediocre handwriting.</seg>
-                          <locus from="76vb" n="14" to="77" facs="0082"/>
+                          <locus from="76vb14" to="77" facs="0082"/>
                           <locus from="102" to="125" facs="0107"/>
                           <seg type="ink">Black, red</seg>
                           <date notBefore="1500" notAfter="1599">16th century</date>


### PR DESCRIPTION
this was previously used to mark a line, with the new referencing system this can be done inside `@from`, `@to`, `@target`. In this commit there are also some fixes of instances of `@from` `@n` , a mistake for `@from` `@to` and a few other corrections. especially intriguing are cases of locus possibly being marked up out of context, see  BAVet36 . I also added a couple of instances of `rec[@cRef]`