### PR TITLE
PDF edits

### DIFF
--- a/OxfordBodleian/Juel-Jensen/BDLaethb4.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethb4.xml
@@ -91,7 +91,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         target="#14vc #30rb #37rc"/>.</note>
                                 <textLang mainLang="gez"/>
                                 <incipit xml:lang="gez">
-                                    <locus target="14va"/>
+                                    <locus target="#14va"/>
                                     <pb n="14v"/>
                                     <cb n="a"/>
                                     <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱ</hi>ስ፡ ፩ አምላክ። ገድል፡
@@ -112,7 +112,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <title type="complete" ref="LIT1455GadlaG#coloph1">Colophon</title>
                                 <textLang mainLang="gez"/>
                                 <incipit xml:lang="gez">
-                                    <locus target="84vb"/>ወሶበ፡ ፈጸመ፡ ቅዱስ፡ <hi rend="rubric"
+                                    <locus target="#84vb"/>ወሶበ፡ ፈጸመ፡ ቅዱስ፡ <hi rend="rubric"
                                         >ጊዮርጊስ፡</hi> ገድሎ፡ አነ፡ <persName ref="PRS13151Saqrates"
                                         >ስቅራጥስ፡</persName> ገብሩ፡ ለእግዚእየ፡ <hi rend="rubric"
                                         >ጊዮርጊስ፡</hi> ኮንኩ፡ እትልዎ፡ ለእግዚእየ፡ <hi rend="rubric"
@@ -148,7 +148,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     >ጸ</supplied>ሐፎ፡ ወለአጽሐፎ፡ ለዘአንበቦ፡ ወተርጐሞ፡ ወለዘሰምዓ፡ ቃላቲሁ፡
                                     ኅቡረ፡</incipit>
                                 <explicit xml:lang="gez">
-                                    <locus target="85vc"/>ወአመ፡ ይፈድዮ፡ ለኵሉ፡ በከመ፡ ምግባሩ፡ አሜሃ፡ ይዕሥዮ፡ ዕሤተ፡
+                                    <locus target="#85vc"/>ወአመ፡ ይፈድዮ፡ ለኵሉ፡ በከመ፡ ምግባሩ፡ አሜሃ፡ ይዕሥዮ፡ ዕሤተ፡
                                     ሠናየ፡ ትጉሃነ፡ ሰማይ፡ እስከ፡ ያነክሩ፡ ለዓለመ፡ ዓለም፡ አሜን፡ ለይኩን፡ በእንተ፡ ሥጋሁ፡ ወደሙ፡
                                     ለክርስቶስ፡ አሜን።</explicit>
                             </msItem>
@@ -208,7 +208,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title type="complete" ref="LIT6209MGAndrew"/>
                                     <textLang mainLang="gez"/>
                                     <incipit xml:lang="gez">
-                                        <locus target="89vc"/><hi rend="rubric">፩፡ ተአምሪሁ፡ ለብፁዕ፡
+                                        <locus target="#89vc"/><hi rend="rubric">፩፡ ተአምሪሁ፡ ለብፁዕ፡
                                             ወለቅዱስ፡</hi> መስተጋ<supplied reason="omitted" resp="SH"
                                             >ድ</supplied>ል፡ ማር፡ <hi rend="rubric">ጊዮርጊስ፡</hi> ጸሎቱ፡
                                         ወበረከቱ፡ የሀሉ፡ ምስለ፡ ፍቁሩ፡ <persName ref="PRS13193Giyorgis"><hi
@@ -360,7 +360,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title type="complete" ref="LIT6215MGChurchProp"/>
                                     <textLang mainLang="gez"/>
                                     <incipit xml:lang="gez">
-                                        <locus target="104ra"/>
+                                        <locus target="#104ra"/>
                                         <pb n="104r"/>
                                         <cb n="a"/>
                                         <hi rend="rubric">፯፡ ተአምሪሁ፡</hi>
@@ -381,7 +381,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title type="complete" ref="LIT6216MGAwheyos"/>
                                     <textLang mainLang="gez"/>
                                     <incipit xml:lang="gez">
-                                        <locus target="106ra"/>
+                                        <locus target="#106ra"/>
                                         <pb n="106r"/>
                                         <cb n="a"/>
                                         <hi rend="rubric">፰፡ ተአምሪሁ፡</hi>
@@ -401,7 +401,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title type="complete" ref="LIT6217MGEulogius"/>
                                     <textLang mainLang="gez"/>
                                     <incipit xml:lang="gez">
-                                        <locus target="109va"/>
+                                        <locus target="#109va"/>
                                         <pb n="109v"/>
                                         <cb n="a"/>
                                         <hi rend="rubric">፱ ተአምሪሁ፡</hi>
@@ -423,7 +423,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title type="complete" ref="LIT6218MGMoney"/>
                                     <textLang mainLang="gez"/>
                                     <incipit xml:lang="gez">
-                                        <locus target="114ra"/>
+                                        <locus target="#114ra"/>
                                         <pb n="114r"/>
                                         <cb n="a"/>
                                         <hi rend="rubric">፲ ተአምሪሁ፡</hi>
@@ -536,7 +536,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title type="complete" ref="LIT6225MGBebaLights"/>
                                     <textLang mainLang="gez"/>
                                     <incipit xml:lang="gez">
-                                        <locus target="132va"/>
+                                        <locus target="#132va"/>
                                         <hi rend="rubric">፲ወ፭። ተአምሪሁ፡</hi>
                                         <gap reason="ellipsis" resp="SH"/>ወሶበ፡ ሰምዑ፡ ኵሉ፡ ሰብእ፡ እለ፡
                                         ውስተ፡ ምድረ፡ ግብጽ፡ ብዙኃ፡ <surplus resp="SH">ግብጽ፡</surplus> ተአምራተ፡
@@ -555,13 +555,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title type="complete" ref="LIT6226MGBebaMuslim"/>
                                     <textLang mainLang="gez"/>
                                     <incipit xml:lang="gez">
