### PR TITLE
Bl orient 735

### DIFF
--- a/LondonBritishLibrary/orient/BLorient735.xml
+++ b/LondonBritishLibrary/orient/BLorient735.xml
@@ -5,7 +5,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <title>Commentary on the  Gospel of Matthew, theological texts</title>
+                <title>Tǝrgʷāme Mātewos, theological texts</title>
                 <editor key="SG"/>
                 <editor key="DE"></editor>
                 <editor key="AB" role="generalEditor"/>

--- a/LondonBritishLibrary/orient/BLorient735.xml
+++ b/LondonBritishLibrary/orient/BLorient735.xml
@@ -1,12 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
    schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="BLorient735" type="mss">
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <title>Commentaries on the  Gospel of Matthew</title>
+                <title>Commentary on the  Gospel of Matthew</title>
                 <editor key="SG"/>
+                <editor key="DE"></editor>
                 <editor key="AB" role="generalEditor"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
@@ -30,20 +31,112 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         </altIdentifier>
                         <altIdentifier>
                             <idno>Wright 311</idno>
-                            
+
                         </altIdentifier>
-                        
+
                     </msIdentifier>
                     <msContents>
                         <summary/>
-                        
+                        <!-- The first msItems have not been identified. I have also not
+                      created any new textual units for the so far, since their status in the manuscript is
+                    completely unclear. They might turn out to be additions, at least some of them. So,
+                  I prefer to keep the description like that until the digital copy becomes available. -->
+                    <msItem xml:id="ms_i1">
+                      <locus from="3r"></locus>
+                      <title type="incomplete" xml:lang="en">Theological treatise on the
+                      Nature of God</title>
+                      <textLang mainLang="gez"></textLang>
+                      <incipit xml:lang="gez">አንቀጽ፡ ሣልስ፡ በእንተ፡ ሀልዎተ፡ ፈጣሪ፡ ልዑል፡
+                      ወነገሩ፡ እምቅድመ፡ ተዋሕዶ፡ ወውእቱ፡ በዝየ፡ ፫ተ፡ ክፍላተ። አንቀጽ፡ ራብዕ፡ እስመ፡ ፈጣሪ፡ ልዑል፡
+                    ኢሀሎ፡ ውስተ፡ መካን፡ ወኢውስተ፡ ግጽ፡ <gap reason="ellipsis"></gap> አንቀጽ፡ ኃምስቱ፡
+                  በእንተ፡ ረኪቦተ፡ ፈጣሪ፡ ልዑል፡ ኵሉ፡ ግብር፡ ዘተሣረረ፡ ይፈቅድ፡ ኀበ፡ ሳራሪ፡ ወንሬእዮ፡ ለዓለም፡ ሱሩረ፡
+                ላዕለ፡ ፍጹም፡ ሱራሬ። <gap reason="ellipsis"></gap> ክፍል፡ ፮ ውስተ፡ ብያኔ፡ ከመ፡ ፈጣሪ፡
+              ልዑል፡ ፩ ወለዋህድናሁኒ፡ አልቦ፡ ዛይሳተፎ፡ ባቲ፡ ካልኡ። አንቀጽ፡ <sic>ሣልስ፡</sic> እስመ፡ ፈጣሪ፡ ልዑል፡ የአምር፡ መክፈልታተ።</incipit>
+                      <note>Incomplete at the beginning.</note>
+                    </msItem>
+                    <msItem xml:id="ms_i2">
+                      <locus from="7r"></locus>
+                      <title type="complete" xml:lang="en">Another theological treatise</title>
+                      <textLang mainLang="gez"></textLang>
+                      <incipit xml:lang="gez">ዘከመ፡ እፎ፡ ይሄሉ፡ እግዚአብሔር፡ ኵላንታሁ፡ ውስተ፡ ፩ መካን፡ እንዘ፡
+                      ኢይትአመር፡ በኀበ፡ ፩ እምኔሆሙ።</incipit>
+                    </msItem>
+                    <msItem xml:id="ms_i3">
+                      <locus from="7v"></locus>
+                      <title type="complete" xml:lang="gez">ተስዕሎት፡ ሐዲስ፡</title>
+                      <textLang mainLang="gez"></textLang>
+                      <msItem xml:id="ms_i3.1">
+                        <locus from="7v"></locus>
+                        <title type="complete" xml:lang="en">First question</title>
+                        <textLang mainLang="gez"></textLang>
+                        <incipit xml:lang="gez">ምንት፡ ምክንያቱ፡ ለዘ፡ በእንቲአሁ፡ መጽአ፡ ክርስቶስ፡ በተፍጻሜተ፡
+                        ዘመን፡ ወኢያስተርአየ፡ በቀዳሚ፡ ዘመን።</incipit>
+                      </msItem>
+                      <msItem xml:id="ms_i3.2">
+                        <locus from="8r"></locus>
+                        <title type="complete" xml:lang="en">Second question</title>
+                        <textLang mainLang="gez"></textLang>
+                        <incipit xml:lang="gez">በእንተ፡ ምንትኑ፡ ምክንያት፡ ተዋሐዳ፡ ፈጣሪ፡ ምስለ፡ ዘመድነ።</incipit>
+                      </msItem>
+                      <msItem xml:id="ms_i3.3">
+                        <locus from="9v"></locus>
+                        <title type="complete" xml:lang="en">Third question</title>
+                        <textLang mainLang="gez"></textLang>
+                        <incipit xml:lang="gez">ምንት፡ <sic>ምክያቱ፡</sic> ዘበእንቲአሆሙ፡ ኮነ፡ ፍልጣን፡ ማእከለ፡ ፬ ወንጌላዊያን፡
+                        እንዘ፡ የኃብሩ፡ በኵሉ፡ ትእዛዛተ፡ ወቃላተ፡ በእንተ፡ ጥምቀታት፡ ወፋሲካ፡ ወስቅለት፡ ወትንሣኤ፡</incipit>
+                      </msItem>
+                      <msItem xml:id="ms_i3.4">
+                        <locus from="11r"></locus>
+                        <title type="complete" xml:lang="en">Fourth question</title>
+                        <textLang mainLang="gez"></textLang>
+                        <incipit xml:lang="gez">ተስዕሎት፡ ዘዮሐንስ፡ ማር፡ ዘተሰመየ፡ <sic>የርስኒ፡</sic> በእንተ፡ ሥርዓተ፡ ጉባኤ፡ ወተወክሎ፡
+                        ላዕለ፡ እግዚአብሔር፡ ወአስተብቍዖት፡ ወባርኮት።</incipit>
+                      </msItem>
+                      <msItem xml:id="ms_i3.5">
+                        <locus from="11v"></locus>
+                        <title type="complete" xml:lang="en">Fifth question</title>
+                        <textLang mainLang="gez"></textLang>
+                        <incipit xml:lang="gez">ነገር፡ በእንተ፡ ረባሐ፡ ጸሎታት፡ ወተጋንዮ፡ ወአስተብቍዖ፡ ወአንብቦ፡ መጻሕፍት፡
+                        ብዙኃ፡ በከመ፡ ሥርዓተ፡ ሃይማኖቶሙ፡ ለፈላስፋ።</incipit>
+                      </msItem>
+                      <msItem xml:id="ms_i3.6">
+                        <locus from="12v"></locus>
+                        <title type="complete" xml:lang="en">Sixth question</title>
+                        <textLang mainLang="gez"></textLang>
+                        <incipit xml:lang="gez">መርህ፡ በእንተ፡ <sic>ዘይፈደፍ፡</sic> ምጽዋት፡ እምጾም፡ ወጸሎት።</incipit>
+                      </msItem>
+                      <msItem xml:id="ms_i3.7">
+                        <locus from="13r"></locus>
+                        <title type="complete" xml:lang="en">Seventh question</title>
+                        <textLang mainLang="gez"></textLang>
+                        <incipit xml:lang="gez">በእንተ፡ ምንትኑ፡ ምክንያት፡ ዘአዘዞሙ፡ ለክርስቲያን፡ ከመ፡ ይሰምይዎ፡ ለእግዚአብሔር፡ አበ፡
+                        በጥንተ፡ ሀልዮቶሙ፡ ባቲ።</incipit>
+                      </msItem>
+                      <msItem xml:id="ms_i3.8">
+                        <locus from="13v"></locus>
+                        <title type="complete" xml:lang="en">Eighth question</title>
+                        <textLang mainLang="gez"></textLang>
+                        <incipit xml:lang="gez">ቃል፡ አውሥኦ፡ ሐፂር፡ ዘኢያሱ፡ እልዠልትቅ፡ ተስዕሎት፡ ዘብእሲ፡ ጻድቅ፡ መነኮስ፡
+                        ወኍልቆሙሰ፡ ፸፪ አውሥአ፡ ወይቤ፡ ምንት፡ ምክንያቱ፡ ለመዝሙረ፡ ዳዊት፡ ቦእምኔሁ፡ ዘያዜክር፡ በበ፪ፊደላት፡ ወቦ፡ በበ፡
+                      ፩፩ፊደላት።</incipit>
+                      </msItem>
+                      <msItem xml:id="ms_i4">
+                        <locus from="13v"></locus>
+                        <title type="incomplete" ref="LIT5858FastingPrayer" xml:lang="en">Introduction
+                        from the work by <persName ref="PRS3827Ephrem"></persName>.</title>
+                        <textLang mainLang="gez"></textLang>
+                      </msItem>
+                      <msItem xml:id="ms_i5">
+                      </msItem>
+                    </msItem>
+
                     </msContents>
