### PR TITLE
Emip 1953 corrections

### DIFF
--- a/EMIP/1001-2000/EMIP01953.xml
+++ b/EMIP/1001-2000/EMIP01953.xml
@@ -51,7 +51,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   </msItem>
 
                   <msItem xml:id="ms_i2">
-                    <locus from="36v" to="58r" facs="045"/>
+                    <locus from="36v" to="58r" facs="039"/>
                     <title type="complete" ref="LIT1758Lefafa"/>
                     <textLang mainLang="gez">Gǝ‘ǝz</textLang>
 
@@ -329,6 +329,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <change when="2020-01-27" who="ABe">Minor edits on additions and extras</change>
          <change when="2020-02-12" who="RL">Correction to image link numbers</change>
          <change when="2020-04-17" who="RL">corrected ǝ character</change>
+         <change when="2020-10-08" who="AD">Corrected divisions of Lǝfāfa ṣǝdq</change>
     </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">

--- a/EMIP/1001-2000/EMIP01953.xml
+++ b/EMIP/1001-2000/EMIP01953.xml
@@ -42,7 +42,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <textLang mainLang="gez">Gǝ‘ǝz</textLang>
 
                   <msItem xml:id="ms_i1">
-                    <locus from="1r" to="43r" facs="003"/>
+                    <locus from="1r" to="36v" facs="003"/>
                     <title type="complete" ref="LIT2246salotz"/>
                     <textLang mainLang="gez">Gǝ‘ǝz</textLang>
                     <incipit xml:lang="gez">
@@ -51,89 +51,101 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   </msItem>
 
                   <msItem xml:id="ms_i2">
-                    <locus from="43r" to="58r" facs="045"/>
+                    <locus from="36v" to="58r" facs="045"/>
                     <title type="complete" ref="LIT1758Lefafa"/>
                     <textLang mainLang="gez">Gǝ‘ǝz</textLang>
 
-                     <msItem xml:id="ms_i2.1">
-                        <locus from="43r" to="44r" facs="045"/>
-                        <title>Prayer for the momebannt of the agony of death, ጸሎት፡ በእንተ፡ ፃዕረ፡ ሞት።</title>
-                        <incipit xml:lang="gez">
-                      ‎በስመ፡ አብ፡ <gap reason="omitted"/> ጸሎት፡ በእንተ፡ ፃዕረ፡ ሞት፡ ድቃስ፡ በትሮን ‎‎ምጕያዮን፡ ከዋስ፡ ቄርላዎስ፡ <gap reason="omitted"/> ‎
-                    </incipit>
-                     </msItem>
-                     <msItem xml:id="ms_i2.2">
-                        <locus from="44r" to="47v" facs="046"/>
-                        <title>Prayer for Cleansing from Sin, ጸሎት፡ በእንተ፡ መንጽሔ፡ ኃጢአት።</title>
-                        <incipit xml:lang="gez">
-                      ‎በስመ፡ አብ፡ <gap reason="omitted"/> ጸሎት፡ በእንተ፡ መንጽሔ፡ ኃጢአት፡ ለትንጻሕ፡ ‎‎እምድር፡ በከመ፡ እግዚአብሔር፡ አንጻሕኮ፡ ለአቡነ፡ አዳም፡ ከመ፡ ‎clፈጠሮ፡ <gap reason="omitted"/> ‎
-                    </incipit>
-                     </msItem>
+                    <msItem xml:id="ms_i2.1">
+                       <locus from="36v" to="39r" facs="039"/>
+                       <title>Beginning of the Bandlet of Righteousness</title>
+                       <incipit xml:lang="gez">በስመ፡ አብ፡ ወወልድ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ መድኃኒተ፡ ነፍስ፡ ወሥጋ፡ ልፋፈ፡ ጽድቅ፡ ዘጸሐፋ፡ ኣብ፡ በእደዊሁ፡ ቅዱሳት፡ <gap reason="ellipsis"/></incipit>
+                    </msItem>
+
+                    <msItem xml:id="ms_i2.2">
+                       <locus from="39r" to="43r" facs="041"/>
+                       <title type="complete" ref="LIT1758Lefafa#FirstChapter">How Mary Received the Bandlet of Righteousness</title>
+                       <incipit xml:lang="gez">በስመ፡ አብ፡ ወወልድ፡ <gap reason="ellipsis"/> ንግባዕኬ፡ ኀበ፡ ጥንተ፡ ነገር፡ ዝንቱ፡ መጽሐፈ፡ ሕይወት፡ ልፋፈ፡ ጽድቅ፡ <gap reason="ellipsis"/></incipit>
+                    </msItem>
+
                      <msItem xml:id="ms_i2.3">