-                                        <locus target="133ra"/>
+                                        <locus target="#133ra"/>
                                         <hi rend="rubric">፲ወ፮። ተአምሪሁ፡</hi>
                                         <gap reason="ellipsis" resp="SH"/> ወሀሎ፡ ፩ ብእሲ፡ አረማዊ፡ እምሰብአ፡
                                         ሀገረ፡ ብባ፡ ወሖረ፡ ኀበ፡ ሀገረ፡ አልዛዠ፡ ከመ፡ የሐውጽ፡ ምስጋዶ፡ በሀገረ፡
                                         መካ።</incipit>
                                     <explicit xml:lang="gez">
-                                        <locus target="134rb"/>ወለዛ፡ ለብሐ፡ ሰቀልዋ፡ ለዝክረ፡ ዛቲ፡ ተአምር፡ ወአንሰ፡
+                                        <locus target="#134rb"/>ወለዛ፡ ለብሐ፡ ሰቀልዋ፡ ለዝክረ፡ ዛቲ፡ ተአምር፡ ወአንሰ፡
                                         ሶበ፡ ሰማዕኩ፡ ዘንተ፡ ሰባሕክዎ፡ ለእግዚአብሔር፡ ገባሬ፡ መንክራት፡ በቅዱሳኒሁ፡ ጸሎቱ፡
                                             <gap reason="ellipsis" resp="SH"/>
                                     </explicit>
@@ -572,14 +572,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title type="complete" ref="LIT6227MGBebaPagan"/>
                                     <textLang mainLang="gez"/>
                                     <incipit xml:lang="gez">
-                                        <locus target="134rb"/>
+                                        <locus target="#134rb"/>
                                         <hi rend="rubric">፲ወ፯። ተአምሪሁ፡</hi>
                                         <gap reason="ellipsis" resp="SH"/>
                                         <cb n="c"/> ወሀሎ፡ ፩ ብእሲ፡ አረማዊ፡ በይእቲ፡ ሀገር፡ እንተ፡ ስማ፡ ብባ፡ ወበአሐቲ፡
                                         ዕለት፡ ቦአ፡ ውስተ፡ መርጡል፡ ዘቅዱስ፡ <hi rend="rubric">ጊዮርጊስ፡</hi> ከመ፡
                                         ይሣለቅ፡ ላዕሌሁ፡</incipit>
                                     <explicit xml:lang="gez">
-                                        <locus target="134vc"/>ወዜነወ፡ ዘንተ፡ ተአምረ፡ ለኵሉ፡ ሰብአ፡ ሀገር፡
+                                        <locus target="#134vc"/>ወዜነወ፡ ዘንተ፡ ተአምረ፡ ለኵሉ፡ ሰብአ፡ ሀገር፡
                                         ወአንከሩ፡ ወፈርሁ፡ ጥቀ፡ ጸሎቱ፡ <gap reason="ellipsis" resp="SH"/>
                                     </explicit>
                                 </msItem>
@@ -608,7 +608,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title type="complete" ref="LIT6229MGBebaHorse"/>
                                     <textLang mainLang="gez"/>
                                     <incipit xml:lang="gez">
-                                        <locus target="136rb"/>
+                                        <locus target="#136rb"/>
                                         <hi rend="rubric">፲ወ፱፡ ተአምሪሁ፡</hi>
                                         <gap reason="ellipsis" resp="SH"/> ወሀሎ፡ ፩ ብእሲ፡ በሀገረ፡ ብባ፡
                                         አረሚ፡ እምሰብአ፡ ይእቲ፡ ሀገር፡ ወያፈቅሮ፡ ለሰማዕት፡ ወለቤተ፡ ክርስቲያኑ።</incipit>
@@ -648,7 +648,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title type="complete" ref="LIT6235MGOldCairo"/>
                                     <textLang mainLang="gez"/>
                                     <incipit xml:lang="gez">
-                                        <locus target="140ra"/>
+                                        <locus target="#140ra"/>
                                         <pb n="140r"/>
                                         <cb n="a"/>
                                         <hi rend="rubric">፳፩፡ ተአምሪሁ፡</hi>
@@ -705,7 +705,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title type="complete" ref="LIT6267MGChurchDoor2"/>
                                     <textLang mainLang="gez"/>
                                     <incipit xml:lang="gez">
-                                        <locus target="144va"/>
+                                        <locus target="#144va"/>
                                         <hi rend="rubric">፳ወ፬፡ ተአምሪሁ፡</hi>
                                         <gap reason="ellipsis" resp="SH"/> ወሀሎ፡ ቤቱ፡ ለኤጲስ፡ ቆጶስ፡ በዛቲ፡
                                         መርጡል፡ ኀበ፡ ዴዴ፡ ቤተ፡ ክርስቲያን፡ ወበአሐቲ፡ ዕለት፡ ረስዑ፡ ላዕካኒሁ፡ አጺወ፡ ኃዋኅወ፡
@@ -801,7 +801,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             >ዋ</supplied>ዕል፡ አውዓየ፡ እሳት፡ ቤቶ፡ ለ፩ብእሲ፡ በጎሩ፡ ፩ መነኮስ።
                                         ወተመይጠ፡ እሳት፡ መንገለ፡ ቤቱ፡ ለውእቱ፡ መነኮስ፡ ወለወለወ፡ ልሳኖ፡</incipit>
                                     <explicit xml:lang="gez">
-                                        <locus target="150ra"/>ወአልዓለ፡ በትሮ፡ ወዘበጦ፡ ለነበልባለ፡ እሳት፡ ወሜጦ፡
+                                        <locus target="#150ra"/>ወአልዓለ፡ በትሮ፡ ወዘበጦ፡ ለነበልባለ፡ እሳት፡ ወሜጦ፡
                                         ፍጡነ፡ ወርእየ፡ ውእቱ፡ መነኮስ፡ ወብእሲኒ፡ ዘውዕየ፡ ቤቱ። ወአንከሩ፡ አድ<supplied
                                             reason="omitted" resp="SH">ኅ</supplied>ኖቶ፡ ለቅዱስ፡ ማር፡ <hi
                                             rend="rubric">ጊዮርጊስ፡</hi> ጸሎቱ፡ ወበረከቱ፡ የሀሉ፡ ምስለ፡ <gap
