### PR TITLE
idno facs values corrected to iiif

### DIFF
--- a/ParisBNF/abb/BNFabb112.xml
+++ b/ParisBNF/abb/BNFabb112.xml
@@ -28,7 +28,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <collection>Manuscrits orientaux</collection>
                   <collection>Fonds éthiopien</collection>
                   <collection>d'Abbadie</collection>
-                  <idno facs="https://archivesetmanuscrits.bnf.fr/ark:/12148/cc1090764">BnF Éthiopien d'Abbadie 112</idno>
+                 <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b100886865">BnF Éthiopien d'Abbadie 112</idno>
                     </msIdentifier>
                <msContents>
                   <summary>

--- a/ParisBNF/abb/BNFabb119.xml
+++ b/ParisBNF/abb/BNFabb119.xml
@@ -27,7 +27,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   <collection>Fonds éthiopien</collection>
                   <collection>d'Abbadie</collection>
 
-                  <idno facs="https://archivesetmanuscrits.bnf.fr/ark:/12148/cc109121r">BnF Éthiopien d'Abbadie 119</idno>
+                  <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b10087117g">BnF Éthiopien d'Abbadie 119</idno>
 
                     </msIdentifier>
 

--- a/ParisBNF/abb/BNFabb137.xml
+++ b/ParisBNF/abb/BNFabb137.xml
@@ -31,7 +31,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <collection>d'Abbadie</collection>
                         <idno>BnF Éthiopien d'Abbadie 137</idno>
                         <altIdentifier>
-                        <idno facs="https://archivesetmanuscrits.bnf.fr/ark:/12148/cc94965m">BnF Éthiopien d'Abbadie 137</idno>
+                          <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b52510669f">BnF Éthiopien d'Abbadie 137</idno>
                           </altIdentifier>
                         </msIdentifier>
 

--- a/ParisBNF/abb/BNFabb147.xml
+++ b/ParisBNF/abb/BNFabb147.xml
@@ -28,9 +28,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <collection>Manuscrits orientaux</collection>
                   <collection>Fonds éthiopien</collection>
                   <collection>d'Abbadie</collection>
-                  <idno facs="https://archivesetmanuscrits.bnf.fr/ark:/12148/cc109105c">BnF Éthiopien d'Abbadie 147</idno>
+                <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b10088590h">BnF Éthiopien d'Abbadie 147</idno>
                     </msIdentifier>
-
+<msContents><summary></summary></msContents>
                   <physDesc>
                     <objectDesc form="Codex">
                        <supportDesc>

--- a/ParisBNF/abb/BNFabb149.xml
+++ b/ParisBNF/abb/BNFabb149.xml
@@ -26,7 +26,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <collection>Manuscrits orientaux</collection>
                         <collection>Fonds éthiopien</collection>
                         <collection>d'Abbadie</collection>
-                        <idno facs="https://archivesetmanuscrits.bnf.fr/ark:/12148/cc109107x">BnF Éthiopien d'Abbadie 149</idno>
+                      <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b10088591z">BnF Éthiopien d'Abbadie 149</idno>
                     </msIdentifier>
 
                     <physDesc>

--- a/ParisBNF/abb/BNFabb16.xml
+++ b/ParisBNF/abb/BNFabb16.xml
@@ -32,13 +32,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <idno>BnF Éthiopien d'Abbadie 16</idno>
                         <altIdentifier>
 
-                        <idno facs="https://archivesetmanuscrits.bnf.fr/ark:/12148/cc96419z">BnF Éthiopien d'Abbadie 16</idno>
+                          <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b52507491f">BnF Éthiopien d'Abbadie 16</idno>
 
                           </altIdentifier>
                         </msIdentifier>
 
 
                           <msContents>
+                            <summary/>
                           <msItem xml:id="ms_i1">
                              <locus from="1ra" to="22vc"/>
                              <title type="complete" ref="LIT1340EnochE">

--- a/ParisBNF/abb/BNFabb160.xml
+++ b/ParisBNF/abb/BNFabb160.xml
@@ -28,7 +28,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <collection>Manuscrits orientaux</collection>
                   <collection>Fonds éthiopien</collection>
                   <collection>d'Abbadie</collection>
