### PR TITLE
Tuebingen new stubs (and corrections)

### DIFF
--- a/Tuebingen/Ewald15.xml
+++ b/Tuebingen/Ewald15.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
 ?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth3" type="mss">
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="Ewald15" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Maṣḥafa ʾAnṭǝyakos, On the Eight Thoughts of Evilness, Mazgaba haymānot, Maṣḥafa faws manfasāwi, Questions of ʾAb Qǝsmu, Dǝrsāna Māryām</title>
-            <editor key="DR"/>
+            <title>Zenā ʾAyhud</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
@@ -22,13 +22,11 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
-                     <repository ref="INS0313UBT"/>
-                     <collection>Codices aethiopici</collection>
-                      <idno>Tübingen Aeth. 3</idno>
-                     <altIdentifier>
-                        <idno>Ewald cat. no. 8</idno>
-                     </altIdentifier>
+                     <repository/>
+                     
+                      <idno>Ewald cat. no. 15</idno>
                   </msIdentifier>
+               <history><p>The manuscript was in possession of the theologian Christian Friedrich Schmid, d. 1852. It is not known where it went after Schmid's death.</p> </history>
                   <additional>
                      <adminInfo>
                         <recordHist>
@@ -36,7 +34,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <listBibl type="catalogue">
                                  <bibl>
                                  <ptr target="bm:Ewald1844Tuebingen"/>
-                                 <citedRange unit="page">191-194</citedRange>
+                                 <citedRange unit="page">200-201</citedRange>
                               </bibl>
                               </listBibl>
                            </source>
@@ -57,10 +55,15 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="ChristianLiterature"/>               
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="DR" when="2016-08-03">Created catalogue entry</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">

--- a/Tuebingen/Ewald6.xml
+++ b/Tuebingen/Ewald6.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
 ?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth3" type="mss">
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="Ewald6" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Maṣḥafa ʾAnṭǝyakos, On the Eight Thoughts of Evilness, Mazgaba haymānot, Maṣḥafa faws manfasāwi, Questions of ʾAb Qǝsmu, Dǝrsāna Māryām</title>
-            <editor key="DR"/>
+            <title>Homilies of John Chrysostomos</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
@@ -22,13 +22,11 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
-                     <repository ref="INS0313UBT"/>
-                     <collection>Codices aethiopici</collection>
-                      <idno>Tübingen Aeth. 3</idno>
-                     <altIdentifier>
-                        <idno>Ewald cat. no. 8</idno>
-                     </altIdentifier>
+                     <repository/>
+                     
+                      <idno>Ewald cat. no. 6</idno>
                   </msIdentifier>
+               <history><p>In 1844 the manuscript was in possession of Oberhelfer Sarwey in Tuebingen.</p> </history>
                   <additional>
                      <adminInfo>
                         <recordHist>
@@ -36,7 +34,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <listBibl type="catalogue">
                                  <bibl>
                                  <ptr target="bm:Ewald1844Tuebingen"/>
-                                 <citedRange unit="page">191-194</citedRange>
+                                 <citedRange unit="page">184-187</citedRange>
                               </bibl>
                               </listBibl>
                            </source>
@@ -57,10 +55,15 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="ChristianLiterature"/>               
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="DR" when="2016-08-03">Created catalogue entry</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">

--- a/Tuebingen/Ewald9.xml
+++ b/Tuebingen/Ewald9.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
 ?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth3" type="mss">
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="Ewald9" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Maṣḥafa ʾAnṭǝyakos, On the Eight Thoughts of Evilness, Mazgaba haymānot, Maṣḥafa faws manfasāwi, Questions of ʾAb Qǝsmu, Dǝrsāna Māryām</title>
-            <editor key="DR"/>
+            <title>Maṣḥafa məśṭir</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
@@ -22,13 +22,11 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
-                     <repository ref="INS0313UBT"/>
-                     <collection>Codices aethiopici</collection>
-                      <idno>Tübingen Aeth. 3</idno>
-                     <altIdentifier>
-                        <idno>Ewald cat. no. 8</idno>
-                     </altIdentifier>
+                     <repository/>
+                     
+                      <idno>Ewald cat. no.9</idno>
                   </msIdentifier>
+               <history><p>The earliest MS of the Maṣḥafa məśṭir known in Europe. It was donated to the Tuebingen library by Krapf and later sent to Missionshaus Basel; currently lost.</p> </history>
                   <additional>
                      <adminInfo>
                         <recordHist>