@@ -861,7 +861,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <cb n="a"/> ወካዕበ፡ በ፩ እመዋዕል፡ መጽአ፡ ከይሲ፡ ዐቢይ፡ ውስተ፡ ይእቲ፡ ቤተ፡
                                         ክርስቲያን። ወፀጕረ፡ ርእሱ፡ ይመስል፡ ከመ፡ ቈናዝዓ፡ ብእሲ፡</incipit>
                                     <explicit xml:lang="gez">
-                                        <locus target="151vc"/>ወኮነ፡ ኑኁ፡ ፲ወ፭ በእመት፡ ወስፍሑ፡ ፫ በእመት፡
+                                        <locus target="#151vc"/>ወኮነ፡ ኑኁ፡ ፲ወ፭ በእመት፡ ወስፍሑ፡ ፫ በእመት፡
                                         ወነሥእዎ፡ ወሰቀልዎ፡ ዲበ፡ ኦም፡ በአፍአ፡ እምሐፁረ፡ ቤተ፡ ክርስቲያን። ወኵሎሙ፡ እለ፡
                                         ርእዩ፡ ኃይሎ፡ ወተአምሪሁ፡ ለቅዱስ፡ <hi rend="rubric">ጊዮርጊስ፡</hi> ጸሎቱ፡
                                         ወበረከቱ፡ የሀሉ፡ ምስለ፡<gap reason="ellipsis" resp="SH"/>
@@ -894,7 +894,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title type="complete" ref="LIT6294MGWetDream"/>
                                     <textLang mainLang="gez"/>
                                     <incipit xml:lang="gez">
-                                        <locus target="152rc"/>
+                                        <locus target="#152rc"/>
                                         <hi rend="rubric">፴፫ ተአምሪሁ፡</hi>
                                         <gap reason="ellipsis" resp="SH"/> ወሀሎ፡ ፩፡ መነኮስ፡ ወአጥረየ፡ ሎቱ፡
                                         ሥዕለ፡ ቅዱስ፡ ማር፡ <hi rend="rubric">ጊዮርጊስ፡</hi> ወኮነ፡ ይፀውሮ፡ ለውእቱ፡
@@ -1008,7 +1008,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         /> እንዘ፡ ይሥዕሉ፡ ሥዕላተ፡ ወያሠረግው፡ ቤተ፡ ክርስቲያኑ፡ ለቅዱስ፡ ማር፡ <hi
                                             rend="rubric">ጊዮርጊስ፡</hi> ወ፩፡ ብእሲ፡ ወሀበ፡ ዶርሆ፡</incipit>
                                     <explicit xml:lang="gez">
-                                        <locus target="156rc"/>ወሠፈሩ፡ ኒኆ፡ ለውእቱ፡ ተስላስ፡ እምኀበ፡ ወድቀ፡ ወኮነ፡
+                                        <locus target="#156rc"/>ወሠፈሩ፡ ኒኆ፡ ለውእቱ፡ ተስላስ፡ እምኀበ፡ ወድቀ፡ ወኮነ፡
                                         ኑኁ፡ እምድር፡ ፭ እመተ፡ ሥዝረ፡ ወስፍሑ፡ ፫ አፃብዓ፡ ወአንከሩ፡ ኃይለ፡ ተአምሪሁ፡ ለቅዱስ፡
                                         ማር፡ <hi rend="rubric">ጊዮርጊስ፡</hi> ጸሎቱ፡ ወበረከቱ፡ የሀሉ፡ ምስለ፡ <gap
                                             reason="ellipsis" resp="SH"/>
@@ -1029,7 +1029,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <corr resp="SH">ሁ</corr>
                                         </choice>። ወተሰብረ፡ ዕፀ፡ ተስላስ፡</incipit>
                                     <explicit xml:lang="gez">
-                                        <locus target="156vb"/>ተንሥአ፡ ፍጡነ፡ ወኢነክዮ፡ ምንተኒ፡ ወንዋየ፡ ቀለምሂ፡
+                                        <locus target="#156vb"/>ተንሥአ፡ ፍጡነ፡ ወኢነክዮ፡ ምንተኒ፡ ወንዋየ፡ ቀለምሂ፡
                                         አልቦ፡ ዘተጐድዓ። ወአንከ<supplied reason="lost" resp="SH"
                                             >ረ</supplied>፡ ውእቱ፡ ብእሲ፡ ወኵሎሙ፡ እለ፡ ርእዩ፡ አድኅኖቶ፡ ለቅዱስ፡ <hi
                                             rend="rubric">ጊዮርጊስ፡</hi> ጸሎቱ፡ ወበረከቱ፡ የሀሉ፡ ምስለ፡ <gap
@@ -1068,7 +1068,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         ወበጸሎቱ፡ ለቅዱስ፡ ማር፡ <hi rend="rubric">ጊዮርጊስ፡</hi> ወይሴፎ፡ ወትረ፡
                                         ረድኤቶ፡ በፍሥሐሁ፡ ወበምንዳቤሁ፡</incipit>
                                     <explicit xml:lang="gez">
-                                        <locus target="162rc"/>ወእምይእቲ፡ ዕለት፡ ኮነ፡ ይሁብ፡ ንጉሥ፡ መባዓ፡ ለካህን፡
+                                        <locus target="#162rc"/>ወእምይእቲ፡ ዕለት፡ ኮነ፡ ይሁብ፡ ንጉሥ፡ መባዓ፡ ለካህን፡
                                         ከመ፡ ይግበር፡ በዓሎ፡ ለቅዱስ፡ ማር፡ <hi rend="rubric">ጊዮርጊስ፡</hi> ርእዩኬ፡
                                         ዘከመ፡ ድኅኑ፡ ደቂቀ፡ ካህን፡ በጸሎቱ፡ ለቅዱስ፡ ብፁዓዊ፡ ማር፡ <hi rend="rubric"
                                             >ጊዮርጊስ፡</hi> ምእመን። ከማሁ፡ ያድኅኖ፡ እመሥገርተ፡ እኩያት፡ ለፍቁሩ፡ <gap
@@ -1079,7 +1079,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <msItem xml:id="ms_i1.1.3.43">
                                     <locus from="162rc" to="162vc"/>
                                     <title type="incomplete" ref="LIT6303MGJoseph"/>