-                    
-                    
-                    
-                    
-                    
-                    
+
+
+
+
+
+
                     <physDesc>
                         <objectDesc form="Codex">
                             <supportDesc>
@@ -57,43 +150,43 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                         <width>260</width>
                                     </dimensions>
                                 </extent>
-                                
-                                
+
+
                             </supportDesc>
-                            
+
                             <layoutDesc>
                                 <layout columns="3" writtenLines="33" cert="high"/>
                             </layoutDesc>
                         </objectDesc>
-                        
+
                         <handDesc>
-                            
+
                             <handNote script="Ethiopic" xml:id="h1">
                                 <desc>The manuscript is written in a fair hand,  of the <date>18th century</date>.
                                 </desc>
-                                
+
                                 <date notBefore="1700" notAfter="1800" resp="PRS10171Wright"/>
-                                
+
                             </handNote>
-                            
-                        </handDesc>   
+
+                        </handDesc>
                         <additions>
-                            
+
                         </additions>
-                        
+
                     </physDesc>
-                    
+
                     <history>
                         <origin>
-                            
+
                             <origDate/>
                         </origin>
-                        <provenance>Looted by the British <persName ref="PRS7484Napier">Napier</persName> 
+                        <provenance>Looted by the British <persName ref="PRS7484Napier">Napier</persName>
                             expedition in <date>1868</date> from the church of <placeName ref="INS0101MadhaneAlam">Madḫāne ʿAlam</placeName>
                         </provenance>
