### PR TITLE
Update BerOrOct555.xml

### DIFF
--- a/Berlin/BerOrOct555.xml
+++ b/Berlin/BerOrOct555.xml
@@ -33,7 +33,73 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
 
                   <idno facs="https://content.staatsbibliothek-berlin.de/dc/863181112/manifest">SBP, Ms. orient. oct. 555</idno>
                </msIdentifier>
-
+              <msContents><summary>I. Vita des Abbā Gabra Manfas Qeddus, f. 6a-94b;
+                II. Bericht und Wunder des seligen und heiligen Abuna Gabra Manfas Qeddus, f. 94a-118a; III. Magische Gebete  f. 119</summary></msContents>
+              <physDesc>
+                
+                <objectDesc form="Codex">
+                  <supportDesc>
+                    <support>
+                      <material key="parchment"/>
+                    </support>
+                    <extent>
+                      <measure unit="leaf">120</measure>
+                      <dimensions type="outer" unit="mm">
+                        <height>150</height>
+                        <width>130</width>
+                        <depth>70</depth>
+                      </dimensions>
+                    </extent>
+                    
+                    <foliation>
+                      <locus from="1r" to="120r"/>
+                      Foliation in pencil in the upper right corner.
+                    </foliation>
+                  </supportDesc>
+                  
+                  
+                </objectDesc>
+                
+                
+                
+                
+                <additions>
+                  <list>
+                    <item xml:id="a1">
+                      <locus target="#2v"/>
+                      <desc type="Invocation">Short invocation.</desc>
+                      <q xml:lang="gez">
+                      </q>
+                    </item>
+                    
+                    <item xml:id="a2">
+                      <locus target="#118rb"/>
+                      <desc type="OwnershipNote">The beginning of the note was erased, no names inserted.</desc>
+                      <q xml:lang="gez">
+                      </q>
+                    </item>
+                  </list>
+                </additions>
+                
+                <bindingDesc>
+                  <binding xml:id="binding">
+                    <decoNote xml:id="b1">Ethiopian. Two wooden boards covered with reddish
+                      brown blind-tooled leather. Blind-tooled mitred turn-ins, textile inlays.
+                    </decoNote>
+                    <decoNote xml:id="b2" type="bindingMaterial">
+                      <material key="wood"/>
+                      <material key="leather"/>
+                      <material key="textile"/>
+                    </decoNote>
+                    <decoNote xml:id="b3" type="SewingStations">4</decoNote>
+                    <decoNote xml:id= "b4" type="Endbands">Head and tail bands in dark brown leather.</decoNote>
+                    <decoNote xml:id="b5" type="Other">
+                      <term key="leafStringMark"></term> inserted in the upper corner of <locus target="#6 #16 #20 #35 #53 #65 #78 #82 #86 #94"/>
+                    </decoNote>
+                  </binding>
+                </bindingDesc>
+                
+              </physDesc>
                <additional>
                   <adminInfo>
                   <recordHist>
@@ -83,7 +149,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                           <material key="parchment"/>
                        </support>
                      <extent>
-                       <measure unit="leaf">120</measure>
+                       <measure unit="leaf">118</measure>
                         <dimensions type="outer" unit="mm">
                            <height>150</height>
                            <width>130</width>
@@ -91,10 +157,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </dimensions>
                       </extent>
 
-                      <foliation>
-                         <locus from="1r" to="120r"/>
-                               Foliation in pencil in the upper right corner.
-                        </foliation>
+                      
                       </supportDesc>
 
                       <layoutDesc>
@@ -111,46 +174,60 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <desc>Careful, well trained hand.</desc>
                          </handNote>
                        </handDesc>