-                  <idno facs="https://archivesetmanuscrits.bnf.fr/ark:/12148/cc1091175">BnF Éthiopien d'Abbadie 160</idno>
+                <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b10088592d">BnF Éthiopien d'Abbadie 160</idno>
                     </msIdentifier>
                     <msContents>
                        <summary/>

--- a/ParisBNF/abb/BNFabb164.xml
+++ b/ParisBNF/abb/BNFabb164.xml
@@ -27,7 +27,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   <collection>Fonds éthiopien</collection>
                   <collection>d'Abbadie</collection>
 
-                  <idno facs="https://archivesetmanuscrits.bnf.fr/ark:/12148/cc109121r">BnF Éthiopien d'Abbadie 164</idno>
+                  <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b10087117g">BnF Éthiopien d'Abbadie 164</idno>
 
                     </msIdentifier>
 

--- a/ParisBNF/abb/BNFabb173.xml
+++ b/ParisBNF/abb/BNFabb173.xml
@@ -29,7 +29,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <collection>Fonds éthiopien</collection>
                   <collection>d'Abbadie</collection>
 
-                  <idno facs="https://archivesetmanuscrits.bnf.fr/ark:/12148/cc109127d">BnF Éthiopien d'Abbadie 173</idno>
+                <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b10088593v">BnF Éthiopien d'Abbadie 173</idno>
 
                     </msIdentifier>
                <msContents>

--- a/ParisBNF/abb/BNFabb179.xml
+++ b/ParisBNF/abb/BNFabb179.xml
@@ -29,11 +29,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <collection>d'Abbadie</collection>
                         <idno>BnF Éthiopien d'Abbadie 179</idno>
                         <altIdentifier>
-                        <idno facs="https://archivesetmanuscrits.bnf.fr/ark:/12148/cc109133j">BnF Éthiopien d'Abbadie 179</idno>
+                            <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b10087970v">BnF Éthiopien d'Abbadie 179</idno>
                           </altIdentifier>
                     </msIdentifier>
-<msContents>
-
+<msContents><summary/>
 <msItem xml:id="ms_i1">
 <locus from="1r" to="259v"/>
 <title type="complete" ref="LIT1493Gadlas"/>

--- a/ParisBNF/abb/BNFabb195.xml
+++ b/ParisBNF/abb/BNFabb195.xml
@@ -34,6 +34,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
 
 
                           <msContents>
+                            <summary/>
                             <msItem xml:id="ms_i1">
                                <locus from="1ra" to="4rb"/>
                                <title type="complete" ref="LIT1811Liveso"/>
@@ -651,7 +652,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
 
                                     <item xml:id="e15">
                                       <locus target="#74r #96v #104r #109r #113r #113v #116r #136v #140rb"/>
-                                    <desc type="Unclear">Notes on division into parts within one text
+                                    <desc type="Gloss">Notes on division into parts within one text
                                        or boundaries between the texts,
                                       in the upper margin of the folia.</desc>
                                      </item>
@@ -781,7 +782,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                     <term key="ZaMa"/>
                   </keywords>
             </textClass>
-            <langUsage><language ident="gez">Gǝʿǝz</language></langUsage>
+          <langUsage><language ident="gez">Gǝʿǝz</language><language ident="en">English</language></langUsage>
         </profileDesc>
         <revisionDesc>
             <change who="DN" when="2020-08-12">Created entity</change>

--- a/ParisBNF/abb/BNFabb202.xml
+++ b/ParisBNF/abb/BNFabb202.xml
@@ -29,7 +29,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <collection>Manuscrits orientaux</collection>
                         <collection>Fonds éthiopien</collection>
                         <collection>d'Abbadie</collection>
-                    <idno facs="https://archivesetmanuscrits.bnf.fr/ark:/12148/cc103289k">BnF Éthiopien d'Abbadie 202</idno>
+                      <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b52508092q">BnF Éthiopien d'Abbadie 202</idno>
 
 
                         </msIdentifier>

--- a/ParisBNF/abb/BNFabb30.xml
+++ b/ParisBNF/abb/BNFabb30.xml
@@ -31,12 +31,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <collection>d'Abbadie</collection>
                         <idno>BnF Éthiopien d'Abbadie 30</idno>
                         <altIdentifier>
-                        <idno facs="https://archivesetmanuscrits.bnf.fr/ark:/12148/cc99487b">BnF Éthiopien d'Abbadie 35</idno>
+                          <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b10090692b">BnF Éthiopien d'Abbadie 35</idno>
                           </altIdentifier>
                         </msIdentifier>
 
 
                           <msContents>