-                        
+
                     </history>
-                    
+
                     <additional>
                         <adminInfo>
                             <recordHist>
@@ -104,13 +197,13 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                             <citedRange unit="page">202a-203a</citedRange>
                                         </bibl>
                                     </listBibl>
-                                    
+
                                 </source>
                             </recordHist>
                         </adminInfo>
                     </additional>
                 </msDesc>
-                
+
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -127,15 +220,15 @@ schematypens="http://relaxng.org/ns/structure/1.0"
             <textClass>
                 <keywords>
                     <term key="Commentary"/>
-                    
+
                 </keywords>
             </textClass>
             <langUsage><language ident="en">English</language></langUsage>
         </profileDesc>
         <revisionDesc>
             <change who="SG" when="2019-04-25">Created catalogue entry</change>
-            
-            
+
+
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">

--- a/LondonBritishLibrary/orient/BLorient735.xml
+++ b/LondonBritishLibrary/orient/BLorient735.xml
@@ -5,7 +5,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <title>Commentary on the  Gospel of Matthew</title>
+                <title>Commentary on the  Gospel of Matthew, theological texts</title>
                 <editor key="SG"/>
                 <editor key="DE"></editor>
                 <editor key="AB" role="generalEditor"/>
@@ -42,7 +42,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                     relation with the text of the commentary is also unclear. So,
                   I prefer to keep the description like that until the digital copy of
                   the manuscript becomes available, or there will be some more work done on the
-                study of the texts whoch accompany such commentaries. I could not find any
+                study of the texts which accompany such commentaries. I could not find any
               relevant information neither in Cowley, nor in EAE -->
                     <msItem xml:id="ms_i1">
                       <locus from="3r"></locus>

--- a/LondonBritishLibrary/orient/BLorient735.xml
+++ b/LondonBritishLibrary/orient/BLorient735.xml
@@ -31,16 +31,19 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         </altIdentifier>
                         <altIdentifier>
                             <idno>Wright 311</idno>
-
                         </altIdentifier>
-
                     </msIdentifier>
                     <msContents>
                         <summary/>
-                        <!-- The first msItems have not been identified. I have also not
-                      created any new textual units for the so far, since their status in the manuscript is
-                    completely unclear. They might turn out to be additions, at least some of them. So,
-                  I prefer to keep the description like that until the digital copy becomes available. -->
+                        <!-- Most of the msItems have not been identified and do not have refs.
+                        I have also not
+                      created any new textual units for them so far, since their status in the manuscript is
+                    completely unclear. They might turn out to be additions, at least some of them. Their
+                    relation with the text of the commentary is also unclear. So,
+                  I prefer to keep the description like that until the digital copy of
+                  the manuscript becomes available, or there will be some more work done on the
+                study of the texts whoch accompany such commentaries. I could not find any
+              relevant information neither in Cowley, nor in EAE -->
                     <msItem xml:id="ms_i1">
                       <locus from="3r"></locus>
                       <title type="incomplete" xml:lang="en">Theological treatise on the
