### PR TITLE
Change LIT2742RepCh26

### DIFF
--- a/EMIP/2001-3000/EMIP02019.xml
+++ b/EMIP/2001-3000/EMIP02019.xml
@@ -171,7 +171,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   </msItem>
                   <msItem xml:id="ms_i20">
                      <locus from="116r" to="125v" facs="120"/>
-                     <title type="complete" ref="LIT2742RepCh26"/>
+                     <title type="complete" ref="LIT2980RepCh261"/>
                      <incipit xml:lang="gez">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ሥላሴ፡ <gap reason="omitted"/>
                      </incipit>
                   </msItem>
@@ -418,6 +418,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <change when="2020-04-17" who="RL">corrected ǝ character</change>
          <change when="2020-05-21" who="RL">Added Asmat prayer as work</change>
          <change when="2020-06-15" who="RL">Corrected reference to prayers of the disciples/Peter</change>
+         <change when="2020-10-06" who="AD">Corrected reference from LIT2742RepCh26 to LIT2980RepCh261.</change>
   </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">

--- a/VaticanBAV/et/BAVet63.xml
+++ b/VaticanBAV/et/BAVet63.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"
 ?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="BAVet63" xml:lang="en" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
@@ -23,25 +23,25 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
-               
+
                <msIdentifier>
                   <repository ref="INS0003BAV"/>
                   <collection>Aethiopici</collection>
                   <idno facs="http://digi.vatlib.it/iiif/MSS_Vat.et.63/manifest.json">Aeth. 63</idno>
                </msIdentifier>
-               
+
                <physDesc>
                   <bindingDesc>
                      <binding contemporary="true">
                         <decoNote xml:id="b1">Two covers of red leather</decoNote>
                         <decoNote xml:id="b2" type="bindingMaterial">
-                           <material key="leather"/>                           
+                           <material key="leather"/>
                         </decoNote>
                         <decoNote xml:id="b5"/>
                      </binding>
                   </bindingDesc>
                </physDesc>
-               
+
               <msPart xml:id="p1">
                  <msIdentifier>
                      <idno/>
@@ -53,49 +53,49 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <incipit xml:lang="gez">
                            ሃሌሉያ፡ ሙሓዘ፡ ስብሐት፡ <choice>
                               <sic>ልሰንኪ፡</sic>
-                           </choice> 
+                           </choice>
                            <choice>
                               <sic>ወማዓር፡</sic>
-                           </choice> ጕርዔኪ፡ ማርያም፡ ዕንቍየ፡ በከርሠ፡ ቀለያት፡ 
+                           </choice> ጕርዔኪ፡ ማርያም፡ ዕንቍየ፡ በከርሠ፡ ቀለያት፡
                            <choice>
                               <sic>ዘትወኪ፨</sic>
-                           </choice> 
+                           </choice>
                            <choice>
                               <sic>አሐገለ፡</sic>
-                           </choice> ጌጋይ፡ እምእደውየ፡ ብትኪ። ነፍስየ፡ ወሥጋየ፡ ገደፍኩ፡ ኀቤኪ፡ 
+                           </choice> ጌጋይ፡ እምእደውየ፡ ብትኪ። ነፍስየ፡ ወሥጋየ፡ ገደፍኩ፡ ኀቤኪ፡
                         </incipit>
                         <explicit xml:lang="gez">
                            <choice>
                               <sic>ተማሐፀንኩ፡</sic>
                            </choice> ድንግል፡ ሥዕርትየ፡ በሥዕርትኪ፡ ርእስየ፡ በርእስኪ፡ ገጽየ፡ በገጽኪ፡ <choice>
                               <sic>ቃረንብትየ፡</sic>
-                           </choice> 
+                           </choice>
                            <choice>
                               <sic>በቃረንብተኪ፨</sic>
                            </choice> አዕይንትየ፡ በአዕይን<supplied reason="omitted">ት</supplied>ኪ፨ <choice>
                               <sic>አእዘንየ፡</sic>
-                           </choice> 
+                           </choice>
                            <choice>
                               <sic>በአእዘንኪ፨</sic>
-                           </choice> 
+                           </choice>
                            <choice>
                               <sic>መለትሕየ፡</sic>
-                           </choice> 
+                           </choice>
                            <choice>
                               <sic>በመለትሕኪ፨</sic>
-                           </choice> 
+                           </choice>
                            <choice>
                               <sic>ወኢይትሐጐለ፡</sic>
                            </choice> ይሕየዋ፡ ምስሌኪ፡ ውስተ፡ <choice>
                               <sic>ከብከቡ፡</sic>
                            </choice> ለፍቁር፡ ወልድኪ፨ <choice>
                               <sic>ተማሐፀንኩ፡</sic>
-                           </choice> 
+                           </choice>
                            <add place="inline">
                               <supplied reason="omitted">ድንግል፡</supplied>
                            </add> አእናፍየ፡ በአእናፍኪ፨ ከናፍርየ፡ በ
                         </explicit>
