### PR TITLE
Max07

### DIFF
--- a/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
@@ -38,203 +38,495 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </altIdentifier>
                     </msIdentifier>
                     
-                    <msContents>
-                        <summary/>
+                    <physDesc>
                         
-                        <msItem xml:id="ms_i1">
-                            <locus from="1ra" to="130va"/>
-                            <title type="complete" ref="LIT1560Gospel"/>
-                            <note>The introductory materials to the Four Gospels, i.e. the Synopis of the class, the Letter of Eusebius to Carpianus and the Eusebian Canons, are missing.</note>
-                            
-                            <msItem xml:id="ms_i1.1">
-                                <locus from="1ra" to="35ra"/>
-                                <title type="complete" ref="LIT1558Matthew"></title>
-                                <msItem xml:id="ms_i1.1.1">
-                                    <locus from="1ra" to="1va"/>
-                                    <title type="complete" ref="LIT1558Matthew#TituliMatthew"/>
-                                    <textLang mainLang="gez"/>
-                                    <incipit xml:lang="gez">
-                                        <locus target="#1ra"/>
-                                        <lb/><hi rend="rubric">፩</hi> በእንተ፡ ቅዳሜ፡ ትምህርት፡
-                                        <lb/><hi rend="rubric">፪</hi> በእንተ፡ ብፁዓም።
-                                        <lb/><hi rend="rubric">፫</hi> በእንተ፡ ዘለምጽ።
-                                        <lb/><hi rend="rubric">፬</hi> በእንተ፡ ወልደ መስፍን፡
-                                    </incipit>
-                                    <explicit xml:lang="gez">
-                                        <locus target="#1va"/>
-                                        <lb/><hi rend="rubric">፷</hi> በእንተ፡ ግብአቱ፡ ለክርስቶስ።
-                                        <lb/><hi rend="rubric">፷፩</hi> በእንተ፡ 
-                                        <lb/><hi rend="rubric">፷፪</hi> በእንተ፡ ዘከመ፡ ነስሐ፡ ይሁዳ።
-                                        <lb/><hi rend="rubric">፷፫</hi> በእንተ፡ ስእለተ፡ ሥጋሁ፡ <supplied reason="lost">ለእግ</supplied>ዚእነ።
-                                    </explicit>
-                                    <note>The first three lines are blank, in correspondence of the first three <foreign xml:lang="la">tituli</foreign>.
-                                        The <foreign xml:lang="la">tituli</foreign> are numbered from 1 to 63.</note>
+                        <bindingDesc>
+                            <binding contemporary="true">
+                                <decoNote xml:id="b1">Two <material key="wood">wooden</material> boards previously covered with brown tooled <material key="leather"/>.
+                                    A decorated <material key="textile"/> inlay is glued onto the front board.
+                                </decoNote>
+                                <decoNote xml:id="b2" type="bindingMaterial">
+                                    <material key="wood"/>       
+                                    <material key="leather"/>     
+                                    <material key="textile"/>  
+                                </decoNote>
+                                <decoNote xml:id="b3" type="Cover" color="brown">
+                                    The leather cover was decorated with blind tooled ornament (double lines).
+                                    <!-- Description of the tooled ornamentation will need some revision --></decoNote>
+                                <decoNote xml:id="b4" type="SewingStations">4</decoNote>
+                                <decoNote xml:id="b5" type="Spine">The spine cover is missing.</decoNote>
+                                <decoNote xml:id="b6" type="Other">
+                                    Threads of various origin are inserted in the outer margins for navigating the text. 
+                                    More specifically, a red <term key="leafTabMark">leaf tab marker</term> for is inserted in the lower margin of <locus target="#86"/> and a
+                                    uncoloured <term key="leafStringMark">leaf string marker</term> is inserted in the upper margin of <locus target="#104"/>.
+                                </decoNote>
+                            </binding>
+                        </bindingDesc>
+                    </physDesc>
+                    
+                    <msPart xml:id="p1">
+                        <msIdentifier>
+                            <idno/>
+                        </msIdentifier>
+                        <msContents>
+                            <msItem xml:id="p1_i1">
+                                <locus from="1ra" to="123vb"/>
+                                <title type="incomplete" ref="LIT1560Gospel"/>
+                                <note>The introductory materials to the Four Gospels, i.e. the Synopis of the class, the Letter of Eusebius to Carpianus and the Eusebian Canons, are missing.</note>
+                                
+                                <msItem xml:id="p1_i1.1">
+                                    <locus from="1ra" to="35ra"/>
+                                    <title type="complete" ref="LIT1558Matthew"></title>
+                                    <msItem xml:id="p1_i1.1.1">
+                                        <locus from="1ra" to="1va"/>
+                                        <title type="complete" ref="LIT1558Matthew#TituliMatthew"/>
+                                        <textLang mainLang="gez"/>
+                                        <incipit xml:lang="gez">
+                                            <locus target="#1ra"/>
+                                            <lb/><hi rend="rubric">፩</hi> በእንተ፡ ቅዳሜ፡ ትምህርት፡
+                                            <lb/><hi rend="rubric">፪</hi> በእንተ፡ ብፁዓም።
+                                            <lb/><hi rend="rubric">፫</hi> በእንተ፡ ዘለምጽ።
+                                            <lb/><hi rend="rubric">፬</hi> በእንተ፡ ወልደ መስፍን፡
+                                        </incipit>
+                                        <explicit xml:lang="gez">
+                                            <locus target="#1va"/>
+                                            <lb/><hi rend="rubric">፷</hi> በእንተ፡ ግብአቱ፡ ለክርስቶስ።
+                                            <lb/><hi rend="rubric">፷፩</hi> በእንተ፡ 
+                                            <lb/><hi rend="rubric">፷፪</hi> በእንተ፡ ዘከመ፡ ነስሐ፡ ይሁዳ።
+                                            <lb/><hi rend="rubric">፷፫</hi> በእንተ፡ ስእለተ፡ ሥጋሁ፡ <supplied reason="lost">ለእግ</supplied>ዚእነ።
+                                        </explicit>
+                                        <note>The first three lines are blank, in correspondence of the first three <foreign xml:lang="la">tituli</foreign>.
+                                            The <foreign xml:lang="la">tituli</foreign> are numbered from 1 to 63.</note>
+                                    </msItem>
+                                    <msItem xml:id="p1_i1.1.2">
+                                        <locus from="2ra" to="35ra"/>
+                                        <title type="complete" ref="LIT2709Matthew"/>
+                                        <textLang mainLang="gez"/>
+                                        <incipit xml:lang="gez" type="inscription">
+                                            <locus target="#2ra"/>
+                                            <hi rend="rubric">በስመ፡ ኣብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ አሐዱ፡ አምላክ፡</hi> ብስራተ፡ ቅዱስ፡ ማቴዎስ፡ ሐዋርያ፡ ቡሩክ፡ ዘዜነወ፡ 
+                                            ወን<hi rend="rubric">ንጌለ፡ ጸጋሁ፡ ለእግዚእነ፡ ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡ ጸሎ</hi>ቱ፡ ወበረከቱ፡ የሀሉ፡ ምስሌነ፡ ለዓለመ፡ ዓለም፡ አሜን። 
+                                            <hi rend="rubric">ወንጌል፡ ዘማቴዎስ።</hi>
+                                        </incipit>
+                                        <incipit xml:lang="gez">
+                                            <locus target="#2ra"/>
+                                            <hi rend="rubric">መጽሐፈ፡ ለደቱ፡ ለእግዚእነ፡ ኢ</hi>የሱስ፡ ክርስቶስ፡ ወልደ፡ ዳዊት፡ <hi rend="rubric">ወልደ፡ አብርሃም። አብርሃም፡</hi> ወለዶ፡ 
+                                            ለይስሐቅ። ወይስሐቅ<hi rend="rubric">ኒ፡ ወለዶ፡ ለያዕቆብ። ወያዕቆብ</hi>ኒ፡ ወለደ፡ <sic>ይሁዳ፡ ሃ፡</sic> ወአኃዊሁ።
+                                        </incipit>
+                                        <explicit xml:lang="gez">
+                                            <locus from="34vb" to="35ra"/>
+                                            ወቀረቦሙ፡ እግዚእ፡ ኢየሱስ፡ ወነበቦሙ፡ ወይቤሎሙ፡ ተውህበ፡ ሊተ፡ ስልጣን፡ በሰማይ፡ ወበምድር፡ ሑ<supplied reason="undefined">ሩ</supplied>ኬ፡ 
+                                            እንከ፡ ወመሀሩ፡ ለኵሉ፡ አሕዛብ፡ ወአጥምቅዎሙ፡ በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ። ወመሀርዎሙ፡ ይዕቀቡ፡ ኵሎ፡ ዘአዘዝኩክሙ፡ ወናሁ፡ አነ፡ 
+                                            ሀለውኩ፡ ም<pb n="35r"/><cb n="a"/>ስሌክሙ፡ በኵሉ፡ መዋዕል፡ እስከ፡ ኅልቀተ፡ ዓለም። =።
+                                        </explicit>
+                                        <note>Stichometry is added at the end of the text, on <locus target="#35ra"/>: <q xml:lang="gez">ወንጌል፡ ዘማቴዎስ፡ ቃሉ፡ ፳፻ወ፯፻።</q>.
+                                            The stichometric note states that the gospel of Matthew consists of 2700 lines, according to the meaning of <foreign xml:lang="gez">ቃል፡</foreign> in 
+                                            this context.
+                                        </note>                                    
+                                    </msItem>
                                 </msItem>
-                                <msItem xml:id="ms_i1.1.2">
-                                    <locus from="2ra" to="35ra"/>
-                                    <title type="complete" ref="LIT2709Matthew"/>
-                                    <textLang mainLang="gez"/>
-                                    <incipit xml:lang="gez" type="inscription">
-                                        <locus target="#2ra"/>
-                                        <hi rend="rubric">በስመ፡ ኣብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ አሐዱ፡ አምላክ፡</hi> ብስራተ፡ ቅዱስ፡ ማቴዎስ፡ ሐዋርያ፡ ቡሩክ፡ ዘዜነወ፡ 
-                                        ወን<hi rend="rubric">ንጌለ፡ ጸጋሁ፡ ለእግዚእነ፡ ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡ ጸሎ</hi>ቱ፡ ወበረከቱ፡ የሀሉ፡ ምስሌነ፡ ለዓለመ፡ ዓለም፡ አሜን። 
-                                        <hi rend="rubric">ወንጌል፡ ዘማቴዎስ።</hi>
-                                    </incipit>
-                                    <incipit xml:lang="gez">
-                                        <locus target="#2ra"/>
-                                        <hi rend="rubric">መጽሐፈ፡ ለደቱ፡ ለእግዚእነ፡ ኢ</hi>የሱስ፡ ክርስቶስ፡ ወልደ፡ ዳዊት፡ <hi rend="rubric">ወልደ፡ አብርሃም። አብርሃም፡</hi> ወለዶ፡ 
-                                        ለይስሐቅ። ወይስሐቅ<hi rend="rubric">ኒ፡ ወለዶ፡ ለያዕቆብ። ወያዕቆብ</hi>ኒ፡ ወለደ፡ <sic>ይሁዳ፡ ሃ፡</sic> ወአኃዊሁ።
-                                    </incipit>
-                                    <explicit xml:lang="gez">
-                                        <locus from="34vb" to="35ra"/>
-                                        ወቀረቦሙ፡ እግዚእ፡ ኢየሱስ፡ ወነበቦሙ፡ ወይቤሎሙ፡ ተውህበ፡ ሊተ፡ ስልጣን፡ በሰማይ፡ ወበምድር፡ ሑ<supplied reason="undefined">ሩ</supplied>ኬ፡ 
-                                        እንከ፡ ወመሀሩ፡ ለኵሉ፡ አሕዛብ፡ ወአጥምቅዎሙ፡ በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ። ወመሀርዎሙ፡ ይዕቀቡ፡ ኵሎ፡ ዘአዘዝኩክሙ፡ ወናሁ፡ አነ፡ 
-                                        ሀለውኩ፡ ም<pb n="35r"/><cb n="a"/>ስሌክሙ፡ በኵሉ፡ መዋዕል፡ እስከ፡ ኅልቀተ፡ ዓለም። =።
-                                    </explicit>
-                                    <note>Stichometry is added at the end of the text, on <locus target="#35ra"/>: <q xml:lang="gez">ወንጌል፡ ዘማቴዎስ፡ ቃሉ፡ ፳፻ወ፯፻።</q>.
-                                        The stichometric note states that the gospel of Matthew consists of 2700 lines, according to the meaning of <foreign xml:lang="gez">ቃል፡</foreign> in 
-                                        this context.
-                                    </note>                                    
+                                
+                                <msItem xml:id="p1_i1.2">
+                                    <locus from="35rb" to="60vb"/>
+                                    <title type="complete" ref="LIT1882MarkGo"></title>
+                                    <msItem xml:id="p1_i1.2.1">
+                                        <locus from="35rb" to="35va"/>
+                                        <title type="complete" ref="LIT1882MarkGo#TituliMark"/>
+                                        <textLang mainLang="gez"/>
+                                        <incipit xml:lang="gez">
+                                            <locus target="#35rb"/>
+                                            <lb/><hi rend="rubric">፩</hi> በእንተ፡ ዘጋኔን።
+                                            <lb/><hi rend="rubric">፪</hi> በእንተ፡ ሐማተ፡ ጴጥሮስ።
+                                            <lb/><hi rend="rubric">፫</hi> በእንተ፡ እለ፡ ተፈውሱ፡ እምብዙኅ፡ <seg rend="below">ደዌ።</seg>
+                                            <lb/><hi rend="rubric">፬</hi> በእንተ፡ ዘለምጽ።
+                                        </incipit>
+                                        <explicit xml:lang="gez">
+                                            <locus target="#35va"/>
+                                            <lb/><hi rend="rubric">፵፭</hi> በእንተ፡ ፋሲካ። 
+                                            <lb/><hi rend="rubric">፵፮</hi> በእንተ፡ ዘከመ፡ ኣግብኦ፡ ይሁዳ።
+                                            <lb/><hi rend="rubric">፵፯</hi> በእንተ፡ ዘከመ፡ ክሕደ፡ ጴጥሮስ።
+                                            <lb/><hi rend="rubric">፵፰</hi> በእንተ፡ ስእለተ፡ ሥጋሁ፡ ለእ<hi rend="ligature">ግዚ</hi>እነ።
+                                        </explicit>
+                                        <note>The <foreign xml:lang="la">tituli</foreign> are numbered from 1 to 48.</note>
+                                    </msItem>
+                                    <msItem xml:id="p1_i1.2.2">
+                                        <locus from="36ra" to="60vb"/>
+                                        <title type="complete" ref="LIT2711Mark"/>
+                                        <textLang mainLang="gez"/>
+                                        <incipit xml:lang="gez" type="inscription">
+                                            <locus target="#36ra"/>
+                                            <hi rend="rubric">ወንጌል። ዘ። ማርቆስ።</hi>
+                                        </incipit>
+                                        <incipit xml:lang="gez">
+                                            <locus target="#36ra"/>
+                                            <hi rend="rubric">ቀዳሚሁ፡ ለወንጌል፡ እግዚ</hi>እ፡ ኢየሱስ፡ ክርስቶስ፡ ወልደ፡ እግዚአ፡ ብሔር፡ በከመ፡ ጽ<hi rend="rubric">ሑፍ፡ ውስተ፡ ነቢያት፡ 
+                                                ናሁ፡ አነ፡ እፌኑ፡ መልኣክየ፡ ቅድመ፡</hi> ገጽከ፡ ዘይጻይሕ፡ ፍኖተከ። ቃለ፡ ኣዋዲ፡ ዘይሰብክ፡ በገዳ<hi rend="rubric">ም፡ ወይብል፡ ጺሑአ፡ ፍኖቶ፡ 
+                                                    ለእግዚአ፡ ብሔር፡ ወዐርዩ፡ መ</hi>ጽያሕቶ። ወሀሎ፡ ዮሐንስ፡ ያጠምቅ፡ በገዳም፡ ወይሰብክ፡ ጥምቀተ፡ ከመ፡ ይነስሑ፡ ወይትኀደግ፡ ሎሙ፡ 
+                                            ኃጢኣቶሙ።
+                                        </incipit>
+                                        <explicit xml:lang="gez">
+                                            <locus target="#60vb"/>
+                                            በስመ፡ ዚኣየ፡ አጋንንት፡ ያወፅኡ፡ ወበካልእ፡ ልሳን፡ ይትናገሩ፡ ሐዲሰ። ወኣራዊተ፡ ምድር፡ ይእኅዙ፡ ወዘሂ፡ ይቀትል፡ እመ፡ ሰትዩ፡ አልቦ፡ ዘይነክዮሙ። 
+                                            ወዲበ፡ ድዉያን፡ እደዊሆሙ፡ ያነብሩ፡ ወይሜጥኑ። ወእግዚእነሰ፡ ኢየሱስ፡ ክርስቶስ፡ እምድኅረ፡ ተናገሮሙ፡ ዐርገ፡ ውስተ፡ ሰማይ፡ ወነበረ፡ በየማነ፡ እግዚአ፡ 
+                                            ብሔር፡ ኣቡሁ። ወወፂኦሙ፡ እምህየ፡ እሙንቱ፡ በኵለሄ፡ ሰበኩ፡ እንዘ፡ እግዚእ፡ ይረድእ፡ ወቃሎ፡ ያጸንዕ፡ በተኣምር፡ ዘይተሉ፡ አሜን።
+                                        </explicit>
+                                        <note>Stichometry is added at the end of the text, on <locus target="#60vb"/>: <q xml:lang="gez">ወንጌል፡ ዘማርቆስ፡ ቃሉ፡ ፲፻፡፯፻</q>.
+                                            The stichometric note states that the gospel of Mark consists of 1700 lines.</note>
+                                    </msItem>
                                 </msItem>
-                            </msItem>
-                            
-                            <msItem xml:id="ms_i1.2">
-                                <locus from="35rb" to="60vb"/>
-                                <title type="complete" ref="LIT1882MarkGo"></title>
-                                <msItem xml:id="ms_i1.2.1">
-                                    <locus from="35rb" to="35va"/>
-                                    <title type="complete" ref="LIT1882MarkGo#TituliMark"/>
-                                    <textLang mainLang="gez"/>
-                                    <incipit xml:lang="gez">
-                                        <locus target="#35rb"/>
-                                        <lb/><hi rend="rubric">፩</hi> በእንተ፡ ዘጋኔን።
-                                        <lb/><hi rend="rubric">፪</hi> በእንተ፡ ሐማተ፡ ጴጥሮስ።
-                                        <lb/><hi rend="rubric">፫</hi> በእንተ፡ እለ፡ ተፈውሱ፡ እምብዙኅ፡ <seg rend="below">ደዌ።</seg>
-                                        <lb/><hi rend="rubric">፬</hi> በእንተ፡ ዘለምጽ።
-                                    </incipit>
-                                    <explicit xml:lang="gez">
-                                        <locus target="#35va"/>
-                                        <lb/><hi rend="rubric">፵፭</hi> በእንተ፡ ፋሲካ። 
-                                        <lb/><hi rend="rubric">፵፮</hi> በእንተ፡ ዘከመ፡ ኣግብኦ፡ ይሁዳ።
-                                        <lb/><hi rend="rubric">፵፯</hi> በእንተ፡ ዘከመ፡ ክሕደ፡ ጴጥሮስ።
-                                        <lb/><hi rend="rubric">፵፰</hi> በእንተ፡ ስእለተ፡ ሥጋሁ፡ ለእ<hi rend="ligature">ግዚ</hi>እነ።
-                                    </explicit>
-                                    <note>The <foreign xml:lang="la">tituli</foreign> are numbered from 1 to 48.</note>
+                                
+                                <msItem xml:id="p1_i1.3">
+                                    <locus from="61ra" to="100rb"/>
+                                    <title type="complete" ref="LIT1812GospelLuke"></title>
+                                    <msItem xml:id="p1_i1.3.1">
+                                        <locus from="61ra" to="61vb"/>
+                                        <title type="complete" ref="LIT1812GospelLuke#TituliLuke"/>
+                                        <textLang mainLang="gez"/>
+                                        <incipit xml:lang="gez">
+                                            <locus target="#61ra"/>
+                                            <lb/><gap reason="illegible" unit="chars" quantity="1"></gap> በእንተ፡ ጸሕፍ። ፪ በእንተ፡ ኖሎት።
+                                            <lb/><gap reason="illegible" unit="chars" quantity="1"></gap> በእንተ፡ ስምዖን። <hi rend="rubric">፬</hi> በእንተ፡ ሐና፡ ነቢት።
+                                            <lb/><gap reason="illegible" unit="chars" quantity="1"></gap> በእንተ፡ ቃል፡ ዘኮነ፡ ኃበ፡ ዮሐንስ።
+                                            <lb/><gap reason="illegible" unit="chars" quantity="1"></gap> በእንተ፡ ዘከመ፡ ተመከረ፡ መድኃኒነ።
+                                        </incipit>
+                                        <explicit xml:lang="gez">
+                                            <locus from="61va" to="61vb"/>
+                                            <lb/><hi rend="rubric">፹</hi> በእንተ፡ ዘከመ፡ ኣስተኣከዮ፡ ሄሮድስ።
+                                            <cb n="b"/>
+                                            <lb/><hi rend="rubric">፹፩</hi> በእንተ፡ እለ፡ ይበክያ፡ አንስት። 
+                                            <lb/><hi rend="rubric">፹፪</hi> በእንተ፡ ዘከመ፡ ነስሐ፡ ፈያታዊ።
+                                            <lb/><hi rend="rubric">፹፫</hi> በእንተ፡ ስእለተ፡ ሥጋሁ፡ ለእግዚእነ።
+                                        </explicit>
+                                        <note>The <foreign xml:lang="la">tituli</foreign> are written over erasure up to 83.</note>
+                                    </msItem>
+                                    <msItem xml:id="p1_i1.3.2">
+                                        <locus from="62ra" to="100rb"/>
+                                        <title type="complete" ref="LIT2713Luke"/>
+                                        <textLang mainLang="gez"/>
+                                        <incipit xml:lang="gez" type="inscription">
+                                            <locus target="#62r"/>
+                                            <hi rend="rubric">ወንጌል፡ ዘሉቃስ።</hi>
+                                        </incipit>
+                                        <incipit xml:lang="gez">
+                                            <locus target="#62ra"/>
+                                            <hi rend="rubric">እስመ፡ ብዙኃን፡ እለ፡ አኃዙ፡ ወ</hi>ጠኑ፡ ይግበሩ፡ ወይምሀሩ፡ በእ<hi rend="rubric">ንተ፡ ግብር፡ ዘኣምኑ፡ በላዕሌነ፡</hi> በከመ፡ 
+                                            መሀሩነ፡ እለ፡ ቀደሙ፡ <hi rend="rubric">ርእዮቶ፡ ወተልእኩዎ፡ በቃሉ፡</hi> ወረትዓኒ፡ ሊተኒ፡ እትልዎ፡ እም<hi rend="rubric">ጥንቱ፡ ወእጠይቆ፡ 
+                                                ለኵሉ፡ በበ፡</hi> መትልዉ። እጽሕፍ፡ ለከ፡ ዓዚዝ፡ <hi rend="rubric">ቴዎፍሊ፡ ለኣኃዚ፡ ከመ፡ ታእም</hi>ር፡ ጥዩቀ፡ በእንተ፡ ኵሉ፡ ኃይለ፡ ነገር፡ 
+                                            ትምህርተ፡ ዘተመሀርከ።
+                                        </incipit>
+                                        <explicit xml:lang="gez">
+                                            <locus from="100ra" to="100rb"/>
+                                            ወናሁ፡ አነ፡ እፌኑ፡ ተስፋሁ፡ ለአቡየ፡ ላዕሌክሙ። ወአንትሙሰ፡ ንበሩ፡ ሀገረ፡ ኢየሩሳሌም፡ እስከ፡ ትለብሱ፡ ኃይለ፡ እምኣርያም። ወኣውፅኦሙ፡ ኣፍኣ፡ 
+                                            እስከ፡ ቢቲንያ። ወአንሥአ፡ እዴሁ፡ ወኣንበ<cb n="b"/>ረ፡ ወባረኮሙ። ወእንዘ፡ ይባርኮሙ፡ ተራሐቆሙ፡ ወዐርገ፡ ሰማየ። ወእሙንቱሰ፡ ሰገዱ፡ ሎቱ፡ 
+                                            ወተሰውጡ፡ ኢየሩሳሌም፡ በዐቢይ፡ ፍሥሓ፡ ወነበሩ፡ ቤተ፡ መቅደስ፡ ዘልፈ፡ እንዘ፡ ይሴብሕዎ፡ ወይባርክዎ፡ ለእግዚአብሔር፡ ለዓለም፡ ወለዓለመ፡ ዓለም፡ 
+                                            ኣሜን።
+                                        </explicit>
+                                        <note>Stichometry is added at the end of the text, on <locus target="#100rb"/>: <q xml:lang="gez">ወንጌል፡ ዘሉቃስ፡ ቃሉ፡ ፳፻፰፻።</q>.
+                                            The stichometric note states that the gospel of Luke consists of 2800 lines.</note>
+                                    </msItem>
                                 </msItem>