-                                    <note>The miracle stops abruptly on <locus target="162vc"/> in
+                                    <note>The miracle stops abruptly on <locus target="#162vc"/> in
                                         the middle of a word.</note>
                                     <textLang mainLang="gez"/>
                                     <incipit xml:lang="gez">

--- a/OxfordBodleian/Juel-Jensen/BDLaethb6.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethb6.xml
@@ -1836,7 +1836,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </msItem>
                                     
                                     <msItem xml:id="p2_i1.2.24.3">
-                                        <locus target="26rb"/>
+                                        <locus target="#26rb"/>
                                         <title type="complete"
                                             ref="LIT4035SenkessarDL#Mask24SalGorgoryos">Salām-hymn
                                             to Gorgoryos and St Quadratus</title>
@@ -1886,7 +1886,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </msItem>
                                     
                                     <msItem xml:id="p2_i1.2.26.2">
-                                        <locus target="27rc"/>
+                                        <locus target="#27rc"/>
                                         <title type="complete"
                                             ref="LIT4035SenkessarDL#Mask26SalJohn">Salām-hymn to the
                                             conception of John the Baptist</title>
@@ -3675,7 +3675,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </msItem>
                                     
                                     <msItem xml:id="p2_i1.4.5.2">
-                                        <locus target="60rc"/>
+                                        <locus target="#60rc"/>
                                         <title type="complete"
                                             ref="LIT4035SenkessarDL#Heda4SalAbimakos">Salām-hymn to
                                             ʾAbimākos and ʾAzǝryānos</title>

--- a/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
@@ -510,7 +510,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <decoNote type="miniature" xml:id="d1">
                                     <locus target="#1v"/>
                                     <desc> A standing
-                                        <ref type="authFile" corresp="AT1013EvaPortrait"/> of <persName ref="PRS6902Matthew">Matthew</persName> with a <term key="cross">hand cross</term>
+                                        <ref type="authFile" corresp="AT1013EvaPortrait">Evangelist portrait</ref> of <persName ref="PRS6902Matthew">Matthew</persName> with a <term key="cross">hand cross</term>
                                         in his right hand and a <term key="codex">codex</term> in the other. <q xml:lang="gez">ሥዕለ፡ <persName ref="PRS6902Matthew">ማቴዎስ፡</persName></q>
                                     </desc>
                                 </decoNote>
@@ -518,7 +518,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <decoNote type="miniature" xml:id="d2">
                                     <locus target="#35v"/>
                                     <desc> An
-                                        <ref type="authFile" corresp="AT1013EvaPortrait">evangelist portrait</ref> of <persName ref="PRS6751Mark">Mark</persName> seated on a wicker chair under a canopy.
+                                        <ref type="authFile" corresp="AT1013EvaPortrait">Evangelist portrait</ref> of <persName ref="PRS6751Mark">Mark</persName> seated on a wicker chair under a canopy.
                                         He has a halo and is inscribing a <term key="codex">codex</term>. <q xml:lang="gez"><persName ref="PRS6751Mark">ማርቆስ፡</persName></q>
                                     </desc>
                                 </decoNote>
@@ -526,7 +526,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <decoNote type="miniature" xml:id="d3">
                                     <locus target="#61v"/>
                                     <desc> A standing
-                                        <ref type="authFile" corresp="AT1013EvaPortrait">evangelist portrait</ref> of <persName ref="PRS6387Luke">Luke</persName> with a <term key="cross">hand cross</term>
+                                        <ref type="authFile" corresp="AT1013EvaPortrait">Evangelist portrait</ref> of <persName ref="PRS6387Luke">Luke</persName> with a <term key="cross">hand cross</term>
                                         in his right hand and a <term key="codex">codex</term> in the other. He wears an unusual tiara. <q xml:lang="gez">ሥዕለ፡  <persName ref="PRS6387Luke">ሉቃስ።</persName></q>
                                     </desc>
                                 </decoNote>
@@ -534,7 +534,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <decoNote type="miniature" xml:id="d4">
                                     <locus target="#100v"/>
                                     <desc> A standing
-                                        <ref type="authFile" corresp="AT1013EvaPortrait">evangelist portrait</ref> of <persName ref="PRS5695John"/> with a <term key="cross">hand cross</term>
+                                        <ref type="authFile" corresp="AT1013EvaPortrait">Evangelist portrait</ref> of <persName ref="PRS5695John"/> with a <term key="cross">hand cross</term>
                                         in his right hand and a <term key="codex">codex</term> in the other.
                                         <q xml:lang="gez"><persName ref="PRS5695John">ዮሐንስ</persName></q>
                                     </desc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
@@ -66,14 +66,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <bindingDesc>
                             <binding contemporary="true">
                             <decoNote xml:id="b1" type="bindingMaterial">
-                              The book is bound in <material key="wood">wooden</material> boards which were previously covered with brown blind-tooled <material key="leather"/>.
-                              A decorated <material key="textile"/> inlay is glued on the inner side of the upper board.
+                              The book is bound in <material key="wood">wooden</material> boards which were previously covered with brown blind-tooled <material key="leather">leather</material>.
+                              A decorated <material key="textileInlay">textile inlay</material>  is glued on the inner side of the upper board.
                             </decoNote>
                             <decoNote xml:id="b2" type="Boards">
                               The boards are cut to the same size as the bookblock and have external shallow bevels. The grain runs vertically.
                             </decoNote>
                             <decoNote xml:id="b3" type="Cover" color="brown">
-                              Of the leather cover, only the turn-ins are preserved. Concentric frames of blind-tooled <term key="tripleStraightLine"/> outline the borders of straight trimmed turn-ins.
+                                Of the leather cover, only the turn-ins are preserved. Concentric frames of blind-tooled <term key="tripleStraightLine">triple straight lines</term> outline the borders of straight trimmed turn-ins.
                               The edges of turn-ins meet to form butt mitres.
                             </decoNote>
                             <decoNote xml:id="b4" type="SewingStations">4</decoNote>
@@ -85,8 +85,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                               Threads of various colours are inserted in the outer margins for navigating the text.
                               More specifically, a red <term key="leafStringMark">leaf string marker</term> is inserted in the lower margin of <locus target="#86"/> and a
                               uncoloured <term key="leafStringMark">leaf string marker</term> is inserted in the upper margin of <locus target="#104"/>.
