### PR TITLE
fixing folio and column numeration in EMML4398

### DIFF
--- a/EMML/4001-5000/EMML4398/transkribus.xml
+++ b/EMML/4001-5000/EMML4398/transkribus.xml
@@ -2,7 +2,7 @@
 <div xmlns="http://www.tei-c.org/ns/1.0" type="edition" xml:id="Transkribus" subtype="transkribus">
             <div type="textpart" subtype="folio" n="67">
                <ab>
-              <pb facs="#facs_1" n="67r"/>
+               	<pb facs="#facs_1" n="67r"/><!--image n.1  folio n.67r-->
                   <cb facs="#facs_1_r1" n="a"/>
                   <lb facs='#facs_1_line_1606814137692_40' n='1'/><hi rend="rubric"><gap reason="illegible"/>ስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩፡</hi>
                   <lb facs='#facs_1_line_1606814082856_18' n='2'/>አምላክ<hi rend="rubric">፨</hi> ዘወርኀ፡ ግንቦት፡ ዮም፡ ቀዳማዊ፡
@@ -61,7 +61,10 @@
                   <lb facs="#facs_1_r2l27" n="26"/>አመ፡ ኃጥእ፡ ንዋዮ፡ እግዚአብሔር፡ ወ<gap reason="illegible"/>፡ ወ 
                   <lb facs="#facs_1_r2l28" n="27"/>እግዚአብሔር፡ ነሥኦ፡ ግዱፈ፡ ላዕለ፡ አ<gap reason="illegible"/>
                   <lb facs="#facs_1_r2l29" n="28"/>ወተወሰከ፡ በዘኮነ፡ ላዕሌሁ፡ ገስጾተ፡ ፍ<gap reason="illegible"/>
-			<pb facs="#facs_2" n="67v"/>
+               	
+               	
+               	
+               	<pb facs="#facs_2" n="67v"/><!--image n.2  folio n.67v-68r-->
                   <cb facs="#facs_2_r3" n="a"/>
 				              <lb facs="#facs_2_r3l1" n="1"/>ኒሁ፡ ዘ<hi rend="rubric">፫</hi>ወብእሲቱ<sic resp="DR">፡ </sic>ኒ፡ ከማሁ፡ ለሊሃ፡ አበከረቶ፡ 
                   <lb facs="#facs_2_r3l2" n="2"/>ሎቱ፡ በአብሰ፡ ወኢ<sic resp="DR">፡ </sic>ቲሰጥዋ፡ ወመማከረ፡ በከ
@@ -199,7 +202,8 @@
 				<lb facs="#facs_2_r1l57" n="30"/>አዕረፈ፡ ኤርምያስ፡ ነቢይ፡ <hi rend="rubric">፩</hi>እምነቢያት፡ ወ
 				<lb facs="#facs_2_line_1600444057135_197" n="31"/><hi rend="rubric">ልደ፡ ሕልቅያን፡ ዝንቱ፡ ካህን፡ ውእቱ፡ ወ</hi>
 				<lb facs="#facs_2_line_1600444140156_211" n="32"/>ተነበየ፡ ዘዮሴዕ፡ ወልደ፡ አሞን፡ ንጉሠ፡ ይሁዳ፡
-			<pb facs="#facs_3" n="68v"/>
+		
+               	<pb facs="#facs_3" n="68v"/> <!--image n.3  folio n. 68v-69r-->
                   <cb facs="#facs_3_TextRegion_1601570045617_353" n="a"/>
 				              <lb facs="#facs_3_line_1601570045731_356" n="1"/>ወኢዮአቄም፡ ወልዱ፡ ወጸዶቃያ፡ በዝንቱ፡
 				              <lb facs="#facs_3_r3l2" n="2"/>ንጹሕ፡ ነበበ፡ እግዚአብሔር፡ በውስተ፡
@@ -337,7 +341,8 @@
                   <lb facs="#facs_3_r1l32" n="30"/>ክራተ፡ ዓቢየ፡ ወኮነ፡ አመ፡ <gap reason="illegible"/>ገብረ፡ <gap reason="illegible"/>ብረ፡
                   <lb facs="#facs_3_r1l33" n="31"/>ወኢያአመሩ፡ ሰብእ፡  ባቲ፡ <gap reason="illegible"/>ከመ፡ ይ<gap reason="illegible"/>ል
 				<lb facs="#facs_3_line_1601571103157_816" n="32"/>ቍ፡ ፈድፋደ፡ ወለእመ፡ ሰምዐ፡ ብእሲ፡ 
-			<pb facs="#facs_4" n="69v"/>
+			
+               	<pb facs="#facs_4" n="69v"/> <!--image n.4  folio n. 69v-70r-->
                   <cb facs="#facs_4_r4" n="a"/>
 				              <lb facs="#facs_4_r4l1" n="1"/>ገብረ፡ ትሩፈ፡ ኢይነውም፡ አው፡ ኢገይብ
 				<lb facs="#facs_4_r4l2" n="2"/>ራ፡ ወሶበ፡ ፈጸመ፡ ሑረቶሙ፡ ውስተ፡ ርስእ
@@ -406,7 +411,7 @@
 				<lb facs="#facs_4_r3l32" n="32"/>ረከብዎ፡ በጽሑ፡ ኀበ፡ ዓቢይ፡ እንጦንዮ
 			</ab>
             </div>
-            <div type="textpart" subtype="folio" n="70"><!--image n.4  folio n.4-->
+            <div type="textpart" subtype="folio" n="70">
                <ab>
                   <pb facs="#facs_4" n="70r"/>
                   <cb facs="#facs_4_r2" n="a"/>
@@ -475,7 +480,8 @@
 				<lb facs="#facs_4_r1l28" n="30"/>ኀበ፡ ትከውን፡ ርእስ፡ ይጸሉ፡ ከመ፡ ት<gap reason="illegible"/>
                   <lb facs="#facs_4_r1l29" n="31"/>መለያልይ፡ ወበከመ፡ አዳም፡ ዘትኪት፡ <gap reason="illegible"/>
                   <lb facs="#facs_4_r1l30" n="32"/>ወ፡ ኀበ፡ ርስታት፡ ምድር፡ ወነበረ፡ ኀበ<gap reason="illegible"/>
-			<pb facs="#facs_5" n="70v"/>
+               	
+               	<pb facs="#facs_5" n="70v"/><!--image n.5  folio n. 70v-71r-->
                   <cb facs="#facs_5_r4" n="a"/>
 				              <lb facs="#facs_5_r4l1" n="1"/>ል፡ ከማሁ፡ ዳግማይ፡ አዳም፡ ዴገነ፡ ኀበ፡ ር
 				<lb facs="#facs_5_r4l2" n="2"/>ስታተ፡ መለኮት፡ ሰማያዊት፡ ወለነቢር፡ እ
@@ -545,7 +551,7 @@
 				<lb facs="#facs_5_r3l32" n="32"/>ንፈሰ፡ ትንቢት፡ ወከሠተ፡ እግዚኣብ
 			</ab>
             </div>
-            <div type="textpart" subtype="folio" n="71"><!--image n.5  folio n.5-->
+            <div type="textpart" subtype="folio" n="71">
                <ab>
                   <pb facs="#facs_5" n="71r"/>
                   <cb facs="#facs_5_r2" n="a"/>
@@ -616,7 +622,7 @@
 				<lb facs="#facs_5_r1l32" n="30"/>ረት፡ በሐውርተ፡ ብዙኀ፡ ወግብራት፡ በእ
 				<lb facs="#facs_5_r1l33" n="31"/>ንተ፡ ቤተ፡ ክርስቲያነ፡ ወመካናት፡ ወለእ
 				<lb facs="#facs_5_r1l34" n="32"/>ምኔታት፡ በእንተ፡ መፍቅዶሙ፡ ወዓራዞ
-			<pb facs="#facs_6" n="71v"/>
+               	<pb facs="#facs_6" n="71v"/><!--image n.6  folio n. 71v-72r-->
                   <cb facs="#facs_6_r3" n="a"/>
                   <lb facs="#facs_6_r3l1" n="1"/>ሙ፡ ለነዳያን፡ ወበጽሐት፡ እስከ፡ <hi rend="rubric">፹</hi>ዓመ 
 				<lb facs="#facs_6_r3l2" n="2"/>ት፡ ወእምዝ፡ አዕረፈት፡ በሰላም፡ ጸሎታ፡ 