+                            <summary/>
                           <msItem xml:id="ms_i1">
                              <locus from="3ra" to="47rc"/>
                              <title type="complete" ref="LIT1340EnochE"/>
@@ -355,7 +356,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
     </msItem>
 
     <msItem xml:id="ms_i7">
-     <locus from="201rb" to="#203rc"/>
+     <locus from="201rb" to="203rc"/>
      <title type="incomplete" ref="LIT5855GIyorgisWaldaAmExcerpt"/>
   <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡
     ፩፡ አምላክ፡ በስ</hi>መ᎓ እግዚአብሔር᎓ መሐሪ᎓ ወመተሳህል᎓ ንዌጥን᎓ ጽሒፈ፡ መጽሐፍ፡ ዘይነግር፡

--- a/ParisBNF/abb/BNFabb35.xml
+++ b/ParisBNF/abb/BNFabb35.xml
@@ -31,7 +31,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <collection>d'Abbadie</collection>
                         <idno>BnF Éthiopien d'Abbadie 35</idno>
                         <altIdentifier>
-                        <idno facs="http://archivesetmanuscrits.bnf.fr/ark:/12148/cc994913">BnF Éthiopien d'Abbadie 35</idno>
+                          <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b52506059h">BnF Éthiopien d'Abbadie 35</idno>
                           </altIdentifier>
                         </msIdentifier>
 

--- a/ParisBNF/abb/BNFabb39.xml
+++ b/ParisBNF/abb/BNFabb39.xml
@@ -27,10 +27,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      <collection>d'Abbadie</collection>
                        <idno>BnF Éthiopien d'Abbadie 39</idno>
                        <altIdentifier>
-                     <idno facs="http://archivesetmanuscrits.bnf.fr/ark:/12148/cc99651m">BnF Éthiopien d'Abbadie 39</idno>
+                         <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b10093217s">BnF Éthiopien d'Abbadie 39</idno>
                        </altIdentifier>
              </msIdentifier>
-
+<msContents><summary/></msContents>
 
               <physDesc>
                  <objectDesc form="Codex">

--- a/ParisBNF/abb/BNFabb41.xml
+++ b/ParisBNF/abb/BNFabb41.xml
@@ -32,7 +32,7 @@ xml:id="BNFabb41" type="mss">
                   <collection>d'Abbadie</collection>
                   <idno>BnF Éthiopien d'Abbadie 41</idno>
                   <altIdentifier>
-                  <idno facs="https://archivesetmanuscrits.bnf.fr/ark:/12148/cc91074m">BnF Éthiopien d'Abbadie 41</idno>
+                     <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b52506747v">BnF Éthiopien d'Abbadie 41</idno>
                     </altIdentifier>
                   </msIdentifier>
 

--- a/ParisBNF/abb/BNFabb55.xml
+++ b/ParisBNF/abb/BNFabb55.xml
@@ -31,12 +31,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <collection>d'Abbadie</collection>
                         <idno>BnF Éthiopien d'Abbadie 55</idno>
                         <altIdentifier>
-                        <idno facs="https://archivesetmanuscrits.bnf.fr/ark:/12148/cc1090322">BnF Éthiopien d'Abbadie 35</idno>
+                          <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b525112698">BnF Éthiopien d'Abbadie 35</idno>
                           </altIdentifier>
                         </msIdentifier>
 
 
                           <msContents>
+                            <summary/>
                           <msItem xml:id="ms_i1">
                              <locus from="1ra" to="14vc"/>
                              <title type="complete" ref="LIT1340EnochE"/>
@@ -508,9 +509,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               <locus target="#1r"/>
                                <desc type="OwnershipNote"/>
                                  <q xml:lang="gez">ዝጉባኤ᎓ ነቢያት᎓ ዘ<placeName ref="LOC2422DagaEs">
