### PR TITLE
desc around titles

### DIFF
--- a/ES/ESmkl002.xml
+++ b/ES/ESmkl002.xml
@@ -157,13 +157,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      <list>
                         
                         <item xml:id="e1"><locus target="#1">1rv, </locus><locus target="#172rv">172rv, </locus><locus target="#174">174rv</locus>
-                           <title ref="LIT2375Synaxa" type="incomplete">Synaxarion</title>
-                           <desc>- Endleaves fols. 1, 172, 174 are fragments of an old
-                           15th-cent. (?) Synaxarion, containing parts of commemorative notices
+                           
+                           <desc>Endleaves fols. 1, 172, 174 are fragments of an old
+                              15th-cent. (?) <title ref="LIT2375Synaxa" type="incomplete">Synaxarion</title>, containing parts of commemorative notices
                            for:&#xD; 22 and 23 Ḫǝdār (Cosmas and Damian, Cornelius); 8 Tāḫśāś (Esi
                            and Thecla, Samuel); 7 and 8 Tāḫśāś (Samuel, Barbara and Juliana,
                            Mathew).</desc> </item>
-                        <item xml:id="e8"><desc> - Crude drawings on <locus target="#173rv">173rv</locus>.</desc></item>
+                        <item xml:id="e8"><desc>Crude drawings on <locus target="#173rv">173rv</locus>.</desc></item>
                      </list>
                   </additions>
                   <bindingDesc>

--- a/LondonBritishLibrary/add/BLadd24991.xml
+++ b/LondonBritishLibrary/add/BLadd24991.xml
@@ -292,9 +292,8 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                 <item xml:id="a4">
                                     <locus target="#14r"/>
                                     <desc type="Excerpt"> A short extract on the properties of the 