@@ -685,7 +691,7 @@
 				<lb facs="#facs_6_r2l32" n="32"/>ሆሙ፡ ወርእዮ፡ ሀገረ፡ በድው፡ ወአልቦ፡
 			</ab>
             </div>
-            <div type="textpart" subtype="folio" n="72"><!--image n.6  folio n.6-->
+            <div type="textpart" subtype="folio" n="72">
                <ab>
                   <pb facs="#facs_6" n="72r"/>
                   <cb facs="#facs_6_TextRegion_1601652788467_1396" n="a"/>
@@ -755,7 +761,9 @@
 				<lb facs="#facs_6_r1l61" n="31"/>ርዮስ፡ ወተጋዳለ፡ በነፍሱ፡ ውስተ፡ ፍድ
 				<lb facs="#facs_6_line_1601652788592_1400" n="32"/>ድና፡ ዓቢይ፡ ወኮነ፡ ይስልዕ፡ ዘልፈ፡ ወኢይበ
 				<lb facs="#facs_6_r1l64" n="33"/>ሬ
-			<pb facs="#facs_7" n="6v"/>
+			            	
+               	              	
+               	<pb facs="#facs_7" n="72v"/> <!--image n.7  folio n. 72v-73r-->
                   <cb facs="#facs_7_r4" n="a"/>
 				              <lb facs="#facs_7_r4l1" n="1"/>ልዕ፡ ብሱለ፡ እሙ፡ ሐመልማላተ፡ ይበ
 				<lb facs="#facs_7_r4l2" n="2"/>ስ፡ ወተምህረ፡ መጻሕፍተ፡ ውስተ፡ ገዳም፡ 
@@ -824,9 +832,9 @@
 				<lb facs="#facs_7_r3l34" n="32"/>ሐርሞ፡ ብዙኀ፡ ወገዱል፡ ዓቢይ። ወ 
 			</ab>
             </div>
-            <div type="textpart" subtype="folio" n="7"><!--image n.7  folio n.7-->
+            <div type="textpart" subtype="folio" n="73">
                <ab>
-                  <pb facs="#facs_7" n="7r"/>
+                  <pb facs="#facs_7" n="73r"/>
                   <cb facs="#facs_7_r2" n="a"/>
 				              <lb facs="#facs_7_r2l1" n="1"/>ር፡ ብእሲ፡ ተቀነዱ፡ መቁሕ፡ ሶርያ
 				<lb facs="#facs_7_r2l2" n="2"/>ስሙ፡ አይስሳኖስ፡ ይኔጽ፡ መንፈ
@@ -893,7 +901,8 @@
 				<lb facs="#facs_7_r1l32" n="30"/>ነወ፡ እምድኅረ፡ ስእለቅ፡ ብዙኀ፡ ይ
 				<lb facs="#facs_7_r1l33" n="31"/>ትኀ፡ አለእከመ፡ እግዚእብሔር፡ ወ
 				<lb facs="#facs_7_r1l34" n="32"/>ግብ፡ ለመ፡ ወስ፡ ቀዝ፡ ዛቱ፡ መ 
-			<pb facs="#facs_8" n="7v"/>
+               	
+               	<pb facs="#facs_8" n="73v"/><!--image n.8  folio n. 73v-->
                   <cb facs="#facs_8_r1" n="a"/>
 				              <lb facs="#facs_8_r1l1" n="1"/>ብዙጎ፡ ወኢሕይወት፡ እስከ፡ ሖረት፡
 				<lb facs="#facs_8_r1l2" n="2"/>ኀበ፡ ሥጋሁ፡ ለቅዱስ፡ ወአስተብቍዓ
@@ -927,12 +936,8 @@
 				<lb facs="#facs_8_r1l29" n="30"/>ትወኮፍ፡ ፩ እምተሊዎቱ፡ ወእምዝ። 
 				<lb facs="#facs_8_r1l30" n="31"/>እስመ፡ ቀናሎስ፡ ጊዜ፡ ዕለተ፡ አስተርእ
 				<lb facs="#facs_8_r1l31" n="32"/>ዮተ፡ ዝንቱ፡ መስቀል፡ ሠርዐ፡ ዘንተ፡ ፀ
-			</ab>
-            </div>
-            <div type="textpart" subtype="folio" n="8"><!--image n.8  folio n.8-->
-               <ab>
-                  <pb facs="#facs_8" n="8r"/>
-                  <cb facs="#facs_8_r2" n="a"/>
+			
+                  <cb facs="#facs_8_r2" n="b"/>
 				              <lb facs="#facs_8_r2l1" n="1"/>ዓለ፡ ውስተ፡ ኢየሩሳሌም፡ መገጸ፡  
 				<lb facs="#facs_8_r2l2" n="2"/>ወነሥእዎን፡ እምኔሁ፡ ትሩፍተ፨ ወ
 				<lb facs="#facs_8_r2l3" n="3"/>እ፡ ዓለም። ወይደሉ፡ ከመ፡ ያብ
@@ -964,85 +969,88 @@
 				<lb facs="#facs_8_r2l27" n="29"/>ኀበ፡ ቅዱስ፡ ወአብጸሐ፡ ውሉፈ፡ በገ 
 				<lb facs="#facs_8_r2l28" n="30"/>ኦሙ፡ ወመገሮሙ፡ በከመ፡ ይደሎ
 				<lb facs="#facs_8_r2l29" n="31"/>ሁ፡ አምሰሎሙ፡ ወመጽአ፡ ተገጽ
-				<lb facs="#facs_8_r2l30" n="32"/>ስተ፡ ትምህርት፡ እስከ፡ አመ
-			<pb facs="#facs_9" n="8v"/>
-                  <cb facs="#facs_9_r1" n="a"/>
+				<lb facs="#facs_8_r2l30" n="32"/>ስተ፡ ትምህርት፡ እስከ፡ አመ               	
+               </ab>
+	</div>
+	
+	<div type="textpart" subtype="folio" n="74"><!--image n.9  folio n.74r-->
+		<ab>
+               	<pb facs="#facs_9" n="74r"/><!--image n.9  folio n.74r-->
+               	<cb facs="#facs_9_r1" n="a"/>
 				              <lb facs="#facs_9_line_1601901895435_55" n="1"/>፡ በእመተርምተአባረፈ፡ ተ 
 				<lb facs="#facs_9_r1l3" n="2"/>ወነግሠ፡ ወልደ፡ ወልደ፡ አንሬ
 				<lb facs="#facs_9_r1l4" n="3"/>ላዕለ፡ ሮሜ፡ ወአርገድዮስ፡ ላዕለቍ
 				<lb facs="#facs_9_r1l5" n="4"/>ዋንያ፡ ወገባረ፡ እግዚሰብሔር፡ ው