-                        <note>The test is incomplete. Both the beginning and the end are missing.</note>
+                        <note>The text is incomplete. Both the beginning and the end are missing.</note>
                      </msItem>
                      </msContents>
                  <physDesc>
@@ -159,9 +159,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                           <date notBefore="1450" notAfter="1550"/>
                           <seg type="ink">Black, red</seg>
                           <desc>
-                         Some archaic palaeographic features: 
-                         ሎ has the loop marking the 7th order attached directly to the body of the letter, without the linking line; 
-                         መ, ቆ, ቶ, ዐ, የ, ደ, and ጸ have angular shapes; 
+                         Some archaic palaeographic features:
+                         ሎ has the loop marking the 7th order attached directly to the body of the letter, without the linking line;
+                         መ, ቆ, ቶ, ዐ, የ, ደ, and ጸ have angular shapes;
                          እግዚኣብሔር፡ and ኣሚን፡ are written with አ in the 4th order.
                           </desc>
                        </handNote>
@@ -169,13 +169,13 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                           <locus from="33v" to="42r"/>
                           <seg type="script">Written in a fine 15th-16th century handwriting</seg>
                           <date notBefore="1450" notAfter="1550"/>
-                          <seg type="ink">Black, red</seg>                          
+                          <seg type="ink">Black, red</seg>
                        </handNote>
                     </handDesc>
                     <additions>
                        <list>
                           <item xml:id="e1">
-                             <desc>The shelfmark of the Vatican Library <q xml:lang="la">Vat. | 63 | Aethio</q> is written on the cover, together with the coat of arms of 
+                             <desc>The shelfmark of the Vatican Library <q xml:lang="la">Vat. | 63 | Aethio</q> is written on the cover, together with the coat of arms of
                                 pope <persName ref="PRS6258LeoXIII"/> and of the librarian <persName ref="PRS11256PitraGB"/>.</desc>
                           </item>
                           <item xml:id="e2">
@@ -210,7 +210,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                     </adminInfo>
                  </additional>
                   </msPart>
-               
+
                <msPart xml:id="p2">
                   <msIdentifier>
                      <idno/>
@@ -218,7 +218,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   <msContents>
                      <msItem xml:id="p2_i1">
                         <locus from="49r" to="51r" facs="0048"/>
-                        <title type="incomplete" ref="LIT2742RepCh26">Malkǝʾ-hymn to Our Lord Jesus Christ</title>
+                        <title type="incomplete" ref="LIT2741RepCh25">Malkǝʾ-hymn to Our Lord Jesus Christ</title>
                         <incipit xml:lang="gez">
                            <supplied reason="omitted">ሰላም፡</supplied> ለሕማምከ፡ ቤተ፡ አይሁድ፡ ዘአንደደ፡ ወረሰዮሙ፡ ሐመደ።</incipit>
                         <explicit xml:lang="gez">
@@ -226,7 +226,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <sic>ተማሕጸና፡</sic>
                            </choice> በስቅለትከ፡ <choice>
                               <sic>ለረድኤተነ፡</sic>
-                           </choice> ቅንጽ፡ ኢየሱስ፡ ክርስቶስ፡ 
+                           </choice> ቅንጽ፡ ኢየሱስ፡ ክርስቶስ፡
                         ቤተነ፡ ኃውጽ፨</explicit>
                         <note>The end is missing.</note>
                      </msItem>
@@ -268,7 +268,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               </list>
                            </collation>
                            <condition key="deficient">
-                             <locus target="#45" facs="0045"/> and <locus target="#58" facs="0059"/> originate from a bifolium which contained a Latin text from a 
+                             <locus target="#45" facs="0045"/> and <locus target="#58" facs="0059"/> originate from a bifolium which contained a Latin text from a
                               document dated to the <date>14th century</date> and roughly erased.
                            </condition>
                         </supportDesc>
@@ -289,8 +289,8 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <date notBefore="1550" notAfter="1599">Second half of the 16th century</date>
                            <seg type="ink">Black, red</seg>
                            <desc>
-                              Some palaeographical features: 
-                              መ, ዐ, የ have angular shapes; 
+                              Some palaeographical features:
+                              መ, ዐ, የ have angular shapes;
                               ሐ is squared.
                            </desc>
                            <seg type="rubrication"/>
@@ -331,7 +331,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   </additional>
                </msPart>
             </msDesc>
-            
+
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
@@ -356,7 +356,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
             <keywords>
               <term key="Poetry"/>
                <term key="Liturgy"/>
-               <term key="Prayers"/> 
+               <term key="Prayers"/>
                <term key="ChristianLiterature"/>
                <term key="Paks2"/>
             </keywords>


### PR DESCRIPTION
Merging LIT2742RepCh26 into LIT2741RepCh25.

In the case of EMIP 2019, the text was not Chaîne no. 26 but rather no. 261.

https://github.com/BetaMasaheft/Documentation/issues/1508