@@ -36,7 +34,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <listBibl type="catalogue">
                                  <bibl>
                                  <ptr target="bm:Ewald1844Tuebingen"/>
-                                 <citedRange unit="page">191-194</citedRange>
+                                 <citedRange unit="page">194-196</citedRange>
                               </bibl>
                               </listBibl>
                            </source>
@@ -57,10 +55,15 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="ChristianLiterature"/>               
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="DR" when="2016-08-03">Created catalogue entry</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">

--- a/Tuebingen/UBTaeth1.xml
+++ b/Tuebingen/UBTaeth1.xml
@@ -1,61 +1,45 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth1" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>Qālemenṭos</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 1</idno>
+                     <altIdentifier><idno>Ma IX 1</idno></altIdentifier>
+                     <altIdentifier>
+                        <idno>Ewald cat. no. 4</idno>
+                     </altIdentifier>
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
                            <source>
                               <listBibl type="catalogue">
                                  <bibl>
-                                    <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <ptr target="bm:Ewald1844Tuebingen"/>
+                                 <citedRange unit="page">180-183</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,14 +58,20 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="Homily"/>               
+               <term key="ChristianLiterature"/>
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
    <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
+      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX1"/>
    </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>

--- a/Tuebingen/UBTaeth10.xml
+++ b/Tuebingen/UBTaeth10.xml
@@ -1,61 +1,44 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth10" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>Bārṭos</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 10</idno>
+                     <altIdentifier>
+                        <idno>Ewald cat. no. 5</idno>
+                     </altIdentifier>
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
                            <source>
                               <listBibl type="catalogue">
                                  <bibl>
-                                    <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <ptr target="bm:Ewald1844Tuebingen"/>
+                                 <citedRange unit="page">183-184</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,15 +57,17 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="ChristianLiterature"/>
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
-   <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
-   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <ab/>

--- a/Tuebingen/UBTaeth11.xml
+++ b/Tuebingen/UBTaeth11.xml
@@ -1,46 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth11" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>Basəlyos</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 11</idno>
+                     <altIdentifier>
+                        <idno>Ewald cat. no. II-8</idno>
+                     </altIdentifier>
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
@@ -48,14 +36,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <listBibl type="catalogue">
                                  <bibl>
                                     <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <citedRange unit="page">33-35</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,15 +57,18 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="ChristianLiterature"/>
+               
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
-   <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
-   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <ab/>

--- a/Tuebingen/UBTaeth12.xml
+++ b/Tuebingen/UBTaeth12.xml
@@ -1,46 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth12" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>Basəlyos</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 12</idno>
+                     <altIdentifier>
+                        <idno>Ewald cat. no. II-8</idno>
+                     </altIdentifier>
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
@@ -48,14 +36,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <listBibl type="catalogue">
                                  <bibl>
                                     <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <citedRange unit="page">33-35</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,15 +57,18 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="ChristianLiterature"/>
+               
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
-   <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
-   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <ab/>

--- a/Tuebingen/UBTaeth13.xml
+++ b/Tuebingen/UBTaeth13.xml
@@ -1,46 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth13" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>Tagśāsa beta krəstiyan</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 13</idno>
+                     <altIdentifier>
+                        <idno>Ewald cat. no. II-4</idno>
+                     </altIdentifier>
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
@@ -48,14 +36,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <listBibl type="catalogue">
                                  <bibl>
                                     <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <citedRange unit="page">23-24</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,15 +57,18 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="ChristianLiterature"/>
+               
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
-   <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
-   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <ab/>

--- a/Tuebingen/UBTaeth14.xml
+++ b/Tuebingen/UBTaeth14.xml
@@ -1,46 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth14" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>Maṣḥafa gənzat</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 14</idno>
+                     <altIdentifier>
+                        <idno>Ewald cat. no. II-9</idno>
+                     </altIdentifier>
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
@@ -48,14 +36,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <listBibl type="catalogue">
                                  <bibl>
                                     <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <citedRange unit="page">35-36</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,15 +57,18 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="ChristianLiterature"/>
+               
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
-   <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
-   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <ab/>

--- a/Tuebingen/UBTaeth15.xml
+++ b/Tuebingen/UBTaeth15.xml
@@ -1,46 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth15" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>Filkəsyos</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 15</idno>
+                     <altIdentifier>
+                        <idno>Ewald cat. no. II-5</idno>
+                     </altIdentifier>
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
@@ -48,14 +36,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <listBibl type="catalogue">
                                  <bibl>
                                     <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <citedRange unit="page">24-26</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,15 +57,18 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="ChristianLiterature"/>