-				<lb facs="#facs_9_r1l6" n="5"/>ቶሰ፡ ዝንቱ፡ ቅዱስ፡ ትምህርት፡ እ
-				<lb facs="#facs_9_r1l7" n="6"/>ተ፡ ዝብጠተ፡ ወያከ፡ ለወፂ
-				<lb facs="#facs_9_r1l8" n="7"/>በለዓለ፡ ከመ፡ ይክነ፡ ማሕቶተ፡ 
-				<lb facs="#facs_9_r1l9" n="8"/>ርሁ፡ ቦቱ፡ ለእሉ፡ ዘይአቅድ፡ ሥ
-				<lb facs="#facs_9_r1l10" n="9"/>ፍሱ፡ ወእነዘ፡ ይሔሊ፡ ምንተ፡ ይገካ
-				<lb facs="#facs_9_r1l11" n="10"/>አዲ፡ ቃል፡ ዝንቱ፡ በጽሐ፡ እምኃበ፡ እ
-				<lb facs="#facs_9_r1l12" n="11"/> ይብሔር፡ ዘይብል፡ አርሰኒ፡ አርሰኒ፡ ሣእ፡ 
-				<lb facs="#facs_9_r1l13" n="12"/>ንቱ፡ ዓለም፡ ወለሊከ፡ ትድኅን፡ ወኢ
-				<lb facs="#facs_9_r1l14" n="13"/>ዊየ፡ እምድኅረ፡ ሰምዐ፡ ቃል፡ ዳእሙ፡ ወ
-				<lb facs="#facs_9_r1l15" n="14"/>ርአልባሲሁ፡ ወበጸሐ፡ ኀበ፡ ሃገረ፡ እለ፡ 
-				<lb facs="#facs_9_r1l16" n="15"/>ክንድርያ፡ ወካዕበ፡ እምኔሃ፡ ኀበ፡ ዘገዳ
-				<lb facs="#facs_9_r1l17" n="16"/>፡ቅዱዘ፡ መቃርዮስ፡ ወአመንደበ፡ ነፍሶ፡
-				<lb facs="#facs_9_r1l18" n="17"/>ም፡ ወበስራሕ፡ ዓቢይ፡ ወአጥረዮ፡ ምስ
-				<lb facs="#facs_9_r1l19" n="18"/>ወቡራኒሁ፡ ፍድፍድና፡ ዘአርምሞ፡ ወሎ
-				<lb facs="#facs_9_r1l20" n="19"/> ናገረ፡ አሐተ፡ ዕለተ፡ ይብል፡ ብዙኀ፡ ተ
-				<lb facs="#facs_9_r1l21" n="20"/>ርኩ፡ ወተፀስኩ፡ ወኢ፡ እቴከዝ፡ ዲበ፡ 
-				<lb facs="#facs_9_r1l22" n="21"/>ምሞትየ፡ ዕለተ፡ ግሙራ፡ ወኮነ፡ የዋሀ፡ 
-				<lb facs="#facs_9_r1l23" n="22"/>ቡእ፡ ወከሡት፡ ወኮነ፡ ያወቅር፡ ለማ
-				<lb facs="#facs_9_r1l24" n="23"/>ዚ፡ እደዊሁ፡ ወይበኪ፡ ወይመጸውት፡ በዘ
-				<lb facs="#facs_9_r1l25" n="24"/>ተ፡ ስምኔሁ፨ ወአስቀፃበረ፡ ለኵ
-				<lb facs="#facs_9_r1l26" n="25"/>ይ፡ መይኃኒተ፡ ነፍሱ፡ ትምህር
-				<lb facs="#facs_9_r1l27" n="26"/>ምዑ፡ ወኮነ፡ ሶበ፡ ገብአ፡ ኀበ፡ ቤ
-				<lb facs="#facs_9_r1l28" n="27"/>ዛቲያን፡ ይጼላል፡ በአዕማድ፡ ከመ፡ 
-				<lb facs="#facs_9_r1l29" n="28"/>። ወገብረ፡ ዝንቱ፡ ቅዱስ፡ ተ
-				<lb facs="#facs_9_r1l30" n="29"/>ዐቢየ፡ ወከሠተ፡ ሎቱ፡ እግዚአ
-				<lb facs="#facs_9_r1l31" n="30"/>ድሎ፡ ለሰብእ፡ ብዙኀ፡ ጊዜ፡ ወከ
-				<lb facs="#facs_9_r1l32" n="31"/>አባሁ፡ ሠናየ፡ ወትሩየ፡ ወፍሱሕ፡ ገጹ፡
-				<lb facs="#facs_9_r1l33" n="32"/>ቤ፡ ኵሎሙ፡ ትብጽሕ፡ ኀበ፡ ከርሠ፡ 
-			</ab>
-            </div>
-            <div type="textpart" subtype="folio" n="9"><!--image n.9  folio n.9-->
-               <ab>
-                  <pb facs="#facs_9" n="9r"/>
-                  <cb facs="#facs_9_r2" n="a"/>
+               	<lb facs="#facs_9_r1l6" n="5"/>ቶሰ፡ ዝንቱ፡ ቅዱስ፡ ትምህርት፡ እ
+               	<lb facs="#facs_9_r1l7" n="6"/>ተ፡ ዝብጠተ፡ ወያከ፡ ለወፂ
+               	<lb facs="#facs_9_r1l8" n="7"/>በለዓለ፡ ከመ፡ ይክነ፡ ማሕቶተ፡ 
+               	<lb facs="#facs_9_r1l9" n="8"/>ርሁ፡ ቦቱ፡ ለእሉ፡ ዘይአቅድ፡ ሥ
+               	<lb facs="#facs_9_r1l10" n="9"/>ፍሱ፡ ወእነዘ፡ ይሔሊ፡ ምንተ፡ ይገካ
+               	<lb facs="#facs_9_r1l11" n="10"/>አዲ፡ ቃል፡ ዝንቱ፡ በጽሐ፡ እምኃበ፡ እ
+               	<lb facs="#facs_9_r1l12" n="11"/> ይብሔር፡ ዘይብል፡ አርሰኒ፡ አርሰኒ፡ ሣእ፡ 
+               	<lb facs="#facs_9_r1l13" n="12"/>ንቱ፡ ዓለም፡ ወለሊከ፡ ትድኅን፡ ወኢ
+               	<lb facs="#facs_9_r1l14" n="13"/>ዊየ፡ እምድኅረ፡ ሰምዐ፡ ቃል፡ ዳእሙ፡ ወ
+               	<lb facs="#facs_9_r1l15" n="14"/>ርአልባሲሁ፡ ወበጸሐ፡ ኀበ፡ ሃገረ፡ እለ፡ 
+               	<lb facs="#facs_9_r1l16" n="15"/>ክንድርያ፡ ወካዕበ፡ እምኔሃ፡ ኀበ፡ ዘገዳ
+               	<lb facs="#facs_9_r1l17" n="16"/>፡ቅዱዘ፡ መቃርዮስ፡ ወአመንደበ፡ ነፍሶ፡
+               	<lb facs="#facs_9_r1l18" n="17"/>ም፡ ወበስራሕ፡ ዓቢይ፡ ወአጥረዮ፡ ምስ
+               	<lb facs="#facs_9_r1l19" n="18"/>ወቡራኒሁ፡ ፍድፍድና፡ ዘአርምሞ፡ ወሎ
+               	<lb facs="#facs_9_r1l20" n="19"/> ናገረ፡ አሐተ፡ ዕለተ፡ ይብል፡ ብዙኀ፡ ተ
+               	<lb facs="#facs_9_r1l21" n="20"/>ርኩ፡ ወተፀስኩ፡ ወኢ፡ እቴከዝ፡ ዲበ፡ 
+               	<lb facs="#facs_9_r1l22" n="21"/>ምሞትየ፡ ዕለተ፡ ግሙራ፡ ወኮነ፡ የዋሀ፡ 
+               	<lb facs="#facs_9_r1l23" n="22"/>ቡእ፡ ወከሡት፡ ወኮነ፡ ያወቅር፡ ለማ
+               	<lb facs="#facs_9_r1l24" n="23"/>ዚ፡ እደዊሁ፡ ወይበኪ፡ ወይመጸውት፡ በዘ
+               	<lb facs="#facs_9_r1l25" n="24"/>ተ፡ ስምኔሁ፨ ወአስቀፃበረ፡ ለኵ
+               	<lb facs="#facs_9_r1l26" n="25"/>ይ፡ መይኃኒተ፡ ነፍሱ፡ ትምህር
+               	<lb facs="#facs_9_r1l27" n="26"/>ምዑ፡ ወኮነ፡ ሶበ፡ ገብአ፡ ኀበ፡ ቤ
+               	<lb facs="#facs_9_r1l28" n="27"/>ዛቲያን፡ ይጼላል፡ በአዕማድ፡ ከመ፡ 
+               	<lb facs="#facs_9_r1l29" n="28"/>። ወገብረ፡ ዝንቱ፡ ቅዱስ፡ ተ
+               	<lb facs="#facs_9_r1l30" n="29"/>ዐቢየ፡ ወከሠተ፡ ሎቱ፡ እግዚአ
+               	<lb facs="#facs_9_r1l31" n="30"/>ድሎ፡ ለሰብእ፡ ብዙኀ፡ ጊዜ፡ ወከ
+               	<lb facs="#facs_9_r1l32" n="31"/>አባሁ፡ ሠናየ፡ ወትሩየ፡ ወፍሱሕ፡ ገጹ፡
+               	<lb facs="#facs_9_r1l33" n="32"/>ቤ፡ ኵሎሙ፡ ትብጽሕ፡ ኀበ፡ ከርሠ፡ 
+			
+                  <cb facs="#facs_9_r2" n="b"/>
 				              <lb facs="#facs_9_r2l1" n="1"/>ወእምነ፡ ብካዩ፡ ወአናመሞ፡ ተገድኅት፡ ም