-                                 ደብረ᎓ ዳጋ᎓</placeName> ዘሠረቆ᎓ ውጉዘ᎓ ለይኩን።</q>
-                                 <q xml:lang="en">This collection of the Prophets is of <placeName ref="LOC2422DagaEs">
-                                   Dāgā ʾƎsṭifānos</placeName>. Whoever steals it, will be excommunicated.</q>
+                                   ደብረ᎓ ዳጋ᎓</placeName> ዘሠረቆ᎓ ውጉዘ᎓ ለይኩን። <foreign xml:lang="en">This collection of the Prophets is of <placeName ref="LOC2422DagaEs">
+                                     Dāgā ʾƎsṭifānos</placeName>. Whoever steals it, will be excommunicated.</foreign></q>
+                                 
                                    <note>Written in the upper margin of the folio.</note>
                              </item>
 
@@ -700,7 +701,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                     <term key="Gon"/>
                                         </keywords>
             </textClass>
-            <langUsage><language ident="gez">Gǝʿǝz</language><language ident="am">Amharic</language></langUsage>
+          <langUsage><language ident="gez">Gǝʿǝz</language><language ident="am">Amharic</language><language ident="en">English</language></langUsage>
         </profileDesc>
         <revisionDesc>
             <change who="DN" when="2019-12-12">Created entity</change>

--- a/ParisBNF/abb/BNFabb55.xml
+++ b/ParisBNF/abb/BNFabb55.xml
@@ -31,7 +31,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <collection>d'Abbadie</collection>
                         <idno>BnF Éthiopien d'Abbadie 55</idno>
                         <altIdentifier>
-                          <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b525112698">BnF Éthiopien d'Abbadie 35</idno>
+                          <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b525112698">BnF Éthiopien d'Abbadie 55</idno>
                           </altIdentifier>
                         </msIdentifier>
 

--- a/ParisBNF/abb/BNFabb82.xml
+++ b/ParisBNF/abb/BNFabb82.xml
@@ -28,7 +28,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <collection>Manuscrits orientaux</collection>
                   <collection>Fonds éthiopien</collection>
                   <collection>d'Abbadie</collection>
-                  <idno facs="https://archivesetmanuscrits.bnf.fr/ark:/12148/cc94952p">BnF Éthiopien d'Abbadie 82</idno>
+                <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b8538810r">BnF Éthiopien d'Abbadie 82</idno>
                     </msIdentifier>
                <msContents>
                   <summary>

--- a/ParisBNF/abb/BNFabb9.xml
+++ b/ParisBNF/abb/BNFabb9.xml
@@ -27,7 +27,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   <collection>Fonds éthiopien</collection>
                   <collection>d'Abbadie</collection>
 
-                  <idno facs="https://archivesetmanuscrits.bnf.fr/ark:/12148/cc13513f">BnF Éthiopien d'Abbadie 9</idno>
+                <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b100906858">BnF Éthiopien d'Abbadie 9</idno>
 
                     </msIdentifier>
 

--- a/ParisBNF/abb/BNFabb95.xml
+++ b/ParisBNF/abb/BNFabb95.xml
@@ -28,7 +28,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <collection>Manuscrits orientaux</collection>
                   <collection>Fonds éthiopien</collection>
                   <collection>d'Abbadie</collection>
-                  <idno facs="https://archivesetmanuscrits.bnf.fr/ark:/12148/cc109065m">BnF Éthiopien d'Abbadie 95</idno>
+                <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b10088387g">BnF Éthiopien d'Abbadie 95</idno>
                     </msIdentifier>
                <msContents>
                   <summary>

--- a/ParisBNF/abb/BNFabb96.xml
+++ b/ParisBNF/abb/BNFabb96.xml
@@ -28,9 +28,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <collection>Manuscrits orientaux</collection>
                   <collection>Fonds éthiopien</collection>
                   <collection>d'Abbadie</collection>
-                  <idno facs="https://archivesetmanuscrits.bnf.fr/ark:/12148/cc944226">BnF Éthiopien d'Abbadie 96</idno>
+                <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b525002774">BnF Éthiopien d'Abbadie 96</idno>
                     </msIdentifier>
-
+<msContents><summary/></msContents>
                     <physDesc>
                        <objectDesc form="Codex">
                           <supportDesc>


### PR DESCRIPTION
`idno facs` should contain link to `iiif `(here: gallica, not archivesetmanuscrits)

links of the general type can be added in 
`<facsimile>
`      `<graphic url="https://archivesetmanuscrits.bnf.fr/ark:/12148/cc1090764"/>`
   `</facsimile>`

(an example for BNFabb112, where we have `<idno facs="https://gallica.bnf.fr/ark:/12148/btv1b100886865">`