-                                        four elements.</desc>
-                                    <title corresp="BLorient482#a1"/>
-                                    
+                                        four elements (<ref type="work" corresp="BLorient482#a1"/>.</desc>
+                                                                        
                                 </item>
                                 
                                 <item xml:id="a5">
@@ -415,7 +414,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                     <term key="Gon" cert="medium"/>
                 </keywords>
             </textClass>
-            <langUsage><language ident="gez">Gǝʿǝz</language></langUsage>
+            <langUsage><language ident="gez">Gǝʿǝz</language><language ident="am">Amharic</language></langUsage>
             
         </profileDesc>
         <revisionDesc>

--- a/LondonBritishLibrary/orient/BLorient494.xml
+++ b/LondonBritishLibrary/orient/BLorient494.xml
@@ -211,8 +211,8 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                 
                                 <item xml:id="a8">
                                     <locus from="49r" to="49v"/>
-                                    <title type="incomplete" ref="LIT3529Daniel"/>
-                                    <desc type="MagicText">Daniel chapter XI, apparently written as an amulet.
+                                    
+                                    <desc type="MagicText"><title type="incomplete" ref="LIT3529Daniel">Daniel chapter XI</title> , apparently written as an amulet.
                                     </desc>
                                     
                                 </item>

--- a/LondonBritishLibrary/orient/BLorient706.xml
+++ b/LondonBritishLibrary/orient/BLorient706.xml
@@ -203,8 +203,8 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                 </item>
                                 <item xml:id="a10">
                                     <locus target="#1r #a202r"/>
-                                    <title type="incomplete" ref="LIT4957SebhataF"/>
-                                    <desc type="GuestText">A hymn to George</desc> 
+                                    
+                                    <desc type="GuestText">A hymn to George (<title type="incomplete" ref="LIT4957SebhataF"/>)</desc> 
                                     <q xml:lang="gez">ሰላም፡ ለዝክረ፡ ስምከ፡  አምሳለ፡ ገሪፍ፡ ወመርከብ፡ አሣተ፡ ባሕር፡ ዘይስኅብ፡ ውስተ፡ ሰማያዊት፡ ከብካብ።</q>
                                     
                                     

--- a/ParisBNF/abb/BNFabb152.xml
+++ b/ParisBNF/abb/BNFabb152.xml
@@ -777,8 +777,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                           </listRelation>
                            <locus from="59vb" to="60a">Fol. 59vb-60a</locus>
                            <desc><title xml:lang="fra">Ordonnance (<term>te’ezāz</term>) émise par Lebna Dengel
-                  relative à la titulature du <roleName type="title">śeyum</roleName> d’Amba Śannayt</title></desc>
-                           <title xml:lang="gez">በእንተ፡ ሕዱግ፡ ዘአምባ፡ ሠነይት፡ </title>
+                               relative à la titulature du <roleName type="title">śeyum</roleName> d’Amba Śannayt</title>. <title xml:lang="gez">በእንተ፡ ሕዱግ፡ ዘአምባ፡ ሠነይት፡ </title></desc>
+                           
                            <note type="résumé">Ce document rappelle en premier lieu qu’à l’époque du roi Amda
                   Ṣeyon et suite à une révolte, la région de Amba Śannayt avait été punie et à sa
                   tête avaient été nommés des êtres non-humains. Le roi Lebna Dengel impose ensuite

--- a/StPetersburg/IVorlov11.xml
+++ b/StPetersburg/IVorlov11.xml
@@ -142,8 +142,8 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                       <list>
                         <item xml:id="a1">
                            <locus target="#2r"/>
-                          <desc type="GuestText"/>
-                          <title type="complete" ref="LIT2965RepChr246" cert="low"/>
+                           <desc type="GuestText"><title type="complete" ref="LIT2965RepChr246" cert="low"/></desc>
+                          
                         </item>
 
                            <item xml:id="a2">

--- a/StPetersburg/RNBefns5.xml
+++ b/StPetersburg/RNBefns5.xml
@@ -108,11 +108,10 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   <additions>
                      <list>
                         <item xml:id="a1">
-                           <desc type="GuestText"/>
+                           <desc type="GuestText"><title type="incomplete" ref="LIT1356eqaban" cert="low"/></desc>
                            <locus from="1r" to="3v"/>
-                           <q xml:lang="gez">እግዚእየ᎓  ኢየሱስ᎓ ክርስቶስ ᎓ ዕቀበኒ᎓ ... </q>
-                           <q xml:lang="en"/>Oh my Lord, Jesus Christ, protect me...
-                    <title type="incomplete" ref="LIT1356eqaban" cert="low"/>
+                           <q xml:lang="gez">እግዚእየ᎓  ኢየሱስ᎓ ክርስቶስ ᎓ ዕቀበኒ᎓ ... <foreign xml:lang="en">Oh my Lord, Jesus Christ, protect me..</foreign></q>
+                                               
                            <note> Written in a secondary hand, fine and old; the letters are of smaller size.
                              The beginning and the end of the text are missing. </note>
                            <p/>
@@ -123,10 +122,10 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <locus target="#111v"/>
                            <q xml:lang="gez">ኦእግዚኦ᎓  መሐረኒ᎓ ለገብርከ᎓ <del rend="erasure"/>᎓ በእንተ᎓ ማርያም᎓
                     ወላዲትስ᎓ በእንተ᎓ ማኅፀና᎓ ዘጾራከ᎓ ወበእንተ᎓ አጥባቲሓ᎓ እለ᎓ ኀጸናከ᎓ በእንተ᎓ ከናፍሪሓ᎓ እለ᎓ ሰአማከ᎓ በእንተ᎓ ነፍሳ᎓ ወሥጋሐ᎓ ዘነሰእከ᎓
-                    ለከ᎓ ከመ᎓ ይኩንከ᎓ አባለ᎓ አንጽሕ᎓ እግዚኦ᎓ ርስሐተ᎓ ዚአየ᎓ ኅረይ᎓ እግዚኦ᎓ ኪ... </q>
-                           <q xml:lang="en"/>Oh Lord, have mercy upon you servant <del rend="erasure"/> for the sake of Mary, your mother, for the sake of her womb that bore
-                  you, for the sake of her breasts that feeded you, for the sake of her lips that kissed you, for the sake of her sole and flesh that you took on
-                  so that it would be you limb. Clean, oh Lord, my impurity, chose me, oh Lord...
+                    ለከ᎓ ከመ᎓ ይኩንከ᎓ አባለ᎓ አንጽሕ᎓ እግዚኦ᎓ ርስሐተ᎓ ዚአየ᎓ ኅረይ᎓ እግዚኦ᎓ ኪ... <foreign xml:lang="en">Oh Lord, have mercy upon you servant <del rend="erasure"/> for the sake of Mary, your mother, for the sake of her womb that bore
+                       you, for the sake of her breasts that feeded you, for the sake of her lips that kissed you, for the sake of her sole and flesh that you took on
+                       so that it would be you limb. Clean, oh Lord, my impurity, chose me, oh Lord...</foreign></q>
+                           
                   <note>Written in a secondary hand, less old and less careful.</note>
                         </item>
                      </list>


### PR DESCRIPTION
@DenisNosnitsin1970 
I also updated RNBefns5 and IVorlov11 where some instances remained

note also in RNBefns5 : the English translation of a quotation should go inside of a `<foreign>` element nested inside of `<q>` (we have no English texts in the mss, so no `<q xml:lang="en">` should be there