### PR TITLE
Update EMIP03003.xml

### DIFF
--- a/EMIP/3001-4000/EMIP03003.xml
+++ b/EMIP/3001-4000/EMIP03003.xml
@@ -26,9 +26,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="INS0447EMIP">UNESCO Collection</repository>
-                        <collection>EMIP</collection>
-                        <idno facs="EMIP/Codices/3003/" n="98">Unesco</idno>
+                        <repository ref="INS0690BQG"></repository>
+                        <collection>UNESCO</collection>
+                        <idno facs="EMIP/Codices/3003/" n="98">UNESCO 8-9</idno>
+                        <altIdentifier>
+                            <repository ref="INS0447EMIP"></repository>
+                            <collection>EMIP</collection>
+                            <idno>EMIP 3003</idno>
+                        </altIdentifier>
                     </msIdentifier>
                     <msContents>
 
@@ -218,7 +223,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
   </signatures>
 
 <list>
-  <item xml:id="q1" n="A"><dim unit="leaf"></dim>I-III<note>F. 1r not microfilmed.</note></item>
+  <item xml:id="q1" n="A"><dim unit="leaf">3</dim>I-III, s.l. 1, no stub<note>F. 1r not microfilmed.</note></item>
   <item xml:id="q2" n="1"><num value="1">፩</num><dim unit="leaf">8</dim><locus from="4r" to="11v"/></item>
   <item xml:id="q3" n="2"><num value="2">፪</num><dim unit="leaf">8</dim><locus from="12r" to="19v"/></item>
   <item xml:id="q4" n="3"><num value="3">፫</num><dim unit="leaf">8</dim><locus from="20r" to="27v"/></item>
@@ -301,9 +306,13 @@ for <persName role="patron" ref="PRS13960Walda">Walda Gabrǝʾel</persName> and 
         </profileDesc>
         <revisionDesc>
             <change who="PL" when="2021-11-10">Created XML record from EMIP set of images.</change>
-            <change who="MKr" when="2023-01-09">Added metadata based on Ted Erho's description in the vHMML</change>
+            <change who="MKr" when="2023-01-09">Added metadata based on Ted Erho's description in the vHMML (reading room 540062)</change>
+            <change when="2023-01-10" who="ES">fixed idno with institution, fixed collation, added link to vHMML</change>
         </revisionDesc>
     </teiHeader>
+    <facsimile>
+        <graphic url="https://w3id.org/vhmml/readingRoom/view/540062"/>
+    </facsimile>
     <text xml:base="https://betamasaheft.eu/">
         <body>
             <ab/>


### PR DESCRIPTION
I have fixed the collation as requested in https://github.com/BetaMasaheft/Documentation/issues/2295
 and corrected the shelfmark / repository; 

I further wonder if the record should be actually renamed and moved to a Bechana Giyorgis or a Unesco folder, as EMIP is a secondary repo in this case (as I have done in other cases of EMIP doublets).

This should be eventually be done for all EMIP doublets as also mentioned here https://github.com/BetaMasaheft/Documentation/issues/2284

BG or UNESCO @thea-m @DenisNosnitsin1970 ?