@@ -120,6 +123,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         ወኍልቆሙሰ፡ ፸፪ አውሥአ፡ ወይቤ፡ ምንት፡ ምክንያቱ፡ ለመዝሙረ፡ ዳዊት፡ ቦእምኔሁ፡ ዘያዜክር፡ በበ፪ፊደላት፡ ወቦ፡ በበ፡
                       ፩፩ፊደላት።</incipit>
                       </msItem>
+                      </msItem>
                       <msItem xml:id="ms_i4">
                         <locus from="13v"></locus>
                         <title type="incomplete" ref="LIT5858FastingPrayer" xml:lang="en">Introduction
@@ -127,16 +131,50 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <textLang mainLang="gez"></textLang>
                       </msItem>
                       <msItem xml:id="ms_i5">
+                        <locus from="20v"></locus>
+                        <title type="complete" xml:lang="gez">ሐተታ፡ በእንተ፡ ምንት፡ ኢዘከሮሙ፡ ማቴዎስ፡
+                        ለ፫ ነገሥት።</title>
+                        <textLang mainLang="gez"></textLang>
                       </msItem>
-                    </msItem>
+                      <msItem xml:id="ms_i6">
+                        <locus from="21r"></locus>
+                        <title type="complete" ref="LIT3190Tergwam"></title>
+                        <textLang mainLang="gez"></textLang>
+                      </msItem>
+                      <msItem xml:id="ms_i7">
+                        <locus from="230r"></locus>
+                        <title type="complete" xml:lang="en">Theological treatise</title>
+                        <textLang mainLang="gez"></textLang>
+                        <incipit xml:lang="gez">
+                          ይቤ፡ በዓለ፡ ጸዋትው፡ አእምር፡ እስመ፡ ኵሉ፡ ሥርዓታተ፡ እግዚእነ፡ ክርስቶስ፡ ሎቱ፡ ስብሐት፡
+                          ዘዘከሩ፡ በእንቲአሁ፡ ሐዋርያት። ሶበ፡ ጠየቀ፡ ጥያቄ፡ በልሳን፡ ትረክብ፡ ዘይነግር፡ ኀበ፡ ፮ አክፋል፡
+                          ጥዩቃት፡ ወለእመ፡ ኮኑ፡ እምድኅረ፡ መምህራን፡ ናሁ፡ ከፈልዋ፡ ኀበ፡ ፬ ክፍል። ክፍል፡ ክሂሎታዊ፡
+                          ወክፍል፡ ጠባይዓዊ፡ ወክፍል፡ ሕጋዊ። ክፍል፡ ሥርዓተዊ። ወክፍል፡ ምግብናዊ፡ ክፍል፡ ትምህርታዊ፡
+                          ወክፍል፡ መጽሐፋዊ።
+                        </incipit>
+                      </msItem>
 
+                      <msItem xml:id="ms_i8">
+                        <locus from="233r"></locus>
+                        <title type="complete" xml:lang="en">Theological tract</title>
+                        <textLang mainLang="gez"></textLang>
+                        <incipit xml:lang="gez">ይቤ፡ መተርጕም፡ ወባሕቱ፡ ይደልወነ፡ ከመ፡ ንክሥት፡ ዕበየ፡
+                        ረባሐት፡ እንተ፡ ኮነት፡ ለነ፡ በሞት፡ ዲበ፡ መስቀል፡ ካልእ፡ እምነ፡ ካልኣኒሁ፡ እምፍኖት፡ መዊተ፡ መዊት።</incipit>
+                      </msItem>
+                      <msItem xml:id="ms_i9">
+                        <locus from="235r"></locus>
+                        <title type="incomplete" ref="LIT2050Nagara">Extracts from the Lives
+                        of Egyptian Fathers</title>
+                      </msItem>
+                      <msItem xml:id="ms_i10">
+                        <locus from="241r"></locus>
+                        <title type="complete" xml:lang="en">Short chapters on the Soul</title>
+                        <textLang mainLang="gez"></textLang>
+                        <incipit xml:lang="gez">
+                          ነገር፡ በእንተ፡ ኅድረተ፡ ነፍስ። ነገር፡ በእንተ፡ ስክረተ፡ ነፍስ። ነገር፡ በእንተ፡ ፍልጠተ፡ ነፍስ፡ እምሥጋ።
+                        </incipit>
+                      </msItem>
                     </msContents>