-				<lb facs="#facs_9_r2l2" n="2"/>ገሱ፡ ዘኮነ፡ ነባሕ፡ አላ፡ ውእቱ፡ ዓላፈ፡ እ  
-				<lb facs="#facs_9_r2l3" n="3"/>ነ፡ ርስእና፡ ወበጽሐ፡ አመነ፡ ዓታቲሁ፡ አም 
-				<lb facs="#facs_9_r2l4" n="4"/>፩፡ ዓመታተ፡ ወእምኔሁ፡ በውስተ፡ ሮሜ፡ 
-				<lb facs="#facs_9_r2l5" n="5"/>ዓዓመታተ፡ ወበውስተ፡ አስቶአበ፡ ለቅዱ
-				<lb facs="#facs_9_r2l6" n="6"/>ስ፡ መቃርዮስ፡ ፴ዓመተ፡ ወ፩ዓመተ፡ ውስ
-				<lb facs="#facs_9_r2l7" n="7"/>ተ፡ ድብረ፡ ግብዕጽ፡ ወ፫ዓመተ፡ ውስተ፡ መ
-				<lb facs="#facs_9_r2l8" n="8"/>ስሁሁ፡ በእምአድርያ፡ ወካዕበ፡ ተሐ
-				<lb facs="#facs_9_r2l9" n="9"/>ይጠ፡ ኀሖ፡ ምስር፡ ወነበረ፡ ውስቴቱ፡ የ
-				<lb facs="#facs_9_r2l10" n="10"/>መተዎ፡ ወአዕረፈ፡ በህየ፡ ጸሎቱ፡ ወበረከ፡ 
-				<lb facs="#facs_9_r2l11" n="11"/>ሁ፡ ስኀሉ፡ ለስለ፡ በ መስ፡ 
-				<lb facs="#facs_9_r2l12" n="12"/>አመ፡ ጐወ፬፡ ለወርኀ፡ ግንበት፡ በዛቲ፡ 
-				<lb facs="#facs_9_r2l13" n="13"/>ለት፡ አዕረፈ፡ አብ፡ አጕሚስ፡ አበ፡ ደጊገተ፡
-				<lb facs="#facs_9_r2l14" n="14"/>መንፈሳዊ፡ ዝንቱ፡ ቅዱስ፡ መንኰሰ፡ እን
-				<lb facs="#facs_9_r2l15" n="15"/>እሱ፡ ኀሰ፡ አብ፡ በለሞን፡ ወአንበረ፡ ላዕለ፡ 
-				<lb facs="#facs_9_r2l16" n="16"/>ቀስጥዎቱ፡ ብዙኃ፡ ዓመታተ፡ ወአጥረየ፡ 
-				<lb facs="#facs_9_r2l17" n="17"/>መዋዕለ፡ ምንኵስና፡ ሠናየ፡ ወእምድኅረ፡ 
-				<lb facs="#facs_9_r2l18" n="18"/>ውእቱ፡ አስተርአዮ፡ መልአከ፡ እግዚአዝሐ
-				<lb facs="#facs_9_r2l19" n="19"/>ር፡ ወአዘዘ፡ ከመ፡ ያስተገብእ፡ መነኮላት፨ 
-				<lb facs="#facs_9_r2l20" n="20"/>ወያቅም፡ ድርገተ፡ ዘሓዊርያት፡ ወኮእተ፡ ን
-				<lb facs="#facs_9_r2l21" n="21"/>ብእ፡ ጉባኤ፡ ብዙኀ፡ ዐረገየ፡ ሎሙ፡ ብዙ
-				<lb facs="#facs_9_r2l22" n="22"/>ኀ፡ ምነታተ፡ ወሠርዖሙ፡ ለኵሎሙ፡ ፩ድ
-				<lb facs="#facs_9_r2l23" n="23"/>ደገቲ፡ ውስተ፡ ግብረ፡ እቶሙ፡ ተወነበተ፡ 
-				<lb facs="#facs_9_r2l24" n="24"/>መብልዖሙ፡ ወሠርዐ፡ ላሙ፡ ቀኖናት፡ ዘይ
-				<lb facs="#facs_9_r2l25" n="25"/>ግብር ዋ፡ ውስተ፡ ጸሎቶሙ፡ ወመብልኦ።  
-				<lb facs="#facs_9_r2l26" n="26"/>ወኮነ፡ አብ፡ ላዕለኵሉ፡ ወረሰሎ፡ ለኵሉ፡ 
-				<lb facs="#facs_9_r2l27" n="27"/>ድብር፡ ሊቀ፡ ወኮነ፡ ውእቱ፡ ያንከሱ፡ ከመ፡ የ
-				<lb facs="#facs_9_r2l28" n="28"/>ኅውጾመ፡ ሰኩሎሙ፡ እምኒ፡ ኢትጼ፡ ዝገ
-				<lb facs="#facs_9_r2l29" n="29"/>ረ፡ አሳዋን፡ ወአንኅ፡ ወአከሚን፡ ወዳናስ፡ 
-				<lb facs="#facs_9_r2l30" n="30"/>ቦቦ፡ ካልእ፡ ጽዔጽ፡ እምተአግሖተ፡ በሕራ
-				<lb facs="#facs_9_r2l31" n="31"/>ዊያን፡ ወአ፡ ኮነ፡ የሕድብ፡ ፩አመጽቴተ፡ 
-				<lb facs="#facs_9_r2l32" n="32"/>ን፡ ካህነ፡ በእንተ፡ ውኅሴ፡ ከንቱ፡ ወእሳከ፡ 
-				<lb facs="#facs_9_r2l33" n="33"/>ም፡በወወ፡ 
-			<pb facs="#facs_10" n="9v"/>
+               	<lb facs="#facs_9_r2l2" n="2"/>ገሱ፡ ዘኮነ፡ ነባሕ፡ አላ፡ ውእቱ፡ ዓላፈ፡ እ  
+               	<lb facs="#facs_9_r2l3" n="3"/>ነ፡ ርስእና፡ ወበጽሐ፡ አመነ፡ ዓታቲሁ፡ አም 
+               	<lb facs="#facs_9_r2l4" n="4"/>፩፡ ዓመታተ፡ ወእምኔሁ፡ በውስተ፡ ሮሜ፡ 
+               	<lb facs="#facs_9_r2l5" n="5"/>ዓዓመታተ፡ ወበውስተ፡ አስቶአበ፡ ለቅዱ
+               	<lb facs="#facs_9_r2l6" n="6"/>ስ፡ መቃርዮስ፡ ፴ዓመተ፡ ወ፩ዓመተ፡ ውስ
+               	<lb facs="#facs_9_r2l7" n="7"/>ተ፡ ድብረ፡ ግብዕጽ፡ ወ፫ዓመተ፡ ውስተ፡ መ
+               	<lb facs="#facs_9_r2l8" n="8"/>ስሁሁ፡ በእምአድርያ፡ ወካዕበ፡ ተሐ
+               	<lb facs="#facs_9_r2l9" n="9"/>ይጠ፡ ኀሖ፡ ምስር፡ ወነበረ፡ ውስቴቱ፡ የ
+               	<lb facs="#facs_9_r2l10" n="10"/>መተዎ፡ ወአዕረፈ፡ በህየ፡ ጸሎቱ፡ ወበረከ፡ 
+               	<lb facs="#facs_9_r2l11" n="11"/>ሁ፡ ስኀሉ፡ ለስለ፡ በ መስ፡ 
+               	<lb facs="#facs_9_r2l12" n="12"/>አመ፡ ጐወ፬፡ ለወርኀ፡ ግንበት፡ በዛቲ፡ 
+               	<lb facs="#facs_9_r2l13" n="13"/>ለት፡ አዕረፈ፡ አብ፡ አጕሚስ፡ አበ፡ ደጊገተ፡
+               	<lb facs="#facs_9_r2l14" n="14"/>መንፈሳዊ፡ ዝንቱ፡ ቅዱስ፡ መንኰሰ፡ እን
+               	<lb facs="#facs_9_r2l15" n="15"/>እሱ፡ ኀሰ፡ አብ፡ በለሞን፡ ወአንበረ፡ ላዕለ፡ 
+               	<lb facs="#facs_9_r2l16" n="16"/>ቀስጥዎቱ፡ ብዙኃ፡ ዓመታተ፡ ወአጥረየ፡ 
+               	<lb facs="#facs_9_r2l17" n="17"/>መዋዕለ፡ ምንኵስና፡ ሠናየ፡ ወእምድኅረ፡ 
+               	<lb facs="#facs_9_r2l18" n="18"/>ውእቱ፡ አስተርአዮ፡ መልአከ፡ እግዚአዝሐ
+               	<lb facs="#facs_9_r2l19" n="19"/>ር፡ ወአዘዘ፡ ከመ፡ ያስተገብእ፡ መነኮላት፨ 
+               	<lb facs="#facs_9_r2l20" n="20"/>ወያቅም፡ ድርገተ፡ ዘሓዊርያት፡ ወኮእተ፡ ን
+               	<lb facs="#facs_9_r2l21" n="21"/>ብእ፡ ጉባኤ፡ ብዙኀ፡ ዐረገየ፡ ሎሙ፡ ብዙ
+               	<lb facs="#facs_9_r2l22" n="22"/>ኀ፡ ምነታተ፡ ወሠርዖሙ፡ ለኵሎሙ፡ ፩ድ
+               	<lb facs="#facs_9_r2l23" n="23"/>ደገቲ፡ ውስተ፡ ግብረ፡ እቶሙ፡ ተወነበተ፡ 
+               	<lb facs="#facs_9_r2l24" n="24"/>መብልዖሙ፡ ወሠርዐ፡ ላሙ፡ ቀኖናት፡ ዘይ
+               	<lb facs="#facs_9_r2l25" n="25"/>ግብር ዋ፡ ውስተ፡ ጸሎቶሙ፡ ወመብልኦ።  
+               	<lb facs="#facs_9_r2l26" n="26"/>ወኮነ፡ አብ፡ ላዕለኵሉ፡ ወረሰሎ፡ ለኵሉ፡ 
+               	<lb facs="#facs_9_r2l27" n="27"/>ድብር፡ ሊቀ፡ ወኮነ፡ ውእቱ፡ ያንከሱ፡ ከመ፡ የ
+               	<lb facs="#facs_9_r2l28" n="28"/>ኅውጾመ፡ ሰኩሎሙ፡ እምኒ፡ ኢትጼ፡ ዝገ
+               	<lb facs="#facs_9_r2l29" n="29"/>ረ፡ አሳዋን፡ ወአንኅ፡ ወአከሚን፡ ወዳናስ፡ 
+               	<lb facs="#facs_9_r2l30" n="30"/>ቦቦ፡ ካልእ፡ ጽዔጽ፡ እምተአግሖተ፡ በሕራ
+               	<lb facs="#facs_9_r2l31" n="31"/>ዊያን፡ ወአ፡ ኮነ፡ የሕድብ፡ ፩አመጽቴተ፡ 
+               	<lb facs="#facs_9_r2l32" n="32"/>ን፡ ካህነ፡ በእንተ፡ ውኅሴ፡ ከንቱ፡ ወእሳከ፡ 
+               	<lb facs="#facs_9_r2l33" n="33"/>ም፡በወወ፡ 
+               	
+               	
+               	<pb facs="#facs_10" n="74v"/><!--image n.10  folio n.74v-->
                   <cb facs="#facs_10_r1" n="a"/>
