### PR TITLE
BDLaethg45

### DIFF
--- a/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <title>Magic prayers</title>
+                <title>Protective prayers</title>
                 <editor key="DR"/>
                 <editor key="JG"/>
                 <editor key="MV"/><editor key="SH"/><funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -37,6 +37,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <msContents>
                         <summary/>
                         
+                       <!-- https://github.com/BetaMasaheft/Documentation/issues/2184-->
+                        
                         <msItem xml:id="ms_i1">
                       <locus from="1r1" to="1r21"/>
                       <!--      <title type="complete" ref=""/>-->
@@ -46,7 +48,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 ቅዱ<hi rend="rubric">ስ፡ ቅዱስ፡ ቅዱስ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ አምላከ፡ አማልክት፡</hi></incipit>
                             <explicit xml:lang="gez">ወእምኵሉ፡ ደዌ፡ ወሕማም፡ አድኅና፡ ለአመትከ፡ ወለተ፡ <space reason="rubrication"/>
                             <hi rend="rubric">ወገጽ፡ ዘፍፁም፡ በጽልመት፡ ፈርሃ፡ ወደንገፀ፡</hi> ዲያብሎስ፡ ርእዮ፡ ብሁተ፡ ልደት፡ በሥጋ፡ አምላክ፡ በሲኦል፡ በዝ፡ ቃለ፡ መለኮትከ፡
-                            አድኅና፡ ለአመትከ፡ <persName ref="" role="owner">ወለተ፡ <hi rend="rubric">ሰንበት፡ ትበርህ፡</hi></persName></explicit>
+                                አድኅና፡ ለአመትከ፡ <persName ref="PRS13850WalattaS" role="owner">ወለተ፡ <hi rend="rubric">ሰንበት፡ ትበርህ፡</hi></persName></explicit>
                         </msItem>
                         
                         <msItem xml:id="ms_i2">
@@ -56,7 +58,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ሕማመ፡ ቍርፀት፡ ኪስ፡ ኪስ፡ ኪስ፡ አራኪስ፡  ስርንኪስ፡ ስርዋጽ፡ 
                             ምርዋጽ፡ ስር፡ ነኬር፡ ሲቃ፡ ወጼቃ፡ ወቤቓ፡ ድማኄል፡ አዶናይ፡ ቄጼቤ፡ ቄጼቤ፡ ቄጼቤ፡</incipit>
                             <explicit xml:lang="gez">ቄፌኑ፡ ቄፌኑ፡ ቄፌኑ፡ ቡያክ፡ ቡያክ፡ ሞሊ፡ ሞሊ፡ ሞሊ፡ ኪያሞሌ፡ ኪያሞሌ፡ ኪያሞሌ፡ ዘአርጋእክ፡ ኃይለ፡
-                            በረድ፡ ወነፋስ፡ ከማሁ፡ አርግዕ፡ ወአቁም፡ ሕማመ፡ ቁርፀት፡ እምላእለ፡ አመትከ፡ <persName ref="">ወለተ፡ <hi rend="rubric">ሰንበት፡ ወለተ፡ ትበርሂ፡</hi></persName></explicit>
+                                በረድ፡ ወነፋስ፡ ከማሁ፡ አርግዕ፡ ወአቁም፡ ሕማመ፡ ቁርፀት፡ እምላእለ፡ አመትከ፡ <persName ref="PRS13850WalattaS">ወለተ፡ <hi rend="rubric">ሰንበት፡ ወለተ፡ ትበርሂ፡</hi></persName></explicit>
                         </msItem>
                         
                         <msItem xml:id="ms_i3">
@@ -64,18 +66,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <!--<title type="complete" ref=""/>-->
                             <!--this is the complete text-->
                             <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ሕማመ፡ ውግዓት፡ እልመክኩን፡ እልመክኩን፡ እልመክኩን፡
-                            አዝቤ፡ ረቤ፡ ታኦስ፡ ብርስባሔል፡ አልፋ፡ ወዕ፡ ቤጣ፡ ምስምያስ፡ ምድምያ፡ ምድምያስ፡ የሐቄ፡ የሐቄ፡ የሐቄ፡</incipit>
-                            <explicit xml:lang="gez">የኃብራስቄ፡ የኃብራስቄ፡ የኃብራስቄ፡ ክርስትቂ፡ ክርስቂ፡ ክርስቂ፡ በከመ፡ አድኃንከ፡ ለወለተ፡ ከራስቄ፡ ከማሃ፡ 
-                            አድኅና፡ በእንተ፡ ሕማመ፡ ውግዓት፡ ለአመትከ፡ <persName ref="">ወለተ፡ <hi rend="rubric">ሰንበት፡ ወለተ፡ ትበርሄ፡</hi></persName></explicit>
+                            አዝቤ፡ ረቤ፡ ታኦስ፡ ብርስባሔል፡ አልፋ፡ ወዕ፡ ቤጣ፡ ምድምያስ፡ ምድምያ፡ ምድምያስ፡ የሐቄ፡ የሐቄ፡ የሐቄ፡</incipit>
+                            <explicit xml:lang="gez">የኃብራስቄ፡ የኃብራስቄ፡ የኃብራስቄ፡ ክርስትቂ፡ ክርስቂ፡ ክርስቄ፡ በከመ፡ አድኃንከ፡ ለወለተ፡ ከራስቄ፡ ከማሃ፡ 
+                                አድኅና፡ በእንተ፡ ሕማመ፡ ውግዓት፡ ለአመትከ፡ <persName ref="PRS13850WalattaS">ወለተ፡ <hi rend="rubric">ሰንበት፡ ወለተ፡ ትበርሄ፡</hi></persName></explicit>
                         </msItem>
                         
                         <msItem xml:id="ms_i4">
                             <locus from="1r39" to="1r49"/>
                          <!--   <title type="complete" ref=""/>-->
+                            <!--this is the complete text-->
                             <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ፍልፀት፡ ያጣውጢ፡ ያጣውጢ፡ ያጣውጢ፡ ያሽላክፊ፡ ያሽላክፊ፡ ያሽላክፊ፡
-                            ያበጋር፡ ሽሩራን፡ ሽኃል፡ መጃል፡ ካፍ፡ ላፍ፡ አፈና፡ ጋዲን፡ ታኦስ፡ አብኖዲ፡ ብርስባኄል፡ አዶና፡ አማኑኤል፡ እምንስቲት፡ ሙኬርያ፡</incipit>
+                            ያበጋር፡ ሽሩራን፡ ሽኃል፡ መጃል፡ ካፍ፡ ላፍ፡ አፈና፡ ጋዲን፡ ታኦስ፡ አብኖዲ፡ ብርስባኄል፡ አዶናይ፡ አማኑኤል፡ እምንስቲት፡ ሙኬርያ፡</incipit>
                             <explicit xml:lang="gez">መዓግያ፡ ሙዳሱጣ፡ ኢየሱስ፡ ክርስቶስ። ወልደ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ሕያው፡ ዘኢይመውት፡ በኃይለ፡ ዝንቱ፡ አስማቲከ፡ 
-                            አርኅቆሙ፡ ለምታት፡ <sic>ወለፍፀተ፡</sic> ርክስ፡ እምላእለ፡ አመትከ፡ <persName ref="">ወለተ፡ <hi rend="rubric">ሰንበት፡ ትበርሄ።</hi></persName></explicit>
+                                አርኅቆሙ፡ ለምታት፡ <sic>ወለፍፀተ፡</sic> ርክስ፡ እምላእለ፡ አመትከ፡ <persName ref="PRS13850WalattaS">ወለተ፡ <hi rend="rubric">ሰንበት፡ ትበርሄ።</hi></persName></explicit>
                         </msItem>
                         
                         <msItem xml:id="ms_i5">
@@ -84,10 +87,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <note>The version of the work attested here is close to that attested in <ref type="mss" corresp="EMIP00616"/>, 
                                 <locus from="51r" to="61v"/>, and <ref type="mss" corresp="EMIP00292"/>.</note>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ አስማተ፡ ሰሎሞን፡</hi>
-                            ዘረበቦሙ፡ ለአንንት፡ ወለነሃብት፡ ከመ፡ በርበብተ፡ አሣ፡ እንዘ፡ ይብል፡ ሰዳቃኤል፡ አዳናኤል፡ አዳናኤል፡ ኤል፡ ሮሜል፡ ስርማ፡ ሩባ፡ ዕፍ፡ በአፍ፡ ጸልለኒ፡ በክንፍከ፡
-                            እግዚኦ፡ እምፀርየ፡ ወአድኅነኒ፡ እምሕማመ፡ ፀላኢ፡</incipit>
-                            <explicit xml:lang="gez">አድኅነኒ፡ እምፀርየ፡ ወነገርጋር፡ ከመ፡ ኢይንበሩ፡ በትርአስየ፡ ወኢበትርጋጽየ፡ ወኢይብቡኒ፡ ነገረ፡ እኵይ፡ ለአሴደ፡ ወእምኵሎሙ፡
-                            መናፍስት፡ ርኵሳን፡ ወሰብዕ፡ መሠርያን፡ ሠርከ፡ ወነግሃ፡ ወዓልተ፡ ወሌሊተ፡ ከመ፡ ኢያህሶም፡ ላእሌየ፡ ኵሎሙ፡ ገበርተ፡ አመፃ፡ ሊተ፡ ለአመትከ፡ <persName ref="">ወለተ፡
+                            ዘረበቦሙ<supplied reason="omitted">፡</supplied> <sic>ለአንንት፡</sic> ወለነሃብት፡ ከመ፡ መርበብተ፡ አሣ፡ እንዘ፡ ይብል፡ ሰዳቃኤል፡ አዳናኤል፡ አዳዳኤል፡ ኤል፡ 
+                                ርሜል፡ ስርማ፡ ሩባ፡ ዕፍ፡ በዕፍ፡ ጸልለኒ፡ በክንፍከ፡
+                            እ<hi rend="ligature">ግዚ</hi>ኦ፡ እምፀርየ፡ ወአድኅነኒ፡ እምሕማመ፡ ፀላኢ፡</incipit>
+                            <explicit xml:lang="gez">አድኅነኒ<supplied reason="omitted">፡</supplied> እምፀርየ፡ ወነገርጋር፡ ከመ፡ ኢይንበሩ፡ በትርአስየ፡ ወኢበትርጋጽየ፡ 
+                                ወኢይብቡኒ፡ ነገረ፡ እኵይ፡ ላእሌየ፡ ወእምኵሎሙ፡
+                                መናፍስት፡ ርኵሳን፡ ወሰብዕ፡ መሠርያን፡ ሠርከ፡ ወነግሃ፡ <sic>ወዓልተ፡</sic> ወሌሊተ፡ ከመ፡ ኢያህሶም፡ ላእሌየ፡ ኵሎሙ፡ ገበርተ፡ አመፃ፡ ሊተ፡ ለአመትከ፡ <persName ref="PRS13850WalattaS">ወለተ፡
                             <hi rend="rubric">ሰንበት፡ ትበርሄ፡</hi></persName></explicit>
                         </msItem>
                         