-                              Disjoint bifolia have been repaired with overcasting, e.g. <locus from="51" to="53"></locus> or by sewing parchment <term key="guard">guards</term> with <term key="sidestitches"/>
-                              along the <term key="spinefold"></term> of the quires, e.g. <locus target="#q18"></locus>
+                              Disjoint bifolia have been repaired with overcasting, e.g. <locus from="51" to="53"></locus> or by sewing parchment <term key="guard">guards</term> with <term key="sidestitches">side stitches</term>
+                              along the <term key="spinefold">spine fold</term> of the quires, e.g. <ref target="#q18">quire 18</ref>
                           </decoNote>
                           </binding>
                       </bindingDesc>
@@ -94,10 +94,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     
                     <history>
                         <provenance>
-                            The provenance of the manuscript is unknown. According to <ref target="#a2"/>, <ref target="#p1"/> was hosted in or linked to the church of
-                            <placeName ref="LOC7349DabraMi">Dabra Mikāʾel</placeName>. Remarkably, the same place is also mentioned in <ref target="#coloph1"/>,
-                            which, however, refers to <ref target="#p2"/>.
-                            According to <ref target="#coloph1"/>, <ref target="#p2"/> belonged to <placeName ref="LOC7349DabraMi">Dabra Mikāʾel</placeName>
+                            The provenance of the manuscript is unknown. According to <ref target="#a2">additional note 2</ref>, <ref target="#p1">unit 1</ref> was hosted in or linked to the church of
+                            <placeName ref="LOC7349DabraMi">Dabra Mikāʾel</placeName>. Remarkably, the same place is also mentioned in <ref target="#coloph1">colophon 1</ref>,
+                            which, however, refers to <ref target="#p2">unit 2</ref>.
+                            According to <ref target="#coloph1">colophon 1</ref>, <ref target="#p2">unit 2</ref> belonged to <placeName ref="LOC7349DabraMi">Dabra Mikāʾel</placeName>
                             of the city of <placeName ref="LOC6450Zatta">Zāttā</placeName> in <placeName ref="LOC6573NorthWallo">Northern Wallo</placeName>.
                         </provenance>
                     </history>
@@ -503,7 +503,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     full height and the width of one column of text.
                                     <bibl><ptr target="bm:JuelJensen1996MikaelZata"/></bibl>
                                     believed that these were painted by the Italian artist <persName ref=" PRS2887Brancale"/>, but a closer analysis of their
-                                    style and iconography, <bibl><ptr target="bm:2019GnisciGospel"/></bibl>, does not support this attribution.
+                                    style and iconography (<bibl><ptr target="bm:2019GnisciGospel"/></bibl>) does not support this attribution.
                                     Small ornamental bands with arabesque or interlace patterns mark the end of paragraphs throughout the manuscript.
                                     These fill the empty space left at the end of a paragraph or are placed between columns.
                                     They often cover punctuation marks or chapter divisions and it is difficult to establish when they were added.</summary>
@@ -511,31 +511,31 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <locus target="#1v"/>
                                     <desc> A standing
                                         <ref type="authFile" corresp="AT1013EvaPortrait"/> of <persName ref="PRS6902Matthew">Matthew</persName> with a <term key="cross">hand cross</term>
-                                        in his right hand and a <term key="codex"/> in the other. <q xml:lang="gez">ሥዕለ፡ <persName ref="PRS6902Matthew">ማቴዎስ፡</persName></q>
+                                        in his right hand and a <term key="codex">codex</term> in the other. <q xml:lang="gez">ሥዕለ፡ <persName ref="PRS6902Matthew">ማቴዎስ፡</persName></q>
                                     </desc>
                                 </decoNote>
                                 
                                 <decoNote type="miniature" xml:id="d2">
                                     <locus target="#35v"/>
                                     <desc> An
-                                        <ref type="authFile" corresp="AT1013EvaPortrait"/> of <persName ref="PRS6751Mark">Mark</persName> seated on a wicker chair under a canopy.
-                                        He has a halo and is inscribing a <term key="codex"/>. <q xml:lang="gez"><persName ref="PRS6751Mark">ማርቆስ፡</persName></q>
+                                        <ref type="authFile" corresp="AT1013EvaPortrait">evangelist portrait</ref> of <persName ref="PRS6751Mark">Mark</persName> seated on a wicker chair under a canopy.
+                                        He has a halo and is inscribing a <term key="codex">codex</term>. <q xml:lang="gez"><persName ref="PRS6751Mark">ማርቆስ፡</persName></q>
                                     </desc>
                                 </decoNote>
                                 
                                 <decoNote type="miniature" xml:id="d3">
                                     <locus target="#61v"/>
                                     <desc> A standing
-                                        <ref type="authFile" corresp="AT1013EvaPortrait"/> of <persName ref="PRS6387Luke">Luke</persName> with a <term key="cross">hand cross</term>
-                                        in his right hand and a <term key="codex"/> in the other. He wears an unusual tiara. <q xml:lang="gez">ሥዕለ፡  <persName ref="PRS6387Luke">ሉቃስ።</persName></q>
+                                        <ref type="authFile" corresp="AT1013EvaPortrait">evangelist portrait</ref> of <persName ref="PRS6387Luke">Luke</persName> with a <term key="cross">hand cross</term>
+                                        in his right hand and a <term key="codex">codex</term> in the other. He wears an unusual tiara. <q xml:lang="gez">ሥዕለ፡  <persName ref="PRS6387Luke">ሉቃስ።</persName></q>
                                     </desc>
                                 </decoNote>
                                 
                                 <decoNote type="miniature" xml:id="d4">
                                     <locus target="#100v"/>
                                     <desc> A standing
-                                        <ref type="authFile" corresp="AT1013EvaPortrait"/> of <persName ref="PRS5695John"/> with a <term key="cross">hand cross</term>
-                                        in his right hand and a <term key="codex"/> in the other.
+                                        <ref type="authFile" corresp="AT1013EvaPortrait">evangelist portrait</ref> of <persName ref="PRS5695John"/> with a <term key="cross">hand cross</term>
+                                        in his right hand and a <term key="codex">codex</term> in the other.
                                         <q xml:lang="gez"><persName ref="PRS5695John">ዮሐንስ</persName></q>
                                     </desc>
                                 </decoNote>