-				              <lb facs="#facs_10_r1l1" n="1"/>ለለተ፡ መይኒ፡ ዳእሙ፡ ኮነ፡ እምቀሲሰ፡ ዓ
-				<lb facs="#facs_10_r1l2" n="2"/>እም፡ ያቄድስ፡ ውስተ፡ ኵሉ፡ ዓለም፡ ወአ
-				<lb facs="#facs_10_r1l3" n="3"/>ብር፡ ወሶበ፡ ባርስ፡ ቅዱስ፡ አተክለዮስግ
+               	<lb facs="#facs_10_r1l1" n="1"/>ለለተ፡ መይኒ፡ ዳእሙ፡ ኮነ፡ እምቀሲሰ፡ ዓ
+               	<lb facs="#facs_10_r1l2" n="2"/>እም፡ ያቄድስ፡ ውስተ፡ ኵሉ፡ ዓለም፡ ወአ
+               	<lb facs="#facs_10_r1l3" n="3"/>ብር፡ ወሶበ፡ ባርስ፡ ቅዱስ፡ አተክለዮስግ
 				<lb facs="#facs_10_r1l4" n="4"/>በ፡ ዘስነድ፡ ፈነወ፡ ይሢም፡ ዘንተ፡ ኀበ፡ ቀ
 				<lb facs="#facs_10_r1l5" n="5"/>ዮስ፡ ወጐየ፡ እምኔሁ። ወይቤ፡ ለደቂቁ፡ 
 				<lb facs="#facs_10_r1l6" n="6"/>በልዎ፡ ለአቡክሙ፡ ኵሎ፡ ዘኃነጸ፡ በቶ፡
@@ -1072,12 +1080,8 @@
 				<lb facs="#facs_10_r1l32" n="30"/>ሴንና፡ ለብእሲቱ፡ ወናሁ፡ ወገራ፡ ውስተ፡ 
 				<lb facs="#facs_10_r1l33" n="31"/>ን፡ ወፈጸመት፡ ስምዓ። ወእምድሕረ፡ 
 				<lb facs="#facs_10_r1l34" n="32"/>ምቱ፡ ኮነ፡ እዮነ፡ ከመ፡ በረድ፡ ሐፊር፡ ወን
-			</ab>
-            </div>
-            <div type="textpart" subtype="folio" n="10"><!--image n.10  folio n.10-->
-               <ab>
-                  <pb facs="#facs_10" n="10r"/>
-                  <cb facs="#facs_10_r2" n="a"/>
+			
+                  <cb facs="#facs_10_r2" n="b"/>
 				              <lb facs="#facs_10_r2l1" n="1"/>፨ወቀርበ፡ ኀበ 
 				<lb facs="#facs_10_r2l2" n="2"/>ንን፡ ወአምቀ፡ በክርስቶስ፡ ወኰነና፡
 				<lb facs="#facs_10_line_1601902151135_203" n="3"/>ወኮነ፡ መዋዕላሁ፡ እመሕት፡ አመን 
@@ -1110,7 +1114,11 @@
 				<lb facs="#facs_10_r2l31" n="30"/>ሌሁ፡ ቤተ፡ ክርስቲያን፡ አላብ፡ 
 				<lb facs="#facs_10_r2l32" n="31"/>ርስቶ፡ ለርስስስምተ፡ 
 				<lb facs="#facs_10_r2l33" n="32"/>አመ፡ ጐወር፡ ለግዓበት፡ በዛቲ፡ ዕለት፡ 
-			<pb facs="#facs_11" n="10v"/>
+               </ab>
+	</div>
+	<div type="textpart" subtype="folio" n="75"><!--image n.11  folio n.75r-->
+		<ab>
+               	<pb facs="#facs_11" n="75r"/> <!--image n.11  folio n.75r-->
                   <cb facs="#facs_11_r1" n="a"/>
 				              <lb facs="#facs_11_r1l1" n="1"/>ተ፡ ቀናኤ፡ ወበእቱ፡ ዘይሰመ፡ 
 				<lb facs="#facs_11_r1l2" n="2"/>ታንተ፡ ኮነ፡ እምነታና፡ ዘገለለ፡ 