+               
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
-   <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
-   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <ab/>

--- a/Tuebingen/UBTaeth16.xml
+++ b/Tuebingen/UBTaeth16.xml
@@ -1,46 +1,35 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth16" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>Gadla Giyorgis</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 16</idno>
+                     <altIdentifier><idno>Ma IX 16</idno></altIdentifier>
+                     <altIdentifier>
+                        <idno>Ewald cat. no. II-6</idno>
+                     </altIdentifier>
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
@@ -48,14 +37,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <listBibl type="catalogue">
                                  <bibl>
                                     <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <citedRange unit="page">29-31</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,14 +58,20 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="Hagiography"/>               
+               <term key="ChristianLiterature"/>
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
    <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
+      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX16"/>
    </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>

--- a/Tuebingen/UBTaeth17.xml
+++ b/Tuebingen/UBTaeth17.xml
@@ -1,46 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth17" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>Sənkəssar</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 17</idno>
+                     <altIdentifier>
+                        <idno>Ewald cat. no. II-5</idno>
+                     </altIdentifier>
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
@@ -48,14 +36,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <listBibl type="catalogue">
                                  <bibl>
                                     <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <citedRange unit="page">26-29</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,15 +57,18 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="ChristianLiterature"/>
+               
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
-   <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
-   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <ab/>

--- a/Tuebingen/UBTaeth18.xml
+++ b/Tuebingen/UBTaeth18.xml
@@ -1,46 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth18" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>Haymānota ʾabaw</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 18</idno>
+                     <altIdentifier>
+                        <idno>Ewald cat. no. II-3</idno>
+                     </altIdentifier>
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
@@ -48,14 +36,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <listBibl type="catalogue">
                                  <bibl>
                                     <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <citedRange unit="page">15-23</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,15 +57,18 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="ChristianLiterature"/>
+               <term key="Liturgy"/>
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
-   <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
-   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <ab/>

--- a/Tuebingen/UBTaeth2.xml
+++ b/Tuebingen/UBTaeth2.xml
@@ -27,6 +27,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <collection>Codices aethiopici</collection>
                         <idno>Tübingen Aeth. 2</idno>
                         <altIdentifier><idno>Ma IX 2</idno></altIdentifier>
+                        <altIdentifier>
+                            <idno>Ewald cat. no. 10</idno>
+                        </altIdentifier>
                     </msIdentifier>
 
 <msContents>

--- a/Tuebingen/UBTaeth20.xml
+++ b/Tuebingen/UBTaeth20.xml
@@ -1,46 +1,32 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth20" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>ʾəgziʾabəḥer nagśa</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 20</idno>
+                     
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
@@ -48,14 +34,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <listBibl type="catalogue">
                                  <bibl>
                                     <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <citedRange unit="page">37-38</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,15 +55,18 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="ChristianLiterature"/>
+               <term key="Poetry"/>
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
-   <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
-   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <ab/>

--- a/Tuebingen/UBTaeth21.xml
+++ b/Tuebingen/UBTaeth21.xml
@@ -1,46 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth21" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>Miracles of Jesus</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 21</idno>
+                     <altIdentifier>
+                        <idno>Ewald cat. no. II-2</idno>
+                     </altIdentifier>
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
@@ -48,14 +36,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <listBibl type="catalogue">
                                  <bibl>
                                     <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <citedRange unit="page">14-15</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,15 +57,18 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="ChristianLiterature"/>
+               <term key="Miracle"/>
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
-   <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
-   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <ab/>

--- a/Tuebingen/UBTaeth22.xml
+++ b/Tuebingen/UBTaeth22.xml
@@ -1,46 +1,32 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth22" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>ʾArganona Maryam</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 22</idno>
+                     
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
@@ -48,14 +34,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <listBibl type="catalogue">
                                  <bibl>
                                     <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <citedRange unit="page">39</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,15 +55,18 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="ChristianLiterature"/>
+               <term key="Poetry"/>
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
-   <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
-   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <ab/>

--- a/Tuebingen/UBTaeth23.xml
+++ b/Tuebingen/UBTaeth23.xml
@@ -1,46 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth23" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>ʾAʿmāda məśṭir</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 23</idno>
+                     <altIdentifier>
+                        <idno>Ewald cat. no. II-6</idno>
+                     </altIdentifier>
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
@@ -48,14 +36,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <listBibl type="catalogue">
                                  <bibl>
                                     <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <citedRange unit="page">26</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,15 +57,18 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="ChristianLiterature"/>
