### PR TITLE
Moving and renaming

### DIFF
--- a/Abennat/HMK003.xml
+++ b/Abennat/HMK003.xml
@@ -1,17 +1,17 @@
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
-schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="HNK-002" xml:lang="en" type="mss">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="HMK003" xml:lang="en" type="mss">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Dǝggʷā</title>
+                <title>Ṣoma Dǝggʷā</title>
                 <editor role="generalEditor" key="AB"/>
-                <editor key="MA"/>
+                <editor key="AY"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
-            <editionStmt><p>Digitized within the framework of the project Documenting an Ancient Education System in Africa: 
-                ʾAbǝnnät Tǝmhǝrt in Ethiopia (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
+            <editionStmt><p>Digitized within the framework of the project Documenting an Ancient Education System in Africa:
+              ʾAbǝnnät Tǝmhǝrt in Ethiopia (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
                 <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
@@ -27,7 +27,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <msIdentifier>
                         <repository ref="INS0448HamaraN"/>
                         <collection>ʾAbǝnnat</collection>
-                        <idno>HNK-002</idno>
+                        <idno>HNK-003</idno>
                     </msIdentifier>
                     <msContents></msContents>
                     <physDesc></physDesc>
@@ -42,11 +42,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <abstract>
                 <p/>
             </abstract>
-            <textClass>
-                <keywords>
-                    <term key="ChristianLiterature"/>
-                </keywords>
-            </textClass>
             <langUsage>
                 <language ident="en">English</language>
                 <language ident="gez">Gǝʿǝz</language>
@@ -54,7 +49,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MA" when="2021-12-01">ʾAbǝnnät team (Senkoris Ayalew and Tsehay Ademe) photographed the manuscript</change>
-            <change who="MA" when="2022-04-06">Created entity</change>
+            <change who="AY" when="2022-04-06">Created entity</change>
+            <change when="2022-04-05" who="AY">edit the transliteration</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/Abennat/HNK001.xml
+++ b/Abennat/HNK001.xml
@@ -1,17 +1,18 @@
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
-schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="HNK-005" xml:lang="en" type="mss">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="HNK001" xml:lang="en" type="mss">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Zǝmmāre</title>
+                <title>ʾAmmǝstu ṣawātǝwa zemā</title>
                 <editor role="generalEditor" key="AB"/>
-                <editor key="DB"/>
+                <editor key="ES"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
-            <editionStmt><p>Digitized within the framework of the project Documenting an Ancient Education System in Africa:
-              ʾAbǝnnät Tǝmhǝrt in Ethiopia (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
+            <editionStmt><p>Digitized within the framework of the project Documenting an 
+                Ancient Education System in Africa: ʾAbǝnnät Tǝmhǝrt in Ethiopia 
+                (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
                 <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
@@ -27,7 +28,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <msIdentifier>
                         <repository ref="INS0448HamaraN"/>
                         <collection>ʾAbǝnnat</collection>
-                        <idno>HNK-005</idno>
+                        <idno>HNK-001</idno>
                     </msIdentifier>
                     <msContents></msContents>
                     <physDesc></physDesc>
@@ -44,6 +45,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </abstract>
             <textClass>
                 <keywords>
+                    <term key="ChristianLiterature"/>
                     <term key="Liturgy"/>
                 </keywords>
             </textClass>
@@ -54,8 +56,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MA" when="2021-12-01">ʾAbǝnnät team (Senkoris Ayalew and Tsehay Ademe) photographed the manuscript</change>
-            <change who="DB" when="2022-04-06">Created entity</change>
-            <change when="2022-04-06" who="DB"> title revised</change>
+            <change who="ES" when="2022-04-06">Created entity</change>
+            <change when="2022-04-06" who="ES">added metadata</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/Abennat/HNK002.xml
+++ b/Abennat/HNK002.xml
@@ -1,17 +1,17 @@
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
-schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="HMK-003" xml:lang="en" type="mss">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="HNK002" xml:lang="en" type="mss">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Ṣoma Dǝggwā</title>
+                <title>Dǝggʷā</title>
                 <editor role="generalEditor" key="AB"/>
-                <editor key="AY"/>
+                <editor key="MA"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
-            <editionStmt><p>Digitized within the framework of the project Documenting an Ancient Education System in Africa:
-              ʾAbǝnnät Tǝmhǝrt in Ethiopia (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
+            <editionStmt><p>Digitized within the framework of the project Documenting an Ancient Education System in Africa: 
+                ʾAbǝnnät Tǝmhǝrt in Ethiopia (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
                 <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
@@ -27,7 +27,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <msIdentifier>
                         <repository ref="INS0448HamaraN"/>
                         <collection>ʾAbǝnnat</collection>
-                        <idno>HNK-003</idno>
+                        <idno>HNK-002</idno>
                     </msIdentifier>
                     <msContents></msContents>
                     <physDesc></physDesc>
@@ -42,6 +42,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <abstract>
                 <p/>
             </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                </keywords>
+            </textClass>
             <langUsage>
                 <language ident="en">English</language>
                 <language ident="gez">Gǝʿǝz</language>
@@ -49,8 +54,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MA" when="2021-12-01">ʾAbǝnnät team (Senkoris Ayalew and Tsehay Ademe) photographed the manuscript</change>
-            <change who="AY" when="2022-04-06">Created entity</change>
-            <change when="2022-04-05" who="AY">edit the transliteration</change>
+            <change who="MA" when="2022-04-06">Created entity</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/Abennat/HNK004.xml
+++ b/Abennat/HNK004.xml
@@ -1,15 +1,17 @@
 <?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="HNK-004" xml:lang="en" type="mss">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="HNK004" xml:lang="en" type="mss">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Meraf</title>
+                <title>Mǝʿǝrāf</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="GS"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
+            <editionStmt><p>Digitized within the framework of the project Documenting an Ancient Education System in Africa:
+                ʾAbǝnnät Tǝmhǝrt in Ethiopia (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
                 <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
@@ -24,6 +26,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <msDesc xml:id="ms">
                     <msIdentifier>
                         <repository ref="INS0448HamaraN"/>
+                        <collection>ʾAbǝnnat</collection>
                         <idno>HNK-004</idno>
                     </msIdentifier>
                 </msDesc>

--- a/Abennat/HNK005.xml
+++ b/Abennat/HNK005.xml
@@ -1,15 +1,17 @@
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
-schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="HNK-006" xml:lang="en" type="mss">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="HNK005" xml:lang="en" type="mss">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Qǝddāse</title>
+                <title>Zǝmmāre</title>
                 <editor role="generalEditor" key="AB"/>
-                <editor key="HA"/>
+                <editor key="DB"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
+            <editionStmt><p>Digitized within the framework of the project Documenting an Ancient Education System in Africa:
+              ʾAbǝnnät Tǝmhǝrt in Ethiopia (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
                 <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
@@ -25,8 +27,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <msIdentifier>
                         <repository ref="INS0448HamaraN"/>
                         <collection>ʾAbǝnnat</collection>
-                        <idno>HNK-006</idno>
+                        <idno>HNK-005</idno>
                     </msIdentifier>
+                    <msContents></msContents>
+                    <physDesc></physDesc>
                 </msDesc>
             </sourceDesc>
         </fileDesc>
@@ -40,7 +44,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </abstract>
             <textClass>
                 <keywords>
-                    <term key="ChristianLiterature"/>
                     <term key="Liturgy"/>
                 </keywords>
             </textClass>
@@ -51,7 +54,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MA" when="2021-12-01">ʾAbǝnnät team (Senkoris Ayalew and Tsehay Ademe) photographed the manuscript</change>
-            <change who="HA" when="2022-04-06">Created entity</change>
+            <change who="DB" when="2022-04-06">Created entity</change>
+            <change when="2022-04-06" who="DB"> title revised</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/Abennat/HNK006.xml
+++ b/Abennat/HNK006.xml
@@ -1,18 +1,17 @@
 <?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="HNK-001" xml:lang="en" type="mss">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="HNK006" xml:lang="en" type="mss">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>ʾAmmǝstu ṣawātǝwa zemā</title>
+                <title>Qǝddāse</title>
                 <editor role="generalEditor" key="AB"/>
-                <editor key="ES"/>
+                <editor key="HA"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
-            <editionStmt><p>Digitized within the framework of the project Documenting an 
-                Ancient Education System in Africa: ʾAbǝnnät Tǝmhǝrt in Ethiopia 
-                (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
+            <editionStmt><p>Digitized within the framework of the project Documenting an Ancient Education System in Africa:
+                ʾAbǝnnät Tǝmhǝrt in Ethiopia (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
                 <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
@@ -28,10 +27,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <msIdentifier>
                         <repository ref="INS0448HamaraN"/>
                         <collection>ʾAbǝnnat</collection>
-                        <idno>HNK-001</idno>
+                        <idno>HNK-006</idno>
                     </msIdentifier>
-                    <msContents></msContents>
-                    <physDesc></physDesc>
                 </msDesc>
             </sourceDesc>
         </fileDesc>
@@ -56,8 +53,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MA" when="2021-12-01">ʾAbǝnnät team (Senkoris Ayalew and Tsehay Ademe) photographed the manuscript</change>
-            <change who="ES" when="2022-04-06">Created entity</change>
-            <change when="2022-04-06" who="ES">added metadata</change>
+            <change who="HA" when="2022-04-06">Created entity</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/Abennat/HNK007.xml
+++ b/Abennat/HNK007.xml
@@ -1,7 +1,7 @@
 <?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="HNK-007" xml:lang="en" type="mss">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="HNK007" xml:lang="en" type="mss">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -10,7 +10,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <editor key="JK"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
-            <editionStmt><p>Digitized within the framework of the project Documenting an Ancient Education System in Africa: ʾAbǝnnät Tǝmhǝrt in Ethiopia (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
+            <editionStmt><p>Digitized within the framework of the project Documenting an 
+                Ancient Education System in Africa: ʾAbǝnnät Tǝmhǝrt in Ethiopia (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
                 <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale


### PR DESCRIPTION
HNK-stubs moved to Abennat folder and renamed to comply with the Guidelines
https://github.com/BetaMasaheft/Documentation/issues/2069