@@ -97,11 +102,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <note>The version of the work attested here is close to that attested in <ref type="mss" corresp="EMIP00616"/>, 
                                 <locus from="51r" to="61v"/>, and <ref type="mss" corresp="EMIP00292"/>.</note>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡</hi> ቅዱስ፡ ፩ አምላክ፡ ጸሎተ፡ አቍያጻት፡ ወአቃብያነ፡
-                            ሥራይ፡ እለ፡ ይቀትሉ፡ ነፍሰ፡ ሰብዕ፡ እንበለ፡ ጊዜ፡ ወስውረ፡ ወእለ፡ ይትሜሰሉ፡ በሕልመ፡ ሌሊት፡ ወበራእየ፡ ን፡ ወበራእየ፡ መዓልት፡ እለ፡ የሃውሩ፡ በሞችኃት፡
+                            ሥራይ፡ እለ፡ ይቀትሉ፡ ነፍሰ፡ ሰብዕ፡ እንበለ፡ ጊዜ፡ ወስውረ፡ ወእለ፡ ይትሜሰሉ፡ በሕልመ፡ ሌሊት፡ ወበራእየ፡ <surplus>ን፡ ወበራእየ፡</surplus> መዓልት፡ እለ፡ የሃውሩ፡ በሞችኃት፡
                             ወእለ፡ ይትሜሰሉ፡ ዝእበ፡</incipit>
-                            <explicit xml:lang="gez">ከመ፡ ኢይማዑኒ፡ ኵሎሙ፡ አቃብያነ፡ ሥራይ፡ ወገበርተ፡ አምፃ፡ እለ፡ የሐውሩ፡ በሌሊት፡ ኀበ፡ ኵሉ፡ ሰብዕ፡ ይደምስሱ፡
-                            ወይዘረው፡ ሠራዊትሙ፡ ለአጋንንት፡ በኵሉ፡ ጊዜ፡ ወበኵሉ፡ ሠአት፡ ዘመዓልት፡ ወዘሌሊት፡ በቀትር፡ ወበሠአት፡ ለአለመ፡ አለም፡ አሜን፡ ለአመትከ፡
-                            <persName ref="">ወለተ፡ <hi rend="rubric">ሰንበት፡</hi></persName> እስመ፡ አልቦ፡ ነገር፡ ዘይስእኖ፡ ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ ሥጋ፡ ቃል፡ ኮነ፡ ቃል፡ ሥጋ፡ ኮነ፡</explicit>
+                            <explicit xml:lang="gez">ከመ፡ ኢይማዑኒ፡ ኵሎሙ፡ አቃብያነ፡ ሥራይ፡ ወገበርተ፡ አመፃ፡ እለ፡ የሐውሩ፡ በሌሊት፡ ኀበ፡ ኵሉ፡ ሰብዕ፡ ይደምስሱ፡
+                            ወይዘረው፡ <sic>ሠራዊትሙ፡</sic> ለአጋንንት፡ በኵሉ፡ ጊዜ፡ ወበኵሉ፡ ሠአት፡ ዘመዓልት፡ ወዘሌሊት፡ በቀትር፡ ወበሠአት፡ ለአለመ፡ አለም፡ አሜን፡ ለአመትከ፡
+                                <persName ref="PRS13850WalattaS">ወለተ፡ <hi rend="rubric">ሰንበት፡</hi></persName> እስመ፡ አልቦ፡ ነገር፡ ዘይስእኖ፡ 
+                                ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ ሥጋ፡ ቃል፡ ኮነ፡ ቃል፡ ሥጋ፡ ኮነ፡</explicit>
                       </msItem>
                     </msContents>
                     
@@ -198,7 +204,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <additions>
                             <list>
                                 <item xml:id="e1">
-                                    <desc>The name of the owner, mentioned in supplications throughout, was <persName ref=""/>.</desc>
+                                    <desc>The name of the owner, mentioned in supplications throughout, was 
+                                        <persName ref="PRS13850WalattaS"/>. The last part of the name is spelled with variation
+                                        <foreign xml:lang="gez">ትበርህ፡</foreign>, <foreign xml:lang="gez">ትበርሂ፡</foreign> and <foreign xml:lang="gez">ትበርሄ፡</foreign>.</desc>
                                 </item>
                                 
                                 <item xml:id="e2">

--- a/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
@@ -89,7 +89,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <locus from="1r50" to="1r148"/>
                             <title type="complete" ref="LIT1878Marbab"/>
                             <note>The version of the work attested here is close to that attested in <ref type="mss" corresp="EMIP00616"/> 
-                                (<locus from="51r" to="61v"/>) and <ref type="mss" corresp="EMIP00292"/>.</note>
+                                (<locus from="51r" to="53v"/>) and <ref type="mss" corresp="EMIP00292"/> (<locus from="7v" to="9v"/>).</note>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ አስማተ፡ ሰሎሞን፡</hi>
                             ዘረበቦሙ<supplied reason="omitted">፡</supplied> <sic>ለአንንት፡</sic> ወለነሃብት፡ ከመ፡ መርበብተ፡ አሣ፡ እንዘ፡ ይብል፡ ሰዳቃኤል፡ አዳናኤል፡ አዳዳኤል፡ ኤል፡ 
                                 ርሜል፡ ስርማ፡ ሩባ፡ ዕፍ፡ በዕፍ፡ ጸልለኒ፡ በክንፍከ፡
@@ -105,7 +105,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <title type="complete" ref="LIT6718PPAqweyasat"/>
                             <textLang mainLang="gez"/>
                             <note>The version of the work attested here is close to that attested in <ref type="mss" corresp="EMIP00616"/>
-                                (<locus from="51r" to="61v"/>) and <ref type="mss" corresp="EMIP00292"/>.</note>
+                                (<locus from="53v" to="61v"/>) and <ref type="mss" corresp="EMIP00292"/> (<locus from="3v" to="7v"/>).</note>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡</hi> ቅዱስ፡ ፩ አምላክ፡ ጸሎተ፡ አቍያጻት፡ ወአቃብያነ፡
                             ሥራይ፡ እለ፡ ይቀትሉ፡ ነፍሰ፡ ሰብዕ፡ እንበለ፡ ጊዜ፡ ወስውረ፡ ወእለ፡ ይትሜሰሉ፡ በሕልመ፡ ሌሊት፡ ወበራእየ፡ <surplus>ን፡ ወበራእየ፡</surplus> መዓልት፡ እለ፡ የሃውሩ፡ በሞችኃት፡
                             ወእለ፡ ይትሜሰሉ፡ ዝእበ፡</incipit>
@@ -121,11 +121,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <supportDesc>
                                 <support>
                                     <material key="parchment"/>
+                                    <note>Consists of <measure unit="strips">2</measure> strips sewn together.</note>
                                 </support>
                                 <extent>
                                     <measure type="weight" unit="g">93</measure>
-                                    <note>Consists of <measure unit="strips">2</measure> strips sewn together with small parchment strips.</note>
-                                    <!--Is the information on sewing best encoded here? Or better in binding?-->
                                     <dimensions type="outer" unit="mm">
                                         <height>1858</height>
                                         <width>112</width>
@@ -230,6 +229,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </item>
                             </list>
                         </additions>
+                        
+                       <bindingDesc>
+                           <binding xml:id="binding">
+                               <decoNote xml:id="b1">The strips are sewn together with small parchment strips.</decoNote>
+                           </binding>
+                       </bindingDesc>
                         
                     </physDesc>
                     

--- a/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
@@ -37,9 +37,78 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <msContents>
                         <summary/>
                         