-                                <msItem xml:id="ms_i1.2.2">
-                                    <locus from="36ra" to="60vb"/>
-                                    <title type="complete" ref="LIT2711Mark"/>
-                                    <textLang mainLang="gez"/>
-                                    <incipit xml:lang="gez" type="inscription">
-                                        <locus target="#36ra"/>
-                                        <hi rend="rubric">ወንጌል። ዘ። ማርቆስ።</hi>
-                                    </incipit>
-                                    <incipit xml:lang="gez">
-                                        <locus target="#36ra"/>
-                                        <hi rend="rubric">ቀዳሚሁ፡ ለወንጌል፡ እግዚ</hi>እ፡ ኢየሱስ፡ ክርስቶስ፡ ወልደ፡ እግዚአ፡ ብሔር፡ በከመ፡ ጽ<hi rend="rubric">ሑፍ፡ ውስተ፡ ነቢያት፡ 
-                                            ናሁ፡ አነ፡ እፌኑ፡ መልኣክየ፡ ቅድመ፡</hi> ገጽከ፡ ዘይጻይሕ፡ ፍኖተከ። ቃለ፡ ኣዋዲ፡ ዘይሰብክ፡ በገዳ<hi rend="rubric">ም፡ ወይብል፡ ጺሑአ፡ ፍኖቶ፡ 
-                                                ለእግዚአ፡ ብሔር፡ ወዐርዩ፡ መ</hi>ጽያሕቶ። ወሀሎ፡ ዮሐንስ፡ ያጠምቅ፡ በገዳም፡ ወይሰብክ፡ ጥምቀተ፡ ከመ፡ ይነስሑ፡ ወይትኀደግ፡ ሎሙ፡ 
-                                        ኃጢኣቶሙ።
-                                    </incipit>
-                                    <explicit xml:lang="gez">
-                                        <locus target="#60vb"/>
-                                        በስመ፡ ዚኣየ፡ አጋንንት፡ ያወፅኡ፡ ወበካልእ፡ ልሳን፡ ይትናገሩ፡ ሐዲሰ። ወኣራዊተ፡ ምድር፡ ይእኅዙ፡ ወዘሂ፡ ይቀትል፡ እመ፡ ሰትዩ፡ አልቦ፡ ዘይነክዮሙ። 
-                                        ወዲበ፡ ድዉያን፡ እደዊሆሙ፡ ያነብሩ፡ ወይሜጥኑ። ወእግዚእነሰ፡ ኢየሱስ፡ ክርስቶስ፡ እምድኅረ፡ ተናገሮሙ፡ ዐርገ፡ ውስተ፡ ሰማይ፡ ወነበረ፡ በየማነ፡ እግዚአ፡ 
-                                        ብሔር፡ ኣቡሁ። ወወፂኦሙ፡ እምህየ፡ እሙንቱ፡ በኵለሄ፡ ሰበኩ፡ እንዘ፡ እግዚእ፡ ይረድእ፡ ወቃሎ፡ ያጸንዕ፡ በተኣምር፡ ዘይተሉ፡ አሜን።
-                                    </explicit>
-                                    <note>Stichometry is added at the end of the text, on <locus target="#60vb"/>: <q xml:lang="gez">ወንጌል፡ ዘማርቆስ፡ ቃሉ፡ ፲፻፡፯፻</q>.
-                                        The stichometric note states that the gospel of Mark consists of 1700 lines.</note>
-                                </msItem>
-                            </msItem>
-                            
-                            <msItem xml:id="ms_i1.3">
-                                <locus from="61ra" to="100rb"/>
-                                <title type="complete" ref="LIT1812GospelLuke"></title>
-                                <msItem xml:id="ms_i1.3.1">
-                                    <locus from="61ra" to="61vb"/>
-                                    <title type="complete" ref="LIT1812GospelLuke#TituliLuke"/>
-                                    <textLang mainLang="gez"/>
-                                    <incipit xml:lang="gez">
-                                        <locus target="#61ra"/>
-                                        <lb/><gap reason="illegible" unit="chars" quantity="1"></gap> በእንተ፡ ጸሕፍ። ፪ በእንተ፡ ኖሎት።
-                                        <lb/><gap reason="illegible" unit="chars" quantity="1"></gap> በእንተ፡ ስምዖን። <hi rend="rubric">፬</hi> በእንተ፡ ሐና፡ ነቢት።
-                                        <lb/><gap reason="illegible" unit="chars" quantity="1"></gap> በእንተ፡ ቃል፡ ዘኮነ፡ ኃበ፡ ዮሐንስ።
-                                        <lb/><gap reason="illegible" unit="chars" quantity="1"></gap> በእንተ፡ ዘከመ፡ ተመከረ፡ መድኃኒነ።
-                                    </incipit>
-                                    <explicit xml:lang="gez">
-                                        <locus from="61va" to="61vb"/>
-                                        <lb/><hi rend="rubric">፹</hi> በእንተ፡ ዘከመ፡ ኣስተኣከዮ፡ ሄሮድስ።
-                                        <cb n="b"/>
-                                        <lb/><hi rend="rubric">፹፩</hi> በእንተ፡ እለ፡ ይበክያ፡ አንስት። 
-                                        <lb/><hi rend="rubric">፹፪</hi> በእንተ፡ ዘከመ፡ ነስሐ፡ ፈያታዊ።
-                                        <lb/><hi rend="rubric">፹፫</hi> በእንተ፡ ስእለተ፡ ሥጋሁ፡ ለእግዚእነ።
-                                    </explicit>
-                                    <note>The <foreign xml:lang="la">tituli</foreign> are written over erasure up to 83.</note>
-                                </msItem>
-                                <msItem xml:id="ms_i1.3.2">
-                                    <locus from="62ra" to="100rb"/>
-                                    <title type="complete" ref="LIT2713Luke"/>
-                                    <textLang mainLang="gez"/>
-                                    <incipit xml:lang="gez" type="inscription">
-                                        <locus target="#62r"/>
-                                        <hi rend="rubric">ወንጌል፡ ዘሉቃስ።</hi>
-                                    </incipit>
-                                    <incipit xml:lang="gez">
-                                        <locus target="#62ra"/>
-                                        <hi rend="rubric">እስመ፡ ብዙኃን፡ እለ፡ አኃዙ፡ ወ</hi>ጠኑ፡ ይግበሩ፡ ወይምሀሩ፡ በእ<hi rend="rubric">ንተ፡ ግብር፡ ዘኣምኑ፡ በላዕሌነ፡</hi> በከመ፡ 
-                                        መሀሩነ፡ እለ፡ ቀደሙ፡ <hi rend="rubric">ርእዮቶ፡ ወተልእኩዎ፡ በቃሉ፡</hi> ወረትዓኒ፡ ሊተኒ፡ እትልዎ፡ እም<hi rend="rubric">ጥንቱ፡ ወእጠይቆ፡ 
-                                            ለኵሉ፡ በበ፡</hi> መትልዉ። እጽሕፍ፡ ለከ፡ ዓዚዝ፡ <hi rend="rubric">ቴዎፍሊ፡ ለኣኃዚ፡ ከመ፡ ታእም</hi>ር፡ ጥዩቀ፡ በእንተ፡ ኵሉ፡ ኃይለ፡ ነገር፡ 
-                                        ትምህርተ፡ ዘተመሀርከ።
-                                    </incipit>
-                                    <explicit xml:lang="gez">
-                                        <locus from="100ra" to="100rb"/>
-                                        ወናሁ፡ አነ፡ እፌኑ፡ ተስፋሁ፡ ለአቡየ፡ ላዕሌክሙ። ወአንትሙሰ፡ ንበሩ፡ ሀገረ፡ ኢየሩሳሌም፡ እስከ፡ ትለብሱ፡ ኃይለ፡ እምኣርያም። ወኣውፅኦሙ፡ ኣፍኣ፡ 
-                                        እስከ፡ ቢቲንያ። ወአንሥአ፡ እዴሁ፡ ወኣንበ<cb n="b"/>ረ፡ ወባረኮሙ። ወእንዘ፡ ይባርኮሙ፡ ተራሐቆሙ፡ ወዐርገ፡ ሰማየ። ወእሙንቱሰ፡ ሰገዱ፡ ሎቱ፡ 
-                                        ወተሰውጡ፡ ኢየሩሳሌም፡ በዐቢይ፡ ፍሥሓ፡ ወነበሩ፡ ቤተ፡ መቅደስ፡ ዘልፈ፡ እንዘ፡ ይሴብሕዎ፡ ወይባርክዎ፡ ለእግዚአብሔር፡ ለዓለም፡ ወለዓለመ፡ ዓለም፡ 
-                                        ኣሜን።
-                                    </explicit>
-                                    <note>Stichometry is added at the end of the text, on <locus target="#100rb"/>: <q xml:lang="gez">ወንጌል፡ ዘሉቃስ፡ ቃሉ፡ ፳፻፰፻።</q>.
-                                        The stichometric note states that the gospel of Luke consists of 2800 lines.</note>
-                                </msItem>
-                            </msItem>
-                            
-                            <msItem xml:id="ms_i1.4">
-                                <locus from="100vb" to="130va"/>
-                                <title type="complete" ref="LIT1693John"></title>
-                                <msItem xml:id="ms_i1.4.1">
-                                    <locus target="#100vb"/>
-                                    <title type="complete" ref="LIT1693John#TituliJohn"/>
-                                    <textLang mainLang="gez"/>
-                                    <incipit xml:lang="gez">
+                                <msItem xml:id="p1_i1.4">
+                                    <locus from="100vb" to="123vb"/>
+                                    <title type="incomplete" ref="LIT1693John"></title>
+                                    <msItem xml:id="p1_i1.4.1">
                                         <locus target="#100vb"/>
-                                        <lb/><hi rend="rubric">፩</hi> በእንተ፡ ከብካብ፡ ዘቃነ።
-                                        <lb/><hi rend="rubric">፪</hi> በእንተ፡ ዘሰደደ፡ እምኵራብ።
-                                        <lb/><hi rend="rubric">፫</hi> በእንተ፡ ኒቆዲሞስ።
-                                        <lb/><hi rend="rubric">፬</hi> በእንተ፡ አጥህሮ።
-                                    </incipit>
-                                    <explicit xml:lang="gez">
-                                        <locus target="#100vb"/>
-                                        <lb/><hi rend="rubric">፲፮</hi> በእንተ፡ እለ፡ መጽኡ፡ አረሚይ።
-                                        <lb/><hi rend="rubric">፲፯</hi> በእንተ፡ ዘከመ፡ ኃፀበ፡ እግረ፡ አርዳኢሁ።
-                                        <lb/><hi rend="rubric">፲፰</hi> በእንተ፡ ጰራቅሊጦስ።
-                                        <lb/><hi rend="rubric">፲፱</hi> በእንተ፡ ስእለተ፡ ሥጋሁ፡ ለእ<hi rend="ligature">ግዚ</hi>እነ።
-                                    </explicit>
-                                    <note>The <foreign xml:lang="la">tituli</foreign> are numbered from 1 to 19.</note>
+                                        <title type="complete" ref="LIT1693John#TituliJohn"/>
+                                        <textLang mainLang="gez"/>
+                                        <incipit xml:lang="gez">
+                                            <locus target="#100vb"/>
+                                            <lb/><hi rend="rubric">፩</hi> በእንተ፡ ከብካብ፡ ዘቃነ።
+                                            <lb/><hi rend="rubric">፪</hi> በእንተ፡ ዘሰደደ፡ እምኵራብ።
+                                            <lb/><hi rend="rubric">፫</hi> በእንተ፡ ኒቆዲሞስ።
+                                            <lb/><hi rend="rubric">፬</hi> በእንተ፡ አጥህሮ።
+                                        </incipit>
+                                        <explicit xml:lang="gez">
+                                            <locus target="#100vb"/>
+                                            <lb/><hi rend="rubric">፲፮</hi> በእንተ፡ እለ፡ መጽኡ፡ አረሚይ።
+                                            <lb/><hi rend="rubric">፲፯</hi> በእንተ፡ ዘከመ፡ ኃፀበ፡ እግረ፡ አርዳኢሁ።
+                                            <lb/><hi rend="rubric">፲፰</hi> በእንተ፡ ጰራቅሊጦስ።
+                                            <lb/><hi rend="rubric">፲፱</hi> በእንተ፡ ስእለተ፡ ሥጋሁ፡ ለእ<hi rend="ligature">ግዚ</hi>እነ።
+                                        </explicit>
+                                        <note>The <foreign xml:lang="la">tituli</foreign> are numbered from 1 to 19.</note>
+                                    </msItem>
+                                    <msItem xml:id="p1_i1.4.2">
+                                        <locus from="101ra" to="123vb"/>
+                                        <title type="incomplete" ref="LIT2715John"/>
+                                        <textLang mainLang="gez"/>
+                                        <incipit xml:lang="gez" type="inscription">
+                                            <locus target="#101r"/>
+                                            <hi rend="rubric">ወንጌል፡ ዘዮሐንስ፡</hi>
+                                        </incipit>
+                                        <incipit xml:lang="gez">
+                                            <locus target="#101ra"/>
+                                            <hi rend="rubric">ቀዳሚሁ፡ ቃል፡ ውእቱ። ወውእ</hi>ቱ፡ ቃል፡ ኃበ፡ እግዚአ፡ ብሔር፡ <hi rend="rubric">ውእቱ፡ ወእግዚአ፡ ብሔር፡ ውእ</hi>ቱ፡ 
+                                            ቃል። ወከማሁ፡ ቀዳሚሁ፡ እ<hi rend="rubric">ምቅዲሙ፡ ኃበ፡ እግዚአ፡ ብሔር፡</hi> ውእቱ። ወኵሉ፡ ቦቱ፡ ኮነ፡ ወዘእ<hi rend="rubric">ንበሌሁሰ፡ 
+                                                አልቦ፡ ዘኮነ፡ ወኢምን</hi>ትኒ። ወዘሂ፡ ኮነ፡ በእንቲኣሁ፡ ቦቱ፡ <hi rend="rubric">ሕይወት፡ ውእቱ። ወሕይወትሰ፡</hi> ብርሃኑ፡ ለእጓለ፡ እመ፡ ሕያው፡ 
+                                            ውእቱ።
+                                        </incipit>
+                                        <explicit xml:lang="gez">
+                                            <locus target="#123vb"/>
+                                            ኵሎ፡ ዘቦ፡ አቡየ፡ ዚአየ፡ ውእቱ። በእንተ፡ ዝንቱ፡ እቤ፡ ለክሙ፡ እምዚአየ፡ ይነሥእ፡ ወይነግረክሙ። ሕዳጠ፡ ወኢትሬእዩኒ፡ ወካዕበ፡ ሕዳጠ፡ ወትሬእዩኒ። 
+                                            ወቦ፡ እለ፡ ይቤሉ፡ እምኣርዳኢሁ፡ በበይናቲሆሙ፡ ምንተኑ፡ ዘይብለነ፡ ሕዳጠ፡ ወኢትሬእዩኒ፡ ወካዕበ፡ ሕዳጠ፡ ወትሬእዩኒ፡ ወአሓወር፡ ኃበ፡ ኣብ። ወይቤሉ፡ 
+                                            ምንትኑ፡ ው
+                                        </explicit>
+                                        <note>The text terminates abruptly at Joh. 16:18.</note>
+                                    </msItem>
                                 </msItem>
