### PR TITLE
Corr repositories mk

### DIFF
--- a/EMML/1001-2000/EMML1194.xml
+++ b/EMML/1001-2000/EMML1194.xml
@@ -299,6 +299,7 @@ have been copied by <persName role="scribe" ref="PRS13646Makwannen">Makʷannen G
          <change who="PL" when="2017-11-30">Created minimal record with link from data sent from Daniel Gullo, HMML
                             project.</change>
         <change who="MKr" when="2021-12-03">Completed description</change>
+        <change who="MKr" when="2021-12-28">Corrected repository</change>
       </revisionDesc>
    </teiHeader>
    <facsimile>

--- a/EMML/1001-2000/EMML1194.xml
+++ b/EMML/1001-2000/EMML1194.xml
@@ -31,8 +31,8 @@ schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://ra
          <sourceDesc>
             <msDesc xml:id="ms">
                <msIdentifier>
-                  <repository ref="INS0004HMML"/>
-                  <collection>Holy Trinity Cathedral, Addis Ababa</collection>
+                  <repository ref="INS0588AHT"/>
+                  <collection>Ethiopian Manuscript Microfilm Library</collection>
                   <idno>MS EMML no. 1194</idno>
                </msIdentifier>
                <msContents>

--- a/EMML/1001-2000/EMML1840.xml
+++ b/EMML/1001-2000/EMML1840.xml
@@ -31,8 +31,8 @@ schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://ra
          <sourceDesc>
             <msDesc xml:id="ms">
                <msIdentifier>
-                  <repository ref="INS0004HMML"/>
-                  <collection>Monastery of Ḥayq Esṭifānos, Ambāssal</collection>
+                  <repository ref="INS0327DHE"/>
+                  <collection>Ethiopian Manuscript Microfilm Library</collection>
                   <idno>MS EMML no. 1840</idno>
                </msIdentifier>
 
@@ -81,7 +81,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://ra
 <msPart xml:id="p1">
 <msIdentifier></msIdentifier>
 <msContents>
-<msItem xml:id="ms_i1">
+<msItem xml:id="p1_i1">
 <locus from="1r" to="2v"/>
 <title type="incomplete" xml:lang="en" ref="LIT1558Matthew">Gospel of Matthew 22, 2-44</title>
 </msItem>
@@ -107,97 +107,97 @@ schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://ra
 <msPart xml:id="p2">
 <msIdentifier></msIdentifier>
 <msContents>
-<msItem xml:id="ms_i2">
+<msItem xml:id="p2_i1">
 <locus from="3r" to="294v"/>
 <title type="complete" xml:lang="en" ref="LIT1493Gadlas">Acts of saints and homilies for the month of Yakkātit called
 <foreign xml:lang="gez">መጽሐፈ፡ የካቲት፡</foreign></title>
 <incipit xml:lang="gez">ገድል፡ ዘቅዱስ፡ አቡ፡ ጳውሊ፡ ቅዳሜሁ፡ ለባሕታዊያን፡ እምድኅረ፡ ኤልያስ፡ ነቢይ፡ ወዮሐንስ፡ መጥምቅ፨</incipit>
 <textLang mainLang="gez"></textLang>
 
-<msItem xml:id="ms_i2.1">
+<msItem xml:id="p2_i1.1">
 <locus from="3r" to="13v"/>
 <title type="complete" xml:lang="en" ref="LIT6233GadlaPawli">Combat of Paul, the first hermit</title>
 <textLang mainLang="gez"></textLang>
 </msItem>
 
-<msItem xml:id="ms_i2.2">
+<msItem xml:id="p2_i1.2">
 <locus from="13v" to="35r"/>
 <title type="complete" xml:lang="en" ref="LIT6237GadlaLanginos">History of St Longinus, the abbot of Dabra Māhǝw</title>
 <textLang mainLang="gez"></textLang>
 </msItem>
 
-<msItem xml:id="ms_i2.3">
+<msItem xml:id="p2_i1.3">
 <locus from="36r" to="46r"/>
 <title type="complete" xml:lang="en" ref="LIT6278StoryOfAbelo">History of the hermit ʾAbbǝlo</title>
 <textLang mainLang="gez"></textLang>
 </msItem>
 
