### PR TITLE
Corrections to Dabra Maso MY 016 018

### DIFF
--- a/ES/ESmy016.xml
+++ b/ES/ESmy016.xml
@@ -28,7 +28,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <msIdentifier>
                   <repository ref="INS0039MY"/>
                   <collection>Ethio-SPaRe</collection>
-                  <idno>MY-016</idno>
+                  <idno facs="MY/016/MY-016" n="54">MY-016</idno>
+                  
                </msIdentifier>
                <msContents>
                 <summary/>
@@ -141,12 +142,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                  </item>
 
                                  <item xml:id="q6" n="6">
+                                   <note> (the structure of the quire
+                                    cannot be ascertained;
+                                    leaf 1 (<locus target="#38"/>) is possibly single.)</note>
                                    <dim unit="leaf">7</dim>
                                  <locus from="38r" to="44v"/>
-                                 s.l.: 1, no stub
-                                 <note>The structure of the quire
-                                   cannot be ascertained;
-                                   possible leaf 1 (<locus target="#38"/>) is possibly single.</note>
+                                    s.l.: 1, no stub 
                                   </item>
                                  <note><locus from ="38" to="40"/> have been misplaced, they should be
                                  before <locus target="#30"/>.</note>
@@ -331,6 +332,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <change who="EG" when="2014-06-05">last edited</change>
          <change who="PL" when="2016-05-10">transformed from mycore to TEI P5</change>
          <change who="PL" when="2019-04-25">added missing extras from domlib</change>
+         <change when="2020-08-07" who="DN">updated description, adjusted to TEI schema, introduced IDs</change>
+         <change when="2020-08-07" who="ES">minor correction in collation, facs added</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">

--- a/ES/ESmy018.xml
+++ b/ES/ESmy018.xml
@@ -27,7 +27,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <msIdentifier>
                   <repository ref="INS0039MY"/>
                   <collection>Ethio-SPaRe</collection>
-                  <idno>MY-018</idno>
+                 <idno facs="MY/018/MY-018_" n="89">MY-018</idno>
+                  
                </msIdentifier>
                <msContents>
                   <summary>
@@ -260,19 +261,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
       <persName ref="PRS13125ZabanaKrestos">Zabāna Krǝstos</persName>.</note>
     </msItem>
 </msItem>
+                    </msItem>
 
  <msItem xml:id="ms_i2">
- <locus from="44ra" to="60va"/>
- <title type="complete" ref="LIT2085OntheL">Discourse by John Chrysostom on the life and
-decollation of John the Baptist</title>
-<incipit xml:lang="gez">
-<locus target="#44ra"/><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወ</hi>መንፈስ፡ ቅዱስ፡ አሐዱ፡ <hi rend="rubric">አምላክ፡
-ዝንቱ፡ ነገር፡ በከ</hi>መ፡ ኮነ፡ ሕይወቱ፡ ለቅዱስ፡ <hi rend="rubric">ዮሐንስ፡ መጥምቅ፡ ወከ</hi>መ፡ እፎ፡
-ኮነ፡ ምትረተ፡ ርእሱ፡ ወተርጐሞ፡ ቅዱስ፡ ዮሐንስ፡ አፈ፡ ወርቅ፡ በትርያርክ፡ ሊቀ፡ ጳጳሳት፡ ብሂል፡ ዘሀገረ፡ ቈስጠንጥንያ፤ ወሶበ፡ ኮነ፡ ስደቱ፡ ውስተ፡ አብራክይስ፡ አመ፡ ተስእሎ፡ አይሁዳዊ፡
-ኬልቄዶናዊ፡ ዘአምነ፡ በእግዚእነ፡ ኢየሱስ፡ ክርስቶስ።
-</incipit>
-
-                     <msItem xml:id="ms_i3">
+<title>Works dedicated to John the Baptist</title>
+ 
+   <msItem xml:id="ms_i2.1">
+  <locus from="44ra" to="60va"/>
+  <title type="complete" ref="LIT2085OntheL">Discourse by John Chrysostom on the life and
+    decollation of John the Baptist</title>
+  <incipit xml:lang="gez">
+    <locus target="#44ra"/><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወ</hi>መንፈስ፡ ቅዱስ፡ አሐዱ፡ <hi rend="rubric">አምላክ፡
+      ዝንቱ፡ ነገር፡ በከ</hi>መ፡ ኮነ፡ ሕይወቱ፡ ለቅዱስ፡ <hi rend="rubric">ዮሐንስ፡ መጥምቅ፡ ወከ</hi>መ፡ እፎ፡
+    ኮነ፡ ምትረተ፡ ርእሱ፡ ወተርጐሞ፡ ቅዱስ፡ ዮሐንስ፡ አፈ፡ ወርቅ፡ በትርያርክ፡ ሊቀ፡ ጳጳሳት፡ ብሂል፡ ዘሀገረ፡ ቈስጠንጥንያ፤ ወሶበ፡ ኮነ፡ ስደቱ፡ ውስተ፡ አብራክይስ፡ አመ፡ ተስእሎ፡ አይሁዳዊ፡
+    ኬልቄዶናዊ፡ ዘአምነ፡ በእግዚእነ፡ ኢየሱስ፡ ክርስቶስ።
+  </incipit>
+</msItem>
+                     <msItem xml:id="ms_i2.2">
                       <locus from="60vb" to="63ra"/>
                       <title type="complete" ref="LIT6162SenYoh30Sane">On the
                         finding of the head of John the Baptist, for 30 Yakkātit</title>
