### PR TITLE
DLS stubs moving and renaming

### DIFF
--- a/Abennat/DLS001.xml
+++ b/Abennat/DLS001.xml
@@ -1,35 +1,34 @@
 <?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
-schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="DLS-007" xml:lang="en" type="mss">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="DLS001" xml:lang="en" type="mss">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Ṣoma Dǝggwā</title>
+                <title>Dǝggʷā</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MA"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
-            <editionStmt><p>Digitized within the framework of the project Documenting an Ancient Education System in Africa:
-                ʾAbǝnnät Tǝmhǝrt in Ethiopia (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
+            <editionStmt><p>Digitized within the framework of the project Documenting an 
+                Ancient Education System in Africa: ʾAbǝnnät Tǝmhǝrt in Ethiopia 
+                (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
-                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
-                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
                 <pubPlace>Hamburg</pubPlace>
                 <availability>
-                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
-                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
                 </availability>
             </publicationStmt>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
                         <repository ref="INS0341DL"/>
-                        <idno>DLS-007</idno>
+                        <collection>ʾAbǝnnat</collection>
+                        <idno>DLS-001</idno>
                     </msIdentifier>
-                    <msContents></msContents>
-                    <physDesc></physDesc>
                 </msDesc>
             </sourceDesc>
         </fileDesc>
@@ -43,7 +42,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </abstract>
             <textClass>
                 <keywords>
-                    <term key="Chants"/>
+                    <term key="Liturgy"/>
                 </keywords>
             </textClass>
             <langUsage>
@@ -53,12 +52,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MA" when="2022-04-07">Created entity</change>
-            <change when="2022-04-07" who="MA"> title revised</change>
         </revisionDesc>
     </teiHeader>
     <text>
         <body>
-            <div type="bibliography"/><!---->
+            <div type="bibliography"/>
+            <!--  -->
         </body>
     </text>
 </TEI>
+

--- a/Abennat/DLS002.xml
+++ b/Abennat/DLS002.xml
@@ -1,30 +1,33 @@
 <?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
-schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="DLS-009" xml:lang="en" type="mss">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="DLS002" xml:lang="en" type="mss">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Ṣoma Dǝggwā</title>
+                <title>Dǝggʷā</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MA"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
+            <editionStmt><p>Digitized within the framework of the project Documenting an 
+                Ancient Education System in Africa: ʾAbǝnnät Tǝmhǝrt in Ethiopia 
+                (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
-                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
-                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
                 <pubPlace>Hamburg</pubPlace>
                 <availability>
-                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
-                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
                 </availability>
             </publicationStmt>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
                         <repository ref="INS0341DL"/>
-                        <idno>DLS-009</idno>
+                        <collection>ʾAbǝnnat</collection>
+                        <idno>DSL-002</idno>
                     </msIdentifier>
                 </msDesc>
             </sourceDesc>
@@ -39,7 +42,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </abstract>
             <textClass>
                 <keywords>
-                    <term key="Chants"/>
+                    <term key="Liturgy"/>
                 </keywords>
             </textClass>
             <langUsage>
@@ -53,7 +56,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text>
         <body>
-            <div type="bibliography"/><!---->
+            <div type="bibliography"/>
+            <!--  -->
         </body>
     </text>
 </TEI>

--- a/Abennat/DLS003.xml
+++ b/Abennat/DLS003.xml
@@ -1,15 +1,18 @@
 <?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="DLS-003" xml:lang="en" type="mss">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="DLS003" xml:lang="en" type="mss">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Dǝggwa</title>
+                <title>Dǝggʷā</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MA"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
+            <editionStmt><p>Digitized within the framework of the project Documenting an 
+                Ancient Education System in Africa: ʾAbǝnnät Tǝmhǝrt in Ethiopia 
+                (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
                 <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
@@ -24,6 +27,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <msDesc xml:id="ms">
                     <msIdentifier>
                         <repository ref="INS0341DL"/>
+                        <collection>ʾAbǝnnat</collection>
                         <idno>DLS-003</idno>
                     </msIdentifier>
                 </msDesc>

--- a/Abennat/DLS004.xml
+++ b/Abennat/DLS004.xml
@@ -1,17 +1,18 @@
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
-schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="HMK003" xml:lang="en" type="mss">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="DLS004" xml:lang="en" type="mss">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Ṣoma Dǝggʷā</title>
+                <title>Dǝggʷā</title>
                 <editor role="generalEditor" key="AB"/>
-                <editor key="AY"/>
+                <editor key="MA"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
-            <editionStmt><p>Digitized within the framework of the project Documenting an Ancient Education System in Africa:
-              ʾAbǝnnät Tǝmhǝrt in Ethiopia (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
+            <editionStmt><p>Digitized within the framework of the project Documenting an 
+                Ancient Education System in Africa: ʾAbǝnnät Tǝmhǝrt in Ethiopia 
+                (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
                 <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
@@ -25,12 +26,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="INS0448HamaraN"/>
+                        <repository ref="INS0341DL"/>
                         <collection>ʾAbǝnnat</collection>
-                        <idno>HNK-003</idno>
+                        <idno>DLS-004</idno>
                     </msIdentifier>
-                    <msContents></msContents>
-                    <physDesc></physDesc>
                 </msDesc>
             </sourceDesc>
         </fileDesc>
@@ -42,15 +41,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <abstract>
                 <p/>
             </abstract>
+            <textClass>
+                <keywords>
+                    <term key="Chants"/>
+                </keywords>
+            </textClass>
             <langUsage>
                 <language ident="en">English</language>
                 <language ident="gez">Gǝʿǝz</language>
             </langUsage>
         </profileDesc>
         <revisionDesc>
-            <change who="MA" when="2021-12-01">ʾAbǝnnät team (Senkoris Ayalew and Tsehay Ademe) photographed the manuscript</change>
-            <change who="AY" when="2022-04-06">Created entity</change>
-            <change when="2022-04-05" who="AY">edit the transliteration</change>
+            <change who="MA" when="2022-04-07">Created entity</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/Abennat/DLS005.xml
+++ b/Abennat/DLS005.xml
@@ -1,15 +1,18 @@
 <?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="DLS-008" xml:lang="en" type="mss">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="DLS005" xml:lang="en" type="mss">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Ṣoma Dǝggwā</title>
+                <title>Ṣoma Dǝggʷā</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MA"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
+            <editionStmt><p>Digitized within the framework of the project Documenting an 
+                Ancient Education System in Africa: ʾAbǝnnät Tǝmhǝrt in Ethiopia 
+                (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
                 <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
@@ -24,7 +27,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <msDesc xml:id="ms">
                     <msIdentifier>
                         <repository ref="INS0341DL"/>
-                        <idno>DLS-008</idno>
+                        <collection>ʾAbǝnnat</collection>
+                        <idno>DLS-005</idno>
                     </msIdentifier>
                 </msDesc>
             </sourceDesc>

--- a/Abennat/DLS006.xml
+++ b/Abennat/DLS006.xml
@@ -1,15 +1,18 @@
 <?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="DLS-005" xml:lang="en" type="mss">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="DLS006" xml:lang="en" type="mss">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Ṣoma Dǝggwā</title>
+                <title>Ṣoma Dǝggʷā</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MA"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
+            <editionStmt><p>Digitized within the framework of the project Documenting an 
+                Ancient Education System in Africa: ʾAbǝnnät Tǝmhǝrt in Ethiopia 
+                (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
                 <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
@@ -24,7 +27,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <msDesc xml:id="ms">
                     <msIdentifier>
                         <repository ref="INS0341DL"/>
-                        <idno>DLS-005</idno>
+                        <collection>ʾAbǝnnat</collection>
+                        <idno>DLS-006</idno>
                     </msIdentifier>
                 </msDesc>
             </sourceDesc>

--- a/Abennat/DLS007.xml
+++ b/Abennat/DLS007.xml
@@ -1,30 +1,36 @@
 <?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
-schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="DLS-001" xml:lang="en" type="mss">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="DLS007" xml:lang="en" type="mss">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Dǝggwa</title>
+                <title>Ṣoma Dǝggʷā</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MA"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
+            <editionStmt><p>Digitized within the framework of the project Documenting an Ancient Education System in Africa:
+                ʾAbǝnnät Tǝmhǝrt in Ethiopia (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
-                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
                 <pubPlace>Hamburg</pubPlace>
                 <availability>
-                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
                 </availability>
             </publicationStmt>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
                         <repository ref="INS0341DL"/>
-                        <idno>DLS-001</idno>
+                        <collection>ʾAbǝnnat</collection>
+                        <idno>DLS-007</idno>
                     </msIdentifier>
+                    <msContents></msContents>
+                    <physDesc></physDesc>
                 </msDesc>
             </sourceDesc>
         </fileDesc>
@@ -38,7 +44,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </abstract>
             <textClass>
                 <keywords>
-                    <term key="Liturgy"/>
+                    <term key="Chants"/>
                 </keywords>
             </textClass>
             <langUsage>
@@ -48,13 +54,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MA" when="2022-04-07">Created entity</change>
+            <change when="2022-04-07" who="MA"> title revised</change>
         </revisionDesc>
     </teiHeader>
     <text>
         <body>
-            <div type="bibliography"/>
-            <!--  -->
+            <div type="bibliography"/><!---->
         </body>
     </text>
 </TEI>
-

--- a/Abennat/DLS008.xml
+++ b/Abennat/DLS008.xml
@@ -1,15 +1,17 @@
 <?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="DLS-010" xml:lang="en" type="mss">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="DLS008" xml:lang="en" type="mss">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Mǝʿǝrāf</title>
+                <title>Ṣoma Dǝggʷā</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MA"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
+            <editionStmt><p>Digitized within the framework of the project Documenting an Ancient Education System in Africa:
+                ʾAbǝnnät Tǝmhǝrt in Ethiopia (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
                 <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
@@ -24,7 +26,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <msDesc xml:id="ms">
                     <msIdentifier>
                         <repository ref="INS0341DL"/>
-                        <idno>DLS-010</idno>
+                        <collection>ʾAbǝnnat</collection>
+                        <idno>DLS-008</idno>
                     </msIdentifier>
                 </msDesc>
             </sourceDesc>

--- a/Abennat/DLS009.xml
+++ b/Abennat/DLS009.xml
@@ -1,15 +1,17 @@
 <?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="DLS-004" xml:lang="en" type="mss">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="DLS009" xml:lang="en" type="mss">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Dǝggwa</title>
+                <title>Ṣoma Dǝggʷā</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MA"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
+            <editionStmt><p>Digitized within the framework of the project Documenting an Ancient Education System in Africa:
+                ʾAbǝnnät Tǝmhǝrt in Ethiopia (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
                 <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
@@ -24,7 +26,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <msDesc xml:id="ms">
                     <msIdentifier>
                         <repository ref="INS0341DL"/>
-                        <idno>DLS-004</idno>
+                        <collection>ʾAbǝnnat</collection>
+                        <idno>DLS-009</idno>
                     </msIdentifier>
                 </msDesc>
             </sourceDesc>

--- a/Abennat/DLS010.xml
+++ b/Abennat/DLS010.xml
@@ -1,29 +1,33 @@
 <?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
-schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="DLS-002" xml:lang="en" type="mss">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="DLS010" xml:lang="en" type="mss">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Dǝggwa</title>
+                <title>Mǝʿǝrāf</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MA"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
+            <editionStmt><p>Digitized within the framework of the project Documenting an Ancient Education System in Africa:
+                ʾAbǝnnät Tǝmhǝrt in Ethiopia (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
-                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
                 <pubPlace>Hamburg</pubPlace>
                 <availability>
-                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
                 </availability>
             </publicationStmt>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
                         <repository ref="INS0341DL"/>
-                        <idno>DSL-002</idno>
+                        <collection>ʾAbǝnnat</collection>
+                        <idno>DLS-010</idno>
                     </msIdentifier>
                 </msDesc>
             </sourceDesc>
@@ -38,7 +42,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </abstract>
             <textClass>
                 <keywords>
-                    <term key="Liturgy"/>
+                    <term key="Chants"/>
                 </keywords>
             </textClass>
             <langUsage>
@@ -52,8 +56,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text>
         <body>
-            <div type="bibliography"/>
-            <!--  -->
+            <div type="bibliography"/><!---->
         </body>
     </text>
 </TEI>

--- a/Abennat/HNK003.xml
+++ b/Abennat/HNK003.xml
@@ -1,15 +1,17 @@
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
-schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="DLS-006" xml:lang="en" type="mss">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="HNK003" xml:lang="en" type="mss">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Ṣoma Dǝggwā</title>
+                <title>Ṣoma Dǝggʷā</title>
                 <editor role="generalEditor" key="AB"/>
-                <editor key="MA"/>
+                <editor key="AY"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
+            <editionStmt><p>Digitized within the framework of the project Documenting an Ancient Education System in Africa:
+              ʾAbǝnnät Tǝmhǝrt in Ethiopia (Universität Hamburg, HLCEES, funded by the Gerda Henkel Stiftung, 2021-2023)</p></editionStmt>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
                 <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
@@ -23,9 +25,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="INS0341DL"/>
-                        <idno>DLS-006</idno>
+                        <repository ref="INS0448HamaraN"/>
+                        <collection>ʾAbǝnnat</collection>
+                        <idno>HNK-003</idno>
                     </msIdentifier>
+                    <msContents></msContents>
+                    <physDesc></physDesc>
                 </msDesc>
             </sourceDesc>
         </fileDesc>
@@ -37,18 +42,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <abstract>
                 <p/>
             </abstract>
-            <textClass>
-                <keywords>
-                    <term key="Chants"/>
-                </keywords>
-            </textClass>
             <langUsage>
                 <language ident="en">English</language>
                 <language ident="gez">Gǝʿǝz</language>
             </langUsage>
         </profileDesc>
         <revisionDesc>
-            <change who="MA" when="2022-04-07">Created entity</change>
+            <change who="MA" when="2021-12-01">ʾAbǝnnät team (Senkoris Ayalew and Tsehay Ademe) photographed the manuscript</change>
+            <change who="AY" when="2022-04-06">Created entity</change>
+            <change when="2022-04-05" who="AY">edit the transliteration</change>
         </revisionDesc>
     </teiHeader>
     <text>


### PR DESCRIPTION
stubs moved to Abennat folder and renamed to comply with the Guidelines
https://github.com/BetaMasaheft/Documentation/issues/2069