-<msItem xml:id="ms_i2.4">
+<msItem xml:id="p2_i1.4">
 <locus from="46r" to="50v"/>
 <title type="complete" xml:lang="en" ref="LIT4975Dersan">Homily of Gerlos, patriarch of Jerusalem, on
 the carrying and presentation of Our Lord Jesus Christ by Simeon</title>
 <textLang mainLang="gez"></textLang>
 </msItem>
 
-<msItem xml:id="ms_i2.5">
+<msItem xml:id="p2_i1.5">
 <locus from="50v" to="58r"/>
 <title type="complete" xml:lang="en" ref="LIT6292DersanMatewos">Homily by bishop Matthew, the martyr, on
 the carrying and presentation of Our Lord by Simeon</title>
 <textLang mainLang="gez"></textLang>
 </msItem>
 
-<msItem xml:id="ms_i2.6">
+<msItem xml:id="p2_i1.6">
 <locus from="58r" to="148r"/>
 <title type="complete" xml:lang="en" ref="LIT4826GadlaBa">Combat of Barsomā the Syrian, by two of his
 disciples, Sāmuʾel, the priest, and Rudā</title>
 <textLang mainLang="gez"></textLang>
 </msItem>
 
-<msItem xml:id="ms_i2.7">
+<msItem xml:id="p2_i1.7">
 <locus from="149r" to="223r"/>
 <title type="complete" xml:lang="en" ref="LIT1804Lifeof">Combat of Severus,
 patriarch of Antioch, by <persName ref="PRS2209Athanasi">St Athanasius</persName></title>
 <textLang mainLang="gez"></textLang>
 </msItem>
 
-<msItem xml:id="ms_i2.8">
+<msItem xml:id="p2_i1.8">
 <locus from="224r" to="264r"/>
 <title type="complete" xml:lang="en" ref="LIT6264GadlaBabnoda">Combat of Paphnutius, the Egyptian hermit by ʾabbā Bǝlo</title>
 <textLang mainLang="gez"></textLang>
 </msItem>
 
-<msItem xml:id="ms_i2.9">
+<msItem xml:id="p2_i1.9">
 <locus from="224r" to="264r"/>
 <title type="complete" xml:lang="en" ref="LIT6231MartyrdomOfAnthonyQorasawi">Martyrdom of Anthony the Qurayshite</title>
 <textLang mainLang="gez"></textLang>
 </msItem>
 
-<msItem xml:id="ms_i2.10">
+<msItem xml:id="p2_i1.10">
 <locus from="271v" to="294v"/>
 <title type="complete" xml:lang="en" ref="LIT6271EphremJudgement">Four homilies by Ephrem the Syrian on judgement and repentance</title>
 <textLang mainLang="gez"></textLang>
 
 
-<msItem xml:id="ms_i2.10.1">
+<msItem xml:id="p2_i1.10.1">
 <locus from="271v" to="276r"/>
 <title type="complete" xml:lang="en" ref="LIT6271EphremJudgement#Sunday1">Homily for the first Sunday</title>
 <incipit>ድርሳን> ዘደረሰ፡ ቅዱስ፡ ማር፡ ኤፍሬም፡ ሶርያዊ፡ በእንተ፡ ኵነኔ፡ ወንስሐ፨</incipit>
 <textLang mainLang="gez"></textLang>
 </msItem>
 
-<msItem xml:id="ms_i2.10.2">
+<msItem xml:id="p2_i1.10.2">
 <locus from="276r" to="287v"/>
 <title type="complete" xml:lang="en" ref="LIT6271EphremJudgement#Sunday2">Homily for the second Sunday</title>
 <textLang mainLang="gez"></textLang>
 </msItem>
 
-<msItem xml:id="ms_i2.10.3">
+<msItem xml:id="p2_i1.10.3">
 <locus from="287v" to="291r"/>
 <title type="complete" xml:lang="en" ref="LIT6271EphremJudgement#Sunday3">Homily for the third Sunday</title>
 <textLang mainLang="gez"></textLang>
 </msItem>
 