@@ -283,7 +288,7 @@ decollation of John the Baptist</title>
                         </incipit>
                       </msItem>
 
-                      <msItem xml:id="ms_i4">
+                      <msItem xml:id="ms_i2.3">
                        <locus from="63ra" to="65ra"/>
                        <title type="complete" ref="LIT6163SenYoh2Sane">On the finding of the
                          body of John the Baptist, 2 Sane</title>
@@ -293,7 +298,7 @@ decollation of John the Baptist</title>
                        ሥጋሁ፡ ለኤልሳዕ፡ ነቢይ፡ ረዱኡ፡ ለኤልያስ፡ ቀናኢ፡</incipit>
                        </msItem>
 
-                       <msItem xml:id="ms_i5">
+                       <msItem xml:id="ms_i2.4">
                         <locus from="65ra" to="74ra"/>
                         <title type="complete" ref="LIT2125OntheG">Homily by John
                           Chrisostom on the glory of John the Baptist</title>
@@ -304,7 +309,7 @@ decollation of John the Baptist</title>
                         አሜን፡ ስምዑ፡ ኦፍቁራንየ፡ አንሰ፡ እፈቅድ፡ በእንተ፡ ዕበዩ፡ ለዮሐንስ፡
                       </incipit>
                         <note>The text is no way separated from the previous one,
-                          <ref target="#ms_i4"/>.</note>
+                          <ref target="#ms_i2.3"/>.</note>
                         </msItem>
 
                         <colophon xml:id="coloph2">
@@ -324,7 +329,7 @@ decollation of John the Baptist</title>
                            Your intercession, your intercession do not forget for us!</foreign>
                          </colophon>
                            </msItem>
-                           </msItem>
+
 
                </msContents>
                <physDesc>
@@ -539,7 +544,7 @@ decollation of John the Baptist</title>
                           <note>Almost complete,
                             only the last two or three lines are missing;
                             Written in an 18th-century hand that may be the same as in
-                             <ref type="hand" corresp="ESmy20#h1">Hand 1 of ESmy 20</ref>.</note>
+                             <ref type="hand" corresp="ESmy020#h1">Hand 1 of ESmy020</ref>.</note>
                          <q xml:lang="gez">እሰግድ፡ ለኪ፡ እሰግድ፡ ለኪ፡ እሰግድ፡ ለኪ።
                            ወእዌድሰኪ፡ አእግዚእትየ፡ ማርያም፡ በከመ፡ ወደሰኪ፡ ዮሐንስ፡ አፈወርቅ፡ በድርሳኑ፡ እንዘ፡ ይብል፡</q>
                           </item>
@@ -684,6 +689,8 @@ decollation of John the Baptist</title>
          <change who="SA" when="2010-09-22">catalogued</change>
          <change who="DN" when="2015-04-03">last edited</change>
          <change who="PL" when="2016-05-10">transformed from mycore to TEI P5</change>
+        <change when="2020-08-07" who="DN">updated description, adjusted to TEI schema, identified miracles, introduced IDs</change>
+        <change when="2020-08-07" who="ES">corrected nesting and minor corrections, facs added</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">

--- a/ES/ESmy018.xml
+++ b/ES/ESmy018.xml
@@ -544,7 +544,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                           <note>Almost complete,
                             only the last two or three lines are missing;
                             Written in an 18th-century hand that may be the same as in
-                             <ref type="hand" corresp="ESmy020#h1">Hand 1 of ESmy020</ref>.</note>
+                             <ref type="hand" corresp="ESmy020#h1">Hand 1 of MY-020</ref>.</note>
                          <q xml:lang="gez">እሰግድ፡ ለኪ፡ እሰግድ፡ ለኪ፡ እሰግድ፡ ለኪ።
                            ወእዌድሰኪ፡ አእግዚእትየ፡ ማርያም፡ በከመ፡ ወደሰኪ፡ ዮሐንስ፡ አፈወርቅ፡ በድርሳኑ፡ እንዘ፡ ይብል፡</q>
                           </item>


### PR DESCRIPTION
It was quicker to correct directly - there were nesting and numbering problems in MY-018 and some smaller issues (e.g. you forgot to add a change element, please check other files, too)

I personally would split MY-018 in 2 msParts - there is a clear break, there is a colophon after the first part, formerly blank pages with additions and a change of hand and change of layout - to me this is clearly a composite manuscript, even if the second part possibly was never a circulation unit of its own it is still an msPart

If you want I can edit the description accordingly