### PR TITLE
Dr 22 08 provenance

### DIFF
--- a/OxfordBodleian/Juel-Jensen/BDLaethb4.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethb4.xml
@@ -1767,7 +1767,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <provenance> The manuscript must have come into the possession of the church
                             of <placeName ref="INS0101MadhaneAlam">Maqdala Madḫāne ʾĀlam</placeName> at a certain
                             time in its history from where it was probably looted on <date when="1868-04-13">13 April 1868</date>
-                            (see <ref target="#a1"/>) and brought to England. It is unknown how and
+                            (see <ref target="#a1"/>) and brought to England. It seems to match the description
+                             of the  ‘Acts of St. George the Martyr’ offered for sale in the catalogue of the London bookseller 
+                            <placeName ref="INS0525Quaritch"/>
+                            (<bibl><ptr target="bm:Quaritch1893List"/><citedRange unit="page">12</citedRange></bibl>).
+It is unknown how and
                             when the manuscript came into the possession of <persName
                                 ref="PRS5782JuelJen"/>.
                             <!--To be checked: Bought by the Antiquarian Bernard Quaritch?
@@ -1823,6 +1827,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <change who="DR" when="2020-02-21">Added dimensions and layout</change>
             <change who="SH" when="2020-04-22">Added editors</change>
             <change who="SH" when="2020-12-17">Full description of the Ms</change>
+            <change who="DR" when="2022-08-31">Added Quaritch reference</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">

--- a/OxfordBodleian/Juel-Jensen/BDLaethf31.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf31.xml
@@ -372,6 +372,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             in <bibl><ptr target="bm:Phillipps1837Catalogus"/><citedRange unit="page">432</citedRange></bibl>.
                            It was purchased by <persName ref="PRS5782JuelJen"/> at auction on <date>27 November 1974</date>, 
                             according to the Sotheby's sale receipt (lot 642).
+                            The manuscript, including its binding, seems to match the description of the ‘Gospel of John’ offered for sale in 
+                            <bibl><ptr target="bm:Quaritch1893List"/><citedRange unit="page">13</citedRange></bibl>, but an identification remains speculative.
                         </provenance>
                     </history>          
                     <additional>

--- a/OxfordBodleian/Juel-Jensen/BDLaethf31.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf31.xml
@@ -365,7 +365,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <origDate from="1700" to="1799" evidence="lettering"/>
                         </origin>
                         <provenance>
-                            The manuscript was acquired by the collector <persName ref="PRS13882PhillippsT "/> in <date>1871</date> from 
+                            The manuscript was acquired by the collector <persName ref="PRS13883PhillippsT"/> in <date>1871</date> from 
                             <persName ref="PRS13027Sturt" role="owner"><roleName type="rank">Captain</roleName> Sturt</persName>,
                             who had brought it from <placeName ref="LOC3010Ethiop">Ethiopia</placeName> in <date>1868</date> after <persName ref="PRS7484Napier"/>'s expedition 
                             (cp. also <ref target="#e2"/>). It was then assigned ‘23451’ as an inventory number and is described under this number 

--- a/OxfordBodleian/Juel-Jensen/BDLaethf31.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf31.xml
@@ -364,17 +364,24 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <origin>
                             <origDate from="1700" to="1799" evidence="lettering"/>
                         </origin>
-                        <provenance>According to the Sotheby's auction catalogue, the manuscript was obtained in <date>1871</date> by 
+                        <provenance>
+                            The manuscript was acquired by the collector <persName ref="PRS13882PhillippsT "/> in <date>1871</date> from 
                             <persName ref="PRS13027Sturt" role="owner"><roleName type="rank">Captain</roleName> Sturt</persName>,
                             who had brought it from <placeName ref="LOC3010Ethiop">Ethiopia</placeName> in <date>1868</date> after <persName ref="PRS7484Napier"/>'s expedition 
-                            (cp. also <ref target="#e2"/>). The manuscript was then assigned "23451" as an inventory number.
-                          It was purchased by <persName ref="PRS5782JuelJen"/> at auction on <date>27 November 1974</date>, according to the Sotheby's sale receipt (lot 642).
+                            (cp. also <ref target="#e2"/>). It was then assigned ‘23451’ as an inventory number and is described under this number 
+                            in <bibl><ptr target="bm:Phillipps1837Catalogus"/><citedRange unit="page">432</citedRange></bibl>.
+                           It was purchased by <persName ref="PRS5782JuelJen"/> at auction on <date>27 November 1974</date>, 
+                            according to the Sotheby's sale receipt (lot 642).
                         </provenance>
                     </history>          
                     <additional>
                         <adminInfo>
                             <recordHist>
-                                <source/>
+                                <source>
+                                      <listBibl type="secondary">
+                                          <bibl><ptr target="bm:Phillipps1837Catalogus"/><citedRange unit="page">432</citedRange></bibl>
+                                    </listBibl>
+                                </source>
                             </recordHist>
                         </adminInfo>
                     </additional>
@@ -420,6 +427,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <change who="MV" when="2020-06-01">Changes after PR.</change>
             <change who="MV" when="2020-06-15">Updated binding, layout, ruling and pricking, extra.</change>
             <change who="MV" when="2020-06-18">Changes after PR.</change>
+            <change who="DR" when="2022-08-31">Updated provenance</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">


### PR DESCRIPTION
See https://archive.org/details/quaritchcatalogue130/page/n21/mode/2up
(I also find that BDLaethf31 would match the "Gospel of John" on p. 13 - but that would only make sense if the manuscript had been offered for sale while still part of the Phillipps estate, never been sold, and then been sold later with the a part of the Phillipps collection at Sotheby's - that seems a bit far-fetched, I guess)