@@ -557,7 +557,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <desc type="OwnershipNote">
                                             Note crudely written in the right margin in Amharic, mentioning <persName ref="PRS13183Tasamma"><roleName type="title">ʾAlaqā</roleName> Tasammā</persName>
                                              (possibly a later owner of the manuscript), <persName ref="PRS13182WaldaSe"><roleName type="title">ʾAbbā</roleName> Walda Śǝllāse</persName>, 
-                                            and the church of <placeName ref="LOC7349DabraMi">Dabra Mikāʾel</placeName> (on which see <ref target="#coloph1"/>).
+                                            and the church of <placeName ref="LOC7349DabraMi">Dabra Mikāʾel</placeName> (on which see <ref target="#coloph1">colophon 1</ref>).
                                             </desc>
                                         <locus target="#64rb"/>
                                         <q xml:lang="am">

--- a/OxfordBodleian/Juel-Jensen/BDLaethd20.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd20.xml
@@ -427,9 +427,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <locus from="21ra" to="25vb"/>
                                 <title ref="LIT1968Mashaf" type="complete"/>
                                 <textLang mainLang="gez"/>
-                                <note>The text does not correspond exactly to either the edition,
-                                    <bibl><ptr target="bm:TasfaGiyorgis1956Taammera"/><citedRange unit="page">15-20</citedRange></bibl>
-                                    or the translation <bibl><ptr target="bm:Budge1923Miracles"/><citedRange unit="page">xlvi-liv</citedRange></bibl>.
+                                <note>The text does not correspond exactly to either the edition
+                                    (<bibl><ptr target="bm:TasfaGiyorgis1956Taammera"/><citedRange unit="page">15-20</citedRange></bibl>)
+                                    or the translation (<bibl><ptr target="bm:Budge1923Miracles"/><citedRange unit="page">xlvi-liv</citedRange></bibl>).
                                     While it corresponds to the more complete form of the text attested in <bibl><ptr target="bm:Budge1923Miracles"/><citedRange unit="page">xlvi-liv</citedRange></bibl>,
                                 in the latter part of the work, there are several transpositions as compared to the translation.</note>
                                 <notatedMusic><desc>The hymn included in this work, which is split here in its two parts with
@@ -3589,6 +3589,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </handNote>
 
                             <handNote xml:id="h2" script="Ethiopic" corresp="#a1 #a2">
+                                <desc>Hand of additional notes 1 and 2.</desc>
                                 <date notAfter="1868"/>
                                 <seg type="ink">Black.</seg>
                             </handNote>
@@ -3597,7 +3598,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <decoDesc>
                    <summary>The manuscript contains twenty framed miniatures in the <term key="SecondGondarineStyle">Second Gondarine Style</term>
                    that appear to have been executed by the same hand. The style of the miniatures bears comparison with that of firmly dated manuscripts
-                   such as <ref type="mss" corresp=" BLorient607"/> and <ref type="mss" corresp="BLorient646"/> suggesting that they were executed around the
+                   such as <ref type="mss" corresp=" BLorient607">MS London, British Library, Or. 607</ref> and <ref type="mss" corresp="BLorient646">MS London, British Library, Or. 646</ref> suggesting that they were executed around the
                    <date notBefore="1700" notAfter="1800"> mid-eighteenth century</date>. The first and last pairs of miniatures of the manuscript function
                    as double-page openings. The Passion cycle at the end of the manuscript anachronistically opens with a representation of the Good Thief
                    at the Garden of paradise which functions as an explicit to the preceding homily. Interestingly, there is some attempt to differentiate
@@ -3635,7 +3636,7 @@ and Child <persName ref="PRS5684JesusCh">Jesus Christ</persName>
 
 <decoNote type="miniature" xml:id="d4">
                       <locus target="#19v"/>
-                      <desc>The <ref type="authFile" corresp="AT1036MercyCovenant"/>
+    <desc>The <ref type="authFile" corresp="AT1036MercyCovenant">Covenant of Mercy</ref>
 showing <persName ref="PRS6819Mary"/> and <persName ref="PRS5684JesusCh"/> under a canopy.
 <q xml:lang="gez">ኪዳነ፡ ምሕረት፡</q>
                       </desc></decoNote>
@@ -3663,7 +3664,7 @@ showing <persName ref="PRS6819Mary"/> and <persName ref="PRS5684JesusCh"/> under
 <decoNote type="miniature" xml:id="d8">
                       <locus target="#82v"/>
 <desc><ref type="authFile" corresp="AT1035HolyMan">
-<persName ref="PRS1246AbibBu"><roleName type="title">Abuna</roleName>ʾAbib</persName></ref> casts himself from a tree
+<persName ref="PRS1246AbibBu"><roleName type="title">Abuna</roleName> ʾAbib</persName></ref> casts himself from a tree
 on to a cluster of blades. His namesake, <term key="donordepiction"><persName ref="PRS1246AbibBu"/></term>, is in proskynesis
 beneath him.
 <q xml:lang="gez"><persName ref="PRS1246AbibBu"><roleName type="title">አቡነ፡</roleName>አቢብ፡</persName></q>
@@ -3673,7 +3674,7 @@ beneath him.
 <decoNote type="miniature" xml:id="d9">
                       <locus target="#83r"/>
 <desc><ref type="authFile" corresp="AT1035HolyMan">
-<persName ref="PRS9162TaklaHa"><roleName type="title">Abuna</roleName>Takla Hāymānot</persName></ref> in prayer.
+<persName ref="PRS9162TaklaHa"><roleName type="title">ʾAbuna</roleName> Takla Hāymānot</persName></ref> in prayer.
 <q xml:lang="gez"><persName ref="PRS9162TaklaHa"><roleName type="title">አቡነ፡</roleName>ተክለ፡ ሃይማኖት።</persName></q>
 </desc></decoNote>
 
@@ -3725,7 +3726,7 @@ embraces the base of the cross which is flanked by
 
 <decoNote type="miniature" xml:id="d15">
                       <locus target="#120r"/>