@@ -1144,12 +1152,8 @@
 				<lb facs="#facs_11_r1l29" n="30"/>፡ መድኅን፡ ወተለዖ፡ ወኮነ፡ እምኆል
 				<lb facs="#facs_11_r1l30" n="31"/>ወተ፡ መሶበ፡ ተወፈየ፡ ጸጋ፡ ዕዛዝ፡ ወተ
 				<lb facs="#facs_11_r1l31" n="32"/>ወብስናተ፡ ሰብአ፡ ኵሉ፡ በለም፡ ወመ
-			</ab>
-            </div>
-            <div type="textpart" subtype="folio" n="11"><!--image n.11  folio n.11-->
-               <ab>
-                  <pb facs="#facs_11" n="11r"/>
-                  <cb facs="#facs_11_r2" n="a"/>
+			
+                  <cb facs="#facs_11_r2" n="b"/>
 				              <lb facs="#facs_11_r2l1" n="1"/>ረ፡ በምሥጠፈተ፡ እምሰክዊ፡ ዘአውዘተመ 
 				<lb facs="#facs_11_r2l2" n="2"/>እስለ፡ ጽልመቶሙ፡ ለአረሳዊያን፡ ወአብር፡ 
 				<lb facs="#facs_11_r2l3" n="3"/>ኀበ፡ ዕባ፡ ዘወፅአ፡ ሎቱ፨ ወግጠብዙኃነ፡ እ
@@ -1181,8 +1185,9 @@
 				<lb facs="#facs_11_r2l28" n="29"/>ንጌለ፡ በትእዘዘ፡ ወበክተ፡አነ፡ እግዚአብሔ
 				<lb facs="#facs_11_r2l29" n="30"/>ር፡ እስከ፡ ነመ፡ አብረ፡ ዘአደጕተ፡ ወንብሰዊ፡
 				<lb facs="#facs_11_r2l30" n="31"/>ያን፡ ለምሰንባት፡ በቀስሙ፡ ወዕሌሁ፡ በተ
-			<pb facs="#facs_12" n="11v"/>
-                  <cb facs="#facs_12_r1" n="a"/>
+               	
+               	<pb facs="#facs_12" n="75v"/><!--image n.12  folio n.75v-->
+               	<cb facs="#facs_12_r1" n="a"/>  
 				              <lb facs="#facs_12_r1l1" n="1"/>ጻማዊ፡ ወልድ፡ ወተሠግዎቱ፡ ወብዝሐ፡ መንክ
 				<lb facs="#facs_12_r1l2" n="2"/>ራቲሁ፡ ዘኢይትዓለቍ፡ በከመ፡ ይዜክር፡ በው
 				<lb facs="#facs_12_r1l3" n="3"/>ስተ፡ ወንጌሉ። ወእምዝ፡ ዐርገ፡ መንፈስ፡ ውስ
@@ -1216,12 +1221,8 @@
 				<lb facs="#facs_12_r1l31" n="31"/>መ፡ ውእቱ። ወሶበ፡ ነጸረ፡ ቅዱስ፡ አቤፋንዮስ፡ 
 				<lb facs="#facs_12_r1l32" n="32"/>ዝንተ፡ መንክራተ፡ ፪ይቤሎሙ፡ ቅዱስ፡ ፊሎ
 				<lb facs="#facs_12_r1l33" n="33"/>ንዮከ፡ መኑ፡ ውእቱ፡ ኢየሱስ፡ ዘስቁል፡ በስም
-			</ab>
-            </div>
-            <div type="textpart" subtype="folio" n="12"><!--image n.12  folio n.12-->
-               <ab>
-                  <pb facs="#facs_12" n="12r"/>
-                  <cb facs="#facs_12_r2" n="a"/>
+			
+                  <cb facs="#facs_12_r2" n="b"/>
 				              <lb facs="#facs_12_r2l1" n="1"/>ይትገበር፡ ዝንቱ፡ መንክረ፡ በ፡ በ
 				<lb facs="#facs_12_r2l2" n="2"/>አ፡ ውእቱ፡ እንዘ፡ ይብል፡ ወለዘአብበ
 				<lb facs="#facs_12_r2l3" n="3"/>ሔር፡ ዘስቀልዎ፡ አይሁድ፡ ለቤተተ፡ ስ፡  
@@ -1255,7 +1256,12 @@
 				<lb facs="#facs_12_r2l31" n="31"/>ስ፡ ቆጶስ፡ ዲበ፡ ቄጸርዜ፡ ወተንሥእ፡ 
 				<lb facs="#facs_12_r2l32" n="32"/>አ፡ በኆሥያጥ፡ ወረከቦ፡ ለአቤተ፡ ን
 				<lb facs="#facs_12_r2l33" n="33"/>ለ፪መነኮሳት፡ ወበእደዊሆሙ፡ እለ 
-			<pb facs="#facs_13" n="12v"/>
+               	
+               </ab>
+            </div>
+	<div type="textpart" subtype="folio" n="76"><!--image n.13  folio n.76r-->
+		<ab>
+               	<pb facs="#facs_13" n="76r"/><!--image n.13  folio n.76r-->
                   <cb facs="#facs_13_r1" n="a"/>
 				              <lb facs="#facs_13_r1l1" n="1"/>ዊ፡ በእንተ፡ ከሙ፨ ወአውሥአ፡ 
 				<lb facs="#facs_13_r1l2" n="2"/>ብቤሎ፡ ግደፍ፡ እዴከ፡ ዘንተ፡ ፪አ
@@ -1290,12 +1296,8 @@
 				<lb facs="#facs_13_r1l31" n="31"/>አ፡ ቅዱስ፡ ወጸለየ፡ ወነገሮሙ፡ ለአርዳአ
 				<lb facs="#facs_13_r1l32" n="32"/>ከመ፡ ውእቶሙ፡ ኤጲስ፡ ቆጶሳት፨ ወእም
 				<lb facs="#facs_13_r1l33" n="33"/>መ፡ ወአዕረፈ።፨ እግዚእ፡ ይምሐ
-			</ab>
-            </div>
-            <div type="textpart" subtype="folio" n="13"><!--image n.13  folio n.13-->
-               <ab>
-                  <pb facs="#facs_13" n="13r"/>
-                  <cb facs="#facs_13_r2" n="a"/>
+			
+                  <cb facs="#facs_13_r2" n="b"/>
 				              <lb facs="#facs_13_r2l1" n="1"/>አመ፡ ፲ወ፰፡ ለግንቦት፡ በዛቲ፡ ዕለተ፡ አዕፈ
 				<lb facs="#facs_13_r2l2" n="2"/>ፈ፡ ቅዱስ፡ ገርጋሀ፡ ቢጹ፡ ለአባ፡ አብርሃም፡ ዝ
 				<lb facs="#facs_13_r2l3" n="3"/>ቱ፡ ቅዱስ፡ ኮነ፡ ክርስቲያናዊ፡ ወእምአበብ
@@ -1330,7 +1332,9 @@
 				<lb facs="#facs_13_r2l32" n="32"/>ም፡ ማእክላዊት፡ ወነበረ፡ ፪ዕለተ፡ ይገይበ፡  
 				<lb facs="#facs_13_r2l33" n="33"/>ወ፡ መ፡ በወ፡ መኮነ፡ ዘቅሩብ፡ እምዘ 
 				<lb facs="#facs_13_r2l34" n="34"/>ሁ፡ ውእቱ፡ መባን፡ ወወር፡ ወዕተተ፡ እበ፡ ተ
-			<pb facs="#facs_14" n="13v"/>
+               	
+               	
+               	<pb facs="#facs_14" n="76v"/> <!--image n.14  folio n.76v-77r left-->
                   <cb facs="#facs_14_r4" n="a"/>
 				              <lb facs="#facs_14_r4l1" n="1"/>ዮሙ፡ በውስተ፡ በበት፡ ዘእምርት፡ በዘ፡ ይእኅ
 				<lb facs="#facs_14_r4l2" n="2"/>ዘ።፡ወይእተ፡ ጊዜ፡ ወረደ፡ ኀቤሁ፡ እግዚእነ፡ ኢየ
@@ -1404,9 +1408,9 @@
 				<lb facs="#facs_14_r3l35" n="34"/>ምየ፡ ወዋዕሌሁ፡ አየባያሮስ፡ በለ
 			</ab>
             </div>