-<msItem xml:id="ms_i2.10.4">
+<msItem xml:id="p2_i1.10.4">
 <locus from="291r" to="294v"/>
 <title type="complete" xml:lang="en" ref="LIT6271EphremJudgement#Sunday4">Homily for the fourth Sunday</title>
 <textLang mainLang="gez"></textLang>
@@ -254,6 +254,7 @@ for ʿaqqābe saʿat <persName ref="PRS8538saraqaB">Śaraqa Bǝrhan</persName>.<
          <change who="PL" when="2017-11-30">Created minimal record with link from data sent from Daniel Gullo, HMML
                             project.</change>
          <change who="MKr" when="2020-12-09">Encoded the contents</change>
+         <change who="MKr" when="2021-12-28">Corrected repository and numbering of msItems</change>
       </revisionDesc>
    </teiHeader>
    <facsimile>

--- a/EMML/1001-2000/EMML1939.xml
+++ b/EMML/1001-2000/EMML1939.xml
@@ -31,8 +31,8 @@ schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://ra
          <sourceDesc>
             <msDesc xml:id="ms">
                <msIdentifier>
-                  <repository ref="INS0004HMML"/>
-                  <collection>Parish Church, Ambāssal</collection>
+                  <repository ref="INS0327DHE"/>
+                  <collection>Ethiopian Manuscript Microfilm Library</collection>
                   <idno>MS EMML no. 1939</idno>
                </msIdentifier>
 
@@ -71,7 +71,7 @@ Holes in the parchment on <locus target="#112 #113 #122 #126 #127 #163 #168"></l
          <source>
             <listBibl type="catalogue">
                <bibl>
-                  <ptr target="bm:EMML5"/>
+                  <ptr target="bm:EMML5"/><citedRange unit="page">429-433</citedRange>
                </bibl>
             </listBibl>
          </source>
@@ -240,7 +240,7 @@ on the death of Aaron</title>
 <msPart xml:id="p2">
 <msIdentifier></msIdentifier>
 <msContents>
-<msItem xml:id="ms_i2">
+<msItem xml:id="p2_i2">
 <locus from="169r" to="174v"/>
 <title xml:lang="en" type="incomplete" ref="LIT1700Judges">Judges 1,21-5,26</title>
 </msItem>
@@ -322,11 +322,15 @@ monastery of <placeName ref="INS0327DHE">Ḥayq ʾƎsṭifānos</placeName>.</de
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <langUsage>
+           <language ident="en">English</language>
+           <language ident="gez">Gǝʿǝz</language>
+         </langUsage>
       </profileDesc>
       <revisionDesc>
          <change who="PL" when="2017-11-30">Created minimal record with link from data sent from Daniel Gullo, HMML
                             project.</change>
+          <change who="MKr" when="2021-17-27">Corrected repository</change>                  
       </revisionDesc>
    </teiHeader>
    <facsimile>

--- a/EMML/2001-3000/EMML2375.xml
+++ b/EMML/2001-3000/EMML2375.xml
@@ -33,8 +33,8 @@ schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://ra
          <sourceDesc>
             <msDesc xml:id="ms">
                <msIdentifier>
-                  <repository ref="INS0004HMML"/>
-                  <collection>Parish Church, Ankober</collection>
+                  <repository ref="INS0608AMI"/>
+                  <collection>Ethiopian Manuscript Microfilm Library</collection>
                   <idno>MS EMML no. 2375</idno>
                </msIdentifier>
                <msContents>
@@ -215,7 +215,7 @@ on death, for the 9th hour of Good Friday</title>
 
 <item xml:id="a2">
 <locus target="#2r #2v 128v"/>
-<desc type="OwnershipNote">Note of ownership by (the church of) <placeName ref="LOC7003AnkobaMikael">ʾAnkobar Mikāʾel</placeName>.</desc>
+<desc type="OwnershipNote">Note of ownership by (the church of) <placeName ref="INS0608AMI">ʾAnkobar Mikāʾel</placeName>.</desc>
 </item>
       </list>
 