+               
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
-   <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
-   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <ab/>

--- a/Tuebingen/UBTaeth24.xml
+++ b/Tuebingen/UBTaeth24.xml
@@ -1,46 +1,32 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth24" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>Mawasəʾət</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 24</idno>
+                     
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
@@ -48,14 +34,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <listBibl type="catalogue">
                                  <bibl>
                                     <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <citedRange unit="page">39-41</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,15 +55,18 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="ChristianLiterature"/>
+               <term key="Poetry"/>
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
-   <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
-   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <ab/>

--- a/Tuebingen/UBTaeth25.xml
+++ b/Tuebingen/UBTaeth25.xml
@@ -1,46 +1,32 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth25" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>Sawāsəw</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 25</idno>
+                     
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
@@ -48,14 +34,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <listBibl type="catalogue">
                                  <bibl>
                                     <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <citedRange unit="page">41-42</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,15 +55,18 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="ChristianLiterature"/>
+               <term key="Poetry"/>
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
-   <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
-   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <ab/>

--- a/Tuebingen/UBTaeth26.xml
+++ b/Tuebingen/UBTaeth26.xml
@@ -1,46 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth26" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>Dərsāna Mikāʾel</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 26</idno>
+                     <altIdentifier>
+                        <idno>Ewald cat. no. II-7</idno>
+                     </altIdentifier>
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
@@ -48,14 +36,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <listBibl type="catalogue">
                                  <bibl>
                                     <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <citedRange unit="page">32-33</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,15 +57,18 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="ChristianLiterature"/>
+               
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
-   <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
-   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <ab/>

--- a/Tuebingen/UBTaeth27.xml
+++ b/Tuebingen/UBTaeth27.xml
@@ -1,61 +1,45 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth27" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>Gadla Addām</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 27</idno>
+                     <altIdentifier><idno>Ma IX 27</idno></altIdentifier>
+                     <altIdentifier>
+                        <idno>Ewald cat. no. 2</idno>
+                     </altIdentifier>
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
                            <source>
                               <listBibl type="catalogue">
                                  <bibl>
-                                    <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <ptr target="bm:Ewald1844Tuebingen"/>
+                                 <citedRange unit="page">179</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,14 +58,20 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="Hagiography"/>               
+               <term key="ChristianLiterature"/>
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
    <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
+      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX27"/>
    </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>

--- a/Tuebingen/UBTaeth4.xml
+++ b/Tuebingen/UBTaeth4.xml
@@ -1,61 +1,44 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth4" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>Kufāle / Book of Jubilees</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 4</idno>
+                     <altIdentifier>
+                        <idno>Ewald cat. no. 1</idno>
+                     </altIdentifier>
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
                            <source>
                               <listBibl type="catalogue">
                                  <bibl>
-                                    <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <ptr target="bm:Ewald1844Tuebingen"/>
+                                 <citedRange unit="page">176-179</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,15 +57,18 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="Homily"/>               
+               <term key="ChristianLiterature"/>
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
-   <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
-   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <ab/>

--- a/Tuebingen/UBTaeth5.xml
+++ b/Tuebingen/UBTaeth5.xml
@@ -1,61 +1,44 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth5" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>Fətha nagaśt</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 5</idno>
+                     <altIdentifier>
+                        <idno>Ewald cat. no. 13</idno>
+                     </altIdentifier>
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
                            <source>
                               <listBibl type="catalogue">
                                  <bibl>
-                                    <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <ptr target="bm:Ewald1844Tuebingen"/>
+                                 <citedRange unit="page">198-199</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,15 +57,18 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="ChristianLiterature"/>
+               <term key="CanonLaw"/>
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
-   <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
-   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <ab/>

--- a/Tuebingen/UBTaeth7.xml
+++ b/Tuebingen/UBTaeth7.xml
@@ -26,6 +26,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <repository ref="INS0313UBT"/>
                   <collection>Codices aethiopici</collection>
                   <idno>Tübingen Cod. Aeth. 7</idno>
+                  <altIdentifier>
+                     <idno>Ewald cat. no. 3</idno>
+                  </altIdentifier>
                </msIdentifier>
                
                <msContents/>