-                                <msItem xml:id="ms_i1.4.2">
-                                    <locus from="101ra" to="130va"/>
+                            </msItem>
+                        </msContents>
+                        
+                        <physDesc>
+                            <objectDesc form="Codex">
+                                <supportDesc>
+                                    <support>
+                                        <material key="parchment"/>
+                                        <p>Holes, presumably resulting from parchment making, are found on <locus target="#1 #14 #16 #40 #42 #67 #74 #85 #92"/>.</p>
+                                    </support>
+                                    <extent>
+                                        <measure unit="leaf">123</measure>
+                                        <dimensions type="outer" unit="mm">
+                                            <height>313</height>
+                                            <width>265</width>
+                                            <depth>95</depth>
+                                        </dimensions>
+                                        <dimensions type="leaf" unit="mm" xml:id="leafdim">
+                                            <height>316</height>
+                                            <width>267</width>
+                                        </dimensions>
+                                        <note corresp="#leafdim">Data on leaves dimensions taken from <locus target="#45r"/>.</note>
+                                        <measure type="weight" unit="g">3858</measure><!--with variances-->
+                                        <!-- This must refer to the entire manuscript, not to this single unit p1 -->
+                                    </extent>
+                                    <foliation>Pencil foliation in the upper right corner carried out by the Bodleian Library during our stay in January 2020.</foliation>
+                                    <collation>
+                                        <signatures>
+                                            ፫ in the upper left corner of <locus target="#18r"/> and upper right corner of <locus target="#25v"/>;
+                                            ፬ in the upper left corner of <locus target="#26r"/>, remains of a quire mark in the upper right corner of <locus target="#31v"/>;
+                                            ፫ in the upper left corner of <locus target="#54r"/>, ፬ in the upper right corner of <locus target="#68v"/>;
+                                            ፪ n the upper left corner of  <locus target="#69r"/> and the upper right corner of <locus target="#76v"/>;
+                                            ፫ in the upper left corner of <locus target="#77r"/>;
+                                            remains of a quire mark in the upper left corner of <locus target="#85r"/>;
+                                            ፭ in the upper left corner of <locus target="#93r"/>;
+                                            ፩ in the upper right corner of <locus target="#108v"/>;
+                                            ፪ in the upper left corner of <locus target="#109r"/>  and the upper right corner of <locus target="#115v"/>;
+                                            ፫ in the upper left corner of <locus target="#116r"/>.</signatures>
+                                        <note>All quires have been secondarily arranged with a parchment guard and secondary sewing. The original quire
+                                            structure cannot be observed anymore.</note>
+                                        <list>
+                                            <item xml:id="q1" n="1">
+                                                <dim unit="leaf">2</dim>
+                                                <locus from="1r" to="2v"/>
+                                            </item>
+                                            <item xml:id="q2" n="2">
+                                                <dim unit="leaf">8</dim>
+                                                <locus from="3r" to="10v"/>
+                                            </item>
+                                            <item xml:id="q3" n="3">
+                                                <dim unit="leaf">6</dim>
+                                                <locus from="11r" to="16v"/>
+                                                <note>The leaves have been sewn together secondarily.</note>
+                                            </item>
+                                            <item xml:id="q4" n="4">
+                                                <dim unit="leaf">8</dim>
+                                                <locus from="17r" to="24v"/>
+                                            </item>
+                                            <item xml:id="q5" n="5">
+                                                <dim unit="leaf">6</dim>
+                                                <locus from="25r" to="30v"/>
+                                            </item>
+                                            <item xml:id="q6" n="6">
+                                                <dim unit="leaf">5</dim>
+                                                <locus from="31r" to="35v"/>
+                                            </item>
+                                            <item xml:id="q7" n="7">
+                                                <dim unit="leaf">8</dim>
+                                                <locus from="36r" to="44v"/>
+                                                stub between <locus target="#38"/> and <locus target="#39"/>
+                                                stub between <locus target="#41"/> and <locus target="#42"/>
+                                            </item>
+                                            <item xml:id="q8" n="8">
+                                                <dim unit="leaf">6</dim>
+                                                <locus from="45r" to="50v"/>
+                                            </item>
+                                            <item xml:id="q9" n="9">
+                                                <dim unit="leaf">3</dim>
+                                                <locus from="51r" to="53v"/>
+                                                <note>The leaves have been stitched together secondarily unto <ref target="#q10"/>.</note>
+                                            </item>
+                                            <item xml:id="q10" n="10">
+                                                <dim unit="leaf">9</dim>
+                                                <locus from="54r" to="62v"/>
+                                                2 stubs between <locus target="#61"/> and <locus target="#62"/>
+                                            </item>
+                                            <item xml:id="q11" n="11">
+                                                <dim unit="leaf">4</dim>
+                                                <locus from="63r" to="67v"/>
+                                            </item>
+                                            <item xml:id="q12" n="12">
+                                                <dim unit="leaf">9</dim>
+                                                <locus from="68r" to="76v"/>
+                                            </item>
+                                            <item xml:id="q13" n="13">
+                                                <dim unit="leaf">8</dim>
+                                                <locus from="77r" to="84v"/>
+                                            </item>
+                                            <item xml:id="q14" n="14">
+                                                <dim unit="leaf">8</dim>
+                                                <locus from="85r" to="92v"/>
+                                                3, stub after 6
+                                                6, stub after 3
+                                            </item>
+                                            <item xml:id="q15" n="15">
+                                                <dim unit="leaf">9</dim>
+                                                <locus from="93r" to="101v"/>
+                                            </item>
+                                            <item xml:id="q16" n="16">
+                                                <dim unit="leaf">7</dim>
+                                                <locus from="102r" to="108v"/>
+                                            </item>
+                                            <item xml:id="q17" n="17">
+                                                <dim unit="leaf">6</dim>
+                                                <locus from="109r" to="114v"/>
+                                                stub between <locus target="#113"/> and <locus target="#114"/>
+                                            </item>
+                                            <item xml:id="q18" n="18">
+                                                <dim unit="leaf">9</dim>
+                                                <locus from="115r" to="123v"/>
+                                            </item>
+                                        </list>
+                                    </collation>
+                                    <condition key="deficient">
+                                        The manuscript is kept in a box, in an embroidered rectangular piece of textile, measuring 620 x 920 mm. <!-- how to encode this info? -->
+                                        The leather cover has been cut off, most probably to facilitate the resewing. Small remains of leather survive on the inner sides of the front and the back board.
+                                        The textblock has been resewn together and parchment guards have been placed around all quires.
+                                        Leaves <locus from="51r" to="62v"/> have been stitched together secondarily.
+                                        The textblock is affected with humidity, especially in the outer margins, and water stains (e.g., on <locus target="#37 #104v"/>).
+                                        Wax stains are visible on <locus target="#31v #72v"/>. The parchment is stained and crumpled on <locus target="#74"/>.
+                                        Tears repaired on <locus target="#2 #35 #100 #106 #118"/>.
+                                    </condition>
+                                </supportDesc>
+                                
+                                <layoutDesc>
+                                    <layout columns="2" writtenLines="24">
+                                        <locus from="1ra" to="123vb"/>
+                                        <note corresp="#textarea #margin">Data on text area and margin dimensions taken from <locus target="#45r"/>.</note>
+                                        <!--      <dimensions unit="mm" xml:id="textarea1">
+                                        <height></height>
+                                        <width></width>
+                                       <!-\- no text area provided?-\->
+                                    </dimensions>-->
+                                        <dimensions type="margin" unit="mm" xml:id="margin1">
+                                            <dim type="top">31</dim>
+                                            <dim type="bottom">56</dim>
+                                            <dim type="right">47</dim>
+                                            <dim type="left">15</dim>
+                                            <dim type="intercolumn">15</dim>
+                                        </dimensions>
+                                        <note> The characters per line are 14-17</note>
+                                        <ab type="punctuation" subtype="Dividers">
+                                            Several caesura signs are attested in the manuscript:
+                                            the <foreign xml:lang="la">crux ansata</foreign> is written in the left margin on <locus target="#65va #74vb"/>;
+                                            the <foreign xml:lang="la">coronis</foreign> sign is written in the left margin, e.g. on <locus target="#3vb #56vb #101va #116va"/>, etc.;
+                                            the <foreign xml:lang="la">crux ansata</foreign> and the <foreign xml:lang="la">coronis</foreign> are written together on <locus target="#90va #93rb #97va #98va #98vb"/>.
+                                            The word <foreign xml:lang="gez">ቁም፡</foreign> is written at the end of the line or in the right margin, most often in red ink, e.g. on <locus target="#5rb #59vb #97ra #116rb"/>, etc.
+                                            Chains of black and red right-pointing chevrons in the left margin, indicating quotations from the Old Testament embedded in the Gospel text, are found e.g. on <locus target="#3rb #14ra #18rb #44rb #93vb"/>, etc.
+                                            Chains of red and black dots separate the chapters are e.g. on <locus target="#4ra #20rb #57ra #94rb"/>, etc.
+                                            Chains of red and black dots and double dashes separate the stichometric notes.
+                                        </ab>
+                                        <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are often visible.</ab>
+                                        <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A-1A1A/0-0/0-0/C.</ab>
+                                        <ab type="ruling"> The upper line is written above the ruling. The bottom line is written above the ruling.
+                                        </ab>                          
+                                    </layout>
+                                </layoutDesc>
+                            </objectDesc>
+                            
+                            <handDesc>
+                                <handNote xml:id="h1" script="Ethiopic">
+                                    <locus from="1ra" to="123vb"/>
+                                    <seg type="script"/>
+                                    <seg type="ink">Black, red</seg>
+                                    <date notBefore="1500" notAfter="1600"></date>
+                                    <desc>
+                                        Fine and trained hand. Characters are regularly spaced.
+                                    </desc>
+                                    <note>
+                                        The script displays some relatively archaic features: the numeral <foreign xml:lang="gez">፮</foreign> has a compressed shape and the open loop; 
+                                        the letter መ has the loops not completely separated; the word <foreign xml:lang="gez">እግዚአ፡ ብሔር፡</foreign> is sometimes written as two separate words. 
+                                        The graphemes ግ and ዚ are occasionally written with ligature in the word <foreign xml:lang="gez">እግዚእነ፡</foreign>, e.g. on <locus target="#35va #100vb"/>. 
+                                        One bottom ruled line has been left unwritten on leaves <locus from="24va" to="25vb"/>.
+                                    </note>                              
+                                    <seg type="rubrication">
+                                        Holy names; several groups of lines on the incipit page of each Gospel, alternating with black lines;                                    
+                                        the numbers of the chapters in the list of the <foreign xml:lang="la">tituli</foreign> at the beginning of each Gospel;
+                                        the numbers of the Eusebian Canons to which the Ammonian sections, penned in black ink in the left margins immediately above those numbers, belong;
+                                        the numbers and titles of the chapters are written in the upper or lower margin, in correspondence of the beginning of the chapters;
+                                        the stichometric note at the end of the Gospels of Matthew, on <locus target="#35ra"/>;
+                                        the captions <foreign xml:lang="gez">ማርቆስ፡</foreign> on <locus target="#35vb"/>, <foreign xml:lang="gez">ስዕለ፡ ሉቃስ፡</foreign> (partly illegible) 
+                                        on <locus target="#61v"/>, and <foreign xml:lang="gez">ዮሐንስ፡</foreign> on <locus target="#100va"/>;
+                                        elements of the numerals and of the punctuation signs, including text dividers and caesura signs
+                                        (the <foreign xml:lang="la">crux ansata</foreign> is entirely rubricated on <locus target="#65va"/>; the <foreign xml:lang="la">coronis</foreign> sign is 
+                                        entirely rubricated on <locus target="#62vb #63ra"/>; the word <foreign xml:lang="gez">ቁም፡</foreign> is rubricated on, e.g., <locus target="#5rb #56ra #59vb #97ra"/>.
+                                    </seg>
+                                </handNote>
+                            </handDesc>
+                            
+                            <!--  für Jacopo
+                        <decoDesc>
+                            <decoNote type="miniature" xml:id="d1">
+                                <locus target="#1v"/>
+                                <desc>...</desc>
+                            </decoNote>    
+                            <decoNote type="band" xml:id="d2">
+                                <locus target="#2r"/>
+                                <desc>...</desc>
+                            </decoNote> 
+                        </decoDesc>
+                        -->
+                            
+                            <additions>
+                                <list>
+                                    <item xml:id="e1">
+                                        <desc>A white sticker is glued to the inner side of the front board, on the top. The name of <persName ref="PRS5782JuelJen"/> is printed on it
+                                            (<foreign xml:lang="gez">ቤንት፡ ዩውል፡ የንሰን።</foreign>) and the signature "MS. Aeth. c. 14" is written in pencil. 
+                                            An additional sticker, with the signature "Ms 46"printed on it, is glued on the bottom of the same side.</desc>
+                                    </item>
+                                    <!--
+                                <item xml:id="e">
+                                    <locus target=""/>
+                                    <desc></desc>
+                                    <q xml:lang="gez"></q>
+                                </item>
+                                
+                                The numbers and titles of the chapters are written in the upper margin, in correspondence of the beginning of the chapters.
+                                    They are often written in the lower margin, e.g. on <locus target="#24va #25ra #29va #37ra #64vb #68vb #87rb #90rb"/> [their position can't go under rubrication! Extra? It must be decided].
+                                -->
+                                </list>
+                            </additions>
+                        </physDesc>
+                        <history>
+                            <origin>
+                                <origDate from="1500" to="" evidence="lettering"/>
+                            </origin>
+                            <provenance></provenance>
+                        </history>
+                    </msPart>
+                    
+                    <msPart xml:id="p2">
+                        <msIdentifier>
+                            <idno/>
+                        </msIdentifier>
+                        <msContents>
+                            <msItem xml:id="p2_i1">
+                                <locus from="124ra" to="130va"/>
+                                <title type="incomplete" ref="LIT1693John"></title>
+                                <msItem xml:id="ms_i1.1">
+                                    <locus from="124ra" to="130va"/>
                                     <title type="complete" ref="LIT2715John"/>
                                     <textLang mainLang="gez"/>
-                                    <incipit xml:lang="gez" type="inscription">
-                                        <locus target="#101r"/>
-                                        <hi rend="rubric">ወንጌል፡ ዘዮሐንስ፡</hi>
-                                    </incipit>
                                     <incipit xml:lang="gez">
-                                        <locus target="#101ra"/>
-                                        <hi rend="rubric">ቀዳሚሁ፡ ቃል፡ ውእቱ። ወውእ</hi>ቱ፡ ቃል፡ ኃበ፡ እግዚአ፡ ብሔር፡ <hi rend="rubric">ውእቱ፡ ወእግዚአ፡ ብሔር፡ ውእ</hi>ቱ፡ 
-                                        ቃል። ወከማሁ፡ ቀዳሚሁ፡ እ<hi rend="rubric">ምቅዲሙ፡ ኃበ፡ እግዚአ፡ ብሔር፡</hi> ውእቱ። ወኵሉ፡ ቦቱ፡ ኮነ፡ ወዘእ<hi rend="rubric">ንበሌሁሰ፡ 
-                                            አልቦ፡ ዘኮነ፡ ወኢምን</hi>ትኒ። ወዘሂ፡ ኮነ፡ በእንቲኣሁ፡ ቦቱ፡ <hi rend="rubric">ሕይወት፡ ውእቱ። ወሕይወትሰ፡</hi> ብርሃኑ፡ ለእጓለ፡ እመ፡ ሕያው፡ 
-                                        ውእቱ።
+                                        <locus target="#124ra"/>
+                                        ...
                                     </incipit>
                                     <explicit xml:lang="gez">
                                         <locus from="130rb" to="130va"/>
@@ -257,27 +549,24 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </incipit>
                                     <note><!-- Add small remark on the content of the Postscript --></note>
                                 </msItem>
+                                <colophon xml:lang="gez" xml:id="coloph1">
+                                    <locus target="#130va"/>
+                                    ዝመጽሐፍ፡ ዘቅዱስ፡ <hi rend="rubric">ሚካኤል፡</hi> ዘሀገረ፡ ዛቲ፡ ተጽሐፈ፡ በሢመተ፡ አካሉ፡ ጸሐፊሁ፡ 
+                                    <persName ref="" role="scribe"><hi rend="rubric">ወልደ፡ ሕፃን፡</hi></persName> ወአጽሐፊሁ፡ 
+                                    <persName ref="" role="patron"><hi rend="rubric">ወልደ፡ </hi> ሚካኤል።</persName>
+                                    <note>The colophon is undated. It states that the manuscript belongs to an unspecified church dedicated to St Michael. 
+                                        It also states that the scribe was <persName ref="" role="scribe">Walda Ḥǝḍān</persName> and the patron was <persName ref="" role="scribe">Walda Mikāʾel</persName>.
+                                    </note>
+                                </colophon>
                             </msItem>
-                            
-                            <colophon xml:lang="gez" xml:id="coloph1">
-                                <locus target="#130va"/>
-                                ዝመጽሐፍ፡ ዘቅዱስ፡ <hi rend="rubric">ሚካኤል፡</hi> ዘሀገረ፡ ዛቲ፡ ተጽሐፈ፡ በሢመተ፡ አካሉ፡ ጸሐፊሁ፡ 
-                                <persName ref="" role="scribe"><hi rend="rubric">ወልደ፡ ሕፃን፡</hi></persName> ወአጽሐፊሁ፡ 
-                                <persName ref="" role="patron"><hi rend="rubric">ወልደ፡ </hi> ሚካኤል።</persName>
-                            </colophon>
-                            <note>The colophon is undated. It states that the manuscript belongs to an unspecified church dedicated to St Michael. 
-                                It also states that the scribe was <persName ref="" role="scribe">Walda Ḥǝḍān</persName> and the patron was <persName ref="" role="scribe">Walda Mikāʾel</persName>.
-                            </note>
-                            
-                        </msItem>
-                    </msContents>
+                        </msContents>
                     
                     <physDesc>
                         <objectDesc form="Codex">
                             <supportDesc>
                                 <support>
                                     <material key="parchment"/>
-                                    <p>Holes, presumably resulting from parchment making, are found on <locus target="#1 #14 #16 #40 #42 #67 #74 #85 #92"/>.</p>
+                                    <p>Holes, presumably resulting from parchment making, are found on <locus target=""/>.</p>
                                 </support>
                                 <extent>
                                     <measure unit="leaf">130</measure>
@@ -295,116 +584,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </extent>
                                 <foliation>Pencil foliation in the upper right corner carried out by the Bodleian Library during our stay in January 2020.</foliation>
                                 <collation>
-                                    <signatures>
-                                        ፫ in the upper left corner of <locus target="#18r"/> and upper right corner of <locus target="#25v"/>;
-                                        ፬ in the upper left corner of <locus target="#26r"/>, remains of a quire mark in the upper right corner of <locus target="#31v"/>;
-                                        ፫ in the upper left corner of <locus target="#54r"/>, ፬ in the upper right corner of <locus target="#68v"/>;
-                                         ፪ n the upper left corner of  <locus target="#69r"/> and the upper right corner of <locus target="#76v"/>;
-                                        ፫ in the upper left corner of <locus target="#77r"/>;
-                                        remains of a quire mark in the upper left corner of <locus target="#85r"/>;
-                                        ፭ in the upper left corner of <locus target="#93r"/>;
-                                        ፩ in the upper right corner of <locus target="#108v"/>;
-                                        ፪ in the upper left corner of <locus target="#109r"/>  and the upper right corner of <locus target="#115v"/>;
-                                        ፫ in the upper left corner of <locus target="#116r"/>.</signatures>
-                                    <note>All quires except <ref target="#q19"/> have been secondarily arranged with a parchment guard and secondary sewing. The original quire
-                                    structure cannot be observed anymore.</note>
                                     <list>
-                                        <item xml:id="q1" n="1">
-                                            <dim unit="leaf">2</dim>
-                                            <locus from="1r" to="2v"/>
-                                            <note>A parchment guard has been placed around the quire.</note>
-                                        </item>
-                                        <item xml:id="q2" n="2">
-                                            <dim unit="leaf">8</dim>
-                                            <locus from="3r" to="10v"/>
-                                            <note>A parchment guard has been placed around the quire.</note>
-                                        </item>
-                                        <item xml:id="q3" n="3">
-                                            <dim unit="leaf">6</dim>
-                                            <locus from="11r" to="16v"/>
-                                            <note>The leaves have been sewn together secondarily.</note>
-                                        </item>
-                                        <item xml:id="q4" n="4">
-                                            <dim unit="leaf">8</dim>
-                                            <locus from="17r" to="24v"/>
-                                            <note>A parchment guard has been placed around the quire.</note>
-                                        </item>
-                                        <item xml:id="q5" n="5">
-                                            <dim unit="leaf">6</dim>
-                                            <locus from="25r" to="30v"/>
-                                            <note>A parchment guard has been placed around the quire.</note>
-                                        </item>
-                                        <item xml:id="q6" n="6">
-                                            <dim unit="leaf">5</dim>
-                                            <locus from="31r" to="35v"/>
-                                            <note>A parchment guard has been placed around the quire.</note>
-                                        </item>
-                                        <item xml:id="q7" n="7">
-                                            <dim unit="leaf">8</dim>
-                                            <locus from="36r" to="44v"/>
-                                            stub between <locus target="#38"/> and <locus target="#39"/>
-                                            stub between <locus target="#41"/> and <locus target="#42"/>
-                                            <note>A parchment guard has been placed around the quire.</note>
-                                        </item>
-                                        <item xml:id="q8" n="8">
-                                            <dim unit="leaf">6</dim>
-                                            <locus from="45r" to="50v"/>
-                                            <note>A parchment guard has been placed around the quire.</note>
-                                        </item>
-                                        <item xml:id="q9" n="9">
-                                            <dim unit="leaf">3</dim>
-                                            <locus from="51r" to="53v"/>
-                                            <note>The leaves have been sewn together secondarily unto <ref target="#q10"/>.</note>
-                                        </item>
-                                        <item xml:id="q10" n="10">
-                                            <dim unit="leaf">9</dim>
-                                            <locus from="54r" to="62v"/>
-                                           2 stubs between <locus target="#61"/> and <locus target="#62"/>
-                                            <note>A parchment guard has been placed around the quire.</note>
-                                        </item>
-                                        <item xml:id="q11" n="11">
-                                            <dim unit="leaf">4</dim>
-                                            <locus from="63r" to="67v"/>
-                                            <note>A parchment guard has been placed around the quire.</note>
-                                        </item>
-                                        <item xml:id="q12" n="12">
-                                            <dim unit="leaf">9</dim>
-                                            <locus from="68r" to="76v"/>
-                                            <note>A parchment guard has been placed around the quire.</note>
-                                        </item>
-                                        <item xml:id="q13" n="13">
-                                            <dim unit="leaf">8</dim>
-                                            <locus from="77r" to="84v"/>
-                                            <note>A parchment guard has been placed around the quire.</note>
-                                        </item>
-                                        <item xml:id="q14" n="14">
-                                            <dim unit="leaf">8</dim>
-                                            <locus from="85r" to="92v"/>
-                                            3, stub after 6
-                                            6, stub after 3
-                                            <note>A parchment guard has been placed around the quire.</note>
-                                        </item>
-                                        <item xml:id="q15" n="15">
-                                            <dim unit="leaf">9</dim>
-                                            <locus from="93r" to="101v"/>
-                                            <note>A parchment guard has been placed around the quire.</note>
-                                        </item>
-                                        <item xml:id="q16" n="16">
-                                            <dim unit="leaf">7</dim>
-                                            <locus from="102r" to="108v"/>
-                                            <note>A parchment guard has been placed around the quire.</note>
-                                        </item>
-                                        <item xml:id="q17" n="17">
-                                            <dim unit="leaf">6</dim>
-                                            <locus from="109r" to="114v"/>
-                                            stub between <locus target="#113"/> and <locus target="#114"/>
-                                            <note>A parchment guard has been placed around the quire.</note>
-                                        </item>
-                                        <item xml:id="q18" n="18">
-                                            <dim unit="leaf">9</dim>
-                                            <locus from="115r" to="123v"/>
-                                            <note>A parchment guard has been placed around the quire.</note>
-                                        </item>
                                         <item xml:id="q19" n="19">
                                             <dim unit="leaf">7</dim>
                                             <locus from="124r" to="130v"/>
@@ -413,64 +593,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
                                 <condition key="deficient">
-                                    <!-- The manuscript is kept in a box, in an embroidered rectangular piece of textile, measuring 620 x 920 mm.  
-                                        The leather cover has been cut off, most probably to facilitate the resewing. Small remains of leather survive on the inner sides of the front and the back board.
-                                        
-                                        The textblock ... with a parchment guard and secondary sewing.
-                                        The textblock is affected with humidity and water stains, especially in the outer margins. 
-                                                                         
-                                        The parchment is crumpled on <locus target="#74"/>.
-
-
-                                     The lowermost sewing station is damaged.
-                                    The textblock is incomplete: an undetermined number of leaves is missing with loss of text from Ps 70 onwards.
-                                    The textblock is affected with humidity, especially at the beginning of the manuscript. Water stains are attested in the outer or inner margins of
-                                    many leaves, e.g., <locus target="#1r #22r #26v"/>. Wax stains are visible on <locus target="#1r #1v #2v #31v #32r #38r #40r #46r"/>. 
-                                    The parchment is crumpled on <locus target="#17"/>.
-                                         The manuscript has been resewn: only two sewing stations, the uppermost and the lowermost ones, have been used.
-                                  
-                               More generally, the conditions of the 
-                                    manuscript and the readability of the text deteriorate towards the end. There are insect holes on the first and the last folia (<locus target="#1 #82"/>). 
-                                    A small hole which appears to have been caused by fire is found on <locus target="#54"/>. 
-                                     --> 
+                                    The unit consists of one quire secondarily sewn ...
+                                      ...
                                 </condition>
                             </supportDesc>
                             
                             <layoutDesc>
-                                <layout columns="2" writtenLines="24">
-                                    <locus from="1ra" to="123vb"/>
-                                    <note corresp="#textarea #margin">Data on text area and margin dimensions taken from <locus target="#45r"/>.</note>
-                              <!--      <dimensions unit="mm" xml:id="textarea1">
-                                        <height></height>
-                                        <width></width>
-                                       <!-\- no text area provided?-\->
-                                    </dimensions>-->
-                                    <dimensions type="margin" unit="mm" xml:id="margin1">
-                                        <dim type="top">31</dim>
-                                        <dim type="bottom">56</dim>
-                                        <dim type="right">47</dim>
-                                        <dim type="left">15</dim>
-                                        <dim type="intercolumn">15</dim>
-                                    </dimensions>
-                                    <note> The characters per line are 14-17</note>
-                                   <!-- <ab type="punctuation" subtype="Dividers">
-                                       Caesura signs:
-                                       - The <foreign xml:lang="la">crux ansata</foreign> in the left margin on <locus target="#65va #74vb"/>.
-                                       - The <foreign xml:lang="la">coronis</foreign> sign in the left margin, e.g. on <locus target="#3vb #41va #56vb #63rb #101va #116va"/>, etc.
-                                       - The <foreign xml:lang="la">crux ansata</foreign> and the <foreign xml:lang="la">coronis</foreign> are written together on <locus target="#90va #93rb #97va #98va #98vb"/>.
-                                       -  The word <foreign xml:lang="gez">ቁም፡</foreign> written at the end of the line or in the right margin, most often in red ink, e.g. on <locus target="#22v #5rb #56ra #59vb #97ra #116rb"/>, etc.
-                                       - Chain of black and red right-pointing chevrons in the left margin, indicating quotations from the Old Testament embedded in the Gospel text, e.g. <locus target="#3rb #14ra #18rb #44rb #93vb"/>, etc.
-                                      - Chains of red and black dots separate the chapters, e.g. on <locus target="#4ra #20rb #57ra #94rb"/>, etc.
-                                      - Chains of red and black dots and double dashes separate the stichometric notes.
-                                      </ab>
-                                            -->   
-                                    <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are often visible.</ab>
-                                            <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A-1A1A/0-0/0-0/C.</ab>
-                                    <ab type="ruling"> The upper line is written above the ruling. The bottom line is written above the ruling.
-                                    One bottom ruled line has been left unwritten by the scribe on <locus from="24va" to="25vb"/>.
-                                    </ab>                          
-                                </layout>
-                                
                                 <layout columns="2" writtenLines="27">
                                     <locus from="124ra" to="130va"/>
                                     <note corresp="#textarea2 #margin2">Data on text area and margin dimensions taken from <locus target="#124r"/>.</note>
@@ -486,45 +614,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <dim type="intercolumn">16</dim>
                                     </dimensions>
                                     <note> The characters per line are 12-13.</note>
-                                    <!-- <ab type="punctuation" subtype="Dividers">
-                                      The word <foreign xml:lang="gez">ቁም፡</foreign> is written at the end of the line on <locus target="#127vb"/>.
-                                      </ab>      -->   
+                                    <ab type="punctuation" subtype="Dividers">
+                                        The word <foreign xml:lang="gez">ቁም፡</foreign> is written at the end of the line on <locus target="#127vb"/>.
+                                    </ab>
                                     <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are visible.</ab>
-                                  <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A-1A1A/0-0/0-0/C.</ab>
+                                    <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A-1A1A/0-0/0-0/C.</ab>
                                     <ab type="ruling"> The upper line is written above the ruling. The bottom line is written above the ruling.</ab>                         
                                 </layout>
                             </layoutDesc>
                         </objectDesc>
                         
                         <handDesc>
-                            <handNote xml:id="h1" script="Ethiopic">
-                                <locus from="1ra" to="123vb"/>
-                                <seg type="script"/>
-                                <seg type="ink">Black, red</seg>
-                                <date notBefore="1500" notAfter=""></date>
-                                <desc>
-                                   <!-- Fine and trained hand. Characters are regularly spaced.
-                                    The numeral <foreign xml:lang="gez">፮</foreign> has a compressed shape and the open loop. 
-                                    The letter መ has the loops not completely separated.
-                                   The word <foreign xml:lang="gez">እግዚአ፡ ብሔር፡</foreign> is sometimes written as two separate words, as in ancient manuscripts. 
-                                   The two letters ግዚ are written with ligature in the word እግዚእነ፡, e.g. on <locus target="#35va #100vb"/>. --> 
-                                </desc>                               
-                                <seg type="rubrication">
-                                    <!-- Rubricated are ...
-                                    Holy names (Jesus Christ).
-                                    
-                                    The numbers of the chapters in the list of the <foreign xml:lang="la">tituli</foreign> at the beginning of each Gospel.
-                                    The captions <foreign xml:lang="gez">ማርቆስ፡</foreign> on <locus target="#35vb"/>, <foreign xml:lang="gez">ስዕለ፡ ሉቃስ፡</foreign> (partly illegible) on <locus target="#61v"/>, and <foreign xml:lang="gez">ዮሐንስ፡</foreign> on <locus target="#100va"/>.
-                                    The stichometric notes at the end of the Gospels of Matthew, on <locus target="#35ra"/>.
-                                    The numbers and titles of the chapters are written in the upper margin, in correspondence of the beginning of the chapters.
-                                    They are often written in the lower margin, e.g. on <locus target="#24va #25ra #29va #37ra #64vb #68vb #87rb #90rb"/> [their position can't go under rubrication! Extra? It must be decided].
-                                    In the left margins, the numbers of the Eusebian Canons to which the Ammonian sections, penned in black ink immediately above the number, belong.
-                                    The word <foreign xml:lang="gez">ቁም፡</foreign>, written in a later hand, at the end of the line or in the right margin, e.g. on <locus target="#5rb #56ra #59vb #97ra"/>.
-                                    Elements of the numerals and of the punctuation signs, including text dividers and caesura signs.
-                                    The <foreign xml:lang="la">crux ansata</foreign> is entirely rubricated on <locus target="#65va"/>; the <foreign xml:lang="la">coronis</foreign> sign is entirely rubricated on <locus target="#62vb #63ra"/>.
-                                    --> 
-                                </seg>
-                            </handNote>
                             <handNote xml:id="h2" script="Ethiopic">
                                 <locus from="124ra" to="130va"/>
                                 <seg type="script"/>
@@ -548,27 +648,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </list>
                             </handNote>
                         </handDesc>
-                        
-                       <!--  für Jacopo
-                        <decoDesc>
-                            <decoNote type="miniature" xml:id="d1">
-                                <locus target="#1v"/>
-                                <desc>...</desc>
-                            </decoNote>    
-                            <decoNote type="band" xml:id="d2">
-                                <locus target="#2r"/>
-                                <desc>...</desc>
-                            </decoNote> 
-                        </decoDesc>
-                        -->
                   
                         <additions>
                             <list>
-                                <item xml:id="e1">
-                                    <desc>A white sticker is glued to the inner side of the front board, on the top. The name of <persName ref="PRS5782JuelJen"/> is printed on it
-                                        (<foreign xml:lang="gez">ቤንት፡ ዩውል፡ የንሰን።</foreign>) and the signature "MS. Aeth. c. 14" is written in pencil. 
-                                        An additional sticker, with the signature "Ms 46"printed on it, is glued on the bottom of the same side.</desc>
-                                </item>
                                 <!--
                                 <item xml:id="e">
                                     <locus target=""/>
@@ -578,34 +660,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 -->
                             </list>
                         </additions>
-                  
-                       
-                             <bindingDesc>
-                            <binding contemporary="true">
-                                <decoNote xml:id="b1">Two <material key="wood">wooden</material> boards previously covered with brown tooled <material key="leather"/>.
-                                </decoNote>
-                                <decoNote xml:id="b2" type="bindingMaterial">
-                                    <material key="wood"/>       
-                                    <material key="leather"/>     
-                                </decoNote>
-                                <decoNote xml:id="b3" type="Cover" color="brown">
-                                    The leather cover was decorated with blind tooled ornament (double lines).
-                                    <!-- Description of the tooled ornamentation will need some revision --></decoNote>
-                                <decoNote xml:id="b4" type="SewingStations"><!-- ... --></decoNote>
-                                <decoNote xml:id="b5" type="Spine">The spine cover is missing.</decoNote>
-                                <decoNote xml:id="b6" type="Other">A red <term key="leafTabMark">leaf tab marker</term> for navigating is inserted in the lower margin of 
-                                    <locus target="#86"/>.</decoNote>
-                            </binding>
-                        </bindingDesc>
-                           
                     </physDesc>
                    
-                    <history>
-                        <origin>
-                            <origDate from="1500" to="" evidence="lettering"/>
-                        </origin>
-                        <provenance></provenance>
-                    </history>
+                        <history>
+                            <origin>
+                                <origDate from="" to="" evidence="lettering"/>
+                            </origin>
+                            <provenance></provenance>
+                        </history>
+                    </msPart>
                 </msDesc>
             </sourceDesc>
         </fileDesc>
@@ -640,6 +703,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <change who="DR" when="2020-02-27">Added dimensions and layout</change>
             <change who="SH" when="2020-04-22">Added editors</change>
             <change who="MV" when="2020-10-06">Added content description</change>
+            <change who="MV" when="2020-10-08">Added layout, conservation, rubrication</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">

--- a/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
@@ -413,7 +413,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <!--      <dimensions unit="mm" xml:id="textarea1">
                                         <height></height>
                                         <width></width>
-                                       <!-\- no text area provided?-\->
+                                       <!- - no text area provided: added to REQUEST FOR FURTHER ACTION list- ->
                                     </dimensions>-->
                                         <dimensions type="margin" unit="mm" xml:id="margin1">
                                             <dim type="top">31</dim>
@@ -422,7 +422,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <dim type="left">15</dim>
                                             <dim type="intercolumn">15</dim>
                                         </dimensions>
-                                        <note> The characters per line are 14-17</note>
+                                        <note> The characters per line are 14-17.</note>
                                         <ab type="punctuation" subtype="Dividers">
                                             Several caesura signs are attested in the manuscript:
                                             the <foreign xml:lang="la">crux ansata</foreign> is written in the left margin on <locus target="#65va #74vb"/>;
@@ -491,17 +491,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <locus target="#4v"/>
                                         <q xml:lang="gez"><seg part="I">ተዘከርነ፡ እ<hi rend="ligature">ግዚ</hi>ኦ፡ በሣህልከ፡ ሕዝብከ፡ ወተሰሀለነ፡ በአድህኖትከ፡</seg></q>
                                     </item>
+                                    
                                     <item xml:id="a2">
                                         <desc type="OwnershipNote">
-                                            Note crudely written in the right margin in Amharic, mentioning <persName ref=""><roleName type="title">ʾabbā</roleName> Walda Śǝllāse</persName> 
+                                            Note crudely written in the right margin in Amharic, mentioning <persName ref="PRS13183Tasamma"><roleName type="title">ʾalaqā</roleName>Tasammā</persName>,
+                                            <persName ref="PRS13182WaldaSe"><roleName type="title">ʾabbā</roleName>Walda Śǝllāse</persName>, 
                                             and an unspecified monastery called <placeName ref="">Dabra Mikāʾel</placeName>.
                                             </desc>
                                         <locus target="#64rb"/>
                                         <q xml:lang="am">
-                                            የደብረ፡ ሚካኤል፡ ዛፍ፡ ያለቃ፡ ተሠማ፡ ነው፡ ዙካው፡ <!-- ??? check!! --> አባ፡ ወልደ፡ ሥላሴ፡ ናቸው፡
+                                            የደብረ፡ ሚካኤል፡ ዛፍ፡ ያለቃ፡ ተሠማ፡ ነው፡ ዙካው፡ አባ፡ ወልደ፡ ሥላሴ፡ ናቸው፡
                                         </q>
-                                        <note> 
-                                            The text is incomplete: it starts and ends abruptly. It might be the continuation of <ref target="#a2"/>. Some letters are hardly legible.</note>
                                     </item>
                                     
                                     <item xml:id="e1">
@@ -516,7 +516,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </desc>
                                     </item>
                                     <item xml:id="e3">
-                                        <desc>Aids for identifying monthly readings are written in the upper margin, sometimes within a frame, probably in the same hand as that of <ref target=""/>: 
+                                        <desc>Aids for identifying monthly readings are written in the upper margin, sometimes within a frame: 
                                             <q xml:lang="gez">ዘጥር፡</q> (<locus target="#4r"/>),
                                             <q xml:lang="gez">ዘጥር፡ <sic>ዘጌወርጊስ፡</sic></q> in red ink (<locus target="#5r"/>),
                                             <q xml:lang="gez"><seg part="I">ዘማቴዎስ፡ ምስማክ፡ ዘመጋቢት፡ወዘሐምሌ፡</seg></q> (<locus target="#16v"/>),
@@ -606,10 +606,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <colophon xml:lang="gez" xml:id="coloph1">
                                     <locus target="#130va"/>
                                     ዝመጽሐፍ፡ ዘቅዱስ፡ <hi rend="rubric">ሚካኤል፡</hi> ዘሀገረ፡ ዛቲ፡ ተጽሐፈ፡ በሢመተ፡ አካሉ፡ ጸሐፊሁ፡ 
-                                    <persName ref="" role="scribe"><hi rend="rubric">ወልደ፡ ሕፃን፡</hi></persName> ወአጽሐፊሁ፡ 
-                                    <persName ref="" role="patron"><hi rend="rubric">ወልደ፡ </hi> ሚካኤል።</persName>
-                                    <note>The colophon is undated. It states that the manuscript belongs to an unspecified church dedicated to St Michael, cp. <placeName ref="">Dabra Mikāʾel</placeName> in <ref target="#a1"/>. 
-                                        It also states that the scribe was <persName ref="" role="scribe">Walda Ḥǝḍān</persName> and the patron was <persName ref="" role="scribe">Walda Mikāʾel</persName>.
+                                    <persName ref="PRS13184WaldaHe" role="scribe"><hi rend="rubric">ወልደ፡ ሕፃን፡</hi></persName> ወአጽሐፊሁ፡ 
+                                    <persName ref="PRS13185WaldaMi" role="patron"><hi rend="rubric">ወልደ፡ </hi> ሚካኤል።</persName>
+                                    <note>The colophon is undated. It states that the manuscript belongs to an unspecified church dedicated to St Michael, cp. <placeName ref="">Dabra Mikāʾel</placeName> in <ref target="#a2"/>. 
+                                        It also states that the scribe was <persName ref="PRS13184WaldaHe" role="scribe">Walda Ḥǝḍān</persName> and the patron was 
+                                        <persName ref="PRS13185WaldaMi" role="patron">Walda Mikāʾel</persName>.
                                     </note>
                                 </colophon>
                             </msItem>
@@ -620,7 +621,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <supportDesc>
                                 <support>
                                     <material key="parchment"/>
-                                    <p>Holes, presumably resulting from parchment making, are found on <locus target=""/>.</p>
                                 </support>
                                 <extent>
                                     <measure unit="leaf">130</measure>
@@ -684,10 +684,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <locus from="124ra" to="130va"/>
                                 <seg type="script"/>
                                 <seg type="ink">Black, red</seg>
-                                <date notBefore="1700" notAfter="1800"></date>
-                                <desc>
-                                    Fine and trained hand. Characters are regularly spaced.
-                                </desc>                               
+                                <date notBefore="1650" notAfter="1800"></date>
+                                <seg type="script"><foreign xml:lang="gez">Gʷǝlḥ</foreign>-script.</seg>
+                                <desc>Fine and trained hand. Characters are regularly spaced.</desc>                               
                                 <seg type="rubrication">
                                     Rubricated are the holy names, the incipit of few chapters and of the postscript, the word <foreign xml:lang="gez">ቁም፡</foreign>, written in a later 
                                     hand on <locus target="#127vb"/>, elements of the numerals and of the punctuation signs, including text dividers.
@@ -719,7 +718,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                    
                         <history>
                             <origin>
-                                <origDate from="1700" to="1800" evidence="lettering"/>
+                                <origDate from="1650" to="1800" evidence="lettering"/>
                             </origin>
                             <provenance></provenance>
                         </history>
@@ -759,6 +758,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <change who="SH" when="2020-04-22">Added editors</change>
             <change who="MV" when="2020-10-06">Added content description</change>
             <change who="MV" when="2020-10-08">Added layout, conservation, rubrication</change>
+            <change who="MV" when="2020-10-13">...</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">

--- a/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
@@ -10,10 +10,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <title>Four Gospels</title>
+                <title xml:lang="gez" xml:id="title1">አርባዑቱ፡ ወንጌል፡</title>
+                <title xml:lang="gez" corresp="#title1" type="normalized">ʾArbāʿǝttu wāngel</title>
+                <title xml:lang="en" corresp="#title1">Four Gospels</title>
                 <editor key="DR"/>
                 <editor key="JG"/>
-                <editor key="MV"/><editor key="SH"/><funder>Akademie der Wissenschaften in Hamburg</funder>
+                <editor key="MV"/>
+                <editor key="SH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
@@ -33,6 +37,240 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <idno>Juel-Jensen 46</idno>
                         </altIdentifier>
                     </msIdentifier>
+                    
+                    <msContents>
+                        <summary/>
+                        
+                        <msItem xml:id="ms_i1">
+                            <locus from="1ra" to="130va"/>
+                            <title type="complete" ref="LIT1560Gospel"/>
+                            <note>The introductory materials to the Four Gospels, i.e. the Synopis of the class, the Letter of Eusebius to Carpianus and the Eusebian Canons, are missing.</note>
+                            
+                            <msItem xml:id="ms_i1.1">
+                                <locus from="1ra" to="35ra"/>
+                                <title type="complete" ref="LIT1558Matthew"></title>
+                                <msItem xml:id="ms_i1.1.1">
+                                    <locus from="1ra" to="1va"/>
+                                    <title type="complete" ref="LIT1558Matthew#TituliMatthew"/>
+                                    <textLang mainLang="gez"/>
+                                    <incipit xml:lang="gez">
+                                        <locus target="#1ra"/>
+                                        <lb/><hi rend="rubric">፩</hi> በእንተ፡ ቅዳሜ፡ ትምህርት፡
+                                        <lb/><hi rend="rubric">፪</hi> በእንተ፡ ብፁዓም።
+                                        <lb/><hi rend="rubric">፫</hi> በእንተ፡ ዘለምጽ።
+                                        <lb/><hi rend="rubric">፬</hi> በእንተ፡ ወልደ መስፍን፡
+                                    </incipit>
+                                    <explicit xml:lang="gez">
+                                        <locus target="#1va"/>
+                                        <lb/><hi rend="rubric">፷</hi> በእንተ፡ ግብአቱ፡ ለክርስቶስ።
+                                        <lb/><hi rend="rubric">፷፩</hi> በእንተ፡ 
+                                        <lb/><hi rend="rubric">፷፪</hi> በእንተ፡ ዘከመ፡ ነስሐ፡ ይሁዳ።
+                                        <lb/><hi rend="rubric">፷፫</hi> በእንተ፡ ስእለተ፡ ሥጋሁ፡ <supplied reason="lost">ለእግ</supplied>ዚእነ።
+                                    </explicit>
+                                    <note>The first three lines are blank, in correspondence of the first three <foreign xml:lang="lat">tituli</foreign>.
+                                        The <foreign xml:lang="lat">tituli</foreign> are numbered from 1 to 63.</note>
+                                </msItem>
+                                <msItem xml:id="ms_i1.1.2">
+                                    <locus from="2ra" to="35ra"/>
+                                    <title type="complete" ref="LIT2709Matthew"/>
+                                    <textLang mainLang="gez"/>
+                                    <incipit xml:lang="gez" type="inscription">
+                                        <locus target="#2ra"/>
+                                        <hi rend="rubric">በስመ፡ ኣብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ አሐዱ፡ አምላክ፡</hi> ብስራተ፡ ቅዱስ፡ ማቴዎስ፡ ሐዋርያ፡ ቡሩክ፡ ዘዜነወ፡ 
+                                        ወን<hi rend="rubric">ንጌለ፡ ጸጋሁ፡ ለእግዚእነ፡ ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡ ጸሎ</hi>ቱ፡ ወበረከቱ፡ የሀሉ፡ ምስሌነ፡ ለዓለመ፡ ዓለም፡ አሜን። 
+                                        <hi rend="rubric">ወንጌል፡ ዘማቴዎስ።</hi>
+                                    </incipit>
+                                    <incipit xml:lang="gez">
+                                        <locus target="#2ra"/>
+                                        <hi rend="rubric">መጽሐፈ፡ ለደቱ፡ ለእግዚእነ፡ ኢ</hi>የሱስ፡ ክርስቶስ፡ ወልደ፡ ዳዊት፡ <hi rend="rubric">ወልደ፡ አብርሃም። አብርሃም፡</hi> ወለዶ፡ 
+                                        ለይስሐቅ። ወይስሐቅ<hi rend="rubric">ኒ፡ ወለዶ፡ ለያዕቆብ። ወያዕቆብ</hi>ኒ፡ ወለደ፡ <sic>ይሁዳ፡ ሃ፡</sic> ወአኃዊሁ።
+                                    </incipit>
+                                    <explicit xml:lang="gez">
+                                        <locus from="34vb" to="35ra"/>
+                                        ወቀረቦሙ፡ እግዚእ፡ ኢየሱስ፡ ወነበቦሙ፡ ወይቤሎሙ፡ ተውህበ፡ ሊተ፡ ስልጣን፡ በሰማይ፡ ወበምድር፡ ሑ<supplied reason="undefined">ሩ</supplied>ኬ፡ 
+                                        እንከ፡ ወመሀሩ፡ ለኵሉ፡ አሕዛብ፡ ወአጥምቅዎሙ፡ በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ። ወመሀርዎሙ፡ ይዕቀቡ፡ ኵሎ፡ ዘአዘዝኩክሙ፡ ወናሁ፡ አነ፡ 
+                                        ሀለውኩ፡ ም<pb n="35r"/><cb n="a"/>ስሌክሙ፡ በኵሉ፡ መዋዕል፡ እስከ፡ ኅልቀተ፡ ዓለም። =።
+                                    </explicit>
+                                    <note>Stichometry is added at the end of the text, on <locus target="#35ra"/>: <q xml:lang="gez">ወንጌል፡ ዘማቴዎስ፡ ቃሉ፡ ፳፻ወ፯፻።</q>.
+                                        The stichometric note states that the gospel of Matthew consists of 2700 lines, according to the meaning of <foreign xml:lang="gez">ቃል፡</foreign> in 
+                                        this context.
+                                    </note>                                    
+                                </msItem>
+                            </msItem>
+                            
+                            <msItem xml:id="ms_i1.2">
+                                <locus from="35rb" to="60vb"/>
+                                <title type="complete" ref="LIT1882MarkGo"></title>
+                                <msItem xml:id="ms_i1.2.1">
+                                    <locus from="35rb" to="35va"/>
+                                    <title type="complete" ref="LIT1882MarkGo#TituliMark"/>
+                                    <textLang mainLang="gez"/>
+                                    <incipit xml:lang="gez">
+                                        <locus target="#35rb"/>
+                                        <lb/><hi rend="rubric">፩</hi> በእንተ፡ ዘጋኔን።
+                                        <lb/><hi rend="rubric">፪</hi> በእንተ፡ ሐማተ፡ ጴጥሮስ።
+                                        <lb/><hi rend="rubric">፫</hi> በእንተ፡ እለ፡ ተፈውሱ፡ እምብዙኅ፡ <seg rend="below">ደዌ።</seg>
+                                        <lb/><hi rend="rubric">፬</hi> በእንተ፡ ዘለምጽ።
+                                    </incipit>
+                                    <explicit xml:lang="gez">
+                                        <locus target="#35va"/>
+                                        <lb/><hi rend="rubric">፵፭</hi> በእንተ፡ ፋሲካ። 
+                                        <lb/><hi rend="rubric">፵፮</hi> በእንተ፡ ዘከመ፡ ኣግብኦ፡ ይሁዳ።
+                                        <lb/><hi rend="rubric">፵፯</hi> በእንተ፡ ዘከመ፡ ክሕደ፡ ጴጥሮስ።
+                                        <lb/><hi rend="rubric">፵፰</hi> በእንተ፡ ስእለተ፡ ሥጋሁ፡ ለእ<hi rend="ligature">ግዚ</hi>እነ።
+                                    </explicit>
+                                    <note>The <foreign xml:lang="lat">tituli</foreign> are numbered from 1 to 48.</note>
+                                </msItem>
+                                <msItem xml:id="ms_i1.2.2">
+                                    <locus from="36ra" to="60vb"/>
+                                    <title type="complete" ref="LIT2711Mark"/>
+                                    <textLang mainLang="gez"/>
+                                    <incipit xml:lang="gez" type="inscription">
+                                        <locus target="#36ra"/>
+                                        <hi rend="rubric">ወንጌል። ዘ። ማርቆስ።</hi>
+                                    </incipit>
+                                    <incipit xml:lang="gez">
+                                        <locus target="#36ra"/>
+                                        <hi rend="rubric">ቀዳሚሁ፡ ለወንጌል፡ እግዚ</hi>እ፡ ኢየሱስ፡ ክርስቶስ፡ ወልደ፡ እግዚአ፡ ብሔር፡ በከመ፡ ጽ<hi rend="rubric">ሑፍ፡ ውስተ፡ ነቢያት፡ 
+                                            ናሁ፡ አነ፡ እፌኑ፡ መልኣክየ፡ ቅድመ፡</hi> ገጽከ፡ ዘይጻይሕ፡ ፍኖተከ። ቃለ፡ ኣዋዲ፡ ዘይሰብክ፡ በገዳ<hi rend="rubric">ም፡ ወይብል፡ ጺሑአ፡ ፍኖቶ፡ 
+                                                ለእግዚአ፡ ብሔር፡ ወዐርዩ፡ መ</hi>ጽያሕቶ። ወሀሎ፡ ዮሐንስ፡ ያጠምቅ፡ በገዳም፡ ወይሰብክ፡ ጥምቀተ፡ ከመ፡ ይነስሑ፡ ወይትኀደግ፡ ሎሙ፡ 
+                                        ኃጢኣቶሙ።
+                                    </incipit>
+                                    <explicit xml:lang="gez">
+                                        <locus target="#60vb"/>
+                                        በስመ፡ ዚኣየ፡ አጋንንት፡ ያወፅኡ፡ ወበካልእ፡ ልሳን፡ ይትናገሩ፡ ሐዲሰ። ወኣራዊተ፡ ምድር፡ ይእኅዙ፡ ወዘሂ፡ ይቀትል፡ እመ፡ ሰትዩ፡ አልቦ፡ ዘይነክዮሙ። 
+                                        ወዲበ፡ ድዉያን፡ እደዊሆሙ፡ ያነብሩ፡ ወይሜጥኑ። ወእግዚእነሰ፡ ኢየሱስ፡ ክርስቶስ፡ እምድኅረ፡ ተናገሮሙ፡ ዐርገ፡ ውስተ፡ ሰማይ፡ ወነበረ፡ በየማነ፡ እግዚአ፡ 
+                                        ብሔር፡ ኣቡሁ። ወወፂኦሙ፡ እምህየ፡ እሙንቱ፡ በኵለሄ፡ ሰበኩ፡ እንዘ፡ እግዚእ፡ ይረድእ፡ ወቃሎ፡ ያጸንዕ፡ በተኣምር፡ ዘይተሉ፡ አሜን።
+                                    </explicit>
+                                    <note>Stichometry is added at the end of the text, on <locus target="#60vb"/>: <q xml:lang="gez">ወንጌል፡ ዘማርቆስ፡ ቃሉ፡ ፲፻፡፯፻</q>.
+                                        The stichometric note states that the gospel of Mark consists of 1700 lines.</note>
+                                </msItem>
+                            </msItem>
+                            
+                            <msItem xml:id="ms_i1.3">
+                                <locus from="61ra" to="100rb"/>
+                                <title type="complete" ref="LIT1812GospelLuke"></title>
+                                <msItem xml:id="ms_i1.3.1">
+                                    <locus from="61ra" to="61vb"/>
+                                    <title type="complete" ref="LIT1812GospelLuke#TituliLuke"/>
+                                    <textLang mainLang="gez"/>
+                                    <incipit xml:lang="gez">
+                                        <locus target="#61ra"/>
+                                        <lb/><gap reason="illegible" unit="chars" quantity="1"></gap> በእንተ፡ ጸሕፍ። ፪ በእንተ፡ ኖሎት።
+                                        <lb/><gap reason="illegible" unit="chars" quantity="1"></gap> በእንተ፡ ስምዖን። <hi rend="rubric">፬</hi> በእንተ፡ ሐና፡ ነቢት።
+                                        <lb/><gap reason="illegible" unit="chars" quantity="1"></gap> በእንተ፡ ቃል፡ ዘኮነ፡ ኃበ፡ ዮሐንስ።
+                                        <lb/><gap reason="illegible" unit="chars" quantity="1"></gap> በእንተ፡ ዘከመ፡ ተመከረ፡ መድኃኒነ።
+                                    </incipit>
+                                    <explicit xml:lang="gez">
+                                        <locus from="61va" to="61vb"/>
+                                        <lb/><hi rend="rubric">፹</hi> በእንተ፡ ዘከመ፡ ኣስተኣከዮ፡ ሄሮድስ።
+                                        <cb n="b"/>
+                                        <lb/><hi rend="rubric">፹፩</hi> በእንተ፡ እለ፡ ይበክያ፡ አንስት። 
+                                        <lb/><hi rend="rubric">፹፪</hi> በእንተ፡ ዘከመ፡ ነስሐ፡ ፈያታዊ።
+                                        <lb/><hi rend="rubric">፹፫</hi> በእንተ፡ ስእለተ፡ ሥጋሁ፡ ለእግዚእነ።
+                                    </explicit>
+                                    <note>The <foreign xml:lang="lat">tituli</foreign> are up to 83.</note>
+                                </msItem>
+                                <msItem xml:id="ms_i1.3.2">
+                                    <locus from="62ra" to="100rb"/>
+                                    <title type="complete" ref="LIT2713Luke"/>
+                                    <textLang mainLang="gez"/>
+                                    <incipit xml:lang="gez" type="inscription">
+                                        <locus target="#62r"/>
+                                        <hi rend="rubric">ወንጌል፡ ዘሉቃስ።</hi>
+                                    </incipit>
+                                    <incipit xml:lang="gez">
+                                        <locus target="#62ra"/>
+                                        <hi rend="rubric">እስመ፡ ብዙኃን፡ እለ፡ አኃዙ፡ ወ</hi>ጠኑ፡ ይግበሩ፡ ወይምሀሩ፡ በእ<hi rend="rubric">ንተ፡ ግብር፡ ዘኣምኑ፡ በላዕሌነ፡</hi> በከመ፡ 
+                                        መሀሩነ፡ እለ፡ ቀደሙ፡ <hi rend="rubric">ርእዮቶ፡ ወተልእኩዎ፡ በቃሉ፡</hi> ወረትዓኒ፡ ሊተኒ፡ እትልዎ፡ እም<hi rend="rubric">ጥንቱ፡ ወእጠይቆ፡ 
+                                            ለኵሉ፡ በበ፡</hi> መትልዉ። እጽሕፍ፡ ለከ፡ ዓዚዝ፡ <hi rend="rubric">ቴዎፍሊ፡ ለኣኃዚ፡ ከመ፡ ታእም</hi>ር፡ ጥዩቀ፡ በእንተ፡ ኵሉ፡ ኃይለ፡ ነገር፡ 
+                                        ትምህርተ፡ ዘተመሀርከ።
+                                    </incipit>
+                                    <explicit xml:lang="gez">
+                                        <locus from="100ra" to="100rb"/>
+                                        ወናሁ፡ አነ፡ እፌኑ፡ ተስፋሁ፡ ለአቡየ፡ ላዕሌክሙ። ወአንትሙሰ፡ ንበሩ፡ ሀገረ፡ ኢየሩሳሌም፡ እስከ፡ ትለብሱ፡ ኃይለ፡ እምኣርያም። ወኣውፅኦሙ፡ ኣፍኣ፡ 
+                                        እስከ፡ ቢቲንያ። ወአንሥአ፡ እዴሁ፡ ወኣንበ<cb n="b"/>ረ፡ ወባረኮሙ። ወእንዘ፡ ይባርኮሙ፡ ተራሐቆሙ፡ ወዐርገ፡ ሰማየ። ወእሙንቱሰ፡ ሰገዱ፡ ሎቱ፡ 
+                                        ወተሰውጡ፡ ኢየሩሳሌም፡ በዐቢይ፡ ፍሥሓ፡ ወነበሩ፡ ቤተ፡ መቅደስ፡ ዘልፈ፡ እንዘ፡ ይሴብሕዎ፡ ወይባርክዎ፡ ለእግዚአብሔር፡ ለዓለም፡ ወለዓለመ፡ ዓለም፡ 
+                                        ኣሜን።
+                                    </explicit>
+                                    <note>Stichometry is added at the end of the text, on <locus target="#60vb"/>: <q xml:lang="gez">ወንጌል፡ ዘሉቃስ፡ ቃሉ፡ ፳፻፰፻።</q>.
+                                        The stichometric note states that the gospel of Luke consists of 2800 lines.</note>
+                                </msItem>
+                            </msItem>
+                            
+                            <msItem xml:id="ms_i1.4">
+                                <locus from="100vb" to="130va"/>
+                                <title type="complete" ref="LIT1693John"></title>
+                                <msItem xml:id="ms_i1.4.1">
+                                    <locus target="#100vb"/>
+                                    <title type="complete" ref="LIT1693John#TituliJohn"/>
+                                    <textLang mainLang="gez"/>
+                                    <incipit xml:lang="gez">
+                                        <locus target="#100vb"/>
+                                        <lb/><hi rend="rubric">፩</hi> በእንተ፡ ከብካብ፡ ዘቃነ።
+                                        <lb/><hi rend="rubric">፪</hi> በእንተ፡ ዘሰደደ፡ እምኵራብ።
+                                        <lb/><hi rend="rubric">፫</hi> በእንተ፡ ኒቆዲሞስ።
+                                        <lb/><hi rend="rubric">፬</hi> በእንተ፡ አጥህሮ።
+                                    </incipit>
+                                    <explicit xml:lang="gez">
+                                        <locus target="#100vb"/>
+                                        <lb/><hi rend="rubric">፲፮</hi> በእንተ፡ እለ፡ መጽኡ፡ አረሚይ።
+                                        <lb/><hi rend="rubric">፲፯</hi> በእንተ፡ ዘከመ፡ ኃፀበ፡ እግረ፡ አርዳኢሁ።
+                                        <lb/><hi rend="rubric">፲፰</hi> በእንተ፡ ጰራቅሊጦስ።
+                                        <lb/><hi rend="rubric">፲፱</hi> በእንተ፡ ስእለተ፡ ሥጋሁ፡ ለእ<hi rend="ligature">ግዚ</hi>እነ።
+                                    </explicit>
+                                    <note>The <foreign xml:lang="lat">tituli</foreign> are numbered from 1 to 19.</note>
+                                </msItem>
+                                <msItem xml:id="ms_i1.4.2">
+                                    <locus from="101ra" to="130va"/>
+                                    <title type="complete" ref="LIT2715John"/>
+                                    <textLang mainLang="gez"/>
+                                    <incipit xml:lang="gez" type="inscription">
+                                        <locus target="#101r"/>
+                                        <hi rend="rubric">ወንጌል፡ ዘዮሐንስ፡</hi>
+                                    </incipit>
+                                    <incipit xml:lang="gez">
+                                        <locus target="#101ra"/>
+                                        <hi rend="rubric">ቀዳሚሁ፡ ቃል፡ ውእቱ። ወውእ</hi>ቱ፡ ቃል፡ ኃበ፡ እግዚአ፡ ብሔር፡ <hi rend="rubric">ውእቱ፡ ወእግዚአ፡ ብሔር፡ ውእ</hi>ቱ፡ 
+                                        ቃል። ወከማሁ፡ ቀዳሚሁ፡ እ<hi rend="rubric">ምቅዲሙ፡ ኃበ፡ እግዚአ፡ ብሔር፡</hi> ውእቱ። ወኵሉ፡ ቦቱ፡ ኮነ፡ ወዘእ<hi rend="rubric">ንበሌሁሰ፡ 
+                                            አልቦ፡ ዘኮነ፡ ወኢምን</hi>ትኒ። ወዘሂ፡ ኮነ፡ በእንቲኣሁ፡ ቦቱ፡ <hi rend="rubric">ሕይወት፡ ውእቱ። ወሕይወትሰ፡</hi> ብርሃኑ፡ ለእጓለ፡ እመ፡ ሕያው፡ 
+                                        ውእቱ።
+                                    </incipit>
+                                    <explicit xml:lang="gez">
+                                        <locus from="130rb" to="130va"/>
+                                        ወእግዚእ፡ <hi rend="rubric">ኢየሱስ፡</hi> ይቤ፡ ኢይመውት፡ አላ፡ ይቤሎ፡ እመኬ፡ ፈቀድኩ፡ የሀሉ፡ ዝንቱ፡ እስከ፡ ሶበ፡ እመጽእ፡ ሚላዕሌከ፡ ወዝንቱ፡ 
+                                        ረድእ፡ ዘኮነ፡ ሰማዕተ፡ በእንተዝ፡ ወጻሐፎ፡ ወንሕነ፡ ነአምር፡ ከመ፡ ጽድቁ፡ ውእቱ፡ ስምዑ። ወዘንተ፡ ገብረ፡ እግዚእ፡ <hi rend="rubric">ኢየሱስ፡</hi> 
+                                        በቅድመ፡ አርዳኢሁ፡ ወባዕደኒ፡ ግብራተ፡ ብዙኃ። ወሶበ፡ ተጽሐፈ፡ <pb n="130v"/><cb n="a"/> ኵሉ፡ በበ፩እምኢያግመሮ፡ ዓለም፡ ጥቀ፡ መጻሕፍቲሁ፡ 
+                                        ዘተጽሐፈ፡ አሜን፡ ወአሜን።
+                                    </explicit>
+                                    <note>The stichometric note is missing.</note>
+                                </msItem>
+                                <msItem xml:id="ms_i1.4.3">
+                                    <locus target="#130va"/>
+                                    <title type="complete" ref="LIT1693John#Postscript"/>
+                                    <textLang mainLang="gez"/>
+                                    <incipit xml:lang="gez">
+                                        <locus target="#130va"/>
+                                        <hi rend="rubric">መልዓ፡ <sic>ጽሕፈቱ፡</sic> ብስራ<supplied reason="lost">ተ</supplied> ለዮሐንስ፡ ሐዋርያ፡ ወልደ፡ ዘ<supplied reason="lost">ብ</supplied></hi>ዴዎስ፡ 
+                                        ፩እም፲ወ፪ሰባክያን፡ እንተ፡ ጸሐፎ፡ በዮናኒ፡ ለሰብአ፡ ሀገረ፡ ኤፌሶን። እምድኅረ፡ ዕርገቱ፡ ለእግዚእነ፡ <hi rend="rubric">ኢየሱስ፡ ክርስቶስ፡</hi> በሥጋ፡ 
+                                        ውስተ፡ ሰማይ፡ በ፴ዓመት፡ በ፰ዓመተ፡ መንግሥቱ፡ ለጢባርዮስ፡ ቄሣር፡ ወስብሐት፡ ለእግዚአብሔር፡ ለዓለመ፡ ዓለም፡ አሜን።
+                                    </incipit>
+                                    <note><!-- Add small remark on the content of the Postscript --></note>
+                                </msItem>
+                            </msItem>
+                            
+                            <colophon xml:lang="gez" xml:id="coloph1">
+                                <locus target="#130va"/>
+                                ዝመጽሐፍ፡ ዘቅዱስ፡ <hi rend="rubric">ሚካኤል፡</hi> ዘሀገረ፡ ዛቲ፡ ተጽሐፈ፡ በሢመተ፡ አካሉ፡ ጸሐፊሁ፡ 
+                                <persName ref="" role="scribe"><hi rend="rubric">ወልደ፡ ሕፃን፡</hi></persName> ወአጽሐፊሁ፡ 
+                                <persName ref="" role="patron"><hi rend="rubric">ወልደ፡ </hi> ሚካኤል።</persName>
+                            </colophon>
+                            <note>The colophon is undated. It states that the manuscript belongs to an unspecified church dedicated to St Michael. 
+                                It also states that the scribe was <persName ref="" role="scribe">Walda Ḥǝḍān</persName> and the patron was <persName ref="" role="scribe">Walda Mikāʾel</persName>.
+                            </note>
+                            
+                        </msItem>
+                    </msContents>
                     
                     <physDesc>
                         <objectDesc form="Codex">

--- a/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
@@ -289,11 +289,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <width>265</width>
                                             <depth>95</depth>
                                         </dimensions>
-                                        <dimensions type="leaf" unit="mm" xml:id="leafdim">
+                                        <dimensions type="leaf" unit="mm" xml:id="leafdim1">
                                             <height>316</height>
                                             <width>267</width>
                                         </dimensions>
-                                        <note corresp="#leafdim">Data on leaves dimensions taken from <locus target="#45r"/>.</note>
+                                        <note corresp="#leafdim1">Data on leaves dimensions taken from <locus target="#45r"/>.</note>
                                         <measure type="weight" unit="g">3858</measure><!--with variances-->
                                         <!-- This must refer to the entire manuscript, not to this single unit p1 -->
                                     </extent>
@@ -445,7 +445,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <handNote xml:id="h1" script="Ethiopic">
                                     <locus from="1ra" to="123vb"/>
                                     <seg type="script"/>
-                                    <seg type="ink">Black, red</seg>
+                                    <seg type="ink">Black, red or deep vermilion</seg>
                                     <date notBefore="1500" notAfter="1600"></date>
                                     <desc>
                                         Fine and trained hand. Characters are regularly spaced.
@@ -486,27 +486,79 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             
                             <additions>
                                 <list>
+                                    <item xml:id="a1">
+                                        <desc type="Supplication">Note crudely written in deep vermilion the upper margin of the leaf.</desc>
+                                        <locus target="#4v"/>
+                                        <q xml:lang="gez"><seg part="I">ተዘከርነ፡ እ<hi rend="ligature">ግዚ</hi>ኦ፡ በሣህልከ፡ ሕዝብከ፡ ወተሰሀለነ፡ በአድህኖትከ፡</seg></q>
+                                    </item>
+                                    <item xml:id="a2">
+                                        <desc type="OwnershipNote">
+                                            Note crudely written in the right margin in Amharic, mentioning <persName ref=""><roleName type="title">ʾabbā</roleName> Walda Śǝllāse</persName> 
+                                            and an unspecified monastery called <placeName ref="">Dabra Mikāʾel</placeName>.
+                                            </desc>
+                                        <locus target="#64rb"/>
+                                        <q xml:lang="am">
+                                            የደብረ፡ ሚካኤል፡ ዛፍ፡ ያለቃ፡ ተሠማ፡ ነው፡ ዙካው፡ <!-- ??? check!! --> አባ፡ ወልደ፡ ሥላሴ፡ ናቸው፡
+                                        </q>
+                                        <note> 
+                                            The text is incomplete: it starts and ends abruptly. It might be the continuation of <ref target="#a2"/>. Some letters are hardly legible.</note>
+                                    </item>
+                                    
                                     <item xml:id="e1">
                                         <desc>A white sticker is glued to the inner side of the front board, on the top. The name of <persName ref="PRS5782JuelJen"/> is printed on it
                                             (<foreign xml:lang="gez">ቤንት፡ ዩውል፡ የንሰን።</foreign>) and the signature "MS. Aeth. c. 14" is written in pencil. 
                                             An additional sticker, with the signature "Ms 46"printed on it, is glued on the bottom of the same side.</desc>
                                     </item>
-                                    <!--
-                                <item xml:id="e">
-                                    <locus target=""/>
-                                    <desc></desc>
-                                    <q xml:lang="gez"></q>
-                                </item>
-                                
-                                The numbers and titles of the chapters are written in the upper margin, in correspondence of the beginning of the chapters.
-                                    They are often written in the lower margin, e.g. on <locus target="#24va #25ra #29va #37ra #64vb #68vb #87rb #90rb"/> [their position can't go under rubrication! Extra? It must be decided].
-                                -->
+                                    <item xml:id="e2">
+                                        <desc>The numbers and titles of the gospel chapters are regularly written in red ink in the upper margin, in correspondence of the beginning of the chapters.
+                                            They are sometimes written in the lower margin, e.g. on <locus target="#24va #29va #64vb #90rb"/>. 
+                                            Additional titles are written in the upper margin black ink, in the same hand as that of the main text, e.g.: on <locus target=" #30v #58r #59v #97r"/>.
+                                        </desc>
+                                    </item>
+                                    <item xml:id="e3">
+                                        <desc>Aids for identifying monthly readings are written in the upper margin, sometimes within a frame, probably in the same hand as that of <ref target=""/>: 
+                                            <q xml:lang="gez">ዘጥር፡</q> (<locus target="#4r"/>),
+                                            <q xml:lang="gez">ዘጥር፡ <sic>ዘጌወርጊስ፡</sic></q> in red ink (<locus target="#5r"/>),
+                                            <q xml:lang="gez"><seg part="I">ዘማቴዎስ፡ ምስማክ፡ ዘመጋቢት፡ወዘሐምሌ፡</seg></q> (<locus target="#16v"/>),
+                                            <q xml:lang="gez">ዘሐምሌ፡ ሚካኤል፡ እስመ፡ ለምላእክቲሁ፡ ይኤዝዞሙ፡ በእንቲአከ፡ ከመ፡ ይሰቀቡከ፡ በኵሉ፡ ፍናዊከ፡ ወበእደዊሆሙ፡ ያነሥሆሙ፡ ፈጸሞ፡</q> in purple ink in in the left margin (<locus target="#16va"/>),
+                                            <q xml:lang="gez"><sic>ዘማዝያ፡</sic></q> (<locus target="#46va"/>),
+                                            <q xml:lang="gez">ዘዮሐንስ፡ ዘታሕሣሥ፡</q> (<locus target="#51va"/>),
+                                            <q xml:lang="gez">ምንባብ፡ <sic>ዘጌወርጊስ፡</sic> ዘነሀሴ፡ ዘማርቆስ፡</q> in red ink in the right margin (<locus target="#54rb"/>),
+                                            <q xml:lang="gez">ወንጌል፡ ዘማርቆስ፡ ምንባብ፡ ዘመስከረም፡ ባህ፡ ስርቀ፡ <sic>ዘጌወርጊስ፡</sic></q> in red ink in the right margin (<locus target="#55rb"/>),
+                                            <q xml:lang="gez">ዘግንቦት፡ <sic>ተፍስሁ፡</sic> ጻድቃን፡</q> (<locus target="#55va"/>),
+                                            <q xml:lang="gez">ዘኅዳር፡ ሚካኤል፡ ዓዲ፡ ዘይረስዮሙ፡ በ<supplied reason="omitted">ዓ</supplied>ል፡</q> (<locus target="#79va"/>),
+                                            <q xml:lang="gez"><sic>ዘጌወርጊስ፡</sic> ዘሀምሌ፡ ወንጌል፡ ዘሉቃስ፡</q> crudely written in deep vermilion (<locus target="#82r"/>),
+                                            <q xml:lang="gez"><seg part="I">ወንጌል፡ ዘሉቃስ፡ ዘየካቲት፡ ምስማክ፡</seg></q> (<locus target="#85r"/>),
+                                            <q xml:lang="gez"><seg part="I">ዘመሥከረም፡ ምስማክ፡ ግነዩ፡ ለእ<hi rend="ligature">ግዚ</hi>ብሔር፡</seg></q> (<locus target="#86rb"/>),
+                                            <q xml:lang="gez"><seg part="I">ዘግንቦት። ሕቀ፡ አህበጽኮ፡ እመላእክቲከ፡ ክብረ፡</seg></q> (<locus target="#115r"/>).
+                                        </desc>
+                                    </item>
+                                    <item xml:id="e4">
+                                        <desc>Aids for identifying liturgical readings concerning the crucifixion of Jesus are written in the upper margin in the main hand: 
+                                            <q xml:lang="gez">ጊዜ፡ ፫ሰዓት፡ አኀዝዎ፡ ለኢየሱስ፡ ወወሰድዎ፡ ይስቅልዎ፡</q> (<locus target="#32v"/>),
+                                            <q xml:lang="gez">ጊዜ፡ ፮ሰዓት፡ አልበስዎ፡ አልባሲሁ፡ ወወሰድዎ፡ ይስቅልዎ፡</q> (<locus target="#33r"/>),
+                                            <q xml:lang="gez">ጊዜ፡ ተስዓቱ፡ ሰዓት፡ ጸርኀ፡ ኢየሱስ፡ በቃሉ፡ ወይቤ፡ ኤሎሂ፡ ኤሎሂ፡</q> (<locus target="#33v"/>),                                            
+                                            <q xml:lang="gez">ጊዜ፡ ፫ሰዓት፡ ቀሠፎ፡ ጲላጦስ፡ ለኢየሱስ፡ ወወሰድዎ፡ ይስቅልዎ፡</q> (<locus target="#59r"/>),                                            
+                                            <q xml:lang="gez">ጊዜ፡ ፫ሰዓት፡ አሕየወ፡ ሎሙ፡ በርባንሃ፡ ወ<pb n="98"/>ወሀቦሙ፡ ኢ<supplied reason="omitted">የ</supplied>ሱስሃ፡ ይስቅልዎ፡</q> (<locus from="97v" to="98r"/>),
+                                            <q xml:lang="gez">ጊዜ፡ ፮ሰዓት፡ ሰቀልዎ፡ ለኢየሱስ፡ በ<add place="above">መካን፡</add> ቀራንዮ፡</q> (<locus target="#98r"/>),
+                                            <q xml:lang="gez">ጊዜ፡ ፱ሰዓት፡ ገዓረ፡ ኢየሱስ፡ በቃሉ፡ ወወፅአት፡ መንፈሱ፡ ሶቤሃ።</q> (<locus target="#98v"/>).
+                                            </desc>
+                                    </item>
+                                    <item xml:id="e5">
+                                        <desc>Small writings crudely executed and sometimes poorly legible:
+                                             <q xml:lang="gez"><sic>ክንክሣር፡</sic></q> in blue pen (<locus target="#27vb"/>),
+                                            <q xml:lang="gez">ወ<supplied reason="omitted">ን</supplied>ጌል፡ ዘሉቃስ፡</q> (<locus target="#27vb"/>),
+                                            <q xml:lang="gez">ጻድቃን፡ ይወርስዎ፡ ለምድር፡</q> crudely written in deep vermilion in the lower margin (<locus target="#71r"/>),
+                                            <q xml:lang="gez"><seg part="I">ወንጌል፡ ዘዮሐንስ፡ ምስማክ፡ ሠረገላቲሁ፡ ለእ<hi rend="ligature">ግዚ</hi>ብሔር፡</seg></q> written in a recent hand in the upper margin (<locus target="#119r"/>).
+                                            Other poorly legible small writings in blue or vermilion ink are found in the margins on <locus target="#46v #52rb #82r #86r"/>.
+                                        </desc>
+                                    </item>
                                 </list>
                             </additions>
                         </physDesc>
                         <history>
                             <origin>
-                                <origDate from="1500" to="" evidence="lettering"/>
+                                <origDate from="1500" to="1600" evidence="lettering"/>
                             </origin>
                             <provenance></provenance>
                         </history>
@@ -526,7 +578,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <textLang mainLang="gez"/>
                                     <incipit xml:lang="gez">
                                         <locus target="#124ra"/>
-                                        ...
+                                        አማን፡ አማን፡ እብለክሙ፡ ከመ፡ ትበክዩ፡ ወትላህዉ፡ አንትሙ፡ ወዓለምሰ፡ ይትፈሣሕ፡ ወአንትሙሰ፡ ተኃዝኑ። አላ፡ ኃዘንክሙ፡ ፍሥሐ፡ ይከውነክሙ፡ 
+                                        ለክሙ። በከመ፡ ብእሲት፡ ትቴክዝ፡ ሶበ፡ አልፀቀት፡ ትለድ፡ እስመ፡ በጽሐ፡ ጊዜሃ። ወእምከመ፡ ወለደት፡ እጓለ፡ ኢትዜከሮ፡ እንከ፡ ለሕማማ፡ በእንተ፡ 
+                                        ፍሥሓሐ፡ እስመ፡ ወለደት፡ ብእሴ፡ ውስተ፡ ዓለም፡ ወአንትሙነ፡ ትቴክዙ፡ ይእዜ። 
                                     </incipit>
                                     <explicit xml:lang="gez">
                                         <locus from="130rb" to="130va"/>
@@ -535,7 +589,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         በቅድመ፡ አርዳኢሁ፡ ወባዕደኒ፡ ግብራተ፡ ብዙኃ። ወሶበ፡ ተጽሐፈ፡ <pb n="130v"/><cb n="a"/> ኵሉ፡ በበ፩እምኢያግመሮ፡ ዓለም፡ ጥቀ፡ መጻሕፍቲሁ፡ 
                                         ዘተጽሐፈ፡ አሜን፡ ወአሜን።
                                     </explicit>
-                                    <note>The stichometric note is missing.</note>
+                                    <note>The text begins abruptly from Joh. 16:20. The stichometric note at the end is missing.</note>
                                 </msItem>
                                 <msItem xml:id="ms_i1.4.3">
                                     <locus target="#130va"/>
@@ -554,7 +608,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     ዝመጽሐፍ፡ ዘቅዱስ፡ <hi rend="rubric">ሚካኤል፡</hi> ዘሀገረ፡ ዛቲ፡ ተጽሐፈ፡ በሢመተ፡ አካሉ፡ ጸሐፊሁ፡ 
                                     <persName ref="" role="scribe"><hi rend="rubric">ወልደ፡ ሕፃን፡</hi></persName> ወአጽሐፊሁ፡ 
                                     <persName ref="" role="patron"><hi rend="rubric">ወልደ፡ </hi> ሚካኤል።</persName>
-                                    <note>The colophon is undated. It states that the manuscript belongs to an unspecified church dedicated to St Michael. 
+                                    <note>The colophon is undated. It states that the manuscript belongs to an unspecified church dedicated to St Michael, cp. <placeName ref="">Dabra Mikāʾel</placeName> in <ref target="#a1"/>. 
                                         It also states that the scribe was <persName ref="" role="scribe">Walda Ḥǝḍān</persName> and the patron was <persName ref="" role="scribe">Walda Mikāʾel</persName>.
                                     </note>
                                 </colophon>
@@ -575,12 +629,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <width>265</width>
                                         <depth>95</depth>
                                     </dimensions>
-                                    <dimensions type="leaf" unit="mm" xml:id="leafdim">
+                                    <dimensions type="leaf" unit="mm" xml:id="leafdim2">
                                         <height>316</height>
                                         <width>267</width>
                                     </dimensions>
-                                    <note corresp="#leafdim">Data on leaves dimensions taken from <locus target="#45r"/>.</note>
+                                    <note corresp="#leafdim2">Data on leaves dimensions taken from <locus target=""/>.</note>
                                     <measure type="weight" unit="g">3858</measure><!--with variances-->
+                                    <!-- This is referred to the entire ms! -->
                                 </extent>
                                 <foliation>Pencil foliation in the upper right corner carried out by the Bodleian Library during our stay in January 2020.</foliation>
                                 <collation>
@@ -592,8 +647,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </item>
                                     </list>
                                 </collation>
-                                <condition key="deficient">
-                                    The unit consists of one quire secondarily sewn ...
+                                <condition key="">
+                                    The unit consists of one quire secondarily sewn to the textblock of the first unit.
                                       ...
                                 </condition>
                             </supportDesc>
@@ -629,17 +684,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <locus from="124ra" to="130va"/>
                                 <seg type="script"/>
                                 <seg type="ink">Black, red</seg>
-                                <date notBefore="1500" notAfter=""></date>
+                                <date notBefore="1700" notAfter="1800"></date>
                                 <desc>
-                                    <!-- Fine and trained hand. Characters are regularly spaced. --> 
+                                    Fine and trained hand. Characters are regularly spaced.
                                 </desc>                               
                                 <seg type="rubrication">
-                                    <!-- Rubricated are ...
-                                    Holy names (Jesus Christ, Mary, the Paraclete).
-                                    The incipit of the postscript to the Gospel of John.
-                                     The word <foreign xml:lang="gez">ቁም፡</foreign>, written in a later hand, on <locus target="#127vb"/>.
-                                    Elements of the numerals and of the punctuation signs, including text dividers.
-                                    --> 
+                                    Rubricated are the holy names, the incipit of few chapters and of the postscript, the word <foreign xml:lang="gez">ቁም፡</foreign>, written in a later 
+                                    hand on <locus target="#127vb"/>, elements of the numerals and of the punctuation signs, including text dividers.
                                 </seg>
                                 <list type="abbreviations">
                                     <item>
@@ -651,20 +702,24 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                   
                         <additions>
                             <list>
-                                <!--
-                                <item xml:id="e">
-                                    <locus target=""/>
-                                    <desc></desc>
-                                    <q xml:lang="gez"></q>
+                                <item xml:id="e6">
+                                    <desc>Aids for identifying readings concerning the crucifixion of Jesus are written in the upper margin in deep vermilion ink: 
+                                        <q xml:lang="gez">ዘአግብአ ፡ <sic>ተግብር፡</sic></q> (<locus target="#124va"/>),
+                                        <q xml:lang="gez">ዘነግህ፡ ወወሰድዎ፡</q> (<locus target="#125rb"/>),
+                                        <q xml:lang="gez">ዘ፫ሰዓት፡</q> (<locus target="#126vb"/>),
+                                        <q xml:lang="gez">ዘቀትር፡</q> (<locus target="#127rb"/>),
+                                        <q xml:lang="gez">ዘሰዓት፡</q> (<locus target="#127vb"/>),
+                                        <q xml:lang="gez">ዘሰርክ፡</q> (<locus target="#128ra"/>),
+                                        <q xml:lang="gez">ዘእሁድ፡ ሰንበት፡</q> (<locus target="#128rb"/>).
+                                    </desc>
                                 </item>
-                                -->
                             </list>
                         </additions>
                     </physDesc>
                    
                         <history>
                             <origin>
-                                <origDate from="" to="" evidence="lettering"/>
+                                <origDate from="1700" to="1800" evidence="lettering"/>
                             </origin>
                             <provenance></provenance>
                         </history>

--- a/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
@@ -41,6 +41,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <physDesc>
                         
                         <bindingDesc>
+                            <!-- bindingDesc to be revised by Eliana -->
                             <binding contemporary="true">
                                 <decoNote xml:id="b1">Two <material key="wood">wooden</material> boards previously covered with brown tooled <material key="leather"/>.
                                     A decorated <material key="textile"/> inlay is glued onto the front board.
@@ -52,7 +53,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </decoNote>
                                 <decoNote xml:id="b3" type="Cover" color="brown">
                                     The leather cover was decorated with blind tooled ornament (double lines).
-                                    <!-- Description of the tooled ornamentation will need some revision --></decoNote>
+                                    <!-- Description of the tooled ornamentation will be revise --></decoNote>
                                 <decoNote xml:id="b4" type="SewingStations">4</decoNote>
                                 <decoNote xml:id="b5" type="Spine">The spine cover is missing.</decoNote>
                                 <decoNote xml:id="b6" type="Other">
@@ -294,8 +295,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <width>267</width>
                                         </dimensions>
                                         <note corresp="#leafdim1">Data on leaves dimensions taken from <locus target="#45r"/>.</note>
-                                        <measure type="weight" unit="g">3858</measure><!--with variances-->
-                                        <!-- This must refer to the entire manuscript, not to this single unit p1 -->
+                                        <measure type="weight" unit="g">3858</measure>
+                                        <!-- Information on leafdim1 is taken once on f. 45r. But this is a composite ms. So, the leaf dimensions of p2 might be taken again at the Bodleian Library 
+                                        (they seem by eye almost identical to those of p1 here given) and provided below under p2. Alternatively, since the dimensions really look the same 
+                                        (see ff. 123v-124r), I might tacitly copy the above information and paste it as leafdim2 below.  
+                                        As for the weight, it obviously refers to the entire manuscript, not to to this single unit p1. So, it should be encoded elsewhere, preferably at the 
+                                        beginning of the description. I think this is a general problem concerning the BM encoding practice. -->
                                     </extent>
                                     <foliation>Pencil foliation in the upper right corner carried out by the Bodleian Library during our stay in January 2020.</foliation>
                                     <collation>
@@ -396,7 +401,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </list>
                                     </collation>
                                     <condition key="deficient">
-                                        The manuscript is kept in a box, in an embroidered rectangular piece of textile, measuring 620 x 920 mm. <!-- how to encode this info? -->
+                                        The manuscript is kept in a box, in an embroidered rectangular piece of textile, measuring 620 x 920 mm. <!-- how to encode this information? -->
                                         The leather cover has been cut off, most probably to facilitate the resewing. Small remains of leather survive on the inner sides of the front and the back board.
                                         The textblock has been resewn together and parchment guards have been placed around all quires.
                                         Leaves <locus from="51r" to="62v"/> have been stitched together secondarily.
@@ -494,9 +499,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     
                                     <item xml:id="a2">
                                         <desc type="OwnershipNote">
-                                            Note crudely written in the right margin in Amharic, mentioning <persName ref="PRS13183Tasamma"><roleName type="title">ʾalaqā</roleName>Tasammā</persName>,
-                                            <persName ref="PRS13182WaldaSe"><roleName type="title">ʾabbā</roleName>Walda Śǝllāse</persName>, 
-                                            and an unspecified monastery called <placeName ref="">Dabra Mikāʾel</placeName>.
+                                            Note crudely written in the right margin in Amharic, mentioning <persName ref="PRS13183Tasamma"><roleName type="title">ʾalaqā</roleName>Tasammā</persName>
+                                             (possibly a later owner of the manuscript), <persName ref="PRS13182WaldaSe"><roleName type="title">ʾabbā</roleName>Walda Śǝllāse</persName>, 
+                                            and an unspecified monastery called <placeName ref="LOC7349DabraMi">Dabra Mikāʾel</placeName>.
                                             </desc>
                                         <locus target="#64rb"/>
                                         <q xml:lang="am">
@@ -560,7 +565,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <origin>
                                 <origDate from="1500" to="1600" evidence="lettering"/>
                             </origin>
-                            <provenance></provenance>
+                            <provenance>The provenance of the manuscript is unknown. According to <ref target="#a2"/>, the manuscript was placed or linked to an unspecified 
+                                monastery called <placeName ref="LOC7349DabraMi">Dabra Mikāʾel</placeName>.</provenance>
                         </history>
                     </msPart>
                     
@@ -601,14 +607,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         ፩እም፲ወ፪ሰባክያን፡ እንተ፡ ጸሐፎ፡ በዮናኒ፡ ለሰብአ፡ ሀገረ፡ ኤፌሶን። እምድኅረ፡ ዕርገቱ፡ ለእግዚእነ፡ <hi rend="rubric">ኢየሱስ፡ ክርስቶስ፡</hi> በሥጋ፡ 
                                         ውስተ፡ ሰማይ፡ በ፴ዓመት፡ በ፰ዓመተ፡ መንግሥቱ፡ ለጢባርዮስ፡ ቄሣር፡ ወስብሐት፡ ለእግዚአብሔር፡ ለዓለመ፡ ዓለም፡ አሜን።
                                     </incipit>
-                                    <note><!-- Add small remark on the content of the Postscript --></note>
+                                    <note>The note includes information on the circumstances of the writing of the Gospel of John, namely the dating and the place of completion.</note>
                                 </msItem>
                                 <colophon xml:lang="gez" xml:id="coloph1">
                                     <locus target="#130va"/>
                                     ዝመጽሐፍ፡ ዘቅዱስ፡ <hi rend="rubric">ሚካኤል፡</hi> ዘሀገረ፡ ዛቲ፡ ተጽሐፈ፡ በሢመተ፡ አካሉ፡ ጸሐፊሁ፡ 
                                     <persName ref="PRS13184WaldaHe" role="scribe"><hi rend="rubric">ወልደ፡ ሕፃን፡</hi></persName> ወአጽሐፊሁ፡ 
                                     <persName ref="PRS13185WaldaMi" role="patron"><hi rend="rubric">ወልደ፡ </hi> ሚካኤል።</persName>
-                                    <note>The colophon is undated. It states that the manuscript belongs to an unspecified church dedicated to St Michael, cp. <placeName ref="">Dabra Mikāʾel</placeName> in <ref target="#a2"/>. 
+                                    <note>The colophon is undated. It states that the manuscript belongs to an unspecified church dedicated to St Michael, cp. <placeName ref="LOC7349DabraMi">Dabra Mikāʾel</placeName> in <ref target="#a2"/>. 
                                         It also states that the scribe was <persName ref="PRS13184WaldaHe" role="scribe">Walda Ḥǝḍān</persName> and the patron was 
                                         <persName ref="PRS13185WaldaMi" role="patron">Walda Mikāʾel</persName>.
                                     </note>
@@ -633,7 +639,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <height>316</height>
                                         <width>267</width>
                                     </dimensions>
-                                    <note corresp="#leafdim2">Data on leaves dimensions taken from <locus target=""/>.</note>
+                                    <note corresp="#leafdim2">Data on leaves dimensions taken from <locus target="#124r"/>.</note>
                                     <measure type="weight" unit="g">3858</measure><!--with variances-->
                                     <!-- This is referred to the entire ms! -->
                                 </extent>
@@ -647,9 +653,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </item>
                                     </list>
                                 </collation>
-                                <condition key="">
-                                    The unit consists of one quire secondarily sewn to the textblock of the first unit.
-                                      ...
+                                <condition key="good">
+                                    The unit consists of one quire secondarily sewn to the textblock of the first unit. The unit is in good state of preservation.
+                                    Some letters are illegible on <locus target="#124r"/> due to faded ink. The verso of the last folio displays traces of intensive use and erasures.
                                 </condition>
                             </supportDesc>
                             
@@ -720,7 +726,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <origin>
                                 <origDate from="1650" to="1800" evidence="lettering"/>
                             </origin>
-                            <provenance></provenance>
+                            <provenance>The provenance of the manuscript is unknown with certainty. According to <ref target="#coloph1"/>, the manuscript 
+                                belonged to an unspecified church dedicated to St Michael, probably the same place as <placeName ref="LOC7349DabraMi">Dabra Mikāʾel</placeName> 
+                                mentioned in <ref target="#a2"/>.</provenance>
                         </history>
                     </msPart>
                 </msDesc>
@@ -758,7 +766,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <change who="SH" when="2020-04-22">Added editors</change>
             <change who="MV" when="2020-10-06">Added content description</change>
             <change who="MV" when="2020-10-08">Added layout, conservation, rubrication</change>
-            <change who="MV" when="2020-10-13">...</change>
+            <change who="MV" when="2020-10-13">Added persName, placeName, provenance</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">

--- a/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
@@ -67,8 +67,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <lb/><hi rend="rubric">፷፪</hi> በእንተ፡ ዘከመ፡ ነስሐ፡ ይሁዳ።
                                         <lb/><hi rend="rubric">፷፫</hi> በእንተ፡ ስእለተ፡ ሥጋሁ፡ <supplied reason="lost">ለእግ</supplied>ዚእነ።
                                     </explicit>
-                                    <note>The first three lines are blank, in correspondence of the first three <foreign xml:lang="lat">tituli</foreign>.
-                                        The <foreign xml:lang="lat">tituli</foreign> are numbered from 1 to 63.</note>
+                                    <note>The first three lines are blank, in correspondence of the first three <foreign xml:lang="la">tituli</foreign>.
+                                        The <foreign xml:lang="la">tituli</foreign> are numbered from 1 to 63.</note>
                                 </msItem>
                                 <msItem xml:id="ms_i1.1.2">
                                     <locus from="2ra" to="35ra"/>
@@ -119,7 +119,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <lb/><hi rend="rubric">፵፯</hi> በእንተ፡ ዘከመ፡ ክሕደ፡ ጴጥሮስ።
                                         <lb/><hi rend="rubric">፵፰</hi> በእንተ፡ ስእለተ፡ ሥጋሁ፡ ለእ<hi rend="ligature">ግዚ</hi>እነ።
                                     </explicit>
-                                    <note>The <foreign xml:lang="lat">tituli</foreign> are numbered from 1 to 48.</note>
+                                    <note>The <foreign xml:lang="la">tituli</foreign> are numbered from 1 to 48.</note>
                                 </msItem>
                                 <msItem xml:id="ms_i1.2.2">
                                     <locus from="36ra" to="60vb"/>
@@ -169,7 +169,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <lb/><hi rend="rubric">፹፪</hi> በእንተ፡ ዘከመ፡ ነስሐ፡ ፈያታዊ።
                                         <lb/><hi rend="rubric">፹፫</hi> በእንተ፡ ስእለተ፡ ሥጋሁ፡ ለእግዚእነ።
                                     </explicit>
-                                    <note>The <foreign xml:lang="lat">tituli</foreign> are up to 83.</note>
+                                    <note>The <foreign xml:lang="la">tituli</foreign> are written over erasure up to 83.</note>
                                 </msItem>
                                 <msItem xml:id="ms_i1.3.2">
                                     <locus from="62ra" to="100rb"/>
@@ -193,7 +193,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         ወተሰውጡ፡ ኢየሩሳሌም፡ በዐቢይ፡ ፍሥሓ፡ ወነበሩ፡ ቤተ፡ መቅደስ፡ ዘልፈ፡ እንዘ፡ ይሴብሕዎ፡ ወይባርክዎ፡ ለእግዚአብሔር፡ ለዓለም፡ ወለዓለመ፡ ዓለም፡ 
                                         ኣሜን።
                                     </explicit>
-                                    <note>Stichometry is added at the end of the text, on <locus target="#60vb"/>: <q xml:lang="gez">ወንጌል፡ ዘሉቃስ፡ ቃሉ፡ ፳፻፰፻።</q>.
+                                    <note>Stichometry is added at the end of the text, on <locus target="#100rb"/>: <q xml:lang="gez">ወንጌል፡ ዘሉቃስ፡ ቃሉ፡ ፳፻፰፻።</q>.
                                         The stichometric note states that the gospel of Luke consists of 2800 lines.</note>
                                 </msItem>
                             </msItem>
@@ -219,7 +219,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <lb/><hi rend="rubric">፲፰</hi> በእንተ፡ ጰራቅሊጦስ።
                                         <lb/><hi rend="rubric">፲፱</hi> በእንተ፡ ስእለተ፡ ሥጋሁ፡ ለእ<hi rend="ligature">ግዚ</hi>እነ።
                                     </explicit>
-                                    <note>The <foreign xml:lang="lat">tituli</foreign> are numbered from 1 to 19.</note>
+                                    <note>The <foreign xml:lang="la">tituli</foreign> are numbered from 1 to 19.</note>
                                 </msItem>
                                 <msItem xml:id="ms_i1.4.2">
                                     <locus from="101ra" to="130va"/>
@@ -277,10 +277,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <supportDesc>
                                 <support>
                                     <material key="parchment"/>
+                                    <p>Holes, presumably resulting from parchment making, are found on <locus target="#1 #14 #16 #40 #42 #67 #74 #85 #92"/>.</p>
                                 </support>
                                 <extent>
                                     <measure unit="leaf">130</measure>
-                                   
                                     <dimensions type="outer" unit="mm">
                                         <height>313</height>
                                         <width>265</width>
@@ -293,6 +293,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <note corresp="#leafdim">Data on leaves dimensions taken from <locus target="#45r"/>.</note>
                                     <measure type="weight" unit="g">3858</measure><!--with variances-->
                                 </extent>
+                                <foliation>Pencil foliation in the upper right corner carried out by the Bodleian Library during our stay in January 2020.</foliation>
                                 <collation>
                                     <signatures>
                                         ፫ in the upper left corner of <locus target="#18r"/> and upper right corner of <locus target="#25v"/>;
@@ -411,24 +412,63 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </item>
                                     </list>
                                 </collation>
+                                <condition key="deficient">
+                                    <!-- The manuscript is kept in a box, in an embroidered rectangular piece of textile, measuring 620 x 920 mm.  
+                                        The leather cover has been cut off, most probably to facilitate the resewing. Small remains of leather survive on the inner sides of the front and the back board.
+                                        
+                                        The textblock ... with a parchment guard and secondary sewing.
+                                        The textblock is affected with humidity and water stains, especially in the outer margins. 
+                                                                         
+                                        The parchment is crumpled on <locus target="#74"/>.
+
+
+                                     The lowermost sewing station is damaged.
+                                    The textblock is incomplete: an undetermined number of leaves is missing with loss of text from Ps 70 onwards.
+                                    The textblock is affected with humidity, especially at the beginning of the manuscript. Water stains are attested in the outer or inner margins of
+                                    many leaves, e.g., <locus target="#1r #22r #26v"/>. Wax stains are visible on <locus target="#1r #1v #2v #31v #32r #38r #40r #46r"/>. 
+                                    The parchment is crumpled on <locus target="#17"/>.
+                                         The manuscript has been resewn: only two sewing stations, the uppermost and the lowermost ones, have been used.
+                                  
+                               More generally, the conditions of the 
+                                    manuscript and the readability of the text deteriorate towards the end. There are insect holes on the first and the last folia (<locus target="#1 #82"/>). 
+                                    A small hole which appears to have been caused by fire is found on <locus target="#54"/>. 
+                                     --> 
+                                </condition>
                             </supportDesc>
                             
                             <layoutDesc>
                                 <layout columns="2" writtenLines="24">
                                     <locus from="1ra" to="123vb"/>
                                     <note corresp="#textarea #margin">Data on text area and margin dimensions taken from <locus target="#45r"/>.</note>
-                              <!--      <dimensions unit="mm" xml:id="textarea">
+                              <!--      <dimensions unit="mm" xml:id="textarea1">
                                         <height></height>
                                         <width></width>
                                        <!-\- no text area provided?-\->
                                     </dimensions>-->
-                                    <dimensions type="margin" unit="mm" xml:id="margin">
+                                    <dimensions type="margin" unit="mm" xml:id="margin1">
                                         <dim type="top">31</dim>
                                         <dim type="bottom">56</dim>
                                         <dim type="right">47</dim>
                                         <dim type="left">15</dim>
                                         <dim type="intercolumn">15</dim>
                                     </dimensions>
+                                    <note> The characters per line are 14-17</note>
+                                   <!-- <ab type="punctuation" subtype="Dividers">
+                                       Caesura signs:
+                                       - The <foreign xml:lang="la">crux ansata</foreign> in the left margin on <locus target="#65va #74vb"/>.
+                                       - The <foreign xml:lang="la">coronis</foreign> sign in the left margin, e.g. on <locus target="#3vb #41va #56vb #63rb #101va #116va"/>, etc.
+                                       - The <foreign xml:lang="la">crux ansata</foreign> and the <foreign xml:lang="la">coronis</foreign> are written together on <locus target="#90va #93rb #97va #98va #98vb"/>.
+                                       -  The word <foreign xml:lang="gez">ቁም፡</foreign> written at the end of the line or in the right margin, most often in red ink, e.g. on <locus target="#22v #5rb #56ra #59vb #97ra #116rb"/>, etc.
+                                       - Chain of black and red right-pointing chevrons in the left margin, indicating quotations from the Old Testament embedded in the Gospel text, e.g. <locus target="#3rb #14ra #18rb #44rb #93vb"/>, etc.
+                                      - Chains of red and black dots separate the chapters, e.g. on <locus target="#4ra #20rb #57ra #94rb"/>, etc.
+                                      - Chains of red and black dots and double dashes separate the stichometric notes.
+                                      </ab>
+                                            -->   
+                                    <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are often visible.</ab>
+                                            <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A-1A1A/0-0/0-0/C.</ab>
+                                    <ab type="ruling"> The upper line is written above the ruling. The bottom line is written above the ruling.
+                                    One bottom ruled line has been left unwritten by the scribe on <locus from="24va" to="25vb"/>.
+                                    </ab>                          
                                 </layout>
                                 
                                 <layout columns="2" writtenLines="27">
@@ -445,76 +485,139 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <dim type="left">13</dim>
                                         <dim type="intercolumn">16</dim>
                                     </dimensions>
+                                    <note> The characters per line are 12-13.</note>
+                                    <!-- <ab type="punctuation" subtype="Dividers">
+                                      The word <foreign xml:lang="gez">ቁም፡</foreign> is written at the end of the line on <locus target="#127vb"/>.
+                                      </ab>      -->   
+                                    <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are visible.</ab>
+                                  <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A-1A1A/0-0/0-0/C.</ab>
+                                    <ab type="ruling"> The upper line is written above the ruling. The bottom line is written above the ruling.</ab>                         
                                 </layout>
                             </layoutDesc>
-                            
                         </objectDesc>
                         
+                        <handDesc>
+                            <handNote xml:id="h1" script="Ethiopic">
+                                <locus from="1ra" to="123vb"/>
+                                <seg type="script"/>
+                                <seg type="ink">Black, red</seg>
+                                <date notBefore="1500" notAfter=""></date>
+                                <desc>
+                                   <!-- Fine and trained hand. Characters are regularly spaced.
+                                    The numeral <foreign xml:lang="gez">፮</foreign> has a compressed shape and the open loop. 
+                                    The letter መ has the loops not completely separated.
+                                   The word <foreign xml:lang="gez">እግዚአ፡ ብሔር፡</foreign> is sometimes written as two separate words, as in ancient manuscripts. 
+                                   The two letters ግዚ are written with ligature in the word እግዚእነ፡, e.g. on <locus target="#35va #100vb"/>. --> 
+                                </desc>                               
+                                <seg type="rubrication">
+                                    <!-- Rubricated are ...
+                                    Holy names (Jesus Christ).
+                                    
+                                    The numbers of the chapters in the list of the <foreign xml:lang="la">tituli</foreign> at the beginning of each Gospel.
+                                    The captions <foreign xml:lang="gez">ማርቆስ፡</foreign> on <locus target="#35vb"/>, <foreign xml:lang="gez">ስዕለ፡ ሉቃስ፡</foreign> (partly illegible) on <locus target="#61v"/>, and <foreign xml:lang="gez">ዮሐንስ፡</foreign> on <locus target="#100va"/>.
+                                    The stichometric notes at the end of the Gospels of Matthew, on <locus target="#35ra"/>.
+                                    The numbers and titles of the chapters are written in the upper margin, in correspondence of the beginning of the chapters.
+                                    They are often written in the lower margin, e.g. on <locus target="#24va #25ra #29va #37ra #64vb #68vb #87rb #90rb"/> [their position can't go under rubrication! Extra? It must be decided].
+                                    In the left margins, the numbers of the Eusebian Canons to which the Ammonian sections, penned in black ink immediately above the number, belong.
+                                    The word <foreign xml:lang="gez">ቁም፡</foreign>, written in a later hand, at the end of the line or in the right margin, e.g. on <locus target="#5rb #56ra #59vb #97ra"/>.
+                                    Elements of the numerals and of the punctuation signs, including text dividers and caesura signs.
+                                    The <foreign xml:lang="la">crux ansata</foreign> is entirely rubricated on <locus target="#65va"/>; the <foreign xml:lang="la">coronis</foreign> sign is entirely rubricated on <locus target="#62vb #63ra"/>.
+                                    --> 
+                                </seg>
+                            </handNote>
+                            <handNote xml:id="h2" script="Ethiopic">
+                                <locus from="124ra" to="130va"/>
+                                <seg type="script"/>
+                                <seg type="ink">Black, red</seg>
+                                <date notBefore="1500" notAfter=""></date>
+                                <desc>
+                                    <!-- Fine and trained hand. Characters are regularly spaced. --> 
+                                </desc>                               
+                                <seg type="rubrication">
+                                    <!-- Rubricated are ...
+                                    Holy names (Jesus Christ, Mary, the Paraclete).
+                                    The incipit of the postscript to the Gospel of John.
+                                     The word <foreign xml:lang="gez">ቁም፡</foreign>, written in a later hand, on <locus target="#127vb"/>.
+                                    Elements of the numerals and of the punctuation signs, including text dividers.
+                                    --> 
+                                </seg>
+                                <list type="abbreviations">
+                                    <item>
+                                        <abbr>ምዕ፡</abbr> for <expan>ምዕራፍ፡</expan> (e.g., <locus target="#128ra #128va"/>)
+                                    </item>
+                                </list>
+                            </handNote>
+                        </handDesc>
+                        
+                       <!--  für Jacopo
+                        <decoDesc>
+                            <decoNote type="miniature" xml:id="d1">
+                                <locus target="#1v"/>
+                                <desc>...</desc>
+                            </decoNote>    
+                            <decoNote type="band" xml:id="d2">
+                                <locus target="#2r"/>
+                                <desc>...</desc>
+                            </decoNote> 
+                        </decoDesc>
+                        -->
                   
-                        
+                        <additions>
+                            <list>
+                                <item xml:id="e1">
+                                    <desc>A white sticker is glued to the inner side of the front board, on the top. The name of <persName ref="PRS5782JuelJen"/> is printed on it
+                                        (<foreign xml:lang="gez">ቤንት፡ ዩውል፡ የንሰን።</foreign>) and the signature "MS. Aeth. c. 14" is written in pencil. 
+                                        An additional sticker, with the signature "Ms 46"printed on it, is glued on the bottom of the same side.</desc>
+                                </item>
+                                <!--
+                                <item xml:id="e">
+                                    <locus target=""/>
+                                    <desc></desc>
+                                    <q xml:lang="gez"></q>
+                                </item>
+                                -->
+                            </list>
+                        </additions>
+                  
+                       
+                             <bindingDesc>
+                            <binding contemporary="true">
+                                <decoNote xml:id="b1">Two <material key="wood">wooden</material> boards previously covered with brown tooled <material key="leather"/>.
+                                </decoNote>
+                                <decoNote xml:id="b2" type="bindingMaterial">
+                                    <material key="wood"/>       
+                                    <material key="leather"/>     
+                                </decoNote>
+                                <decoNote xml:id="b3" type="Cover" color="brown">
+                                    The leather cover was decorated with blind tooled ornament (double lines).
+                                    <!-- Description of the tooled ornamentation will need some revision --></decoNote>
+                                <decoNote xml:id="b4" type="SewingStations"><!-- ... --></decoNote>
+                                <decoNote xml:id="b5" type="Spine">The spine cover is missing.</decoNote>
+                                <decoNote xml:id="b6" type="Other">A red <term key="leafTabMark">leaf tab marker</term> for navigating is inserted in the lower margin of 
+                                    <locus target="#86"/>.</decoNote>
+                            </binding>
+                        </bindingDesc>
+                           
                     </physDesc>
-                    
-                    <additional>
-                        <adminInfo>
-                            <recordHist>
-                                <source>
-                                    <!--  <listBibl type="secondary">
-                                        <bibl></bibl>
-                                    </listBibl>-->
-                                </source>
-                            </recordHist>
-                        </adminInfo>
-                    </additional>
-                    
-                <!--    <history>
+                   
+                    <history>
                         <origin>
-                            <origDate when="" evidence=""/>
+                            <origDate from="1500" to="" evidence="lettering"/>
                         </origin>
-                        <provenance>  </provenance>
-                    </history>-->
-                    
-                    <msPart xml:id="p1">
-                        <msIdentifier>
-                        </msIdentifier>
-                        
-                        <msContents>
-                            <summary/>
-                            
-                       <!--     <msItem xml:id="p1_i1">
-                                <locus from="2r" to=""/>
-                                <title type="" ref=""/>
-                               <textLang xml:lang="gez"/>
-                            </msItem>-->
-                        </msContents>
-                        
-                        
-                    </msPart>
-                    
-                    <msPart xml:id="p2">
-                        <msIdentifier>
-                        </msIdentifier>
-                        
-                        <msContents>
-                            <summary/>
-                          <!--  <msItem xml:id="p2_i1">
-                                <locus from="" to=""/>
-                                <title type="" ref=""/>
-                                <textLang xml:lang="gez"/>
-                            </msItem>-->
-                        </msContents>
-                    </msPart>
+                        <provenance></provenance>
+                    </history>
                 </msDesc>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
             <p>A digital born TEI file</p>
-        <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-                     href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
-            <xi:fallback>
-               <p>Definitions of prefixes used.</p>
-            </xi:fallback>
-         </xi:include>
-      </encodingDesc>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+                <xi:fallback>
+                    <p>Definitions of prefixes used.</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <creation/>
             <abstract>
@@ -523,6 +626,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <textClass>
                 <keywords scheme="#ethioauthlist">
                     <term key="ChristianLiterature"/>
+                    <term key="NewTestament"/>
+                    <term key="Bible"/>
                 </keywords>
             </textClass>
             <langUsage>
@@ -533,7 +638,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <revisionDesc>
             <change who="DR" when="2020-01-23">Created record</change>
             <change who="DR" when="2020-02-27">Added dimensions and layout</change>
-        <change who="SH" when="2020-04-22">Added editors</change></revisionDesc>
+            <change who="SH" when="2020-04-22">Added editors</change>
+            <change who="MV" when="2020-10-06">Added content description</change>
+        </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">
         <body>

--- a/OxfordBodleian/Juel-Jensen/BDLaethd18.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd18.xml
@@ -69,7 +69,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <title type="complete" ref="LIT1340EnochE#Watchers"/>
                                 <incipit xml:lang="gez">
                                     <locus target="#3ra"/>
-                                    <hi rend="rubric">ክፍል፡ ፩ቃለ፡ በረከት፡ ዘሄኖክ፡ ዘከመ፡ ባረከ፡ <choice>
+                                    <hi rend="rubric">ክፍል፡ ፩ ቃለ፡ በረከት፡ ዘሄኖክ፡ ዘከመ፡ ባረከ፡ <choice>
                                         <sic>ኀሩያነ፡</sic>
                                     </choice> ወጻድቃነ፡</hi> እለ፡ ሀለዉ፡ ይኩኑ፡ በዕለተ፡ ምንዳቤ፡ ለአሰስሎ፡ ኵሉ፡ እኩያን፡ ወረሲዓን፡ ወአውሥአ፡ 
                                     እንከ፡ ሄ<hi rend="rubric">ኖክ፡ ወይቤ፡ ብእሲ፡ ጻድቅ፡ ዘእምኃበ፡ እግዚአብሔር፡ እንዘ፡ አ</hi>ዕይንቲሁ፡ ክሡታት፡ ወይሬኢ፡ ራእየ፡ ቅዱሰ፡ ዘበሰማያት፡ ዘአርአዩኒ፡ መላእክት፡ 
@@ -90,7 +90,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <title type="complete" ref="LIT1340EnochE#Parables"/>
                                 <incipit xml:lang="gez">
                                     <locus target="#12vb"/>
-                                    <hi rend="rubric">ክፍል፡</hi> ፴፬ራእይ፡ ዘርእየ፡ ካልዕ፡ ራእየ፡ ጥበብ፡ ዘርእየ፡ ሄኖክ፡ ወልደ፡ ያሬድ፡ ወልደ፡ መላልኤል፡ ወልደ፡ ቃይናን፡ ወልደ፡ ሄኖስ፡ ወልደ፡ ሴት፡ ወልደ፡ 
+                                    <hi rend="rubric">ክፍል፡</hi> ፴፬ ራእይ፡ ዘርእየ፡ ካልዕ፡ ራእየ፡ ጥበብ፡ ዘርእየ፡ ሄኖክ፡ ወልደ፡ ያሬድ፡ ወልደ፡ መላልኤል፡ ወልደ፡ ቃይናን፡ ወልደ፡ ሄኖስ፡ ወልደ፡ ሴት፡ ወልደ፡ 
                                    አዳም። ወዝርእሱ፡ ለነገረ፡ ጥበብ፡ ዘአንሣእኩ፡ እትናገር፡ ወእብል፡ ለእለ፡ የሐድሩ፡ ዲበ፡ የብስ፡ ስምዑ፡ ቀደምት፡ ወርእዩ፡ ደኃርያን፡ ነገረ፡ ቅዱስ፡ 
                                    ዘእነግር፡ ቅድመ፡ እግዚአ፡ መናፍስት፡ እሉ፡ ቀዳሚ፡ ይኄይስ፡ ብሂል፡ ወደኃውያንሂ፡ ኢንከልእ፡ ርእሳ፡ ለጥበብ፡
                                 </incipit>
@@ -105,13 +105,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title type="complete" ref="LIT1340EnochE#Luminaries"/>
                                     <incipit xml:lang="gez">   
                                         <locus target="#27va"/>
-                                        <hi rend="rubric">ክፍል፡ ፷ወ፱መጽሐፈ፡ ሕይወተ፡ ብርሃናተ፡ ሰማይ፡ ፩፩ዘከመ፡</hi> ሀለዉ፡ በበሕዘቢሆሙ፡ ፩፩በበሥልጣኖሙ፡ ወበበዘመኖሙ፡ ፩፩በበስሞሙ፡ ወሙላዳቲሆሙ፡ ወበበአውራሂሆሙ፡ 
-                                        ዘአርአየኒ፡ <hi rend="rubric">ኡርኤል፡</hi> መልአክ፡ ቅዱስ፡ ዘሀሎ፡ ምስሌየ፡ ዘውእቱ፡ መራሂሆሙ፡ ወኲሎ፡ መጽሐፎሙ፡ በከመ፡ ውእቱ፡ አርአየኒ።                                     
+                                        <hi rend="rubric">ክፍል፡ ፷ወ፱መጽሐፈ፡ ሕይወተ፡ ብርሃናተ፡ ሰማይ፡ ፩፩ ዘከመ፡</hi> ሀለዉ፡ በበሕዘቢሆሙ፡ ፩፩ በበሥልጣኖሙ፡ ወበበዘመኖሙ፡ ፩፩ 
+                                        በበስሞሙ፡ ወሙላዳቲሆሙ፡ ወበበአውራሂሆሙ፡ ዘአርአየኒ፡ <hi rend="rubric">ኡርኤል፡</hi> መልአክ፡ ቅዱስ፡ ዘሀሎ፡ ምስሌየ፡ ዘውእቱ፡ 
+                                        መራሂሆሙ፡ ወኲሎ፡ መጽሐፎሙ፡ በከመ፡ ውእቱ፡ አርአየኒ።                                     
                                     </incipit>
                                     <explicit xml:lang="gez">
                                         <locus target="#35vb"/>
-                                        ወእሉ፡ እሙንቱ፡ ስሞሙ፡ ወሥርዓቲሆሙ፡ ወመራኅያኒሆሙ፡ እለ፡ መትሕቲሆሙ፡ ለእሉ፡ ጊዳኤያል፡ ወሲኤል፡ ወሂኤል፡ ወስሙ፡ ለዘይትዌሰክ፡ ምስሌሆሙ፡ ርእሰ፡ ፲፻አስፋኤል፤ 
-                                        ወተፈጸመ፡ መዋዕለ፡ ሥልጣነ፡ ዚአሆሙ ።
+                                        ወእሉ፡ እሙንቱ፡ ስሞሙ፡ ወሥርዓቲሆሙ፡ ወመራኅያኒሆሙ፡ እለ፡ መትሕቲሆሙ፡ ለእሉ፡ ጊዳኤያል፡ ወሲኤል፡ ወሂኤል፡ ወስሙ፡ ለዘይትዌሰክ፡ 
+                                        ምስሌሆሙ፡ ርእሰ፡ ፲፻ አስፋኤል፤ ወተፈጸመ፡ መዋዕለ፡ ሥልጣነ፡ ዚአሆሙ ።
                                     </explicit>
                                 </msItem>
                                 <msItem xml:id="p1_i1.4">
@@ -119,7 +120,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <title type="complete" ref="LIT1340EnochE#DreamVisions"/>
                                 <incipit xml:lang="gez">
                                     <locus from="35vb" to="36ra"/>
-                                    <hi rend="rubric">ክፍል፡</hi> ፹ወይእዜኒ፡ አርእየ፡ ወልድየ፡ ማቱሳላ፡ ኵሎ፡ ራእያተ፡ ዘርኢኩ፡ ወበቅድሜከ፡ እነግር፡ ፪ራእያተ፡ ርኢኩ፡ እንበለ፡ እንሣእ፡ ብእሲተ፡ ወ፩ሂ፡ እምኔሆሙ፡ ኢይትማሰል፡ 
+                                    <hi rend="rubric">ክፍል፡</hi> ፹ወይእዜኒ፡ አርእየ፡ ወልድየ፡ ማቱሳላ፡ ኵሎ፡ ራእያተ፡ ዘርኢኩ፡ ወበቅድሜከ፡ እነግር፡ ፪ ራእያተ፡ ርኢኩ፡ እንበለ፡ እንሣእ፡ ብእሲተ፡ ወ፩ሂ፡ እምኔሆሙ፡ ኢይትማሰል፡ 
                                     ምስለ፡ ካልኡ፡ ቀዳማየ፡ አመ፡ እትመሐር፡ <pb n="36r"/><cb n="a"/> መጽሐፈ፡ ወካልአ፡ ዘእንበለ፡ እነሥኣ፡ ለእምከ፡ እድና። ርኢኩ፡ ራእየ፡ ጽኑዐ፡ ወበእንቲአሆሙ፡ አስተብቋዕክዎ፡ ለእግዚእ፡ ስኩበ፡ 
                                     ኮንኩ፡ በቤተ፡ መላልኤል፡ እምሔውየ፡ ርኢኩ፡ በራእይ።
                                 </incipit>
@@ -136,7 +137,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <title type="complete" ref="LIT1340EnochE#Epistle"/>
                                 <incipit xml:lang="gez">
                                     <locus from="45rb" to="45va"/>
-                                    <hi rend="rubric">ክፍል፡</hi> ፺ወይእዜኒ፡ ወልድየ፡ ማቱሳላ፡ ጸውእ፡ ሊተ፡ ኲሎ፡ አኃዊከ፡ ወአ<pb n="45v"/><cb n="a"/>ስተጋብእ፡ ዘንተ፡ ኲሎ፡ ደቂቀ፡ እምከ፡ እስመ፡ ቃል፡ ይጼውአኒ፡ ወመንፈሰ፡ 
+                                    <hi rend="rubric">ክፍል፡</hi> ፺ ወይእዜኒ፡ ወልድየ፡ ማቱሳላ፡ ጸውእ፡ ሊተ፡ ኲሎ፡ አኃዊከ፡ ወአ<pb n="45v"/><cb n="a"/>ስተጋብእ፡ ዘንተ፡ ኲሎ፡ 
+                                    ደቂቀ፡ እምከ፡ እስመ፡ ቃል፡ ይጼውአኒ፡ ወመንፈሰ፡ 
                                     ተክዕወ፡ ዲቤየ፡ ከመ፡ አርኢክሙ፡ ኲሎ፡ ወይበጽሐክሙ፡ እስከ፡ ለዓለም። ወእምኔሁ፡ ሖረ፡ ማቱሳላ፡ ወጸውዖሙ፡ ለኲሎሙ፡ አኃዊሁ፡ ኀቤሁ፡ 
                                     ወአስተጋብኦሙ፡ ለአዝማደ፡ ዚአሁ። ወተና<supplied reason="omitted">ገ</supplied>ሮሙ፡ ለኲሎሙ፡ ውሉዱ፡ ጽድቀ።
                                 </incipit>
@@ -166,7 +168,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <date when="1975" evidence="internal"/>
                             ዝንቱ፡ መጽሐፍ፡ ዘአጽሐፎ፡ ዶክተር፡ <hi rend="rubric"><persName ref="PRS5782JuelJen">ቤንት፡ ኢ፡ የውል፡ የንሰን፡</persName></hi> 
                             ወምስለ፡ ብእሲቱ፡ ወይዘሮ፡ <hi rend="rubric"><persName ref="PRS12946MaryamMary">ማርያም፡ ሜሪ፡</persName></hi> 
-                            ዝመጽሐፍ፡ ተፈጸመ፡ በወርኃ፡ ታህሣሥ፡ በ፳ወ፭መዓልት፡ <date calendar="grace">በ፲ወ፱፻፷ወ፯ዓመተ፡ ምሕረት፡</date> ወጸሐፊሁ፡ ዲያቆን፡ 
+                            ዝመጽሐፍ፡ ተፈጸመ፡ በወርኃ፡ ታህሣሥ፡ በ፳ወ፭ መዓልት፡ <date calendar="grace">በ፲ወ፱፻፷ወ፯ ዓመተ፡ ምሕረት፡</date> ወጸሐፊሁ፡ ዲያቆን፡ 
                             <hi rend="rubric"><persName ref="PRS21944AmhaSe">አምኃ፡ ሥላሴ፡</persName></hi> ገ፡ ክርስቶስ፡ ዘብሔረ፡ <placeName ref="LOC4505Manawe">ተምቤን፡ መነዌ፡ ገዳም።</placeName> 
                             <note>The colophon states that the manuscript was commissioned by <persName ref="PRS5782JuelJen" role="patron"/> and his wife <persName ref="PRS12946MaryamMary" role="patron"/>.
                                 It was completed on the <date calendar="grace">25th Tāḫśāś of the year of mercy 1967 EC</date>, corresponding to the 18th January 1975.
@@ -418,7 +420,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <incipit xml:lang="am">
                                         በ<roleName type="title">መልአከ፡ ፀሐይ፡</roleName> ሣህሉና፡ በ<roleName type="title">ሊቀ፡ ጠበብት፡</roleName> ገብረ፡ ሥሉስ፡ 
                                         ሹመት፡ የ<roleName type="title">ወይዘሮ፡</roleName> 
-                                        ሣህሉ፡ ልጅ፡ ሰይፈ፡ ሩፋኤል፡ በ፲፪ወቄት፡ ወርቅ፡ የቍስቋምን፡ አሪም፡ ከይብተሮች፡
+                                        ሣህሉ፡ ልጅ፡ ሰይፈ፡ ሩፋኤል፡ በ፲፪ ወቄት፡ ወርቅ፡ የቍስቋምን፡ አሪም፡ ከይብተሮች፡
                                     </incipit>
                                 </msItem>
                                 <msItem xml:id="p2_i1.5">
@@ -426,14 +428,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title>Documentary text</title>
                                     <incipit xml:lang="am">
                                         በ<roleName type="title">መልአከ፡ ፀሐይ፡</roleName> ሣህሉና፡ በ<roleName type="title">ሊቀ፡ ጠበብት፡</roleName> ገብረ፡ ሥሉስ፡ 
-                                        ሹመት፡ ጻፊ፡ ፈንታ፡ በላስ፡ ፩ም፡ እምቡሪፍ፡ ፪ጭየ፡ የቄስ፡ አደነት፡ በወቄት፡ ወርቅ፡
+                                        ሹመት፡ ጻፊ፡ ፈንታ፡ በላስ፡ ፩ም፡ እምቡሪፍ፡ ፪ ጭየ፡ የቄስ፡ አደነት፡ በወቄት፡ ወርቅ፡
                                     </incipit>
                                 </msItem>
                                 <msItem xml:id="p2_i1.6">
                                     <locus target="#iv"/>
                                     <title>Land record</title>
                                     <incipit xml:lang="am">
-                                        የሊቄ፡ ኃይሉ፡ ሪም፡ በይዴም። በ<placeName ref="LOC3659GurAmb">ጕራምባ፡</placeName> ፪ምድር፡ ከጸባሕተ፡ ወልድ፡ 
+                                        የሊቄ፡ ኃይሉ፡ ሪም፡ በይዴም። በ<placeName ref="LOC3659GurAmb">ጕራምባ፡</placeName> ፪ ምድር፡ ከጸባሕተ፡ ወልድ፡ 
                                         ከ<roleName type="title">ባልአምበራስ፡</roleName> ረምኃ፡ ምድር፡ በጸገብና፡ ከብርጭቆ፡ ደጅ፡ ፩ም፡ ባድማ፤ ፩ም፡ ከማሪቺን፡
                                     </incipit>
                                 </msItem>
@@ -442,7 +444,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title>Land record</title>
                                     <incipit xml:lang="am">
                                         በ<placeName ref="LOC3659GurAmb">ጕራምባ፡</placeName> የጽራግ፡ ማሰሬ፡ ዜና፡ ዘጸረመኒ። ሪም፡ ከመርቆረዎስ፡ ያ፬ጬን፡ ምደር። 
-                                        ፩ምድር፡ ያባ፡ ጌትየ። ፪ምድር፡ ዋልዋልታ። የሙዙ። ፩ምድር፡ አኽያ፡
+                                        ፩ ምድር፡ ያባ፡ ጌትየ። ፪ ምድር፡ ዋልዋልታ። የሙዙ። ፩ ምድር፡ አኽያ፡
                                     </incipit>
                                 </msItem>
                                 <msItem xml:id="p2_i1.8">
@@ -456,7 +458,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <locus target="#iir"/>
                                     <title>Land record</title>
                                     <incipit xml:lang="am">
-                                        በዘመነ፡ <del rend="erasure"/><add place="overstrike">ዮሐን</add>ስ፡ <add place="above">በሐምሌ፡</add> በ<roleName type="title">መልአከ፡ ፀሐይ፡</roleName> ሣህሉ፡ አለቅነት፡ 
+                                        በዘመነ፡ <del rend="erasure"/><add place="overstrike">ዮሐን</add>ስ፡ <add place="above">በሐምሌ፡</add> በ<roleName type="title">መልአከ፡ 
+                                            ፀሐይ፡</roleName> ሣህሉ፡ አለቅነት፡ 
                                         በ<roleName type="title">ሊቀ፡ ጠበብት፡</roleName> እንግዳ፡ ሹመት፡ ከ<placeName ref="LOC3659GurAmb">ጕራምባ።</placeName> ፲፫ቱን፡ 
                                         ጫን፡ የዘይቱን፡ ሰቤተ፡ ክርስቲያን፡ ይሁን፡ ብለው፡ ተገዝተው፡ ሰጥቶ፡ አሉ፡ መልአከ፡ ፀሐይ፡ 
                                         ሣህሉ፡ ሊቀ፡ ጠበብት፡ እንግዳ፡ አለቀ፡ አስቡ፡ ግራጌታ፡ ሰሎሞን፡

--- a/OxfordBodleian/Juel-Jensen/BDLaethd18.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd18.xml
@@ -327,14 +327,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <origDate when="1975" evidence="internal-date"/>
                         </origin>
                       <provenance>
-                          The MS was faithfully copied from a manuscript, bound together with the book of Job and coming from <placeName ref="LOC3549Gojjam">Goǧǧām</placeName>, 
+                          The manuscript was faithfully copied from a manuscript, bound together with the book of Job and coming from <placeName ref="LOC3549Gojjam">Goǧǧām</placeName>, 
                           belonging to the deacon <persName ref="PRS12948MalakaMe">Malʿaka Mǝḥrat Yāred Gǝrmāye</persName>
                           from <placeName ref="LOC2091Calaqo">Č̣alaqot Śǝllāse</placeName>, South of Mekelle (Tǝgray).  
-                          According to <ref target="#coloph1"/> and to other information, the MS was commissioned in <placeName ref="LOC4545Maqala"/>
+                          According to <ref target="#coloph1"/> and to other information (cp. <bibl>
+                              <ptr target="bm:JuelJensen1994Bindings"/>
+                              <citedRange>189</citedRange>
+                          </bibl>), the manuscript was commissioned in <placeName ref="LOC4545Maqala"/>
                           by <persName ref="PRS5782JuelJen"/> and his wife <persName ref="PRS12946MaryamMary"/> in September 1974, in the house of 
                           <persName ref="PRS12949YohannesA">Abuna Yoḥannǝs</persName>, Archbishop of Aksum. 
-                          The MS was copied by the deacon <persName ref="PRS12944AmhaSe">ʾAmmǝḫā Śǝllāse</persName> in his monastery of <placeName ref="LOC4505Manawe">Manāwe</placeName> 
+                          The manuscript was copied by the deacon <persName ref="PRS12944AmhaSe">ʾAmmǝḫā Śǝllāse</persName> in his monastery of <placeName ref="LOC4505Manawe">Manāwe</placeName> 
                           in <placeName ref="LOC5882Tamben">Tamben</placeName>, and was completed in the month of January 1975.
+                          It costed 100 Ethiopian birr, and the binding costed 5 birr extra.
                       </provenance>
                     </history>
                     <additional>
@@ -342,6 +346,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <recordHist>
                                 <source>
                                <listBibl type="secondary">
+                                   <bibl>
+                                       <ptr target="bm:JuelJensen1994Bindings"/>
+                                       <citedRange>189</citedRange>
+                                   </bibl>
                                    <bibl><ptr target="bm:Laurence1839Enoch"/></bibl>
                                    <bibl><ptr target="bm:Dillmann1851Henoch"/></bibl>
                                    <bibl><ptr target="bm:Charles1906Enoch"/></bibl>
@@ -534,6 +542,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <change who="SH" when="2020-04-22">Added editors</change>
             <change who="MV" when="2020-06-15">Updated binding, layout, ruling and pricking, extra.</change>
             <change who="MV" when="2020-06-18">Changes after PR.</change>
+            <change who="MV" when="2020-07-23">Added new bibliographic reference.</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">

--- a/OxfordBodleian/Juel-Jensen/BDLaethe30.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe30.xml
@@ -406,7 +406,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title type="complete" ref="LIT2509Weddas#Saturday"/>
                                     <incipit xml:lang="gez">
                                         <locus target="#131rb"/>
-                                        <hi rend="rubric">ውዳሴ፡ ዘቀዳሚት፡ ሰንበት።</hi> ንጽሕት፡   <choice>
+                                        <hi rend="rubric">ውዳሴ፡ ዘቀዳሚት፡ ሰንበት።</hi> ንጽሕት፡ <choice>
                                             <sic>ወብርዘት፡</sic>
                                         </choice> ወቅድስት፡ 
                                         በኵሉ፡ እንተ፡ ሐቀፈቶ፡ ለእግዚእ፡ በእራኅ። ወኵሉ፡ ፍጥረት፡ ይትፌሥሑ፡ ምስሌሃ፡ እንዘ፡ ይጸርሑ፡ ወይብሉ፡ ሰ፡ ለ፡ ቅ።
@@ -748,7 +748,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <material key="leather"/>     
                                 </decoNote>
                                 <decoNote xml:id="b3" type="Cover" color="reddish-brown">
-                                    The leather cover is wrapped in a protective flower-printed cotton cover and is decorated  with blind tooled ornament
+                                    The leather cover is wrapped in a protective flower-printed cotton cover and is decorated with blind tooled ornament
                                     (circles, double circles, straight lines, a cross). The ornamentation decorates both the inner and outer sides of the cover.
                                     <!-- Description of the tooled ornamentation might need some revision --></decoNote>
                                 <decoNote xml:id="b4" type="SewingStations">4</decoNote>

--- a/OxfordBodleian/Juel-Jensen/BDLaethe30.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe30.xml
@@ -50,7 +50,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <locus target="#1r"/>
                                     <lb/><hi rend="rubric">ተግሣጽ፡ ለኵሉ፡ እጓለ፡ እመሕያው። 
                                     <lb/>ፍካሬ፡ ዘጻድቃን፡ ወዘኃጥአን፡ መዝሙር፡ ዘዳዊት።</hi> 
-                                    <lb/>፩ብፁዕ፡ ብእሲ፡ ዘኢሖረ፡ በምክረ፡ ረሲዓን። 
+                                    <lb/>፩ ብፁዕ፡ ብእሲ፡ ዘኢሖረ፡ በምክረ፡ ረሲዓን። 
                                     <lb/>ወዘኢቆመ፡ ውስተ፡ ፍኖተ፡ ኃጥአን።
                                 </incipit>
                                 <explicit xml:lang="gez">
@@ -423,7 +423,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <locus from="132ra" to="132rb"/>
                                         <hi rend="rubric">ውዳሴ፡ ዘሰንበት፡ ክርስቲ</hi><supplied reason="explanation">ያን፡</supplied> 
                                         ተሰመይኪ፡ ፍቅርተ፡ ኦቡርክት፡ እምአንስት። አንቲ፡ ውእ<cb n="b"/>ቱ፡ ዳግሚት፡ ቀመር፡ እንተ፡ ትሰመይ፡ ቅድስተ፡ ቅዱሳን፡ ወውስቴታ፡ ጽላተ፡ ኪዳን፡
-                                        ፲ቃላት፡ እለ፡ ተጽሕፉ፡ በአፃብዒሁ፡ ለእግዚአብሔር።
+                                        ፲ ቃላት፡ እለ፡ ተጽሕፉ፡ በአፃብዒሁ፡ ለእግዚአብሔር።
                                     </incipit>
                                     <explicit xml:lang="gez">     
                                         <locus target="#133ra"/>
@@ -691,8 +691,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <locus target="#ir"/>
                                     <q xml:lang="gez">
                                         ት፡ ሃይማኖት። ወጸሐፍ፡ አስማቲሆሙ፡ ምስለ፡ መላእክት፡ ወሰማዕት፡ በጸሎታ፡ ለእግዝእትነ፡ ወላዲተ፡ አምላክ። በሊቀ፡ መላእክት፡ ወበገዜናዊ፡ ትፍሥሕት፡ 
-                                        በሱራፌል፡ ወበኪሩቤል። ወበ፬እንስሳ። ወበ፳ወ፬ካህናተ፡ ሰማይ። ወበጸሎቶሙ፡ ለቅዱሳን፡ ወመላእክት። በ፲ወ፭ነቢያት። ፲ወ፪ሐዋርያት። ወበ፬ወንጌላውያን። 
-                                        ወበ፫፻፲ወ፰ማኅ<supplied reason="omitted">በ</supplied>ረ፡ ቅዱሳን። ወበቅዱስ፡ ዮሐንስ፡ መጥምቅ። ድንግል፡ ወካህን፡ ወ
+                                        በሱራፌል፡ ወበኪሩቤል። ወበ፬ እንስሳ። ወበ፳ወ፬ ካህናተ፡ ሰማይ። ወበጸሎቶሙ፡ ለቅዱሳን፡ ወመላእክት። በ፲ወ፭ ነቢያት። ፲ወ፪ ሐዋርያት። ወበ፬ ወንጌላውያን። 
+                                        ወበ፫፻፲ወ፰ ማኅ<supplied reason="omitted">በ</supplied>ረ፡ ቅዱሳን። ወበቅዱስ፡ ዮሐንስ፡ መጥምቅ። ድንግል፡ ወካህን፡ ወ
                                     </q>
                                     <note> 
                                         The text is incomplete: it starts and ends abruptly. It might be the continuation of <ref target="#a2"/>. Some letters are hardly legible.</note>

--- a/OxfordBodleian/Juel-Jensen/BDLaethe30.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe30.xml
@@ -648,11 +648,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     written with ligature (e.g., on <locus target="#14v #16v #31v #49r #82r #113r"/>).
                                 </note>
                                 <seg type="rubrication">
-                                   Divine names; several groups of lines on the incipit pages, alternating with black lines; number and titles of the psalms and of the 
+                                   Holy names; several groups of lines on the incipit pages, alternating with black lines; number and titles of the psalms and of the 
                                     canticles; incipits and numbers of the songs; the word <foreign xml:lang="gez">መንፈቁ፡</foreign> indicating the midpoint of the Psalms of David;
                                    name, number, and traditional interpretation of the Hebrew letter in Ps 118; 
                                     some letters, alternating with black letters, of the first word of each line (generally <foreign xml:lang="gez">ይባርክዎ፡</foreign>) 
-                                    of the Third song of the Three Youth ; 
+                                    of the Third song of the Three Youth; 
                                     elements of the punctuation signs, text dividers, and numerals, included quire marks.
                                 </seg>
                                 <list type="abbreviations">    

--- a/OxfordBodleian/Juel-Jensen/BDLaethe33.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe33.xml
@@ -46,7 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 ርዎ። <hi rend="rubric">ሃሌ</hi> እስፍንተ፡ መጠነ፡ ዘአመከርዎ፡ ከመ፡ <gap reason="lost"/>ቅ፡ <choice><sic>በእሰት፡</sic></choice> ፈተንዎ፡ 
                                 አ<add place="above">ሃ</add>ዝዎ፡ ኣሕረጽዎ፡ በደብ<gap reason="lost"/>ድራስ፡ ዘረውዎ። <hi rend="rubric">ሃሌ</hi> በማኅፄ፡ ወጉድብ፡ 
                                 አእፅ<gap reason="lost"/>ቲሁ፡ ሰበሩ፡ እስከ፡ ማሰነት፡ ሐመሩ፡ መድምመ፡ ነገሩ፡ ለልብየ፡ ነዳ፡ በፍቅሩ። <hi rend="rubric">ሃሌ</hi> በእንተ፡ 
-                                ሥ<gap reason="lost"/> ወደሙ፡ ለወልደ፡ ፩መምለኬ፡ <hi rend="rubric">ጊዮርጊ</hi> ነአ፡ ለቡ<gap reason="lost"/>። <hi rend="rubric">ሃሌ</hi> 
+                                ሥ<gap reason="lost"/> ወደሙ፡ ለወልደ፡ ፩ መምለኬ፡ <hi rend="rubric">ጊዮርጊ</hi> ነአ፡ ለቡ<gap reason="lost"/>። <hi rend="rubric">ሃሌ</hi> 
                                 ጽድቀ፡ ትንሣኤ፡ <hi rend="rubric">ጊዮርጊ</hi> ዘአፈድፈደ፡ <gap reason="lost"/>ሔ፡ ስነ፡ ገድሉ፡ ውስተ፡ ኵለሄ፡ ሰላም፡ ይምጻእ፡ 
                                 <gap reason="lost"/>ኅራኄ።
                             </incipit>

--- a/OxfordBodleian/Juel-Jensen/BDLaethe33.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe33.xml
@@ -360,13 +360,22 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <origin>
                             <origDate from="1700" to="1799" evidence="lettering"/>
                         </origin>
-                    <provenance> Bought by <persName ref="PRS5782JuelJen"/> at auction on 26 November 1985, according to the Sotheby's sale receipt.</provenance>
+                    <provenance>Bought by <persName ref="PRS5782JuelJen"/> at auction on 26 November 1985, according to the Sotheby's sale receipt.
+                        The circustamnces of the acquisition are also described in <bibl>
+                            <ptr target="bm:JuelJensen1987IlluminatedMSS"/>
+                            <citedRange>220-224</citedRange></bibl>.</provenance>
                     </history>                    
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source>
-                                </source>
+                            <source>
+                                <listBibl type="secondary">
+                                    <bibl>
+                                        <ptr target="bm:JuelJensen1987IlluminatedMSS"/>
+                                        <citedRange>220-224</citedRange>
+                                    </bibl>
+                                </listBibl>
+                            </source>
                             </recordHist>
                         </adminInfo>
                     </additional>
@@ -411,6 +420,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <change who="MV" when="2020-04-24">Identified i1</change>
             <change who="MV" when="2020-06-15">Updated binding, layout, ruling and pricking, extra.</change>
             <change who="MV" when="2020-06-18">Changes after PR.</change>
+            <change who="MV" when="2020-07-23">Added new bibliographic reference.</change>
         </revisionDesc>
 
     </teiHeader>

--- a/OxfordBodleian/Juel-Jensen/BDLaethe38.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe38.xml
@@ -551,10 +551,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             The manuscript was brought to England by a British officer after the 1868 expedition by <persName ref="PRS7484Napier"/>, in all likelihood coming 
                             from the <placeName ref="INS0101MadhaneAlam"/> collection. 
                             It was then sold to the <placeName ref="INS0525Quaritch"/> and in 1897, after failed negotiations with the <placeName ref="INS00001BL"/>, 
-                            it entered the private collection of <persName ref="PRS9721Valerie"/> as ms. Lady Meux 4. The manuscript was studied and its textual contents edited 
+                            it entered the private collection of <persName ref="PRS9721Valerie"/> as ms. Lady Meux 4. The manuscript was inspected and its textual contents edited 
                             and translated by <persName ref="PRS2929Budge"/>, who had been asked to examine it by Lady Meux.
-                            The subsequent owners are unknown, but the manuscript was eventually purchased at a Fine Oriental Manuscripts and Miniatures auction at Sotheby's 
-                            on 16 April 1985 (lot 392), according to the auction catalogue.
+                            After Lady Meux's death, in 1911, the manuscript was probably sold. The subsequent owners are unknown, but the manuscript was eventually purchased 
+                            at a Fine Oriental Manuscripts and Miniatures auction at Sotheby's 
+                            on 16 April 1985 (lot 392), according to the auction catalogue. The circustamnces of the last acquisition are also described in <bibl>
+                                <ptr target="bm:JuelJensen1987IlluminatedMSS"/>
+                                <citedRange>218-220</citedRange></bibl>.
                         </provenance>
                     </history>
                     <additional>
@@ -569,6 +572,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <bibl>
                                             <ptr target="bm:Budge1922Mary"/>
                                             <citedRange>vii-viii</citedRange>
+                                        </bibl>
+                                        <bibl>
+                                            <ptr target="bm:JuelJensen1987IlluminatedMSS"/>
+                                            <citedRange>218-220</citedRange>
                                         </bibl>
                                     </listBibl>
                                 </source>
@@ -618,6 +625,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <change who="MV" when="2020-05-25">Changes after PR</change>
             <change who="MV" when="2020-06-15">Updated binding, layout, ruling and pricking, extra.</change>
             <change who="MV" when="2020-06-18">Changes after PR.</change>
+            <change who="MV" when="2020-07-23">Added new bibliographic reference.</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">

--- a/OxfordBodleian/Juel-Jensen/BDLaethe38.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe38.xml
@@ -109,7 +109,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <title type="complete" ref="LIT1460Gadlah#Monday"/>
                                 <incipit xml:lang="gez">
                                     <locus from="12rb" to="12va"/>
-                                    <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱ</hi>ስ፡ ፩አምላክ፡ በጸሎታ፡ ለቅድ<hi rend="rubric">ስት፡ ሐና፡ ያድኅኖ፡ 
+                                    <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱ</hi>ስ፡ ፩ አምላክ፡ በጸሎታ፡ ለቅድ<hi rend="rubric">ስት፡ ሐና፡ ያድኅኖ፡ 
                                         ለ<persName ref="PRS12983GabraMa" role="patron">ገብረ፡ ማርያም፡</persName></hi> እዌጥን፡ በረድኤተ፡ እግዚአብሔር፡ ወጸጋሁ፡ ዘተውህበ፡ 
                                     ለለ፩፩፡ ለለኵሉ፡ በበመሥፈርተ፡ ሀብቱ፡ ለ<hi rend="rubric">ክርስቶስ፡</hi> ዘዓርገሂ፡ ውእቱ፡ ወዘወደረሂ፡ ው<pb n="12v"/>እቱ፡ ወዘሀሎ፡ 
                                     መልዕተ፡ ሰማያት፡ ውእቱ፡ ከመ፡ ይፈጽም፡ ኵሎ፡ በወዳሚ፡ ዘነቢያት፡ ወበዳግም፡ ዘሐዋ<add place="above">ር</add>ያት፡ ወበሣልስ፡ ዘሊቃውንት።
@@ -128,13 +128,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <locus from="26ra" to="26rb"/>
                                     <hi rend="rubric">በእንተ፡ ዝንቱ፡ ነገር፡ ንዑ፡ ንወድሳ፡ ለሐና፡</hi> እስመ፡ እግዚአብሔር፡ ወደሳ፡ ወበውዳሴሁ፡ ኃደረ፡ ለወለተ፡ 
                                     <hi rend="rubric">ሐና፡</hi> በከርሣ። ንዑ፡ ናዕብያ፡ ለ<hi rend="rubric">ሐና፡</hi> <cb n="b"/> እስመ፡ እግዚአብሔር፡ አዕበያ፡ 
-                                    እምሔውቱ፡ ይእቲ፡ እመንገለ፡ ሥጋ። ይእቲ፡ ትትበደር፡ እምነ፡ ወርቅ፡ ወብሩር፡ ወትኄይስ፡ ፈድፋደ፡ እምነ፡ ፲ወ፪አዕናቍ፡ 
+                                    እምሔውቱ፡ ይእቲ፡ እመንገለ፡ ሥጋ። ይእቲ፡ ትትበደር፡ እምነ፡ ወርቅ፡ ወብሩር፡ ወትኄይስ፡ ፈድፋደ፡ እምነ፡ ፲ወ፪ አዕናቍ፡ 
                                     ዘዘዚአሁ፡ ኅብሮን፡ ወትሤኒ፡ እምፀሐይ፡
                                 </incipit>
                                 <explicit xml:lang="gez">
                                     <locus from="34vb" to="35ra"/>
                                     ወአዕረፈት፡ ወፈለሰት፡ በወርኃ፡ ግዕዝ፡ አመ፡ ፲ወ<add place="overstrike">፩፡</add> ለኅዳር። ወበወርኃ፡ ዕብራውያን፡ ዳግማይ፡ ታስሪን። 
-                                    ወበሮሜ፡ ናኦብሮስ፡ አመ፡ ፮ዕረፍታ፡ ወ<pb n="35r"/>ቀበርዋ፡ ውስተ፡ መቃብረ፡ አበዊሃ፡ በከመ፡ ሐጎሙ፡ ለውሉደ፡ አሮን፡ እስከ፡ 
+                                    ወበሮሜ፡ ናኦብሮስ፡ አመ፡ ፮ ዕረፍታ፡ ወ<pb n="35r"/>ቀበርዋ፡ ውስተ፡ መቃብረ፡ አበዊሃ፡ በከመ፡ ሐጎሙ፡ ለውሉደ፡ አሮን፡ እስከ፡ 
                                     ማጣት፡ አቡሃ። ጸሎታ፡ ወበረከታ፡ የሀሉ፡ ምስለ፡ ገብራ፡ <hi rend="rubric"><persName ref="PRS12983GabraMa" role="patron">ገብረ፡ ማርያም፡</persName></hi> 
                                     ለዓለመ፡ ዓለም፡ አሜን።
                                 </explicit>
@@ -162,8 +162,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <incipit xml:lang="gez">
                                     <locus target="#45rb"/>
                                     <hi rend="rubric">ናይድዕ፡ ባህለ፡ ነቢያት፡ ስማዕ፡ ዘይቤሎ፡</hi> እግዚአብሔር፡ ለአቡነ፡ አዳም፡ እመ<hi rend="rubric">ጽእ፡ አነ፡ ለልየ፡ በ፭፡ 
-                                        ዕለተ፡ ወመንፈቀ፡</hi> ዕለት፡ እትወለድ፡ እምወለትከ። አሜሃ፡ እምህረከ፡ ወእሣሃለከ፡ በብዝኃ፡ ምሕረትየ። ለ፶፻ዓመታት፡ ረሰዮን፡ ከመ፡ ፭ዕለታት፡ 
-                                    ወለ፭፻ዓመታት፡ ረሰዮን፡ ከመ፡ ፮ሠዓተ፡ ዕለት።
+                                        ዕለተ፡ ወመንፈቀ፡</hi> ዕለት፡ እትወለድ፡ እምወለትከ። አሜሃ፡ እምህረከ፡ ወእሣሃለከ፡ በብዝኃ፡ ምሕረትየ። ለ፶፻ ዓመታት፡ ረሰዮን፡ ከመ፡ ፭ ዕለታት፡ 
+                                    ወለ፭፻ ዓመታት፡ ረሰዮን፡ ከመ፡ ፮ ሠዓተ፡ ዕለት።
                                 </incipit>
                                 <explicit xml:lang="gez">
                                     <locus from="53vb" to="54ra"/>
@@ -291,7 +291,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <hi rend="rubric">ተአምራቲሆሙ፡ ለሐና፡ ወ</hi>ኢያቄም፡ ዘወለድዋ፡ ለ<hi rend="rubric">ማርያም፡</hi> ወላዲተ፡ ሰማያዊ፡ 
                                 ወምድራዊ፡ ጸሎቶሙ፡ ወበረከቶሙ፡ የሃሉ፡ ምስለ፡ ፍቁሮሙ፡ <hi rend="rubric"><persName ref="PRS12983GabraMa" role="patron">ገብረ፡ ማርያም፡</persName></hi> 
                                 ለዓለመ፡ ዓለም፡ አሜን። ናሁ፡ ተብህለት፡ ከመ፡ ነበረት፡ <cb n="b"/> <hi rend="rubric">ሐና፡ ብፅዕት፡ ብእሲተ፡ ኢያቄም፡</hi> 
-                                በብዙኅ፡ ጸሎት፡ ወወሀባ፡ እግዚአብሔር፡ ዘርዓ፡ ቡርክተ፡ ወእምድኅረ፡ ፯ወርህ፡ ተዓውቀ፡ ፅንሳ፡ ለ<hi rend="rubric">ሐና፡</hi> 
+                                በብዙኅ፡ ጸሎት፡ ወወሀባ፡ እግዚአብሔር፡ ዘርዓ፡ ቡርክተ፡ ወእምድኅረ፡ ፯ ወርህ፡ ተዓውቀ፡ ፅንሳ፡ ለ<hi rend="rubric">ሐና፡</hi> 
                                 ወሰምዑ፡ አዝማዲሃ፡ ወአዝማደ፡ ምታ፡ ወመጽኡ፡ ኀቤሃ፡ 
                             </incipit>
                             <explicit xml:lang="gez">
@@ -471,7 +471,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             ለዳዊት<supplied reason="omitted">፡</supplied> ስምአ<supplied reason="omitted">፡</supplied> ሞተ<supplied reason="omitted">፡</supplied></hi>
                                         ምሕረት<supplied reason="omitted">፡</supplied> ወንጌላዊ<supplied reason="omitted">፡</supplied> ወርህን<supplied reason="omitted">፡</supplied> 
                                         በምቶታ<supplied reason="omitted">፡</supplied> ፶ግደፍ፡ ደግሞሞ<supplied reason="omitted">፡</supplied> ሐባርን<supplied reason="omitted">፡</supplied> 
-                                        ሰምን፻፶ግደፍ፡ የወጸውን፡ የዳዊቱን
+                                        ሰምን ፻፶ ግደፍ፡ የወጸውን፡ የዳዊቱን
                                     </q>
                                 </item>
                                 <item xml:id="a3">
@@ -483,8 +483,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <q xml:lang="gez">
                                         <seg part="I">
                                         <hi rend="rubric">ተአምረ፡ ዘገ<supplied reason="omitted">ብ</supplied>ረ፡</hi> እግዚእነ፡ ወአምላክነ፡ ኢየሱስ፡ ክርስቶ<supplied reason="omitted">ስ</supplied>
-                                        በኃይለ፡ ሞቱ፡ <sic>ማኀየዊ፡</sic> <add place="above">ይምሐሮ፡ ለ</add>ገብሩ፡ ገብረ፡ ማርያም፡ ወሀሎ፡ ፩ድውይ፡ እንዘ፡ ይግ<add place="above">ዕ</add>ር፡ 
-                                        ወየአውዩ፡ ፲<add place="above">፪</add>ዓመተ፡ ወዘረከቦ፡ በብዝኃ፡ ኃጢአቱ፡ ወተፈትነ፡ በእሳት፡ ከመ፡ ወርቅ፡ ወብሩር፡ መዓልተ፡ ወሌሊተ፡ </seg>
+                                        በኃይለ፡ ሞቱ፡ <sic>ማኀየዊ፡</sic> <add place="above">ይምሐሮ፡ ለ</add>ገብሩ፡ ገብረ፡ ማርያም፡ ወሀሎ፡ ፩ ድውይ፡ እንዘ፡ ይግ<add place="above">ዕ</add>ር፡ 
+                                        ወየአውዩ፡ ፲<add place="above">፪</add> ዓመተ፡ ወዘረከቦ፡ በብዝኃ፡ ኃጢአቱ፡ ወተፈትነ፡ በእሳት፡ ከመ፡ ወርቅ፡ ወብሩር፡ መዓልተ፡ ወሌሊተ፡ </seg>
                                     </q>                                  
                                 </item>
                                 <item xml:id="a4">

--- a/OxfordBodleian/Juel-Jensen/BDLaethf23.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf23.xml
@@ -161,7 +161,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                   <locus target="#32"/>
                                   ፲፩፡ ፍካሬ፡ በእንተ፡ ቃሕም፡ ዘአልቦ፡ ኃይል፡ ዘኢይትሐከይ፤ <hi rend="rubric"><choice>
                                       <sic>ወፊልጎስሰ፡</sic>
-                                  </choice></hi> ይቤ፡ ፬ጥበቢሁ፡ ለቃሕም፡ ቀዳሚ፡ ሶበ፡ የሐውር፡ ፃታ፡ ፩፩ይፀውር፡ ኅጠተ፡ በአፉሁ፡
+                                  </choice></hi> ይቤ፡ ፬ ጥበቢሁ፡ ለቃሕም፡ ቀዳሚ፡ ሶበ፡ የሐውር፡ ፃታ፡ ፩፩ ይፀውር፡ ኅጠተ፡ በአፉሁ፡
                               </incipit>
                           </msItem>
                           
@@ -259,7 +259,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                               <title type="complete" ref="LIT4915PhysA#Chapter22">On the unicorn</title>
                               <incipit xml:lang="gez">
                                   <locus from="55" to="56"/>
-                                  ፍካሬ፡ ፳፩፡ ነገር፡ በእንተ፡ አርዌ፡ ዘስሙ፡ መኖቅሪጥስ፡ <pb n="56"/> ዘውእቱ፡ ርኢም፡ ዘ፩ቀርኑ፡ ይቤ፡ በመዝሙር፡ ወይትሌዓል፡ ቀርንየ፡ ከመ፡ ዘ፩፡ ቀርኑ፡   
+                                  ፍካሬ፡ ፳፩፡ ነገር፡ በእንተ፡ አርዌ፡ ዘስሙ፡ መኖቅሪጥስ፡ <pb n="56"/> ዘውእቱ፡ ርኢም፡ ዘ፩ ቀርኑ፡ ይቤ፡ በመዝሙር፡ ወይትሌዓል፡ ቀርንየ፡ ከመ፡ ዘ፩፡ ቀርኑ፡   
                               </incipit>
                           </msItem>
                           
@@ -403,7 +403,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                               <title type="complete" ref="LIT4915PhysA#Chapter37">On the fire-stones</title>
                               <incipit xml:lang="gez">
                                   <locus from="91" to="92"/>
-                                  ፍካሬ፡ ፴፮፡ ነገር፡ በእንተ፡ ዕብን፡ ዘስሙ፡ ጸርጸሮ። ወእምኔሁ፡ ይወጽእ፡ እሳት፡ <pb n="92"/> ወኵሉ፡ ዘለከፎ፡ ይወዒ፡ ወ፩ፍጥረቱ፡ ለተባዕት፡ ወአንስት፡ ወርኁቃን፡ በበይናቲሆሙ።     
+                                  ፍካሬ፡ ፴፮፡ ነገር፡ በእንተ፡ ዕብን፡ ዘስሙ፡ ጸርጸሮ። ወእምኔሁ፡ ይወጽእ፡ እሳት፡ <pb n="92"/> ወኵሉ፡ ዘለከፎ፡ ይወዒ፡ ወ፩ ፍጥረቱ፡ ለተባዕት፡ ወአንስት፡ ወርኁቃን፡ በበይናቲሆሙ።     
                               </incipit>
                           </msItem>
                           
@@ -620,7 +620,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <desc type="Unclear">The text is written upside down in the low margin of the page, perhaps in the same hand as that of the main text.</desc>
                                     <locus target="#vv"/>
                                     <q xml:lang="gez">
-                                        የዓሥሮ፡ እስከ፡ ፫ሰዓት፡ ይከዑ፡ አፍአ፡ ኵሎ፡ ማየ፡ ዘሰረበ፡ ብእሲ፡
+                                        የዓሥሮ፡ እስከ፡ ፫ ሰዓት፡ ይከዑ፡ አፍአ፡ ኵሎ፡ ማየ፡ ዘሰረበ፡ ብእሲ፡
                                     </q>
                                 </item>
                                 

--- a/OxfordBodleian/Juel-Jensen/BDLaethf31.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf31.xml
@@ -69,8 +69,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <title type="complete" ref="LIT1693John#Postscript"/>
                                 <note> The subscription is separated from the explicit of the text by means of two chains of black and red dots. 
                                     <q xml:lang="gez">
-                                    <hi rend="rubric">መልአ፡ ጽሕፈተ፡ ብስራቱ፡ ለዮሐንስ፡ ዜናዊ።</hi> ወልደ፡ ዘብዴዎስ፡ ሐዋርያ፡ ፩እም፲ወ፪ሰባክያን። ወጸሐፋ፡ እንከ፡ በልሳነ፡ 
-                                    ዮናናውያን፡ ለሰብአ፡ ሀገረ፡ ኤፌሶን። እምድኅረ፡ ዕርገቱ፡ <cb n="b"/> ለእግዚእነ፡ ውስተ፡ ሰማይ፡ በሥጋ፡ ፴አመት፡ ወበ፲ወ፫እመንግሥቱ፡ 
+                                    <hi rend="rubric">መልአ፡ ጽሕፈተ፡ ብስራቱ፡ ለዮሐንስ፡ ዜናዊ።</hi> ወልደ፡ ዘብዴዎስ፡ ሐዋርያ፡ ፩እም፲ወ፪ ሰባክያን። ወጸሐፋ፡ እንከ፡ በልሳነ፡ 
+                                    ዮናናውያን፡ ለሰብአ፡ ሀገረ፡ ኤፌሶን። እምድኅረ፡ ዕርገቱ፡ <cb n="b"/> ለእግዚእነ፡ ውስተ፡ ሰማይ፡ በሥጋ፡ ፴ አመት፡ ወበ፲ወ፫ እመንግሥቱ፡ 
                                     ለሄሮድስ፡ ንጉሠ፡ ሮም። ስብሐት፡ ለእግዚአብሔር፡ ወላዕለ፡ ይኩን፡ ምሕረቱ፡ ለዓለም፡ ዓለም፡ አሜን።
                                 </q></note>
                             </msItem>


### PR DESCRIPTION
I added some remarks concerning this composite manuscript, which I also give here:
- Data concerning the text area of p1 is missing. This has been added to the REQUEST FOR FURTHER ACTION list.
- Information on leafdim2 (leaf dimensions of p2) is missing. The leaf size of p2 looks by eye extremely similar to that of p1, so those data might be extended to p2 too, yet I am inclined to add that task to the REQUEST FOR FURTHER ACTION list.
- Information on the weight of the manuscript is currently encoded within p1. Yet, this is misleading since that piece of information obviously refers to the entire manuscript. So, it should be encoded elsewhere, preferably at the beginning of the description. I think this is a general problem concerning the BM encoding practice and needs a consistent solution.
-  The manuscript is kept in a box, in an embroidered rectangular piece of textile, measuring 620 x 920 mm. How to encode this information (currently given under `<condition/>` of p1)? A quick survey of the guidelines has not been helpful.

Thank you for any suggestion!