@@ -268,6 +268,7 @@ on death, for the 9th hour of Good Friday</title>
                             project.</change>
           <change who="MKr" when="2021-02-08">Completed description</change>
           <change who="MKr" when="2021-11-14">Minor correction in ms_i1.18</change>
+          <change who="MKr" when="2021-12-27">Corrected repository</change>
       </revisionDesc>
    </teiHeader>
    <facsimile>

--- a/EMML/7001-8000/EMML7638.xml
+++ b/EMML/7001-8000/EMML7638.xml
@@ -32,8 +32,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://ra
          <sourceDesc>
             <msDesc xml:id="ms">
                <msIdentifier>
-                  <repository ref="INS0004HMML"/>
-                  <collection>, </collection>
+                  <collection>Ethiopian Manuscript Microfilm Library</collection>
                   <idno>MS EMML no. 7638</idno>
                </msIdentifier>
 
@@ -300,6 +299,7 @@ reconstructible due to the quality of the microfilm.</desc>
          <change who="PL" when="2017-11-30">Created minimal record with link from data sent from Daniel Gullo, HMML
                             project.</change>
           <change who="MKr" when="2021-11-07">Completed description</change>
+          <change who="MKr" when="2021-12-21">Corrected collection</change>
       </revisionDesc>
    </teiHeader>
    <facsimile>

--- a/EMML/8001-9000/EMML8897.xml
+++ b/EMML/8001-9000/EMML8897.xml
@@ -32,8 +32,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://ra
          <sourceDesc>
             <msDesc xml:id="ms">
                <msIdentifier>
-                  <repository ref="INS0004HMML"/>
-                  <collection>Māḫdara Māryām</collection>
+                  <collection>Ethiopian Manuscript Microfilm Library</collection>
                   <idno>MS EMML no. 8897</idno>
                </msIdentifier>
                <msContents>
@@ -290,6 +289,7 @@ betrothed to Joseph and how she went to the house of Zeccariah and his wife Eliz
          <change who="PL" when="2017-11-30">Created minimal record with link from data sent from Daniel Gullo, HMML
                             project.</change>
           <change who="MKr" when="2021-07-21">Completed description</change>
+          <change who="MKr" when="2021-12-21">Corrected collection</change>
       </revisionDesc>
    </teiHeader>
    <facsimile>

--- a/EMML/8001-9000/EMML8897.xml
+++ b/EMML/8001-9000/EMML8897.xml
@@ -32,6 +32,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://ra
          <sourceDesc>
             <msDesc xml:id="ms">
                <msIdentifier>
+                 <repository ref="LOC4432Mahdar"/>
                   <collection>Ethiopian Manuscript Microfilm Library</collection>
                   <idno>MS EMML no. 8897</idno>
                </msIdentifier>

--- a/EMML/8001-9000/EMML8913.xml
+++ b/EMML/8001-9000/EMML8913.xml
@@ -31,8 +31,8 @@ schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://ra
          <sourceDesc>
             <msDesc xml:id="ms">
                <msIdentifier>
-                  <repository ref="INS0004HMML"/>
-                  <collection>, </collection>
+                  <repository ref="INS0970Atkana"/>
+                  <collection>Ethiopian Manuscript Microfilm Library</collection>
                   <idno>MS EMML no. 8913</idno>
                </msIdentifier>
 
@@ -244,7 +244,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://ra
       <revisionDesc>
          <change who="PL" when="2017-11-30">Created minimal record with link from data sent from Daniel Gullo, HMML
                             project.</change>
-          <change who="MKr" when="2021-12-15">Completed description.</change>                  
+          <change who="MKr" when="2021-12-15">Completed description, based on the information provided by Ted Erho
+      in the vHMML catalog.</change>
+      <change when="2021-12-27" who="MKr">Corrected repository</change>               
       </revisionDesc>
    </teiHeader>
    <facsimile>


### PR DESCRIPTION
These are all EMML mss. I've done. In two cases (EMML 7638 and EMML 8897) I have deleted the line with {repository} because I cannot find it (the former) or there is no institution record (the latter).