-<desc>The <ref type="authFile" corresp="AT1008Descent"/> of
+    <desc>The <ref type="authFile" corresp="AT1008Descent">Descent into Hell</ref> of
 <persName ref="PRS5684JesusCh"/> with <persName ref="PRS1386Adam"/> and <persName ref="PRS3926Eve"/>.
 <q xml:lang="gez">ትንሣኤ፡</q>
 <q xml:lang="gez"><persName ref="PRS1386Adam">አዳም፡</persName> <persName ref="PRS3926Eve">ሔዋን፡</persName></q>
@@ -3741,14 +3742,14 @@ embraces the base of the cross which is flanked by
 
 <decoNote type="miniature" xml:id="d17">
                       <locus target="#121r"/>
-<desc><ref type="authFile" corresp="AT1142Pentecost"/> with <persName ref="PRS6819Mary"/> and the Apostles.
+    <desc><ref type="authFile" corresp="AT1142Pentecost">Pentecost</ref> with <persName ref="PRS6819Mary"/> and the Apostles.
 <q xml:lang="gez">ጰራቅሊጦስ፡</q>
 </desc></decoNote>
 
 
 <decoNote type="miniature" xml:id="d18">
                       <locus from="121v" to="122r"/>
-<desc>The <ref type="authFile" corresp="AT1143SecondComingJesus"/> of <persName ref="PRS5684JesusCh"/> with
+    <desc>The <ref type="authFile" corresp="AT1143SecondComingJesus">Second Coming</ref> of <persName ref="PRS5684JesusCh"/> with
 <persName ref="PRS6819Mary"/> interceding on behalf of a group of souls.
 <q xml:lang="gez">ምጽአት፡</q>
 </desc></decoNote>
@@ -3781,8 +3782,8 @@ embraces the base of the cross which is flanked by
 
                                 <item xml:id="a2" corresp="#h2">
                                     <locus target="#5r"/>
-                                    <desc type="Inventory">An additional list of objects written in the same hand as <ref target="#a1"/>, separated from
-                                    <ref target="#a1"/> by a fine line.</desc>
+                                    <desc type="Inventory">An additional list of objects written in the same hand as <ref target="#a1">additional note 1</ref>, separated from
+                                        <ref target="#a1">additional note 1</ref> by a fine line.</desc>
                                     <q xml:lang="am">በ፯ ወቄት፡ ከ፫ ድሪም፡ የጕልላት፡ መስቀል፡ የተሰራ፡ ቍጽሩ፡
                                     ፲፱ ነው፡ ከቃቤት፡ አለ፡</q>
                                 </item>
@@ -3880,13 +3881,13 @@ embraces the base of the cross which is flanked by
                                     <decoNote xml:id="b3" type="Cover" color="reddish brown">
                                       Full reddish brown leather cover.
                                       The turn-ins have been trimmed out and at the corners they form butt mitres.
-                                      An <term key="additionalLeatherPatch"></term> has been added along the inner margin of the boards to fill the gap between the turn-ins.
+                                      An <term key="additionalLeatherPatch">additional leather patch</term> has been added along the inner margin of the boards to fill the gap between the turn-ins.
                                       The cover shows a fine blind-tooled decoration, identical on both sides of the cover. The turn-ins and the edges are decorated as well.
                                       The decoration consists of seven concentric frames surrounding a central rectangular panel featuring a Latin cross.
                                       Frames composed by the repetition of single tools, enclosed between <term key="tripleStraightLine">triple straight lines</term>,
                                       alternate with empty ones.
-                                      Proceeding from the outer to the inner frame, the repeating decoration motifs are <term key="crissCross"></term> (two variants),
-                                      <term key="wavyLine"></term>, and <term key="straightStrapwork"></term> elements.
+                                      Proceeding from the outer to the inner frame, the repeating decoration motifs are <term key="crissCross">criss-cross</term> (two variants),
+                                        <term key="wavyLine">wavy line</term>, and <term key="straightStrapwork">straight strapwork</term> elements.
                                       The cross is formed by curved dotted lines between <term key="singleStraightLine">single straight lines</term>.
                                       At the ends of the arms of the cross there are <term key="corniForm">corni-form</term> motifs and three <term key="doubleCircle">double circles</term>.
                                       Double circles are also stamped at the intersections of the triple straight lines.
@@ -3935,7 +3936,7 @@ embraces the base of the cross which is flanked by
                             of the property of a church dedicated to the Saviour of
                             the World (Madḫāne ʿĀlam). However, it is difficult to determine to which church these notes refer to, since many Ethiopian
                             and Eritrean
-                            churches are named in his honour - including <ref target="INS0101MadhaneAlam"/>, from where the manuscript was
+                            churches are named in his honour - including <placeName ref="INS0101MadhaneAlam"/>, from where the manuscript was
                             likely taken in 1868, and Gondar Madḫāne ʿĀlam, from where
                             <persName ref="PRS9430Tewodros"/> took many manuscripts for his own capital.
                         </origin>

--- a/OxfordBodleian/Juel-Jensen/BDLaethe30.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe30.xml
@@ -678,7 +678,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <decoDesc>
                      <summary>The manuscript contains four framed miniatures that were executed by the same hand and that
                        are comparable to one executed about <date notBefore="1900" notAfter="1970">a century later</date> than the text
-                       and opening headpiece <bibl><ptr target="bm:2017HeldmanYared"/><citedRange unit="page">88</citedRange></bibl>.</summary>
+                       and opening headpiece (<bibl><ptr target="bm:2017HeldmanYared"/><citedRange unit="page">88</citedRange></bibl>).</summary>
                      <decoNote type="miniature" xml:id="d1">
                         <locus target="#iv"/>
                         <desc> A <ref type="authFile" corresp="AT1035HolyMan">portrait</ref> of <persName ref=" PRS3417David">David</persName> with a sword.
@@ -693,12 +693,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
 <decoNote type="miniature" xml:id="d3">
                         <locus target="#iiir"/>
-                        <desc> <ref type="authFile" corresp="AT1066DavidHarp"/> .
+    <desc> <ref type="authFile" corresp="AT1066DavidHarp">David playing the harp</ref> .
                         </desc>
                      </decoNote>
                      <decoNote type="miniature" xml:id="d4">
                         <locus target="#137r"/>