-                        <locus from="47v" to="48v" facs="050"/>
-                        <title>Prayer for Burial, ጸሎት፡ ግብዓተ፡ መሬት።</title>
+                        <locus from="43r" to="44r" facs="045"/>
+                        <title type="complete" ref="LIT1758Lefafa#ThirdChapter">Prayer for the agony of death, ጸሎት፡ በእንተ፡ ፃዕረ፡ ሞት።</title>
                         <incipit xml:lang="gez">
-                      ‎በስመ፡ በል፡ ጸሎት፡ ግብዓተ፡ መሬት፡ ኃደግናከ፡ ወአግባዕናከ፡ ‎‎ውስተ፡ መሬት፡ ኀበ፡ ዘቀዳሜ፡ ፍጥረትከ፡ ተዘከር፡ ኃጢአተነ፡ <gap reason="omitted"/> ‎
+                      ‎በስመ፡ አብ፡ <gap reason="omitted"/> ጸሎት፡ በእንተ፡ ፃዕረ፡ ሞት፡ ድቃስ፡ በትሮን ‎‎ምጕያዮን፡ ከዋስ፡ ቄርላዎስ፡ <gap reason="ellipsis"/> ‎
                     </incipit>
                      </msItem>
                      <msItem xml:id="ms_i2.4">
-                        <locus from="48v" to="49v" facs="051"/>
-                        <title>Asmat Prayer of the Trinity for Protection of the Soul</title>
+                        <locus from="44r" to="47v" facs="046"/>
+                        <title>Prayer for Cleansing from Sin, ጸሎት፡ በእንተ፡ መንጽሔ፡ ኃጢአት።</title>
                         <incipit xml:lang="gez">
-                    ‎በስመ፡ በል፡ ፩ ስ፡ መሰብኤል፡ ፩ስሙ፡ ብርሃናኤል፡ ፩ስ፤ ድምናኤል፡ ‎‎<gap reason="omitted"/> እሉ፡ አስማት፡ ዓቃቢያኒሃ፡ ለነፍስ፡‎
-                  </incipit>
+                      ‎በስመ፡ አብ፡ <gap reason="omitted"/> ጸሎት፡ በእንተ፡ መንጽሔ፡ ኃጢአት፡ ለትንጻሕ፡ ‎‎እምድር፡ በከመ፡ እግዚአብሔር፡ አንጻሕኮ፡ ለአቡነ፡ አዳም፡ ከመ፡ ‎clፈጠሮ፡ <gap reason="ellipsis"/> ‎
+                    </incipit>
                      </msItem>
                      <msItem xml:id="ms_i2.5">
-                        <locus from="49v" to="50v" facs="052"/>
-                        <title>Benefits of Reading the Bandlet of Righteouness</title>
+                        <locus from="47v" to="48v" facs="050"/>
+                        <title>Prayer for Burial, ጸሎት፡ ግብዓተ፡ መሬት።</title>
                         <incipit xml:lang="gez">