-                        <!--<msItem xml:id="ms_i1">
-                      
-                        </msItem>-->
+                        <msItem xml:id="ms_i1">
+                      <locus from="1" to=""/>
+                            <title type="complete" ref=""/>
+                            <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ስቡሕ፡ ወውዱስ፡ ዘሣረረ፡ ኵሎ፡ ዓለም፡
+                                በ</hi>አሐቲ፡ ቃል፡ ሃሌ፡ ሉያ፡ እ<hi rend="ligature">ግዚ</hi>ኦ፡ መሐረነ፡ እ<hi rend="ligature">ግዚ</hi>ኦ፡ መሐከነ፡ 
+                                እ<hi rend="ligature">ግዚ</hi>ኦ፡ ተሠሃለነ፡ ስብሐት፡ ለአብ፡ ስብሐት፡ ለወልድ፡ ስብሐት፡ ለመንፈስ፡ ቅዱስ፡
+                                ቅዱ<hi rend="rubric">ስ፡ ቅዱስ፡ ቅዱስ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ አምላከ፡ አማልክት፡</hi></incipit>
+                            <explicit xml:lang="gez"></explicit>
+                        </msItem>
+                        
+                        <msItem xml:id="ms_i">
+                            <locus from="" to=""/>
+                            <title type="complete" ref=""/>
+                            <incipit xml:lang="gez"></incipit>
+                            <explicit xml:lang="gez"></explicit>
+                        </msItem>
+                        
+                        <msItem xml:id="ms_i">
+                            <locus from="" to=""/>
+                            <title type="complete" ref=""/>
+                            <incipit xml:lang="gez"></incipit>
+                            <explicit xml:lang="gez"></explicit>
+                        </msItem>
+                        
+                        <msItem xml:id="ms_i">
+                            <locus from="" to=""/>
+                            <title type="complete" ref=""/>
+                            <incipit xml:lang="gez"></incipit>
+                            <explicit xml:lang="gez"></explicit>
+                        </msItem>
+                        
+                        <msItem xml:id="ms_i">
+                            <locus from="" to=""/>
+                            <title type="complete" ref=""/>
+                            <incipit xml:lang="gez"></incipit>
+                            <explicit xml:lang="gez"></explicit>
+                        </msItem>
+                        
+                        <msItem xml:id="ms_i">
+                            <locus from="" to=""/>
+                            <title type="complete" ref=""/>
+                            <incipit xml:lang="gez"></incipit>
+                            <explicit xml:lang="gez"></explicit>
+                        </msItem>
+                        
+                        <msItem xml:id="ms_i">
+                            <locus from="" to=""/>
+                            <title type="complete" ref=""/>
+                            <incipit xml:lang="gez"></incipit>
+                            <explicit xml:lang="gez"></explicit>
+                        </msItem>
+                        
+                        <msItem xml:id="ms_i">
+                            <locus from="" to=""/>
+                            <title type="complete" ref=""/>
+                            <incipit xml:lang="gez"></incipit>
+                            <explicit xml:lang="gez"></explicit>
+                        </msItem>
+                        
+                        <msItem xml:id="ms_i">
+                            <locus from="" to=""/>
+                            <title type="complete" ref=""/>
+                            <incipit xml:lang="gez"></incipit>
+                            <explicit xml:lang="gez"></explicit>
+                        </msItem>
+                        
+                        <msItem xml:id="ms_i">
+                            <locus from="" to=""/>
+                            <title type="complete" ref=""/>
+                            <incipit xml:lang="gez"></incipit>
+                            <explicit xml:lang="gez"></explicit>
+                        </msItem>
                         
                     </msContents>
                     

--- a/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
@@ -37,11 +37,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <msContents>
                         <summary/>
                         
-                       <!-- https://github.com/BetaMasaheft/Documentation/issues/2184-->
-                        
                         <msItem xml:id="ms_i1">
                       <locus from="1r1" to="1r21"/>
-                      <!--      <title type="complete" ref=""/>-->
+                                  <title type="complete" ref="LIT6714PPIllness"/>
+                            <textLang mainLang="gez"/>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ስቡሕ፡ ወውዱስ፡ ዘሣረረ፡ ኵሎ፡ ዓለም፡
                                 በ</hi>አሐቲ፡ ቃል፡ ሃሌ፡ ሉያ፡ እ<hi rend="ligature">ግዚ</hi>ኦ፡ መሐረነ፡ እ<hi rend="ligature">ግዚ</hi>ኦ፡ መሐከነ፡ 
                                 እ<hi rend="ligature">ግዚ</hi>ኦ፡ ተሠሃለነ፡ ስብሐት፡ ለአብ፡ ስብሐት፡ ለወልድ፡ ስብሐት፡ ለመንፈስ፡ ቅዱስ፡
@@ -53,7 +52,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         
                         <msItem xml:id="ms_i2">
                             <locus from="1r21" to="1r30"/>
-                         <!--   <title type="complete" ref=""/>-->
+                               <title type="complete" ref="LIT6715PPQwerdat"/>
+                            <textLang mainLang="gez"/>
                             <!--this is the complete text-->
                             <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ሕማመ፡ ቍርፀት፡ ኪስ፡ ኪስ፡ ኪስ፡ አራኪስ፡  ስርንኪስ፡ ስርዋጽ፡ 
                             ምርዋጽ፡ ስር፡ ነኬር፡ ሲቃ፡ ወጼቃ፡ ወቤቓ፡ ድማኄል፡ አዶናይ፡ ቄጼቤ፡ ቄጼቤ፡ ቄጼቤ፡</incipit>
@@ -63,7 +63,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         
                         <msItem xml:id="ms_i3">
                             <locus from="1r30" to="1r39"/>
-                            <!--<title type="complete" ref=""/>-->
+                            <title type="complete" ref="LIT6716PPWegat"/>
+                            <textLang mainLang="gez"/>
                             <!--this is the complete text-->
                             <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ሕማመ፡ ውግዓት፡ እልመክኩን፡ እልመክኩን፡ እልመክኩን፡
                             አዝቤ፡ ረቤ፡ ታኦስ፡ ብርስባሔል፡ አልፋ፡ ወዕ፡ ቤጣ፡ ምድምያስ፡ ምድምያ፡ ምድምያስ፡ የሐቄ፡ የሐቄ፡ የሐቄ፡</incipit>
@@ -73,7 +74,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         
                         <msItem xml:id="ms_i4">
                             <locus from="1r39" to="1r49"/>
-                         <!--   <title type="complete" ref=""/>-->
+                               <title type="complete" ref="LIT6717PPFelsat"/>
+                            <textLang mainLang="gez"/>
                             <!--this is the complete text-->
                             <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ፍልፀት፡ ያጣውጢ፡ ያጣውጢ፡ ያጣውጢ፡ ያሽላክፊ፡ ያሽላክፊ፡ ያሽላክፊ፡
                             ያበጋር፡ ሽሩራን፡ ሽኃል፡ መጃል፡ ካፍ፡ ላፍ፡ አፈና፡ ጋዲን፡ ታኦስ፡ አብኖዲ፡ ብርስባኄል፡ አዶናይ፡ አማኑኤል፡ እምንስቲት፡ ሙኬርያ፡</incipit>
@@ -98,7 +100,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         
                         <msItem xml:id="ms_i6">
                             <locus from="1r148" to="1r261"/>
-                        <!--    <title type="complete" ref=""/>-->
+                                <title type="complete" ref="LIT6718PPAqweyasat"/>
+                            <textLang mainLang="gez"/>
                             <note>The version of the work attested here is close to that attested in <ref type="mss" corresp="EMIP00616"/>, 
                                 <locus from="51r" to="61v"/>, and <ref type="mss" corresp="EMIP00292"/>.</note>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡</hi> ቅዱስ፡ ፩ አምላክ፡ ጸሎተ፡ አቍያጻት፡ ወአቃብያነ፡

--- a/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
@@ -56,9 +56,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <textLang mainLang="gez"/>
                             <!--this is the complete text-->
                             <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ሕማመ፡ ቍርፀት፡ ኪስ፡ ኪስ፡ ኪስ፡ አራኪስ፡  ስርንኪስ፡ ስርዋጽ፡ 
-                            ምርዋጽ፡ ስር፡ ነኬር፡ ሲቃ፡ ወጼቃ፡ ወቤቓ፡ ድማኄል፡ አዶናይ፡ ቄጼቤ፡ ቄጼቤ፡ ቄጼቤ፡</incipit>
-                            <explicit xml:lang="gez">ቄፌኑ፡ ቄፌኑ፡ ቄፌኑ፡ ቡያክ፡ ቡያክ፡ ሞሊ፡ ሞሊ፡ ሞሊ፡ ኪያሞሌ፡ ኪያሞሌ፡ ኪያሞሌ፡ ዘአርጋእክ፡ ኃይለ፡
-                                በረድ፡ ወነፋስ፡ ከማሁ፡ አርግዕ፡ ወአቁም፡ ሕማመ፡ ቁርፀት፡ እምላእለ፡ አመትከ፡ <persName ref="PRS13850WalattaS">ወለተ፡ <hi rend="rubric">ሰንበት፡ ወለተ፡ ትበርሂ፡</hi></persName></explicit>
+                            ምርዋጽ፡ ስር፡ ነኬር፡ ሲቃ፡ ወጼቃ፡ ወቤቓ፡ ድማኄል፡ አዶናይ፡ ቄጼቤ፡ ቄጼቤ፡ ቄጼቤ፡
+                         ቄፌኑ፡ ቄፌኑ፡ ቄፌኑ፡ ቡያክ፡ ቡያክ፡ ሞሊ፡ ሞሊ፡ ሞሊ፡ ኪያሞሌ፡ ኪያሞሌ፡ ኪያሞሌ፡ ዘአርጋእክ፡ ኃይለ፡
+                                በረድ፡ ወነፋስ፡ ከማሁ፡ አርግዕ፡ ወአቁም፡ ሕማመ፡ ቁርፀት፡ እምላእለ፡ አመትከ፡
+                                <persName ref="PRS13850WalattaS">ወለተ፡ <hi rend="rubric">ሰንበት፡ ወለተ፡ ትበርሂ፡</hi></persName>
+                            </incipit>
                         </msItem>
                         
                         <msItem xml:id="ms_i3">
@@ -67,10 +69,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <textLang mainLang="gez"/>
                             <!--this is the complete text-->
                             <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ሕማመ፡ ውግዓት፡ እልመክኩን፡ እልመክኩን፡ እልመክኩን፡
