### PR TITLE
ci: fix push workflow

### DIFF
--- a/.github/workflows/validate_push.yml
+++ b/.github/workflows/validate_push.yml
@@ -26,24 +26,20 @@ jobs:
           path: schema
       - name: Install Test Dependencies
         run: sudo apt-get install libxml2-utils
-      - name: Gather all source files
-        id: all
-        run: |
-          echo "::set-output name=files::$( \
-            find . -type f -name '*.xml' \
-            -not -name 'transkribus*.xml' \
-            -not -name 'facsimile*.xml' \
-            -not -name 'build.xml' \
-            -not -name 'repo.xml' \
-            -not -name 'expath-pkg.xml' | \
-            xargs \
-          )"
+      # source files are gathered in a subshell
       - name: Validate all source files
         run: |
           xmllint \
             --noout --xinclude --nowarning \ 
             --relaxng ../schema/tei-betamesaheft.rng \
-            ${{ steps.all.outputs.files }} \
+            $( \
+              find . -type f -name '*.xml' \
+                -not -name 'transkribus*.xml' \
+                -not -name 'facsimile*.xml' \
+                -not -name 'build.xml' \
+                -not -name 'repo.xml' \
+                -not -name 'expath-pkg.xml' \
+            ) \
             2>&1 | \
             { grep -vE 'RNG|validates' || :; }
       - name: Build Expath Package

--- a/.github/workflows/validate_push.yml
+++ b/.github/workflows/validate_push.yml
@@ -32,15 +32,13 @@ jobs:
           xmllint \
             --noout --xinclude --nowarning \ 
             --relaxng ../schema/tei-betamesaheft.rng \
-            $( \
-              find . -type f -name '*.xml' \
+            $( find . -type f -name '*.xml' \
                 -not -name 'transkribus*.xml' \
                 -not -name 'facsimile*.xml' \
                 -not -name 'build.xml' \
                 -not -name 'repo.xml' \
                 -not -name 'expath-pkg.xml' \
-            ) \
-            2>&1 | \
+            ) 2>&1 | \
             { grep -vE 'RNG|validates' || :; }
       - name: Build Expath Package
         uses: actions/setup-java@v3


### PR DESCRIPTION
Gathering all source files in a separate step will lead to the
following validation step to exit with code 1 because the amount
of file names that will be pasted into the command exceeds ARG_MAX.

While not as readable as in two separate steps it is of greater
value to combine both steps and have the find command be executed
in a subshell.