-
-                       <additions>
-                          <list>
-                             <item xml:id="a1">
-                                <locus target="#2v"/>
-                                <desc type="Invocation">Short invocation.</desc>
-                                <q xml:lang="gez">
-                                </q>
-                             </item>
-
-                             <item xml:id="a2">
-                                <locus target="#118rb"/>
-                                <desc type="OwnershipNote">The beginning of the note was erased, no names inserted.</desc>
-                                <q xml:lang="gez">
-                                </q>
-                             </item>
-                           </list>
-                        </additions>
-
-                       <bindingDesc>
-                         <binding xml:id="binding">
-                           <decoNote xml:id="b1">Ethiopian. Two wooden boards covered with reddish
-                             brown blind-tooled leather. Blind-tooled mitred turn-ins, textile inlays.
-                             </decoNote>
-                            <decoNote xml:id="b2" type="bindingMaterial">
-                            <material key="wood"/>
-                            <material key="leather"/>
-                            <material key="textile"/>
-                            </decoNote>
-                            <decoNote xml:id="b3" type="SewingStations">4</decoNote>
-                            <decoNote xml:id= "b4" type="Endbands">Head and tail bands in dark brown leather.</decoNote>
-                            <decoNote xml:id="b5" type="Other">
-                              <term key="leafStringMark"></term> inserted in the upper corner of <locus target="#6 #16 #20 #35 #53 #65 #78 #82 #86 #94"/>
-                              </decoNote>
-                          </binding>
-                        </bindingDesc>
-
+                 <decoDesc>
+                   <summary>18 Kunstvoll ausgeführte Miniaturen auf Bl.4r, 4v, 5r, 5v, 6r, 14v, 15r, 48v, 49r, 58v, 59r, 92v, 93r, 105r, 105v, 
+                     106r, 107r, 107v und 108r. &#xD;
+                     Hinsichtlich der Miniaturen fällt auf, daß sie in keinem Zusammenhang zum Inhalt der Handschrift stehen. 
+                     Es hat den Anschein, daß sie aus einer anderen Handschrift stammen. 
+                     Möglicherweise hat der Besitzer der Handschrift den Auftrag gegeben, sie dieser Handschrift hinzuzubinden, 
+                     denn die Mehrzahl der Miniaturen wurde nicht in die Blattlagen eingefügt, sondern mit je zwei Zusatzstreifen — 
+                     jeweils einer in der Mitte des Knickes und am Rücken des Doppelblattes — in die Handschrift eingebunden.  
+                     Miniaturen sind älter als die Handschrift (15. Jh.)                        
+                   </summary>
+                   
+                   <decoNote type="miniature" xml:id="d1">
+                     <desc>4r: Zwei Apostel</desc>
+                   </decoNote>
+                   <decoNote type="miniature" xml:id="d2">
+                     <desc>4v: Zwei Apostel</desc></decoNote>
+                   <decoNote type="miniature" xml:id="d3">
+                     <desc>5r: Zwei Apostel</desc> </decoNote>
+                   <decoNote type="miniature" xml:id="d4">
+                     <desc>                        5v: Zwei Apostel
+                     </desc>                     </decoNote>
+                   <decoNote type="miniature" xml:id="d5">
+                     <desc>14v: Gott Vater im Oval</desc>  </decoNote>
+                   <decoNote type="miniature" xml:id="d6">
+                     <desc>15r: Abraham, Isaak und Jakob umarmend</desc></decoNote>
+                   <decoNote type="miniature" xml:id="d7">
+                     <desc>48v: der hl. Georg</desc>  </decoNote>
+                   <decoNote type="miniature" xml:id="d8">
+                     <desc>49r: Maria und das Kind</desc></decoNote>
+                   <decoNote type="miniature" xml:id="d9">
+                     <desc>58v: Zwei Apostel (Petrus und Paulus)</desc></decoNote>
+                   <decoNote type="miniature" xml:id="d10">
+                     <desc>59r: Stephanos und Johannes der Täufer;</desc></decoNote>
+                   <decoNote type="miniature" xml:id="d11">
+                     <desc>92v: Matthäus der Evangelist;</desc></decoNote>
+                   <decoNote type="miniature" xml:id="d12">
+                     <desc>93r: Markus der Evangelist</desc></decoNote>
+                   <decoNote type="miniature" xml:id="d13">
+                     <desc>105r: Reiterheiliger mit Lanze</desc>
+                   </decoNote>
+                   <decoNote type="miniature" xml:id="d14">
+                     <desc>105v: Lukas der Evangelist sitzend und schreibend</desc></decoNote>
+                   <decoNote type="miniature" xml:id="d15">
+                     <desc>106r: Johannes der Evangelist sitzend und schreibend</desc></decoNote>
+                   <decoNote type="miniature" xml:id="d16">
+                     <desc>107r: Marqoryos, der heilige Reiter mit Lanze</desc> </decoNote>
+                   <decoNote type="miniature" xml:id="d17">
+                     <desc>107v: Reiterheiliger (Tuschekope eines Schülers)</desc></decoNote>
+                   <decoNote type="miniature" xml:id="d18">
+                     <desc>108r: Reiterheiliger mit Lanze</desc></decoNote>
+                 </decoDesc>
                 </physDesc>
                 </msPart>
-
+<!-- I would describe the elements below as additions (guest texts, on protective leaves) not as msPart - ES -->
                 <msPart xml:id="p2">
                   <msIdentifier/>
 
@@ -205,6 +282,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
       </profileDesc>
       <revisionDesc>
          <change who="SD" when="2021-07-12">Created entry</change>
+        <change when="2022-02-12" who="ES">imported decoDesc from the online description; moved physDesc; added comment</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">


### PR DESCRIPTION
Dear Sophia,
I have been comparing the online SBB descriptions with what we have; I noted that this MS lacked the list of decorations present in the online description so I took it over (in German as it was, it has to be adjusted/translated).
I have also noticed some encoding problems:
1) the binding and general aspects of physical description always belong to the entire MS, not to a specific production unit, so I created the physDesc for the manuscript
2) it is recommended to always have the msContent element, also for composite MSS, at top level, with a `<summary>` element, the `<summary/>` may be left empty, then it will be populated automatically
3) what you describe as a second codicological unit is rather a guest text on a protective leaf which we usually describe as an addition (and Gumbert would describe as part of binding); it is not a codicological unit I believe
I have not changed the msPart, please check the MS and eventually update the description further.
Thank you very much!
Zhenia