-                            አዝቤ፡ ረቤ፡ ታኦስ፡ ብርስባሔል፡ አልፋ፡ ወዕ፡ ቤጣ፡ ምድምያስ፡ ምድምያ፡ ምድምያስ፡ የሐቄ፡ የሐቄ፡ የሐቄ፡</incipit>
-                            <explicit xml:lang="gez">የኃብራስቄ፡ የኃብራስቄ፡ የኃብራስቄ፡ ክርስትቂ፡ ክርስቂ፡ ክርስቄ፡ በከመ፡ አድኃንከ፡ ለወለተ፡ ከራስቄ፡ ከማሃ፡ 
-                                አድኅና፡ በእንተ፡ ሕማመ፡ ውግዓት፡ ለአመትከ፡ <persName ref="PRS13850WalattaS">ወለተ፡ <hi rend="rubric">ሰንበት፡ ወለተ፡ ትበርሄ፡</hi></persName></explicit>
-                        </msItem>
+                            አዝቤ፡ ረቤ፡ ታኦስ፡ ብርስባሔል፡ አልፋ፡ ወዕ፡ ቤጣ፡ ምድምያስ፡ ምድምያ፡ ምድምያስ፡ የሐቄ፡ የሐቄ፡ የሐቄ፡
+                            የኃብራስቄ፡ የኃብራስቄ፡ የኃብራስቄ፡ ክርስትቂ፡ ክርስቂ፡ ክርስቄ፡ በከመ፡ አድኃንከ፡ ለወለተ፡ ከራስቄ፡ ከማሃ፡ 
+                            አድኅና፡ በእንተ፡ ሕማመ፡ ውግዓት፡ ለአመትከ፡ <persName ref="PRS13850WalattaS">ወለተ፡ <hi rend="rubric">ሰንበት፡ ወለተ፡ ትበርሄ፡</hi></persName></incipit>
+            </msItem>
                         
                         <msItem xml:id="ms_i4">
                             <locus from="1r39" to="1r49"/>
@@ -78,10 +80,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <textLang mainLang="gez"/>
                             <!--this is the complete text-->
                             <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ፍልፀት፡ ያጣውጢ፡ ያጣውጢ፡ ያጣውጢ፡ ያሽላክፊ፡ ያሽላክፊ፡ ያሽላክፊ፡
-                            ያበጋር፡ ሽሩራን፡ ሽኃል፡ መጃል፡ ካፍ፡ ላፍ፡ አፈና፡ ጋዲን፡ ታኦስ፡ አብኖዲ፡ ብርስባኄል፡ አዶናይ፡ አማኑኤል፡ እምንስቲት፡ ሙኬርያ፡</incipit>
-                            <explicit xml:lang="gez">መዓግያ፡ ሙዳሱጣ፡ ኢየሱስ፡ ክርስቶስ። ወልደ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ሕያው፡ ዘኢይመውት፡ በኃይለ፡ ዝንቱ፡ አስማቲከ፡ 
-                                አርኅቆሙ፡ ለምታት፡ <sic>ወለፍፀተ፡</sic> ርክስ፡ እምላእለ፡ አመትከ፡ <persName ref="PRS13850WalattaS">ወለተ፡ <hi rend="rubric">ሰንበት፡ ትበርሄ።</hi></persName></explicit>
-                        </msItem>
+                            ያበጋር፡ ሽሩራን፡ ሽኃል፡ መጃል፡ ካፍ፡ ላፍ፡ አፈና፡ ጋዲን፡ ታኦስ፡ አብኖዲ፡ ብርስባኄል፡ አዶናይ፡ አማኑኤል፡ እምንስቲት፡ ሙኬርያ፡
+                            መዓግያ፡ ሙዳሱጣ፡ ኢየሱስ፡ ክርስቶስ። ወልደ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ሕያው፡ ዘኢይመውት፡ በኃይለ፡ ዝንቱ፡ አስማቲከ፡ 
+                                አርኅቆሙ፡ ለምታት፡ <sic>ወለፍፀተ፡</sic> ርክስ፡ እምላእለ፡ አመትከ፡ <persName ref="PRS13850WalattaS">ወለተ፡ <hi rend="rubric">ሰንበት፡ ትበርሄ።</hi></persName></incipit>
+                      </msItem>
                         
                         <msItem xml:id="ms_i5">
                             <locus from="1r50" to="1r148"/>
@@ -300,13 +302,29 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </ab>
                         </div>
                         <div type="textpart" subtype="text" n="2" corresp="#ms_i2" xml:id="text2">
-                            <ab/>
+                            <ab>
+                                <hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ሕማመ፡ ቍርፀት፡ ኪስ፡ ኪስ፡ ኪስ፡ አራኪስ፡  ስርንኪስ፡ ስርዋጽ፡ 
+                                    ምርዋጽ፡ ስር፡ ነኬር፡ ሲቃ፡ ወጼቃ፡ ወቤቓ፡ ድማኄል፡ አዶናይ፡ ቄጼቤ፡ ቄጼቤ፡ ቄጼቤ፡
+                               ቄፌኑ፡ ቄፌኑ፡ ቄፌኑ፡ ቡያክ፡ ቡያክ፡ ሞሊ፡ ሞሊ፡ ሞሊ፡ ኪያሞሌ፡ ኪያሞሌ፡ ኪያሞሌ፡ ዘአርጋእክ፡ ኃይለ፡
+                                    በረድ፡ ወነፋስ፡ ከማሁ፡ አርግዕ፡ ወአቁም፡ ሕማመ፡ ቁርፀት፡ እምላእለ፡ አመትከ፡ <persName ref="PRS13850WalattaS">ወለተ፡ <hi rend="rubric">ሰንበት፡ ወለተ፡ ትበርሂ፡</hi></persName>
+                            </ab>
                         </div>
                         <div type="textpart" subtype="text" n="3" corresp="#ms_i3" xml:id="text3">
-                            <ab/>
+                            <ab>
+                                <hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ሕማመ፡ ውግዓት፡ እልመክኩን፡ እልመክኩን፡ እልመክኩን፡
+                                    አዝቤ፡ ረቤ፡ ታኦስ፡ ብርስባሔል፡ አልፋ፡ ወዕ፡ ቤጣ፡ ምድምያስ፡ ምድምያ፡ ምድምያስ፡ የሐቄ፡ የሐቄ፡ የሐቄ፡
+                                የኃብራስቄ፡ የኃብራስቄ፡ የኃብራስቄ፡ ክርስትቂ፡ ክርስቂ፡ ክርስቄ፡ በከመ፡ አድኃንከ፡ ለወለተ፡ ከራስቄ፡ ከማሃ፡ 
+                                    አድኅና፡ በእንተ፡ ሕማመ፡ ውግዓት፡ ለአመትከ፡ <persName ref="PRS13850WalattaS">ወለተ፡ <hi rend="rubric">ሰንበት፡ ወለተ፡ ትበርሄ፡</hi></persName>
+                                
+                            </ab>
                         </div>
                         <div type="textpart" subtype="text" n="4" corresp="#ms_i4" xml:id="text4">
-                            <ab/>
+                            <ab>
+                                <hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ፍልፀት፡ ያጣውጢ፡ ያጣውጢ፡ ያጣውጢ፡ ያሽላክፊ፡ ያሽላክፊ፡ ያሽላክፊ፡
+                                    ያበጋር፡ ሽሩራን፡ ሽኃል፡ መጃል፡ ካፍ፡ ላፍ፡ አፈና፡ ጋዲን፡ ታኦስ፡ አብኖዲ፡ ብርስባኄል፡ አዶናይ፡ አማኑኤል፡ እምንስቲት፡ ሙኬርያ፡
+                                መዓግያ፡ ሙዳሱጣ፡ ኢየሱስ፡ ክርስቶስ። ወልደ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ሕያው፡ ዘኢይመውት፡ በኃይለ፡ ዝንቱ፡ አስማቲከ፡ 
+                                    አርኅቆሙ፡ ለምታት፡ <sic>ወለፍፀተ፡</sic> ርክስ፡ እምላእለ፡ አመትከ፡ <persName ref="PRS13850WalattaS">ወለተ፡ <hi rend="rubric">ሰንበት፡ ትበርሄ።</hi></persName>
+                            </ab>
                         </div>
                         <div type="textpart" subtype="text" n="5" corresp="#ms_i5" xml:id="text5part1">
                             <ab/>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
@@ -38,7 +38,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <summary/>
                         
                         <msItem xml:id="ms_i1">
-                      <locus from="1" to="21"/>
+                      <locus from="1r1" to="1r21"/>
                             <title type="complete" ref=""/>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ስቡሕ፡ ወውዱስ፡ ዘሣረረ፡ ኵሎ፡ ዓለም፡
                                 በ</hi>አሐቲ፡ ቃል፡ ሃሌ፡ ሉያ፡ እ<hi rend="ligature">ግዚ</hi>ኦ፡ መሐረነ፡ እ<hi rend="ligature">ግዚ</hi>ኦ፡ መሐከነ፡ 
@@ -50,7 +50,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </msItem>
                         
                         <msItem xml:id="ms_i2">
-                            <locus from="21" to="30"/>
+                            <locus from="1r21" to="1r30"/>
                             <title type="complete" ref=""/>
                             <!--this is the complete text-->
                             <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ሕማመ፡ ቍርፀት፡ ኪስ፡ ኪስ፡ ኪስ፡ አራኪስ፡  ስርንኪስ፡ ስርዋጽ፡ 
@@ -60,7 +60,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </msItem>
                         
                         <msItem xml:id="ms_i3">
