### PR TITLE
fixing Miracles of Mary

### DIFF
--- a/Cambridge/CamAdd696.xml
+++ b/Cambridge/CamAdd696.xml
@@ -49,16 +49,19 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
                   </msItem>
                   <msItem xml:id="ms_i2">
                      <locus from="2r" to="3v">2r-3v</locus>
-                     <title ref="LIT3993Miracle">Three Miracles of the Blessed Virgin Mary</title>
+                     <title ref="LIT2384Taamme">Three Miracles of the Blessed Virgin Mary</title>
                      <note>
                         <ref target="https://www.fihrist.org.uk/catalog/work_2904">See in FIHRIST.</ref>
                      </note>
-                     <listBibl type="relations">
-                        <bibl/>
-                        <relation name="skos:broadMatch"
-                                  active="https://www.fihrist.org.uk/catalog/work_2904"
-                                  passive="LIT3993Miracle"/>
-                     </listBibl>
+                     <msItem xml:id="ms_i2.1">
+                        <title ref="LIT3993Miracle">Miracle of  Mary</title>
+                     </msItem>
+                     <msItem xml:id="ms_i2.2">
+                        <title ref="LIT3993Miracle">Miracle of  Mary</title>
+                     </msItem>
+                     <msItem xml:id="ms_i2.3">
+                        <title ref="LIT3993Miracle">Miracle of  Mary</title>
+                     </msItem>
                      <textLang mainLang="gez">Geez</textLang>
                   </msItem>
                   <msItem xml:id="ms_i3">

--- a/Cambridge/CamAdd696.xml
+++ b/Cambridge/CamAdd696.xml
@@ -49,7 +49,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
                   </msItem>
                   <msItem xml:id="ms_i2">
                      <locus from="2r" to="3v">2r-3v</locus>
-                     <title ref="LIT2384Taamme">Three Miracles of the Blessed Virgin Mary</title>
+                     <title ref="LIT3585Taamme">Three Miracles of the Blessed Virgin Mary</title>
                      <note>
                         <ref target="https://www.fihrist.org.uk/catalog/work_2904">See in FIHRIST.</ref>
                      </note>

--- a/LondonBritishLibrary/orient/BLorient562.xml
+++ b/LondonBritishLibrary/orient/BLorient562.xml
@@ -40,7 +40,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <summary/>
                         <msItem xml:id="ms_i1">
                           <locus from="2r"></locus>
-                            <title type="complete" ref="LIT2384Taamme"></title>
+                            <title type="complete" ref="LIT3585Taamme"></title>
                           <textLang mainLang="gez"></textLang>
                             <msItem xml:id="ms_i1.1">
                                 <locus from="2r"></locus>

--- a/LondonBritishLibrary/orient/BLorient562.xml
+++ b/LondonBritishLibrary/orient/BLorient562.xml
@@ -40,14 +40,20 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <summary/>
                         <msItem xml:id="ms_i1">
                           <locus from="2r"></locus>
-                          <title type="complete" ref="LIT3993Miracle"></title>
+                            <title type="complete" ref="LIT2384Taamme"></title>
                           <textLang mainLang="gez"></textLang>
+                            <msItem xml:id="ms_i1.1">
+                                <locus from="2r"></locus>
+                                <title type="complete" ref="LIT3993Miracle"></title>
+                                <textLang mainLang="gez"></textLang>
+                            </msItem>
+                            <msItem xml:id="ms_i1.2">
+                                <locus from="3v"></locus>
+                                <title type="complete" ref="LIT3993Miracle"></title>
+                                <textLang mainLang="gez"></textLang>
+                            </msItem>
                         </msItem>
-                        <msItem xml:id="ms_i2">
-                          <locus from="3v"></locus>
-                          <title type="complete" ref="LIT3993Miracle"></title>
-                          <textLang mainLang="gez"></textLang>
-                        </msItem>
+                        
                         <msItem xml:id="ms_i3">
                           <locus from="5r"></locus>
                           <title type="complete" ref="LIT2505Weddas"></title>


### PR DESCRIPTION
I wonder whether in these cases and also in some others here
https://betamasaheft.eu/xpath.html?xpath=collection%28%24config%3Adata-rootMS%29%2F%2Ft%3Atitle%5B%40ref%5Bcontains%28.%2C%27LIT3993Miracle%27%29%5D%5D
(e.g. BDLaethf1) the single MM should be still grouped under the collection ID...