-                        <desc> <ref type="authFile" corresp="AT1082Angel">St Michael slaying a <term key="demon"/></ref>.
+                        <desc> <ref type="authFile" corresp="AT1082Angel">St Michael slaying a <term key="demon">demon</term></ref>.
                         </desc>
                      </decoNote>
 <decoNote type="ornamentation" xml:id="d5">
@@ -737,7 +737,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                                 <item xml:id="a2">
                                     <desc type="Directive">
-                                        Note written in the same hand as <ref target="#a1"/>, prescribing the reading of the "Prayer of penance" (perhaps <ref type="work" corresp="LIT4523Prayer"/>)
+                                        Note written in the same hand as <ref target="#a1">additional note 1</ref>, prescribing the reading of the ‘Prayer of penance’ (perhaps <ref type="work" corresp="LIT4523Prayer"/>)
                                         and containing formulas concerning the remission of sins.
                                     </desc>
                                     <locus target="#iiv"/>
@@ -751,8 +751,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                                 <item xml:id="e1">
                                     <desc>A white sticker is glued to the inner side of the front board. The name of <persName ref="PRS5782JuelJen"/> is printed on it
-                                        (<foreign xml:lang="gez">ቤንት፡ ዩውል፡ የንሰን።</foreign>) and the signature "MS. Aeth. e. 30" is written in pencil.
-                                        An additional sticker, with the signature "Ms 10" on it, is glued below it.</desc>
+                                        (<foreign xml:lang="gez">ቤንት፡ ዩውል፡ የንሰን።</foreign>) and the signature ‘MS. Aeth. e. 30’ is written in pencil.
+                                        An additional sticker, with the signature ‘Ms 10’ on it, is glued below it.</desc>
                                 </item>
                                 <item xml:id="e2">
                                     <locus target="#ir"/>
@@ -770,9 +770,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <desc>Writings in a blue pen, in a poor hand, on the upper and lower margin of the text area.</desc>
                                 </item>
                                 <item xml:id="e5">
-                                    <desc>Psalms are all numbered, except for Ps 87 (<locus target="#62v"/>). Psalm 138 is erroneously indicated as 137 (<locus target="#99v"/>).
+                                    <desc>Psalms are all numbered, except for Ps 87 (<locus target="#62v"/>). Ps 138 is erroneously indicated as 137 (<locus target="#99v"/>).
                                         The midpoint of the Psalms of David is indicated with the word <foreign xml:lang="gez">መንፈቁ፡</foreign>, encircled in red ink,
-                                        on <locus target="55r"/>.</desc>
+                                        on <locus target="#55r"/>.</desc>
                                 </item>
                             </list>
                         </additions>
@@ -780,8 +780,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <bindingDesc>
                             <binding contemporary="true">
                                 <decoNote xml:id="b1" type="bindingMaterial">
-                                  The book is bound in <material key="wood">wooden</material> boards covered with reddish-brown tooled <material key="leather"/>
-                                  and enclosed in a <material key="textile"/> chemise.
+                                  The book is bound in <material key="wood">wooden</material> boards covered with reddish-brown tooled <material key="leather">leather</material>
+                                  and enclosed in a <material key="textile">textile</material> chemise.
                                 </decoNote>
 
 
@@ -817,7 +817,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                       The rows of holes close to the head and tail of the quires could indicate the former presence of endbands or quire tackets.
                                 </decoNote>
                                 <decoNote xml:id="b7" type="Other">
-                                      A red <term key="leafTabMark"/> is inserted in the upper outer corner of <locus target="#66"/>.
+                                      A red <term key="leafTabMark">leaf tab marker</term> is inserted in the upper outer corner of <locus target="#66"/>.
                                 </decoNote>
                             </binding>
                         </bindingDesc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethe36.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe36.xml
@@ -201,7 +201,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                               </item>
                                 <item xml:id="e2">
                                     <desc>
-                                        Scribal corrections are frequent throughout the text, sometimes interlineally (e.g. on <locus target="#46r #47v"/>), sometimes over erasure in black ink (e.g. <locus target="17v"/>).
+                                        Scribal corrections are frequent throughout the text, sometimes interlineally (e.g. on <locus target="#46r #47v"/>), sometimes over erasure in black ink (e.g. <locus target="#17v"/>).
                                         Scribbles in pale or deep black ink are found, e.g. on <locus target="#21v #25v #30r"/>.
                                         Pen trials in pale or deep black ink are found, e.g. on <locus target="#1v #47v #51r"/>.
                                     </desc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethf29.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf29.xml
@@ -619,7 +619,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </q>
                                 </item>
                                 <item xml:id="a2" corresp="#h2">
-                                    <locus target="120v"/>
+                                    <locus target="#120v"/>
                                     <desc type="GuestText">
                                         <title ref="LIT5991PraiseGod" type="incomplete"/>The text
                                         stops in the middle of a word on the bottom of <locus

--- a/OxfordBodleian/Juel-Jensen/BDLaethg28.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg28.xml
@@ -138,8 +138,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </dimensions>
                                     <note>The characters per line are 10–12.</note>
                                     <ab type="pricking">Ruling and pricking are barely visible.</ab>
-                                    <ab type="ruling">Horizontal lines are visible at the bottom of <locus target="3v"/> and
-                                    <locus target="6r"/>, but most folia seem to have no ruled lines.</ab>
+                                    <ab type="ruling">Horizontal lines are visible at the bottom of <locus target="#3v"/> and
+                                    <locus target="#6r"/>, but most folia seem to have no ruled lines.</ab>
                                     <!--SH: <ab type="ruling" subtype="pattern">
                                         <locus from="2r" to="15v"/>Ruling pattern:
                                         1A-1A/0-0/0-0/C.</ab> EDS: I don't see the the horizontal ruled lines, do you?


### PR DESCRIPTION
I am working on the example PDF. Here are some edits related to the output in our example files e30, c14 and d20.

- I have not been able to edit the script to print the content of elements `<term>` and `<ref>`, so spelled it out manually: please check that my choices of words and capitalisation are as you want, @gnizla  and @ElianaDalSasso .
- added parantheses around bibliographic references
- corrected missing # in `<locus>` (also in other files)

Thanks!