-                            <locus from="30" to="39"/>
+                            <locus from="1r30" to="1r39"/>
                             <title type="complete" ref=""/>
                             <!--this is the complete text-->
                             <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ሕማመ፡ ውግዓት፡ እልመክኩን፡ እልመክኩን፡ እልመክኩን፡
@@ -70,7 +70,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </msItem>
                         
                         <msItem xml:id="ms_i4">
-                            <locus from="39" to="49"/>
+                            <locus from="1r39" to="1r49"/>
                             <title type="complete" ref=""/>
                             <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ፍልፀት፡ ያጣውጢ፡ ያጣውጢ፡ ያጣውጢ፡ ያሽላክፊ፡ ያሽላክፊ፡ ያሽላክፊ፡
                             ያበጋር፡ ሽሩራን፡ ሽኃል፡ መጃል፡ ካፍ፡ ላፍ፡ አፈና፡ ጋዲን፡ ታኦስ፡ አብኖዲ፡ ብርስባኄል፡ አዶና፡ አማኑኤል፡ እምንስቲት፡ ሙኬርያ፡</incipit>
@@ -79,7 +79,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </msItem>
                         
                         <msItem xml:id="ms_i5">
-                            <locus from="50" to=""/>
+                            <locus from="1r50" to="1r"/>
                             <title type="complete" ref="LIT1878Marbab"/>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ አስማተ፡ ሰሎሞን፡</hi>
                             ዘረበቦሙ፡ ለአንንት፡ ወለነሃብት፡ ከመ፡ በርበብተ፡ አሣ፡ እንዘ፡ ይብል፡ ሰዳቃኤል፡ አዳናኤል፡ አዳናኤል፡ ኤል፡ ሮሜል፡ ስርማ፡ ሩባ፡ ዕፍ፡ በአፍ፡ ጸልለኒ፡ በክንፍከ፡
@@ -89,14 +89,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             ሊተ፡ ለአመትከ፡ <persName ref="">ወለተ፡ <hi rend="rubric">ሰንበት፡ ወለተ፡ ትብርህ፡</hi></persName></explicit>
                            <!-- EMIPms00037, same name of owner and similar texts?-->
                            <!-- very close to the text in EMIP00616-->
+                            <!--identify end-->
                         </msItem>
                         
                         <msItem xml:id="ms_i6">
-                            <locus from="" to=""/>
+                            <locus from="1r" to="1r"/>
                             <title type="complete" ref=""/>
-                            <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ተማኅፀንኩ፡</hi>
+                            <!--not the beginning-->
+                      <!--      <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ተማኅፀንኩ፡</hi>
                             በጊዮርጊስ፡ ሰምከ፡ ሰማእት፡ በአቅባዴር፡ በምንቴር፡ ዘከመ፡ ኢይማዑኒ፡ ኵሎሙ፡ አቃብያነ፡ ሥራይ፡ በቤቃ፡ ወሴቃ፡ ወጺቃ፡ በአቅባዴር፡ ስንከ፡ ተማኅፀንኩ፡ 
-                            ከማሁኒ፡ ኵሎሙ፡ ዓቃያነ፡ ሥራይ፡ ዘአብዴዩስ፡ ስምከ፡ ዘአቅርልዮድስ፡ ስምከ፡</incipit>
+                            ከማሁኒ፡ ኵሎሙ፡ ዓቃያነ፡ ሥራይ፡ ዘአብዴዩስ፡ ስምከ፡ ዘአቅርልዮድስ፡ ስምከ፡</incipit>-->
                             <explicit xml:lang="gez">ከመ፡ ኢይማዑኒ፡ ኵሎሙ፡ አቃብያነ፡ ሥራይ፡ ወገበርተ፡ አምፃ፡ እለ፡ የሐውሩ፡ በሌሊት፡ ኀበ፡ ኵሉ፡ ሰብዕ፡ ይደምስሱ፡
                             ወይዘረው፡ ሠራዊትሙ፡ ለአጋንንት፡ በኵሉ፡ ጊዜ፡ ወበኵሉ፡ ሠአት፡ ዘመዓልት፡ ወዘሌሊት፡ በቀትር፡ ወበሠአት፡ ለአለመ፡ አለም፡ አሜን፡ ለአመትከ፡
                             <persName ref="">ወለተ፡ <hi rend="rubric">ሰንበት፡</hi></persName> እስመ፡ አልቦ፡ ነገር፡ ዘይስእኖ፡ ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ ሥጋ፡ ቃል፡ ኮነ፡ ቃል፡ ሥጋ፡ ኮነ፡</explicit>
@@ -112,32 +114,117 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </support>
                                 <extent>
                                     <measure type="weight" unit="g">93</measure>
+                                    <note>Consists of <measure unit="strips">2</measure> strips sewn together.</note>
                                     <dimensions type="outer" unit="mm">
                                         <height>1858</height>
                                         <width>112</width>
                                     </dimensions>
+                                    <dimensions type="outer" unit="mm" xml:id="strip1">
+                                        <height>950</height>
+                                        <width>112</width>
+                                    </dimensions>
+                                    <dimensions type="outer" unit="mm" xml:id="strip2">
+                                        <height>920</height>
+                                        <width>112</width>
+                                    </dimensions>
                                 </extent>
+                                <condition key="good">The state of preservation of the manuscript is good. The part of the verso that is exposed
+                                when the scroll is rolled up is darkened.</condition>
                             </supportDesc>
+                            <layoutDesc>
+                                <layout columns="1" writtenLines="115" corresp="#sec2 #strip1">
+                                    <note>Number of characters per line: 20–25.</note>
+                                    <note>The outer margins are delimited by a black line.</note>
+                                    <dimensions unit="mm" xml:id="textarea1">
+                                        <height>645</height>
+                                        <width>105</width>
+                                    </dimensions>
+                                    <dimensions type="margin" unit="mm" xml:id="margin1">
+                                        <dim type="right">3</dim>
+                                        <dim type="left">3</dim>
+                                        <dim type="top">3</dim>
+                                        <dim type="bottom">5</dim>
+                                    </dimensions>
+                                    <ab type="pricking">Ruling and pricking are not visible.</ab>
+                                </layout>
+                                
+                                <layout columns="1" writtenLines="146" corresp="#sec4 #strip2">
+                                    <note>Number of characters per line: 22–27.</note>
+                                    <note>The outer margins are delimited by a black line.</note>
+                                           <dimensions unit="mm" xml:id="textarea2">
+                                        <height>745</height>
+                                        <width>105</width>
+                                    </dimensions>
+                                    <dimensions type="margin" unit="mm" xml:id="margin2">
+                                        <dim type="right">3</dim>
+                                        <dim type="left">3</dim>
+                                        <dim type="top">1</dim>
+                                        <dim type="bottom">13</dim>
+                                    </dimensions>
+                                    <ab type="pricking">Ruling and pricking are not visible.</ab>
+                                </layout>
+                                
+                            </layoutDesc>
                         </objectDesc>
                         
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                           
+                                <date notBefore="1800" notAfter="2006"/>
+                                <!--19th c., Tigray, given in the handlist. -->
+                                <desc>Mediocre but regular hand, cursive script.</desc>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Incipits, holy name as part of the name of the owner.</seg>
                             </handNote>
                         </handDesc>
                         
-                       <!-- <decoDesc>
-                         
+                   <!--     <decoDesc>
+                            <decoNote xml:id="d1" type="miniature" corresp="#pic1">
+                                <desc></desc>
+                                    <dimensions unit="mm">
+                           <height>286</height>
+                           <width>112</width>
+                        </dimensions>
+                            </decoNote>
+                            
+                            <decoNote xml:id="d2" type="miniature" corresp="#pic2">
+                                <desc></desc>
+                                   <dimensions unit="mm">
+                           <height>158</height>
+                           <width>112</width>
+                        </dimensions>
+                            </decoNote>
                         </decoDesc>-->
+                        
+                        <additions>
+                            <list>
+                                <item xml:id="e1">
+                                    <desc>The name of the owner, mentioned in supplications throughout, was <persName ref=""/>.</desc>
+                                </item>
+                                
+                                <item xml:id="e2">
+                                    <desc>There are no corrections or other interventions in the text.</desc>
+                                </item>
+                                
+                                <item xml:id="e3">
+                                    <desc>In the bottom margin of the scroll, following the end of the last text, four Brillenbuchstaben are 
+                                        drawn. Between them, the characters <foreign xml:lang="gez">ሽ</foreign> or  <foreign xml:lang="gez">፳</foreign>, <foreign xml:lang="gez">ሐ</foreign>,
+                                        and <foreign xml:lang="gez">ሩ</foreign> are written.</desc>
+                                </item>
+                                
+                                <item xml:id="e4">
+                                    <desc>Few remains of writing on the verso.</desc>
+                                   <!-- I cannot see them in the images, but noted this on the metadata-->
+                                </item>
+                            </list>
+                        </additions>
                         
                     </physDesc>
                     
-                <!--    <history>
+                    <history>
                         <origin>
-                            <origDate when="" evidence=""/>
+                            <origDate notBefore="1800" notAfter="2006" evidence="lettering"/>
                         </origin>
-                        <provenance>  </provenance>
-                    </history>-->
+                    </history>
                     
                     <additional>
                         <adminInfo>
@@ -171,6 +258,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <textClass>
                 <keywords scheme="#ethioauthlist">
                     <term key="ChristianLiterature"/>
+                    <term key="Magic"/>
                 </keywords>
             </textClass>
             <langUsage>
@@ -184,7 +272,48 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">
         <body>