-            <div type="textpart" subtype="folio" n="14"><!--image n.14  folio n.14-->
+	<div type="textpart" subtype="folio" n="77"><!--image n.14  folio n.76v-77r right-->
                <ab>
-                  <pb facs="#facs_14" n="14r"/>
+                  <pb facs="#facs_14" n="77r"/>
                   <cb facs="#facs_14_r2" n="a"/>
 				              <lb facs="#facs_14_r2l1" n="1"/>ምርዋ፡ ወያጸንዕዎ፡ ወያበ 
 				<lb facs="#facs_14_r2l2" n="2"/>ተ፨ ወካዕበ፡ረገሙ፡ ንጉሥ፡ 
@@ -1475,7 +1479,8 @@
 				<lb facs="#facs_14_r1l37" n="31"/>ዕለተ፡ አላ፡ እስአ፡ ትእንሑ፡ ዕረፍተ፡ የዋሂት፡ ወ
 				<lb facs="#facs_14_r1l38" n="32"/>ወሶበ፡ ኮነ፡ የዕለተ፡ ሰዐተ፡ ሊላተ፡ ተእንዘተ፡ ፈ
 				<lb facs="#facs_14_r1l39" n="33"/>ጸንተ፡ ዕዑበ፡ ወሰገደት፡ ሰገደ፡ ቅድመ፡ እግዚ
-			<pb facs="#facs_15" n="14v"/>
+               	
+               	<pb facs="#facs_15" n="77v"/><!--image n.15  folio n.77v-78r left-->
                   <cb facs="#facs_15_r4" n="a"/>
 				              <lb facs="#facs_15_r4l1" n="1"/>ነ፡ ወባቲ፡ መጠወት፡ ነፍሳ፡ ወገነዝዋ፡ በሠናይ፡ 
 				<lb facs="#facs_15_r4l2" n="2"/>ወቀበርዋ፡ ወወጠነ፡ አባ፡ አምናዘ፡ ይንግሮሙ፡ 
@@ -1546,9 +1551,9 @@
 				<lb facs="#facs_15_r3l34" n="33"/>በዳማት፡ ወአሀጉራት፡ እስከ፡ አመ፡ አ
 			</ab>
             </div>
-            <div type="textpart" subtype="folio" n="15"><!--image n.15  folio n.15-->
+            <div type="textpart" subtype="folio" n="78"><!--image n.15  folio n.77v-78r right-->
                <ab>
-                  <pb facs="#facs_15" n="15r"/>
+                  <pb facs="#facs_15" n="78r"/>
                   <cb facs="#facs_15_r2" n="a"/>
 				              <lb facs="#facs_15_r2l1" n="1"/>ህር፡ ወውእቱ፡ ኢየግሀድ፡ በውስተ፡ 
 				<lb facs="#facs_15_r2l2" n="2"/>፡ ሞቅሐ፡ ነፍሶ፨ ወሶበ፡ አእመረ፡ 
@@ -1617,7 +1622,10 @@
 				<lb facs="#facs_15_r1l31" n="31"/>ር፡ አስተርአዮ፡ ለየሴሩ፡ በውስተ፡ ለል 
 				<lb facs="#facs_15_r1l32" n="32"/>ወይቤሎ፡ ተንሥእ፡ ወንሣእ፡ ሕብ፡ ወ 
 				<lb facs="#facs_15_r1l33" n="33"/>ወተይይ፡ ኀበ፡ ምድረ፡ ግብጽ፡ ወኮነ፡ በ  
-			<pb facs="#facs_16" n="15v"/>
+               	
+               	
+               	<pb facs="#facs_16" n="78v"/><!--image n.16  folio n.78v-79r-->
+               	
                   <cb facs="#facs_16_r1" n="a"/>
 				              <lb facs="#facs_16_r1l1" n="1"/>እግዚአብሔር፡ ይናዝዘ፡ ወይልጽእ፡ ወያ
 				<lb facs="#facs_16_r1l2" n="2"/>ጽእ፡ ኀቤሁ፡ ኵሎ፡ ጊዜ። ወገብረ፡ እግዚአብ
@@ -1690,9 +1698,9 @@
 				<lb facs="#facs_16_r2l34" n="34"/>ዎ፡ በዘዘ፡ ዚአሁ፡ ኵነኔያት፡ ወመልአከ፡ 
 			</ab>
             </div>
-            <div type="textpart" subtype="folio" n="16"><!--image n.16  folio n.16-->
+            <div type="textpart" subtype="folio" n="79r"><!--image n.16  folio n.78v-79r-->
                <ab>
-                  <pb facs="#facs_16" n="16r"/>
+               	<pb facs="#facs_16" n="79r"/>
                   <cb facs="#facs_16_r3" n="a"/>
 				              <lb facs="#facs_16_r3l1" n="1"/>ት፡ በውስተ፡ ግብጻዊያን፡ ዓስበመ 
 				<lb facs="#facs_16_r3l2" n="2"/>ተ፡ ለክሙ፡ ቅዱስ፡ ጸሎቱ፡ ይግ
@@ -1761,7 +1769,10 @@
 				<lb facs="#facs_16_r4l40" n="31"/>ወለየምከመ፡ የበዕሉ፡ በዓለ፡ መነፈሳዊ። 
 				<lb facs="#facs_16_r4l41" n="32"/>ወንበገር፡ ውስቴተ፡ ዘይብል፡ ነቢይ፡ ገብረ፡ 
 				<lb facs="#facs_16_r4l42" n="33"/>እእግዚአብሔር፡ መንክራተ፡ ዐበይተ፡ በግብ
-			<pb facs="#facs_17" n="16v"/>
+			
+               	
+               	
+               	<pb facs="#facs_17" n="79v"/><!-- image 17, fol. 79v -->
                   <cb facs="#facs_17_TextRegion_1601906655501_1268" n="a"/>
 				              <lb facs="#facs_17_r1l1" n="1"/> በእንተ፡ ብእሲተ፡ ወለቅዱስ፡ ቆማስ፡ እግዚእ፡ አ
 				<lb facs="#facs_17_r1l3" n="2"/>ቅረረ፡ ቀሥፈታቲሁ፡ ወሐይወሥጋሁ፨ ወይቤ
@@ -1797,12 +1808,9 @@
 				<lb facs="#facs_17_r1l62" n="32"/>ብእሲቱ፡ ወኢክሀሉ፡ ከመ፡ ይቅትሉ፡ ማእስለ፡ 
 				<lb facs="#facs_17_r1l64" n="33"/>ጉቡአን፡ ወአውፅኦ፡ አፍአ። ወአዘዘ፡ ፩እም
 				<lb facs="#facs_17_line_1601906655563_1271" n="34"/>ሐራ፡ ከመ፡ ይርግዝዎ፡ በነኰያንው፡ ወኮነ፡ 
-			</ab>
-            </div>
-            <div type="textpart" subtype="folio" n="17"><!--image n.17  folio n.17-->
-               <ab>
-                  <pb facs="#facs_17" n="17r"/>
-                  <cb facs="#facs_17_TextRegion_1601906655501_1267" n="a"/>
+
+                  
+                  <cb facs="#facs_17_TextRegion_1601906655501_1267" n="b"/>
 				              <lb facs="#facs_17_line_1601906731621_1331" n="1"/>ወልደ፡ ንጉሥ፡ ቀዊመ፡ ይይእ፡    
 				<lb facs="#facs_17_r1l4" n="2"/>በ፡ ይረግዝዎ፡ ወፅአ፡ መንፈ
 				<lb facs="#facs_17_r1l6" n="3"/>ሩ፡ ሰብአ፡ ሀገር፡ ወፅኡ፡ ከሙየ
@@ -1837,7 +1845,9 @@
 				<lb facs="#facs_17_r1l63" n="32"/>በ፪ከዊን፡ በውስተ፡ ሃይማናት፡ ይፈክር፡
 				<lb facs="#facs_17_r1l65" n="33"/>ውስቴተ፡ እስመ፡ ክርስቶስ፡ አምላክ
 				<lb facs="#facs_17_line_1601906655563_1270" n="34"/>ድኅረ፡ ፩ክዊን፡ በወበይዕሂ፡ ዋኅዙ፡ መ