-                      ‎በስ፡ በል፡ እነግረክሙ፡ አኃውየ፡ እለ፡ ትትአመኑ፡ በዝንቱ፡ ልፋፈ፡ ‎‎ጽድቅ፡ ዘወሀባ፡ እግዚአብሔር፡ ለእግዝእትነ፡ <gap reason="omitted"/> ‎
+                      ‎በስመ፡ በል፡ ጸሎት፡ ግብዓተ፡ መሬት፡ ኃደግናከ፡ ወአግባዕናከ፡ ‎‎ውስተ፡ መሬት፡ ኀበ፡ ዘቀዳሜ፡ ፍጥረትከ፡ ተዘከር፡ ኃጢአተነ፡ <gap reason="ellipsis"/> ‎
                     </incipit>
                      </msItem>
                      <msItem xml:id="ms_i2.6">
-                        <locus from="50v" to="53v" facs="053"/>
-                        <title>Prayers for the journey to heaven, ጸሎት፡ ዘመንገደ፡ ሰማይ፡</title>
+                        <locus from="48v" to="49v" facs="051"/>
+                        <title type="complete" ref="LIT1758Lefafa#FifthChapter">Asmat Prayer of the Trinity for Protection of the Soul</title>
                         <incipit xml:lang="gez">
-                      ‎በስመ፡ አብ፡ በል፡ ዘመንገደ፡ ሰማይ፡ ከመ፡ ኢያዕቅፍዋ፡ መላእክተ፡ ‎‎ጽልመት፡ ለነፍስየ፡ በኤልደን፡ ስመ፡ መንበርከ<gap reason="omitted"/> ‎
-                    </incipit>
-
-                      <msItem xml:id="ms_i2.6.1">
-                        <locus from="50v" to="51r" facs="053"/>
-                          <title>First prayer</title>
-                          </msItem>
-                      <msItem xml:id="ms_i2.6.2">
-                          <locus from="51r" to="51v" facs="053"/>
-                          <title>second prayer</title>
-                          </msItem>
-                      <msItem xml:id="ms_i2.6.3">
-                          <locus from="51v" facs="054"/>
-                          <title>third prayer</title>
-                          </msItem>
-                      <msItem xml:id="ms_i2.6.4">
-                          <locus from="51v" to="52r" facs="054"/>
-                          <title>fourth prayer</title>
-                          </msItem>
-                      <msItem xml:id="ms_i2.6.5">
-                          <locus from="52r" to="52v" facs="054"/>
-                          <title>fifth prayer</title>
-                          </msItem>
-                      <msItem xml:id="ms_i2.6.6">
-                          <locus from="52v" to="53r" facs="055"/>
-                          <title>sixth prayer</title>
-                          </msItem>
-                      <msItem xml:id="ms_i2.6.7">
-                          <locus from="53r" to="53v" facs="055"/>
-                          <title>seventh prayer</title>
-                          </msItem>
-
+                    ‎በስመ፡ በል፡ ፩ ስ፡ መሰብኤል፡ ፩ስሙ፡ ብርሃናኤል፡ ፩ስ፤ ድምናኤል፡ ‎‎<gap reason="ellipsis"/> እሉ፡ አስማት፡ ዓቃቢያኒሃ፡ ለነፍስ፡‎
+                  </incipit>
                      </msItem>
                      <msItem xml:id="ms_i2.7">
-                        <locus from="53v" to="54v" facs="056"/>
-                        <title>Homily on the Suffering of Our Lord by Mary Magdalene, Salome, and Elizabeth, ዜና፡ ሕማማቲሁ፡ ለእግዚአነ።</title>
-                        <incipit xml:lang="gez">‎በሰመ፡ አብ፡ ብ፡ ዜና፡ ሕማማቲሁ፡ ለእግዚአነ፡ ኢየሱስ ክርስቶስ፡ ‎‎ዘከሠተ፡ ሎን፡ ለሰላስ፡ አንስት፡ እለ፡ ይሰመያ፡ <gap reason="omitted"/>‎
+                        <locus from="49v" to="50v" facs="052"/>
+                        <title type="complete" ref="LIT1758Lefafa#SixthChapter">Benefits of Reading the Bandlet of Righteouness</title>
+                        <incipit xml:lang="gez">
+                      ‎በስ፡ በል፡ እነግረክሙ፡ አኃውየ፡ እለ፡ ትትአመኑ፡ በዝንቱ፡ ልፋፈ፡ ‎‎ጽድቅ፡ ዘወሀባ፡ እግዚአብሔር፡ ለእግዝእትነ፡ <gap reason="ellipsis"/> ‎
                     </incipit>
                      </msItem>
                      <msItem xml:id="ms_i2.8">