-            <div type="bibliography"/>
+            <div type="edition">
+                <div type="textpart" subtype="recto">
+                    
+                    <div type="textpart" subtype="section" n="1" xml:id="sec1">
+                        <div type="textpart" subtype="picture" n="1" xml:id="pic1" corresp="#d1"/>
+                    </div>
+                    
+                    
+                    <div type="textpart" subtype="section" n="2" xml:id="sec2">
+                        <div type="textpart" subtype="text" n="1" corresp="#ms_i1" xml:id="text1">
+                            <ab>
+                                <pb n="1r"/>
+                            </ab>
+                        </div>
+                        <div type="textpart" subtype="text" n="2" corresp="#ms_i2" xml:id="text2">
+                            <ab/>
+                        </div>
+                        <div type="textpart" subtype="text" n="3" corresp="#ms_i3" xml:id="text3">
+                            <ab/>
+                        </div>
+                        <div type="textpart" subtype="text" n="4" corresp="#ms_i4" xml:id="text4">
+                            <ab/>
+                        </div>
+                        <div type="textpart" subtype="text" n="5" corresp="#ms_i5" xml:id="text5part1">
+                            <ab/>
+                        </div>
+                    </div>
+                    
+                    <div type="textpart" subtype="section" n="3" xml:id="sec3">
+                        <div type="textpart" subtype="picture" n="2" xml:id="pic2" corresp="#d2"/>
+                    </div>
+                    
+                    <div type="textpart" subtype="section" n="4" xml:id="sec4">
+                        <div type="textpart" subtype="text" n="6" corresp="#ms_i5" xml:id="text5part2">
+                            <ab/>
+                        </div>
+                        <div type="textpart" subtype="text" n="7" corresp="#ms_i6" xml:id="text6">
+                            <ab/>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </body>
     </text>
 </TEI>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
@@ -38,78 +38,70 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <summary/>
                         
                         <msItem xml:id="ms_i1">
-                      <locus from="1" to=""/>
+                      <locus from="1" to="21"/>
                             <title type="complete" ref=""/>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ስቡሕ፡ ወውዱስ፡ ዘሣረረ፡ ኵሎ፡ ዓለም፡
                                 በ</hi>አሐቲ፡ ቃል፡ ሃሌ፡ ሉያ፡ እ<hi rend="ligature">ግዚ</hi>ኦ፡ መሐረነ፡ እ<hi rend="ligature">ግዚ</hi>ኦ፡ መሐከነ፡ 
                                 እ<hi rend="ligature">ግዚ</hi>ኦ፡ ተሠሃለነ፡ ስብሐት፡ ለአብ፡ ስብሐት፡ ለወልድ፡ ስብሐት፡ ለመንፈስ፡ ቅዱስ፡
                                 ቅዱ<hi rend="rubric">ስ፡ ቅዱስ፡ ቅዱስ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ አምላከ፡ አማልክት፡</hi></incipit>
-                            <explicit xml:lang="gez"></explicit>
+                            <explicit xml:lang="gez">ወእምኵሉ፡ ደዌ፡ ወሕማም፡ አድኅና፡ ለአመትከ፡ ወለተ፡ <space reason="rubrication"/>
+                            <hi rend="rubric">ወገጽ፡ ዘፍፁም፡ በጽልመት፡ ፈርሃ፡ ወደንገፀ፡</hi> ዲያብሎስ፡ ርእዮ፡ ብሁተ፡ ልደት፡ በሥጋ፡ አምላክ፡ በሲኦል፡ በዝ፡ ቃለ፡ መለኮትከ፡
+                            አድኅና፡ ለአመትከ፡ <persName ref="" role="owner">ወለተ፡ <hi rend="rubric">ሰንበት፡ ትበርህ፡</hi></persName></explicit>
                         </msItem>
                         
-                        <msItem xml:id="ms_i">
+                        <msItem xml:id="ms_i2">
+                            <locus from="21" to="30"/>
+                            <title type="complete" ref=""/>
+                            <!--this is the complete text-->
+                            <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ሕማመ፡ ቍርፀት፡ ኪስ፡ ኪስ፡ ኪስ፡ አራኪስ፡  ስርንኪስ፡ ስርዋጽ፡ 
+                            ምርዋጽ፡ ስር፡ ነኬር፡ ሲቃ፡ ወጼቃ፡ ወቤቓ፡ ድማኄል፡ አዶናይ፡ ቄጼቤ፡ ቄጼቤ፡ ቄጼቤ፡</incipit>
+                            <explicit xml:lang="gez">ቄፌኑ፡ ቄፌኑ፡ ቄፌኑ፡ ቡያክ፡ ቡያክ፡ ሞሊ፡ ሞሊ፡ ሞሊ፡ ኪያሞሌ፡ ኪያሞሌ፡ ኪያሞሌ፡ ዘአርጋእክ፡ ኃይለ፡
+                            በረድ፡ ወነፋስ፡ ከማሁ፡ አርግዕ፡ ወአቁም፡ ሕማመ፡ ቁርፀት፡ እምላእለ፡ አመትከ፡ <persName ref="">ወለተ፡ <hi rend="rubric">ሰንበት፡ ወለተ፡ ትበርሂ፡</hi></persName></explicit>
+                        </msItem>
+                        
+                        <msItem xml:id="ms_i3">
+                            <locus from="30" to="39"/>
+                            <title type="complete" ref=""/>
+                            <!--this is the complete text-->
+                            <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ሕማመ፡ ውግዓት፡ እልመክኩን፡ እልመክኩን፡ እልመክኩን፡
+                            አዝቤ፡ ረቤ፡ ታኦስ፡ ብርስባሔል፡ አልፋ፡ ወዕ፡ ቤጣ፡ ምስምያስ፡ ምድምያ፡ ምድምያስ፡ የሐቄ፡ የሐቄ፡ የሐቄ፡</incipit>
+                            <explicit xml:lang="gez">የኃብራስቄ፡ የኃብራስቄ፡ የኃብራስቄ፡ ክርስትቂ፡ ክርስቂ፡ ክርስቂ፡ በከመ፡ አድኃንከ፡ ለወለተ፡ ከራስቄ፡ ከማሃ፡ 
+                            አድኅና፡ በእንተ፡ ሕማመ፡ ውግዓት፡ ለአመትከ፡ <persName ref="">ወለተ፡ <hi rend="rubric">ሰንበት፡ ወለተ፡ ትበርሄ፡</hi></persName></explicit>
+                        </msItem>
+                        
+                        <msItem xml:id="ms_i4">
+                            <locus from="39" to="49"/>
+                            <title type="complete" ref=""/>
+                            <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ፍልፀት፡ ያጣውጢ፡ ያጣውጢ፡ ያጣውጢ፡ ያሽላክፊ፡ ያሽላክፊ፡ ያሽላክፊ፡
+                            ያበጋር፡ ሽሩራን፡ ሽኃል፡ መጃል፡ ካፍ፡ ላፍ፡ አፈና፡ ጋዲን፡ ታኦስ፡ አብኖዲ፡ ብርስባኄል፡ አዶና፡ አማኑኤል፡ እምንስቲት፡ ሙኬርያ፡</incipit>
+                            <explicit xml:lang="gez">መዓግያ፡ ሙዳሱጣ፡ ኢየሱስ፡ ክርስቶስ። ወልደ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ሕያው፡ ዘኢይመውት፡ በኃይለ፡ ዝንቱ፡ አስማቲከ፡ 
+                            አርኅቆሙ፡ ለምታት፡ <sic>ወለፍፀተ፡</sic> ርክስ፡ እምላእለ፡ አመትከ፡ <persName ref="">ወለተ፡ <hi rend="rubric">ሰንበት፡ ትበርሄ።</hi></persName></explicit>
+                        </msItem>
+                        
+                        <msItem xml:id="ms_i5">
+                            <locus from="50" to=""/>
+                            <title type="complete" ref="LIT1878Marbab"/>
+                            <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ አስማተ፡ ሰሎሞን፡</hi>
+                            ዘረበቦሙ፡ ለአንንት፡ ወለነሃብት፡ ከመ፡ በርበብተ፡ አሣ፡ እንዘ፡ ይብል፡ ሰዳቃኤል፡ አዳናኤል፡ አዳናኤል፡ ኤል፡ ሮሜል፡ ስርማ፡ ሩባ፡ ዕፍ፡ በአፍ፡ ጸልለኒ፡ በክንፍከ፡
+                            እግዚኦ፡ እምፀርየ፡ ወአድኅነኒ፡ እምሕማመ፡ ፀላኢ፡</incipit>
+                            <explicit xml:lang="gez">ተማኅፀንኵ፡ ነፍስየ፡ ወሥጋየ፡ በእ<hi rend="ligature">ግዚ</hi>አብሔር። አብ፡ ወበክርስቶስ፡ ወልድ፡ <sic>ወበሣልይ፡</sic> መንፈስ፡
+                            ቅዱስ፡ በኢየሱስ፡ ክርስቶስ። ጸጋሁ፡ ከመ፡ ኢይማዑኒ፡ ወኢይትቅረቡኒ፡ ኀበ፡ ማህደርየ፡ ወቤትየ፡ ወኀበ፡ ኵሉ፡ ሰብእየ፡ ወእንስሳየ፡ ወኢይቅረቡኒ፡ ኀበ፡ ነፍስየ፡ ወሥጋየ፡
+                            ሊተ፡ ለአመትከ፡ <persName ref="">ወለተ፡ <hi rend="rubric">ሰንበት፡ ወለተ፡ ትብርህ፡</hi></persName></explicit>
+                           <!-- EMIPms00037, same name of owner and similar texts?-->
+                           <!-- very close to the text in EMIP00616-->
+                        </msItem>
+                        
+                        <msItem xml:id="ms_i6">
                             <locus from="" to=""/>
                             <title type="complete" ref=""/>