-			<pb facs="#facs_18" n="17v"/>
+			
+               	
+               	<pb facs="#facs_18" n="17v"/>
                   <cb facs="#facs_18_r1" n="a"/>
 				              <lb facs="#facs_18_r1l1" n="1"/>ልወት፡ በከመ፡ ሃይማናት፡ 
 				<lb facs="#facs_18_r1l2" n="2"/>ወአብ፡ ክርክቆሮስ፡ ወተወከ
@@ -1873,9 +1883,9 @@
 				<lb facs="#facs_18_r1l33" n="32"/>ዘሪም፡ ፡ ምርም፡ 
 			</ab>
             </div>
-            <div type="textpart" subtype="folio" n="18"><!--image n.18  folio n.18-->
+	<div type="textpart" subtype="folio" n="80"><!-- image 18 fol. 80r -->
                <ab>
-                  <pb facs="#facs_18" n="18r"/>
+                  <pb facs="#facs_18" n="80r"/>
                   <cb facs="#facs_18_r2" n="a"/>
 				              <lb facs="#facs_18_r2l1" n="1"/>አበ፡ ጽባእለ፡ ወገበቱ፡ በበተ፡ ምስ፡ እተ፡ 
 				<lb facs="#facs_18_r2l2" n="2"/>ሐ፡ሥጋሁ፡ ኮነ፡ ለቅዱስ፡ ወእርተ፡ ተ፡ 
@@ -1896,7 +1906,8 @@
 				<lb facs="#facs_18_r2l17" n="17"/>ዎ፡ ውስተ፡ ነነጽ፡ ዝኅር፨ ወካዕበ፡ ቀለርሮ፡ ወበተ
 				<lb facs="#facs_18_r2l18" n="18"/>ቤተ፡ ክርስቲያን፡ ወአስተርአየ፡ እምኔሁ፡ ትእም
 				<lb facs="#facs_18_r2l19" n="19"/>ራት፡ ዐበይት፡ በከመ፡ ኮነ፡ ይገብር፡ እምቅድመ፡ አ
-				<lb facs="#facs_18_r2l20" n="20"/>ፍቱ፨ ጸሎቱ፡ ይዕቀበ፡ 
+               	<lb facs="#facs_18_r2l20" n="20"/>ፍቱ፨ ጸሎቱ፡ ይዕቀበ፡ <!-- 80r 2nd column -->
+               	<cb n="b"/>
 				<lb facs="#facs_18_r2l21" n="21"/>አመ፡ ፳ወሀ፡ ለግንበት፡ በዛቲ፡ ዕለት፡ አዕረፈ፡ 
 				<lb facs="#facs_18_r2l22" n="22"/>አብ፡ ቅዱስ፡ ስሞያን፡ ዘአምደብረ፡ አንጾኪየ፡ ወከ
 				<lb facs="#facs_18_r2l23" n="23"/>ነ፡ ከመ፡ አቡሁ፡ ዮሐንስ፡ ወከመ፡ እሙ፡ ማርታ፡ ወ
@@ -1910,13 +1921,10 @@
 				<lb facs="#facs_18_r2l31" n="31"/>ተጸምጾ፡ ወአስተርአይዎ፡ መላእክት፡ በውስተ፡ 
 				<lb facs="#facs_18_r2l32" n="32"/>ምእምለያልይ፡ ብዙኀ፡ ወአይድዕዎ፡ ገደላ፡ ወ
 				<lb facs="#facs_18_r2l33" n="33"/>ምንኵከና፡ በከመ፡ በጽሐ፡ ለአባ፡ አኵሚስ፡ ወነገ
-			<pb facs="#facs_19" n="18v"/>
-               </ab>
-            </div>
-            <div type="textpart" subtype="folio" n="19"><!--image n.19  folio n.19-->
-               <ab>
-                  <pb facs="#facs_19" n="19r"/>
-               	<cb/>
+               	
+               	<pb facs="#facs_19" n="80v"/> <!--image n.19  folio n. 80v-81r-->
+              
+               	<cb n="a"/>
                	<lb facs='#facs_19_line_1601909725724_1518' n='N001'/>ዕበ፡ አዕ፡ ወተ፡ አለም፡ ለመ
                	<lb facs='#facs_19_r4l2' n='N002'/>ቅዱስ፡ ካር፡ አበም፡ ላደለ፡ ለውስም፡ ገዝሩ፨ 
                	<lb facs='#facs_19_r4l3' n='N003'/>በ፡ ንበረት፡ ላዕለ፡ አዕመ፡ ፮ዓመተቱ፨ ወ
@@ -1948,7 +1956,7 @@
                	<lb facs='#facs_19_r4l54' n='N029'/>ወተጋደለ፡ ዐቢየ፡ ወወጽአ፡ ዝካሩ፡ በፍድፍድና፡ 
                	<lb facs='#facs_19_r4l56' n='N030'/>የኔ፡ ወበአእምሮ፡ ወበተሰናእዎ፡ ላዕሌሁ፡ ወተ
                	<lb facs='#facs_19_r4l58' n='N031'/>ወይመ፡ዲበ፡ ሀገረ፡ እለ፡ ስክንድርያ፨ ወሖረ፡ በው
-               	<cb/>
+               	<cb n="b"/>
                	<lb facs='#facs_19_line_1601910174484_1756' n='N001'/>ስ፡ ወር፡ ክስቶስ፡ ወበስ፡ ወ
                	<lb facs='#facs_19_r4l4' n='N002'/>፡ወትጋደል፡ ወስተ፡ አ፡ አር፡  
                	<lb facs='#facs_19_r4l6' n='N003'/>ጽርስወባሩ፡ ወአበተ፡ በተ፡ 
@@ -1978,7 +1986,13 @@
                	<lb facs='#facs_19_line_1601913814582_2311' n='N027'/>ቶሙ፡ ለነድቃን፡ ወለሰግረት፡ ለዓለም፡ አ
                	<lb facs='#facs_19_line_1601913825892_2319' n='N028'/>ተፈጸመ፡ የምወርኀ፡ ግንበት፡ በሰላመ፡ እ
                	<lb facs='#facs_19_line_1601913844819_2336' n='N029'/>አ፡ ለለዓለም፡ ለለሜን፨ ወአ 
-               	<cb/>
+               </ab>
+	</div>
+	<pb n="81r"/>
+	<div type="textpart" subtype="folio" n="81"><!-- image 19 fol. 81r -->
+		<ab>
+			<cb n="a"/>
+               	<!--image n.19  folio n. 81r-->
                	<lb facs='#facs_19_r3l1' n='N001'/>ስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ወ
                	<lb facs='#facs_19_r3l2' n='N002'/>አምላክ። ወርኀ፡ ሰኔዮም፡ ቀዳጣዊ፡ በእ
                	<lb facs='#facs_19_r3l3' n='N003'/>፡ በዛቲ፡ ዕለት፡ ቀቀደስት፡ ቤተ፡ ክርስቲያ 
@@ -2009,7 +2023,7 @@
                	<lb facs='#facs_19_r3l29' n='N028'/>ዘየሠምር፡ ውእቱ፡ ልብስ። ወይቤሎ፡ ው
                	<lb facs='#facs_19_r3l30' n='N029'/>ረሳዊ፡ ኢትኅዛን፡ ወኢትተከዝ፡ ወለለአ 
                	<lb facs='#facs_19_r3l31' n='N030'/>፡ መቅድኅን፡ ወትብል፡ ምስለ፡ ለእሥው 
-               	<cb/>
+               	<cb n="b"/>
                	<lb facs='#facs_19_r2l1' n='N001'/>ተ፡ሥአደ፡ ወተሐውር፡ ኀበ፡ ለዕበ 
                	<lb facs='#facs_19_r2l2' n='N002'/>ፈ፡ ብእሲ፡ እምኀበ፡ ግብር፡ ይኄሊ፡ እም 
                	<lb facs='#facs_19_r2l3' n='N003'/>ፈጠሪሁ፡ ወሠረቅታተ፡ ዘላዕሌሁ፡ እም 


### PR DESCRIPTION
for some reason Transcribus export confused numeration (it probably has issues when images have sometimes two and sometimes one page), fixed manually