@@ -54,7 +57,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="CanonLaw"/>               
+               <term key="ChristianLiterature"/>
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
          <change who="PL" when="2016-11-17">Created XML record from Ethio authority google spreadsheet</change>

--- a/Tuebingen/UBTaeth8.xml
+++ b/Tuebingen/UBTaeth8.xml
@@ -5,7 +5,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Sər۝ʿāta kahənat</title>
+            <title>Sərʿāta kahənat</title>
             <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/Tuebingen/UBTaeth8.xml
+++ b/Tuebingen/UBTaeth8.xml
@@ -1,61 +1,44 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth8" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>Sər۝ʿāta kahənat</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 8</idno>
+                     <altIdentifier>
+                        <idno>Ewald cat. no. 10</idno>
+                     </altIdentifier>
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
                            <source>
                               <listBibl type="catalogue">
                                  <bibl>
-                                    <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <ptr target="bm:Ewald1844Tuebingen"/>
+                                 <citedRange unit="page">197</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,15 +57,18 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="ChristianLiterature"/>
+               <term key="MonasticLiterature"/>
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
-   <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
-   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <ab/>

--- a/Tuebingen/UBTaeth9.xml
+++ b/Tuebingen/UBTaeth9.xml
@@ -1,61 +1,44 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"
-?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth19" type="mss">
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="UBTaeth9" type="mss">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Book of Proverbs</title>
-            <editor key="VP"/>
+            <title>Maṣḥafa qedər</title>
+            <editor key="ES"/>
             <editor key="AB" role="generalEditor"/>
-            <funder></funder>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
-         <editionStmt><p>Cataloguing funded by the AHRC-DFG Project
-               'Demarginalizing medieval Africa: Images, texts, and identity
-               in early Solomonic Ethiopia (1270-1527)', grant ref.
-               nos. AH/V002910/1 - 448410109</p></editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
             <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
-
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
                   licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
             </availability>
-
          </publicationStmt>
          <sourceDesc>
             <msDesc xml:id="ms">
                   <msIdentifier>
                      <repository ref="INS0313UBT"/>
                      <collection>Codices aethiopici</collection>
-                    <idno>Tübingen Aeth. 19</idno>
-                    <altIdentifier><idno>Ma IX 19</idno></altIdentifier>
-                    </msIdentifier>
-                  <history>
-                     <origin>
-                        <origPlace>
-                        <placeName ref="LOC3010Ethiop"/>
-                     </origPlace>
-<origDate ></origDate>
-                     </origin>
-                  </history>
+                      <idno>Tübingen Aeth. 9</idno>
+                     <altIdentifier>
+                        <idno>Ewald cat. no. 12</idno>
+                     </altIdentifier>
+                  </msIdentifier>
                   <additional>
                      <adminInfo>
                         <recordHist>
                            <source>
                               <listBibl type="catalogue">
                                  <bibl>
-                                    <ptr target="bm:Ewald1846Tuebingen"/>
-                                    <citedRange unit="page">13-14</citedRange>
-                                 </bibl>
-                              
-                                 <bibl>
-                                 <ptr target="bm:Six2000Tübingen"/>
-                                 <citedRange unit="page">24-25</citedRange>
+                                 <ptr target="bm:Ewald1844Tuebingen"/>
+                                 <citedRange unit="page">198</citedRange>
                               </bibl>
-                            </listBibl>
+                              </listBibl>
                            </source>
                         </recordHist>
                         </adminInfo>
@@ -74,15 +57,18 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <textClass>
+            <keywords scheme="#ethioauthlist">
+               <term key="ChristianLiterature"/>
+               <term key="MonasticLiterature"/>
+            </keywords>
+         </textClass>
+         <langUsage><language ident="gez">Gǝʿǝz</language> <language ident="en">English</language></langUsage>         
       </profileDesc>
       <revisionDesc>
-         <change who="VP" when="2021-12-02">Created catalogue entry stub</change>
+         <change who="ES" when="2022-04-26">Created stub</change>
       </revisionDesc>
    </teiHeader>
-   <facsimile>
-      <graphic url="http://idb.ub.uni-tuebingen.de/opendigi/MaIX19"></graphic>
-   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <ab/>


### PR DESCRIPTION
Since Tuebingen MSS are often referred to I created some stubs by going through the two Ewald catalogues for now
I am not sure what to do with the MSS which are not in the UBT (and it is unknown where they are). Should we create institution records for the diseased persons that used to have them in the 1840s? 