-                            <incipit xml:lang="gez"></incipit>
-                            <explicit xml:lang="gez"></explicit>
+                            <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ተማኅፀንኩ፡</hi>
+                            በጊዮርጊስ፡ ሰምከ፡ ሰማእት፡ በአቅባዴር፡ በምንቴር፡ ዘከመ፡ ኢይማዑኒ፡ ኵሎሙ፡ አቃብያነ፡ ሥራይ፡ በቤቃ፡ ወሴቃ፡ ወጺቃ፡ በአቅባዴር፡ ስንከ፡ ተማኅፀንኩ፡ 
+                            ከማሁኒ፡ ኵሎሙ፡ ዓቃያነ፡ ሥራይ፡ ዘአብዴዩስ፡ ስምከ፡ ዘአቅርልዮድስ፡ ስምከ፡</incipit>
+                            <explicit xml:lang="gez">ከመ፡ ኢይማዑኒ፡ ኵሎሙ፡ አቃብያነ፡ ሥራይ፡ ወገበርተ፡ አምፃ፡ እለ፡ የሐውሩ፡ በሌሊት፡ ኀበ፡ ኵሉ፡ ሰብዕ፡ ይደምስሱ፡
+                            ወይዘረው፡ ሠራዊትሙ፡ ለአጋንንት፡ በኵሉ፡ ጊዜ፡ ወበኵሉ፡ ሠአት፡ ዘመዓልት፡ ወዘሌሊት፡ በቀትር፡ ወበሠአት፡ ለአለመ፡ አለም፡ አሜን፡ ለአመትከ፡
+                            <persName ref="">ወለተ፡ <hi rend="rubric">ሰንበት፡</hi></persName> እስመ፡ አልቦ፡ ነገር፡ ዘይስእኖ፡ ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ ሥጋ፡ ቃል፡ ኮነ፡ ቃል፡ ሥጋ፡ ኮነ፡</explicit>
+                            <!-- very close to the text in EMIP00616-->
                         </msItem>
-                        
-                        <msItem xml:id="ms_i">
-                            <locus from="" to=""/>
-                            <title type="complete" ref=""/>
-                            <incipit xml:lang="gez"></incipit>
-                            <explicit xml:lang="gez"></explicit>
-                        </msItem>
-                        
-                        <msItem xml:id="ms_i">
-                            <locus from="" to=""/>
-                            <title type="complete" ref=""/>
-                            <incipit xml:lang="gez"></incipit>
-                            <explicit xml:lang="gez"></explicit>
-                        </msItem>
-                        
-                        <msItem xml:id="ms_i">
-                            <locus from="" to=""/>
-                            <title type="complete" ref=""/>
-                            <incipit xml:lang="gez"></incipit>
-                            <explicit xml:lang="gez"></explicit>
-                        </msItem>
-                        
-                        <msItem xml:id="ms_i">
-                            <locus from="" to=""/>
-                            <title type="complete" ref=""/>
-                            <incipit xml:lang="gez"></incipit>
-                            <explicit xml:lang="gez"></explicit>
-                        </msItem>
-                        
-                        <msItem xml:id="ms_i">
-                            <locus from="" to=""/>
-                            <title type="complete" ref=""/>
-                            <incipit xml:lang="gez"></incipit>
-                            <explicit xml:lang="gez"></explicit>
-                        </msItem>
-                        
-                        <msItem xml:id="ms_i">
-                            <locus from="" to=""/>
-                            <title type="complete" ref=""/>
-                            <incipit xml:lang="gez"></incipit>
-                            <explicit xml:lang="gez"></explicit>
-                        </msItem>
-                        
-                        <msItem xml:id="ms_i">
-                            <locus from="" to=""/>
-                            <title type="complete" ref=""/>
-                            <incipit xml:lang="gez"></incipit>
-                            <explicit xml:lang="gez"></explicit>
-                        </msItem>
-                        
-                        <msItem xml:id="ms_i">
-                            <locus from="" to=""/>
-                            <title type="complete" ref=""/>
-                            <incipit xml:lang="gez"></incipit>
-                            <explicit xml:lang="gez"></explicit>
-                        </msItem>
-                        
                     </msContents>
                     
                     <physDesc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
@@ -86,8 +86,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <msItem xml:id="ms_i5">
                             <locus from="1r50" to="1r148"/>
                             <title type="complete" ref="LIT1878Marbab"/>
-                            <note>The version of the work attested here is close to that attested in <ref type="mss" corresp="EMIP00616"/>, 
-                                <locus from="51r" to="61v"/>, and <ref type="mss" corresp="EMIP00292"/>.</note>
+                            <note>The version of the work attested here is close to that attested in <ref type="mss" corresp="EMIP00616"/> 
+                                (<locus from="51r" to="61v"/>) and <ref type="mss" corresp="EMIP00292"/>.</note>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ አስማተ፡ ሰሎሞን፡</hi>
                             ዘረበቦሙ<supplied reason="omitted">፡</supplied> <sic>ለአንንት፡</sic> ወለነሃብት፡ ከመ፡ መርበብተ፡ አሣ፡ እንዘ፡ ይብል፡ ሰዳቃኤል፡ አዳናኤል፡ አዳዳኤል፡ ኤል፡ 
                                 ርሜል፡ ስርማ፡ ሩባ፡ ዕፍ፡ በዕፍ፡ ጸልለኒ፡ በክንፍከ፡
@@ -102,8 +102,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <locus from="1r148" to="1r261"/>
                                 <title type="complete" ref="LIT6718PPAqweyasat"/>
                             <textLang mainLang="gez"/>
-                            <note>The version of the work attested here is close to that attested in <ref type="mss" corresp="EMIP00616"/>, 
-                                <locus from="51r" to="61v"/>, and <ref type="mss" corresp="EMIP00292"/>.</note>
+                            <note>The version of the work attested here is close to that attested in <ref type="mss" corresp="EMIP00616"/>
+                                (<locus from="51r" to="61v"/>) and <ref type="mss" corresp="EMIP00292"/>.</note>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡</hi> ቅዱስ፡ ፩ አምላክ፡ ጸሎተ፡ አቍያጻት፡ ወአቃብያነ፡
                             ሥራይ፡ እለ፡ ይቀትሉ፡ ነፍሰ፡ ሰብዕ፡ እንበለ፡ ጊዜ፡ ወስውረ፡ ወእለ፡ ይትሜሰሉ፡ በሕልመ፡ ሌሊት፡ ወበራእየ፡ <surplus>ን፡ ወበራእየ፡</surplus> መዓልት፡ እለ፡ የሃውሩ፡ በሞችኃት፡
                             ወእለ፡ ይትሜሰሉ፡ ዝእበ፡</incipit>
@@ -213,11 +213,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </item>
                                 
                                 <item xml:id="e2">
-                                    <desc>There are no corrections or other interventions in the text.</desc>
+                                    <desc>There are no corrections or other scribal interventions in the text.</desc>
                                 </item>
                                 
                                 <item xml:id="e3">
-                                    <desc>In the bottom margin of the scroll, following the end of the last text, four Brillenbuchstaben are 
+                                    <desc>In the bottom margin of the scroll, following the end of the last text, four <!--italics--> Brillenbuchstaben are 
                                         drawn. Between them, the characters <foreign xml:lang="gez">ሽ</foreign> or  <foreign xml:lang="gez">፳</foreign>, <foreign xml:lang="gez">ሐ</foreign>,
                                         and <foreign xml:lang="gez">ሩ</foreign> are written.</desc>
                                 </item>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
@@ -311,7 +311,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     </div>
                     
                     <div type="textpart" subtype="section" n="3" xml:id="sec3">
-                        <div type="textpart" subtype="picture" n="2" xml:id="pic2" corresp="#d2"/>
+                        <div type="textpart" subtype="picture" n="2" xml:id="pic2" corresp="#d2">
+                            <milestone unit="parchmentStrip" n="2"/>
+                        </div>
                     </div>
                     
                     <div type="textpart" subtype="section" n="4" xml:id="sec4">

--- a/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
@@ -39,7 +39,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         
                         <msItem xml:id="ms_i1">
                       <locus from="1r1" to="1r21"/>
-                            <title type="complete" ref=""/>
+                      <!--      <title type="complete" ref=""/>-->
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ስቡሕ፡ ወውዱስ፡ ዘሣረረ፡ ኵሎ፡ ዓለም፡
                                 በ</hi>አሐቲ፡ ቃል፡ ሃሌ፡ ሉያ፡ እ<hi rend="ligature">ግዚ</hi>ኦ፡ መሐረነ፡ እ<hi rend="ligature">ግዚ</hi>ኦ፡ መሐከነ፡ 
                                 እ<hi rend="ligature">ግዚ</hi>ኦ፡ ተሠሃለነ፡ ስብሐት፡ ለአብ፡ ስብሐት፡ ለወልድ፡ ስብሐት፡ ለመንፈስ፡ ቅዱስ፡
@@ -51,7 +51,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         
                         <msItem xml:id="ms_i2">
                             <locus from="1r21" to="1r30"/>
-                            <title type="complete" ref=""/>
+                         <!--   <title type="complete" ref=""/>-->
                             <!--this is the complete text-->
                             <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ሕማመ፡ ቍርፀት፡ ኪስ፡ ኪስ፡ ኪስ፡ አራኪስ፡  ስርንኪስ፡ ስርዋጽ፡ 
                             ምርዋጽ፡ ስር፡ ነኬር፡ ሲቃ፡ ወጼቃ፡ ወቤቓ፡ ድማኄል፡ አዶናይ፡ ቄጼቤ፡ ቄጼቤ፡ ቄጼቤ፡</incipit>