-
-
-
-
-
-
                     <physDesc>
                         <objectDesc form="Codex">
                             <supportDesc>
@@ -145,48 +183,47 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                 </support>
                                 <extent>
                                     <measure unit="leaf">241</measure>
-                                    <dimensions type="outer" unit="mm">
-                                        <height>305</height>
-                                        <width>260</width>
+                                    <dimensions type="outer" unit="in">
+                                        <height>12</height>
+                                        <width>10.25</width>
                                     </dimensions>
                                 </extent>
-
-
                             </supportDesc>
-
                             <layoutDesc>
                                 <layout columns="3" writtenLines="33" cert="high"/>
                             </layoutDesc>
                         </objectDesc>
-
                         <handDesc>
-
                             <handNote script="Ethiopic" xml:id="h1">
                                 <desc>The manuscript is written in a fair hand,  of the <date>18th century</date>.
                                 </desc>
-
                                 <date notBefore="1700" notAfter="1800" resp="PRS10171Wright"/>
-
                             </handNote>
-
                         </handDesc>
                         <additions>
-
+                          <list>
+                            <item xml:id="a1">
+                                    <locus target="#3r"/>
+                                    <desc type="OwnershipNote">The note states that the manuscript belongs to the church of
+                                        <placeName ref="INS0101MadhaneAlam"/>.</desc>
+                                <q xml:lang="gez"><title ref="LIT2616Zenaes">አፈ፡ ወርቅ፡</title> ዘ<placeName ref="INS0101MadhaneAlam">ቅዱስ፡ መድኃኔ፡ ዓለም።</placeName>
+                               </q>
+                                </item>
+                                <item xml:id="e1">
+                                  <locus target="#21r"></locus>
+                                  <desc>The name of the owner has been erased.</desc>
+                                </item>
+                          </list>
                         </additions>
-
                     </physDesc>
-
                     <history>
                         <origin>
-
-                            <origDate/>
+                            <origDate notBefore="1700" notAfter="1800" evidence="lettering"/>
                         </origin>
                         <provenance>Looted by the British <persName ref="PRS7484Napier">Napier</persName>
                             expedition in <date>1868</date> from the church of <placeName ref="INS0101MadhaneAlam">Madḫāne ʿAlam</placeName>
                         </provenance>
-
                     </history>
-
                     <additional>
                         <adminInfo>
                             <recordHist>
@@ -220,15 +257,19 @@ schematypens="http://relaxng.org/ns/structure/1.0"
             <textClass>
                 <keywords>
                     <term key="Commentary"/>
-
+                    <term key="Theology"></term>
+                    <term key="ChristianLiterature"></term>
                 </keywords>
             </textClass>
-            <langUsage><language ident="en">English</language></langUsage>
+            <langUsage>
+              <language ident="en">English</language>
+              <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
         </profileDesc>
         <revisionDesc>
             <change who="SG" when="2019-04-25">Created catalogue entry</change>
-
-
+            <change when="2021-06-22" who="DE">Comleted the prelimiary encoding,
+              refs to be added</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">

--- a/LondonBritishLibrary/orient/BLorient735.xml
+++ b/LondonBritishLibrary/orient/BLorient735.xml
@@ -206,7 +206,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                     <locus target="#3r"/>
                                     <desc type="OwnershipNote">The note states that the manuscript belongs to the church of
                                         <placeName ref="INS0101MadhaneAlam"/>.</desc>
-                                <q xml:lang="gez"><title ref="LIT2616Zenaes">አፈ፡ ወርቅ፡</title> ዘ<placeName ref="INS0101MadhaneAlam">ቅዱስ፡ መድኃኔ፡ ዓለም።</placeName>
+                                <q xml:lang="gez">አፈ፡ ወርቅ፡ ዘ<placeName ref="INS0101MadhaneAlam">ቅዱስ፡ መድኃኔ፡ ዓለም።</placeName>
                                </q>
                                 </item>
                                 <item xml:id="e1">


### PR DESCRIPTION
Most of the msItems have not been identified and do not have refs. I have also not created any new textual units for them so far, since their status in the manuscript is completely unclear. They might turn out to be additions, at least some of them. Their relation with the text of the commentary is also unclear. So, I prefer to keep the description like that until the digital copy of the manuscript becomes available, or there will be some more work done on the study of the texts which accompany such commentaries. I could not find any relevant information neither in Cowley, nor in EAE.

P.S. The same commentary is stored in the XML file