+                        <locus from="50v" to="53v" facs="053"/>
+                        <title type="complete" ref="LIT1873Mangad">Prayers for the journey to heaven, ጸሎት፡ ዘመንገደ፡ ሰማይ፡</title>
+                        <incipit xml:lang="gez">
+                      ‎በስመ፡ አብ፡ በል፡ ዘመንገደ፡ ሰማይ፡ ከመ፡ ኢያዕቅፍዋ፡ መላእክተ፡ ‎‎ጽልመት፡ ለነፍስየ፡ በኤልደን፡ ስመ፡ መንበርከ<gap reason="ellipsis"/> ‎
+                    </incipit>
+
+                      <msItem xml:id="ms_i2.8.1">
+                        <locus from="50v" to="51r" facs="053"/>
+                          <title type="complete" ref="LIT1873Mangad#First">First prayer</title>
+                          </msItem>
+                      <msItem xml:id="ms_i2.8.2">
+                          <locus from="51r" to="51v" facs="053"/>
+                          <title type="complete" ref="LIT1873Mangad#Second">Second prayer</title>
+                          </msItem>
+                      <msItem xml:id="ms_i2.8.3">
+                          <locus from="51v" facs="054"/>
+                          <title type="complete" ref="LIT1873Mangad#Third">Third prayer</title>
+                          </msItem>
+                      <msItem xml:id="ms_i2.8.4">
+                          <locus from="51v" to="52r" facs="054"/>
+                          <title type="complete" ref="LIT1873Mangad#Fourth">Fourth prayer</title>
+                          </msItem>
+                      <msItem xml:id="ms_i2.8.5">
+                          <locus from="52r" to="52v" facs="054"/>
+                          <title type="complete" ref="LIT1873Mangad#Fifth">Fifth prayer</title>
+                          </msItem>
+                      <msItem xml:id="ms_i2.8.6">
+                          <locus from="52v" to="53r" facs="055"/>
+                          <title type="complete" ref="LIT1873Mangad#Sixth">Sixth prayer</title>
+                          </msItem>
+                      <msItem xml:id="ms_i2.8.7">
+                          <locus from="53r" to="53v" facs="055"/>
+                          <title type="complete" ref="LIT1873Mangad#Seventh">Seventh prayer</title>
+                          </msItem>
+
+                     </msItem>
+                     <msItem xml:id="ms_i2.9">
+                        <locus from="53v" to="54v" facs="056"/>
+                        <title>Story of the Passion of Christ, ዜና፡ ሕማማቲሁ፡ ለእግዚአነ።</title>
+                        <incipit xml:lang="gez">‎በሰመ፡ አብ፡ ብ፡ ዜና፡ ሕማማቲሁ፡ ለእግዚአነ፡ ኢየሱስ ክርስቶስ፡ ‎‎ዘከሠተ፡ ሎን፡ ለሰላስ፡ አንስት፡ እለ፡ ይሰመያ፡ <gap reason="ellipsis"/>‎
+                    </incipit>
+                     </msItem>
+                     <msItem xml:id="ms_i2.10">
                         <locus from="54v" to="58r" facs="057"/>
                         <title>Asmat Prayers of Our Lord given to the Apostles</title>
                         <incipit xml:lang="gez">


### PR DESCRIPTION
_Lǝfāfa ṣǝdq_ begins earlier than was previously indicated and the subdivisions of the text were not totally according to those in the work file (which follows Euringer's edition).

I would change some of the titles of the subdivisions, but I tried to keep my changes to a minimum.

As per [this issue](https://github.com/BetaMasaheft/Documentation/issues/1501), work record(s) for _Zenā ḥǝmāmātihu la-Krǝstos_ (which is item 2.9 here) need to be created, but I/we are still (?) sorting that out.