@@ -61,7 +61,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         
                         <msItem xml:id="ms_i3">
                             <locus from="1r30" to="1r39"/>
-                            <title type="complete" ref=""/>
+                            <!--<title type="complete" ref=""/>-->
                             <!--this is the complete text-->
                             <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ሕማመ፡ ውግዓት፡ እልመክኩን፡ እልመክኩን፡ እልመክኩን፡
                             አዝቤ፡ ረቤ፡ ታኦስ፡ ብርስባሔል፡ አልፋ፡ ወዕ፡ ቤጣ፡ ምስምያስ፡ ምድምያ፡ ምድምያስ፡ የሐቄ፡ የሐቄ፡ የሐቄ፡</incipit>
@@ -71,7 +71,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         
                         <msItem xml:id="ms_i4">
                             <locus from="1r39" to="1r49"/>
-                            <title type="complete" ref=""/>
+                         <!--   <title type="complete" ref=""/>-->
                             <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ፍልፀት፡ ያጣውጢ፡ ያጣውጢ፡ ያጣውጢ፡ ያሽላክፊ፡ ያሽላክፊ፡ ያሽላክፊ፡
                             ያበጋር፡ ሽሩራን፡ ሽኃል፡ መጃል፡ ካፍ፡ ላፍ፡ አፈና፡ ጋዲን፡ ታኦስ፡ አብኖዲ፡ ብርስባኄል፡ አዶና፡ አማኑኤል፡ እምንስቲት፡ ሙኬርያ፡</incipit>
                             <explicit xml:lang="gez">መዓግያ፡ ሙዳሱጣ፡ ኢየሱስ፡ ክርስቶስ። ወልደ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ሕያው፡ ዘኢይመውት፡ በኃይለ፡ ዝንቱ፡ አስማቲከ፡ 
@@ -79,31 +79,30 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </msItem>
                         
                         <msItem xml:id="ms_i5">
-                            <locus from="1r50" to="1r"/>
+                            <locus from="1r50" to="1r148"/>
                             <title type="complete" ref="LIT1878Marbab"/>
+                            <note>The version of the work attested here is close to that attested in <ref type="mss" corresp="EMIP00616"/>, 
+                                <locus from="51r" to="61v"/>, and <ref type="mss" corresp="EMIP00292"/>.</note>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ አስማተ፡ ሰሎሞን፡</hi>
                             ዘረበቦሙ፡ ለአንንት፡ ወለነሃብት፡ ከመ፡ በርበብተ፡ አሣ፡ እንዘ፡ ይብል፡ ሰዳቃኤል፡ አዳናኤል፡ አዳናኤል፡ ኤል፡ ሮሜል፡ ስርማ፡ ሩባ፡ ዕፍ፡ በአፍ፡ ጸልለኒ፡ በክንፍከ፡
                             እግዚኦ፡ እምፀርየ፡ ወአድኅነኒ፡ እምሕማመ፡ ፀላኢ፡</incipit>
-                            <explicit xml:lang="gez">ተማኅፀንኵ፡ ነፍስየ፡ ወሥጋየ፡ በእ<hi rend="ligature">ግዚ</hi>አብሔር። አብ፡ ወበክርስቶስ፡ ወልድ፡ <sic>ወበሣልይ፡</sic> መንፈስ፡
-                            ቅዱስ፡ በኢየሱስ፡ ክርስቶስ። ጸጋሁ፡ ከመ፡ ኢይማዑኒ፡ ወኢይትቅረቡኒ፡ ኀበ፡ ማህደርየ፡ ወቤትየ፡ ወኀበ፡ ኵሉ፡ ሰብእየ፡ ወእንስሳየ፡ ወኢይቅረቡኒ፡ ኀበ፡ ነፍስየ፡ ወሥጋየ፡
-                            ሊተ፡ ለአመትከ፡ <persName ref="">ወለተ፡ <hi rend="rubric">ሰንበት፡ ወለተ፡ ትብርህ፡</hi></persName></explicit>
-                           <!-- EMIPms00037, same name of owner and similar texts?-->
-                           <!-- very close to the text in EMIP00616-->
-                            <!--identify end-->
+                            <explicit xml:lang="gez">አድኅነኒ፡ እምፀርየ፡ ወነገርጋር፡ ከመ፡ ኢይንበሩ፡ በትርአስየ፡ ወኢበትርጋጽየ፡ ወኢይብቡኒ፡ ነገረ፡ እኵይ፡ ለአሴደ፡ ወእምኵሎሙ፡
+                            መናፍስት፡ ርኵሳን፡ ወሰብዕ፡ መሠርያን፡ ሠርከ፡ ወነግሃ፡ ወዓልተ፡ ወሌሊተ፡ ከመ፡ ኢያህሶም፡ ላእሌየ፡ ኵሎሙ፡ ገበርተ፡ አመፃ፡ ሊተ፡ ለአመትከ፡ <persName ref="">ወለተ፡
+                            <hi rend="rubric">ሰንበት፡ ትበርሄ፡</hi></persName></explicit>
                         </msItem>
                         
                         <msItem xml:id="ms_i6">
-                            <locus from="1r" to="1r"/>
-                            <title type="complete" ref=""/>
-                            <!--not the beginning-->
-                      <!--      <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ተማኅፀንኩ፡</hi>
-                            በጊዮርጊስ፡ ሰምከ፡ ሰማእት፡ በአቅባዴር፡ በምንቴር፡ ዘከመ፡ ኢይማዑኒ፡ ኵሎሙ፡ አቃብያነ፡ ሥራይ፡ በቤቃ፡ ወሴቃ፡ ወጺቃ፡ በአቅባዴር፡ ስንከ፡ ተማኅፀንኩ፡ 
-                            ከማሁኒ፡ ኵሎሙ፡ ዓቃያነ፡ ሥራይ፡ ዘአብዴዩስ፡ ስምከ፡ ዘአቅርልዮድስ፡ ስምከ፡</incipit>-->
+                            <locus from="1r148" to="1r261"/>
+                        <!--    <title type="complete" ref=""/>-->
+                            <note>The version of the work attested here is close to that attested in <ref type="mss" corresp="EMIP00616"/>, 
+                                <locus from="51r" to="61v"/>, and <ref type="mss" corresp="EMIP00292"/>.</note>
+                            <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡</hi> ቅዱስ፡ ፩ አምላክ፡ ጸሎተ፡ አቍያጻት፡ ወአቃብያነ፡
+                            ሥራይ፡ እለ፡ ይቀትሉ፡ ነፍሰ፡ ሰብዕ፡ እንበለ፡ ጊዜ፡ ወስውረ፡ ወእለ፡ ይትሜሰሉ፡ በሕልመ፡ ሌሊት፡ ወበራእየ፡ ን፡ ወበራእየ፡ መዓልት፡ እለ፡ የሃውሩ፡ በሞችኃት፡
+                            ወእለ፡ ይትሜሰሉ፡ ዝእበ፡</incipit>
                             <explicit xml:lang="gez">ከመ፡ ኢይማዑኒ፡ ኵሎሙ፡ አቃብያነ፡ ሥራይ፡ ወገበርተ፡ አምፃ፡ እለ፡ የሐውሩ፡ በሌሊት፡ ኀበ፡ ኵሉ፡ ሰብዕ፡ ይደምስሱ፡
                             ወይዘረው፡ ሠራዊትሙ፡ ለአጋንንት፡ በኵሉ፡ ጊዜ፡ ወበኵሉ፡ ሠአት፡ ዘመዓልት፡ ወዘሌሊት፡ በቀትር፡ ወበሠአት፡ ለአለመ፡ አለም፡ አሜን፡ ለአመትከ፡
                             <persName ref="">ወለተ፡ <hi rend="rubric">ሰንበት፡</hi></persName> እስመ፡ አልቦ፡ ነገር፡ ዘይስእኖ፡ ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ ሥጋ፡ ቃል፡ ኮነ፡ ቃል፡ ሥጋ፡ ኮነ፡</explicit>
-                            <!-- very close to the text in EMIP00616-->
-                        </msItem>
+                      </msItem>
                     </msContents>
                     
                     <physDesc>
@@ -114,7 +113,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </support>
                                 <extent>
                                     <measure type="weight" unit="g">93</measure>
-                                    <note>Consists of <measure unit="strips">2</measure> strips sewn together.</note>
+                                    <note>Consists of <measure unit="strips">2</measure> strips sewn together with small parchment strips.</note>
+                                    <!--Is the information on sewing best encoded here? Or better in binding?-->
                                     <dimensions type="outer" unit="mm">
                                         <height>1858</height>
                                         <width>112</width>
@@ -268,7 +268,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="DR" when="2020-01-20">Created record</change>
-        <change who="SH" when="2020-04-22">Added editors</change></revisionDesc>
+            <change who="SH" when="2020-04-22">Added editors</change>   
+            <change who="DR" when="2022-07-30">Continued description</change>
+        </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">
         <body>


### PR DESCRIPTION
And now, a scroll!
A few remarks:
- there has been no previous example for the PDF rendering of a scroll description, so we will need to discuss this in the future
- `<div type="edition">` serves here to render the structure of the entire scroll, including written and painted areas, location of works and parchment strips. It is not rendered in the PDF in any way now (absolutely impossible for me to automatically produce a schema from this :) If we want them, we need to find a manual solution)
- a few of the texts are so short that it makes no real sense to give only incipit and explicit. From the encoding, it would be more logical to give the text in the `<div type="edition">`, but I assume we will want to print it, and it will be easier if it is encoded in incipit/explicit. So I kept it there with a comment.

I was not sure about the best place in the description for:
- the way the strips are sewn together (now in measure, maybe better in binding?)
- information on the presence or absence of writing on the verso (now in extras)

Let me know what you think!
