### PR TITLE
Encoded BMLacq720

### DIFF
--- a/EMML/2001-3000/EMML2133.xml
+++ b/EMML/2001-3000/EMML2133.xml
@@ -37,6 +37,14 @@ schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://ra
                </msIdentifier>
                <msContents>
                   <summary/>
+                  <msItem xml:id="ms_i1">
+                     <locus from="1r" to="23r"/>
+                     <title ref="LIT1201Bartos"/>
+                  </msItem>
+                  <msItem xml:id="ms_i2">
+                     <locus from="23r" to="41r"/>
+                     <title ref="LIT4520Prayer"/>
+                  </msItem>
                </msContents>
                <physDesc>
                   <objectDesc form="Codex">

--- a/FlorenceBML/BMLacq720/BMLacq720.xml
+++ b/FlorenceBML/BMLacq720/BMLacq720.xml
@@ -48,7 +48,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                             <note>With insertion of magical names in the incipit.</note>
                             <note>Name of the original owner unknown and erased various times, name of the new owner 
                                 <persName role="owner" ref="PRS13993GabraHanaCare">ገብረ፡ ሐና፡ ቸሬ፡ </persName> written over on <locus target="#8v #24ra #24rb"/>, 
-                                whose name again was freqently erased or crossed out and replaced by the name of the new owner
+                                whose name again was frequently erased or crossed out and replaced by the name of the new owner
                                 <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም፡ </persName>.</note>
                         </msItem>
                         <msItem xml:id="ms_i2">
@@ -94,7 +94,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                             <locus from="59ra" to="59vb"/>
                             <title>Unidentified text</title>
                             <note>Unidentified text, according to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">77
-                                </citedRange></bibl> with invocation of possibly magical names, that are infact names of mountains known from the Bible: 
+                                </citedRange></bibl> with invocation of possibly magical names, that are in fact names of mountains known from the Bible: 
                                 <foreign xml:lang="gez">አአትብ፡ ገጸየ፡ ውስተ፡ ርእሰ፡ ሳኒር፡ ወኄርሜን። ርእሱ፡ ከመ፡ ሰሂን። ወኅሩይ፤ ከመ፡ ቂድሮስ። በምድረ፡ ዮርዳኖስ፡ በአርሞንዒ፡ በደብር፤ ንዑስ፡ 
                                 በፈለገ፡ ዮርዳኖስ፡ ወበላዕለ፡ ደብር። ወበቅድመ፡ ኵሎሙ፡ ሕዝብ፡ አብሐከ፡ ቃለ፡ አብ፡ ታቦር። ወአርሞንዒም። በስመ፡ ዚአከ፡ ይትፌሥሑ፡ በደብረ፡ ታቦር፡ ወበደብረ፡ ሲና። ተስብሐ፡ 
                                 ክርስቶስ፡ ከመ፡ ጠለ፡ አርሞንዒም። ወሕይወተ፤ እም፡ ይእዜ፡ ወእስከ፡ ለዓለም፡ አዘሬን፡ መሐቲን፡ ዝንቱ፤ አስማት፡ ዘአውጽኑሙ፡ ለ፫ደቂቅ።  እምእቶነ፡ እሳት። ከማሆሙ፡ አውጽኒ፡ 

--- a/FlorenceBML/BMLacq720/BMLacq720.xml
+++ b/FlorenceBML/BMLacq720/BMLacq720.xml
@@ -72,7 +72,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                 ጸሎታ፡ ወበረከታ፡ የሀሉ፡ ምስለ፡ ገብራ። <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም።</persName> ለዓለመ፡ ዓለም፡ አሜን። ወእመሂ፡ ተንባላታዊሆን። 
                                 ወእመሂ፡ ከለዳዊያን፤ አይሁድ። ወዮናናዊያን፡ ወሳምራዊያን። ወግብፃውያን፡ ወኖናፌ፡ ወኵሉ፤ ክርስቲያን። ወለኵሎሙ፡ ሰብእ፡ እኩያን። ዘርዝር፡ ምክሮሙ። </incipit>
                             <explicit xml:lang="gez">ዝውእቱ፡ ኢየሱስ፡ ክርስቶስ፡ ወኵሎ፡ ሠራዊቶ፡ እሉ፤ እሙንቱ፡ ዘሰመይክዎሙ፡ ከመ፡ ትፈኑ፤ ሊተ፡ ተኢያኮስ፡ ቅድስት፡ ማርያም፡ ድንግል። 
-                                ከመ፡ ትዕተብ፡ ወትባርክ፡ ዘንተ፤ ማየ፤ ወዘንተ፡ ዘይተ። በዛቲ፡ ሰዓት። ወቅብዖ፡ ወአጥምቆ፡ ለገብብርከ፡ <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም።</persName>
+                                ከመ፡ ትዕተብ፡ ወትባርክ፡ ዘንተ፤ ማየ፤ ወዘንተ፡ ዘይተ። በዛቲ፡ ሰዓት። ወቅብዖ፡ ወአጥምቆ፡ ለገብ<surplus>ብ</surplus>ርከ፡ <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም።</persName>
                                 ወይኩን፡ ሎቱ፡ ፍሥሐ፡ ወሐሤት፡ ወፈውስ፡ መድኃኒት። እምኀበ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ይእዜኒ፤ ወዘልፈኒ፡ ወለዓለመ፡ ዓለም፡ አሜን። ወአሜን፡ ለይኩን፤ ለይኩን፤ 
                                 ሊተ፡ ለገብርከ፡ <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም።</persName>። </explicit>
                         </msItem>

--- a/FlorenceBML/BMLacq720/BMLacq720.xml
+++ b/FlorenceBML/BMLacq720/BMLacq720.xml
@@ -7,6 +7,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
             <titleStmt>
                 <title/>
                 <editor key="AB" role="generalEditor"/>
+                <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
             <editionStmt>
@@ -35,7 +36,192 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                             <idno>Marrassini ms. 12</idno>
                         </altIdentifier>
                     </msIdentifier>
-                    <history>
+                    <msContents>
+                        <summary/>
+                        <msItem xml:id="ms_i1">
+                            <locus from="1ra" to="30va"/>
+                            <title ref="LIT1201Bartos"/>
+                            <incipit xml:lang="gez">በስመ፡ አብ፡ ወወወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡ ዛቲ፡ ጸሎት፡ ዘእግዝእትነ፡ ማርያም፡ ዘጸለየት፡ ባቲ፡ በውስተ፡ ዮዳርፍ፡ ወወሎሮኒ፡ 
+                                አፍሎ፡ ጳሎሚስ፡ አሊም፡ ሀገሩ፡ ባርቶስ፡ ወተፈትሑ፡ ኵሉ፡ ኃፃውንት። ወአጽኃነቶ፡ ለማትያስ፡ ረድእ።</incipit>
+                            <explicit xml:lang="gez">አነ፡ እሰምዖ፡ ወዘንተ፡ ይቤ፡ እግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ ሎቱ፡ ስብሐት፡ ወወላዲቱ፡ ድንግል፡ ወወሀባ፡ ሰላም። ወአርገ፡ ውስተ፡ 
+                                ሰማያት። በዓቢይ፤ ስብሐት፡ ሎቱ፡ ይደሉ፤ እስከ፡ ለዓለመ፤ ዓለም፡ አሚን፤ ወአሚን፤ ለይኩን፡ ለይኩን። </explicit>
+                            <note>With insertion of magical names in the incipit.</note>
+                            <note>Name of the original owner unknown and erased various times, name of the new owner 
+                                <persName role="owner" ref="PRS13993GabraHanaCare">ገብረ፡ ሐና፡ ቸሬ፡ </persName> written over on <locus target="#8v #24ra #24rb"/>, 
+                                whose name again was freqently erased or crossed out and replaced by the name of the new owner
+                                <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም፡ </persName>.</note>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <locus from="30va" to="41vb"/>
+                            <title ref="LIT4520Prayer"/>
+                            <incipit xml:lang="gez">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡ ጸሎት፡ ዘእግዝእትነ፡ ማርያም፡ ቅድስት፡ ድንግል፤ እሙ፡ ለእግዚእነ፡ ኢየሱስ፡ 
+                                ክርስቶስ፡ በረከታ፡ የሃሉ፡ ምስለ፡ ገብራ፡ <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም፡</persName> አመ፡ <date>፭ዓመት፡ ወ፩ወርኅ። </date>
+                                አመ፡ <date>፳ወ፩፡ ለሚያዝያ</date>። ከሠተት፡ አፉሃ፡ ቅዱስ፡ ዘምሉዕ፡ ብርሃነ፡ ማርያም፡ ቅድስት፡ ድንግል፡ ወኵሎሙ፡ አሕዛብ፡ ይፈርሁ። </incipit>
+                            <explicit xml:lang="gez">ወካዕበ፤ ሀቦ፤ ሀብተ፡ መንፈስ፡ ቅዱስ። ዘይሰዳድ፡ ኵሎ፡ አጋንንት። ወኵሎ፡ ሕማመ። ወኵሎ፡ ኅሱመ። እምላዕለ፡ ነፍሱ፡ ወሥጋሁ፤ 
+                                ፍጡነ፡ ወአምላዕለ፡ ኵሎሙ፡ ጽውያን፡ ወሕሙማን። እለ፡ ደሰትዩ፡ ወይትረቀዮ፤ እማየ፡ ጸሎቱ፡ ለዝንቱ፡ መጽሐፍ፤ በኵሉ፡ ጊዜ፡ ወበኵሉ፡ ሰዓት። ለዓለመ፡ ዓለም፡ አሜን። 
+                                ሊተ፡ ለገብርከ፡ ገ <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም።</persName></explicit>
+                        </msItem>
+                        <msItem xml:id="ms_i3">
+                            <locus from="41vb" to="44va"/>
+                            <title type="incomplete" ref="LIT4343Prayer"/>
+                            <incipit xml:lang="gez">ወኮነ፤ በዓመት፡ ኃምስ። አመ፡ <date>፳ወ፩ለወርኃ፡ ኃምስ።</date> ተንሥአት፡ ማርያም፡ ቅድስት፡ ድንግል፤ እሙ፡ ለእግዚእነ፡ 
+                                ኢየሱስ፡ ክርስቶስ፡ ቆመት፤ በእገሪሃ፡ ወሜጠት፤ ገጻ፡ መንገለ፡ ምሥራቅ። ወሰፍሃት፡ እደዊሃ፡ ውስተ፡ ሰማይ፡ ወከሠተት፡ አፉሃ።</incipit>
+                            <explicit xml:lang="gez">ለዘያጠምቅዎ፡ ወይቀብዕዎ፡ ቦቱ፡ ወይኩን፡ ሎቱ፡ ፍሥሐ፡ ወሐሢት፤ ወጽንዓ፡ ዘይሰድዶሙ፡ ለአጋንንት። ወለኵሎሙ፡ መሠርያን፡
+                                እኩያን። ሊተ፡ ለገብርከ። <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም።</persName></explicit>
+                        </msItem>
+                        <msItem xml:id="ms_i4">
+                            <locus from="44vb" to="52vb"/>
+                            <title>Prayer of the Virgin</title>
+                            <incipit xml:lang="gez">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ለ፩አምላክ፡ ዛቲ፡ ጸሎት፡ ዘእግዝእትነ፤ ቅድስት፡ ድንግል፡ ማርያም፡ ንጽሕት፡ ወላዲተ፡ አምላክ። 
+                                ጸሎታ፡ ወበረከታ፡ የሀሉ፡ ምስለ፡ ገብራ። <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም።</persName> ለዓለመ፡ ዓለም፡ አሜን። ወእመሂ፡ ተንባላታዊሆን። 
+                                ወእመሂ፡ ከለዳዊያን፤ አይሁድ። ወዮናናዊያን፡ ወሳምራዊያን። ወግብፃውያን፡ ወኖናፌ፡ ወኵሉ፤ ክርስቲያን። ወለኵሎሙ፡ ሰብእ፡ እኩያን። ዘርዝር፡ ምክሮሙ። </incipit>
+                            <explicit xml:lang="gez">ዝውእቱ፡ ኢየሱስ፡ ክርስቶስ፡ ወኵሎ፡ ሠራዊቶ፡ እሉ፤ እሙንቱ፡ ዘሰመይክዎሙ፡ ከመ፡ ትፈኑ፤ ሊተ፡ ተኢያኮስ፡ ቅድስት፡ ማርያም፡ ድንግል። 
+                                ከመ፡ ትዕተብ፡ ወትባርክ፡ ዘንተ፤ ማየ፤ ወዘንተ፡ ዘይተ። በዛቲ፡ ሰዓት። ወቅብዖ፡ ወአጥምቆ፡ ለገብብርከ፡ <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም።</persName>
+                                ወይኩን፡ ሎቱ፡ ፍሥሐ፡ ወሐሤት፡ ወፈውስ፡ መድኃኒት። እምኀበ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ይእዜኒ፤ ወዘልፈኒ፡ ወለዓለመ፡ ዓለም፡ አሜን። ወአሜን፡ ለይኩን፤ ለይኩን፤ 
+                                ሊተ፡ ለገብርከ፡ <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም።</persName>። </explicit>
+                        </msItem>
+                        <msItem xml:id="ms_i5">
+                            <locus from="52vb" to="59vb"/>
+                            <title ref="LIT4343Prayer"/>
+                            <incipit xml:lang="gez">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡ ጸሎት፡ ዘእግዝእትነ፡ ማርያም፡ ድንግል፤ ንጽሕት፡ ወላዲተ፡ ሕይወት፡ አንቅጸ፡ ብርሃን፤ አንቅተ፡ 
+                                ክብር፡ ወመሥተምሕርተ፡ ለኵሉ፡ ዓለም። ጸሎታ፡ ወበረከታ፡ የሃሉ፤ ምስልለ፡ ምገብራ፡ <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም።</persName> ለዓለመ፡ ዓለም፡ 
+                                አሜን፡ ወእምዝ፡ ሰፍሐት፡ እደዊሃ። ወዓንቃዕደውት፡ ውስተ፤ ሰማይ፡ ወከልሐት፡ ኀበ፡ ፍቁር፤ ወልዳ፡ ኢየሱስ፡ ክርስቶስ፡ ትብል፡ ከመዝ። ነዓ፡ ኀቤየ፡ ኢየሱስ፡ ክርስቶስ፡ ወልታ፡ ጽድቅ፡ 
+                                እምየማን፡ ወእምፀጋም።</incipit>
+                            <explicit xml:lang="gez">ወመርሖ፡ ፍኖተ፡ መድኃኒት፤ ወሥረደ፡ ሎቱ፡ ኵሎ፡ ኃጢአቶ። ለገብርከ፡ <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም።</persName>
+                                በዝንቱ፡ አስማቲከ፤ እዮ፤ እዮ፤ ዳኬ፡ ዳኬ፡ ለዓለመ፡ ዓለም፡ አሜን። </explicit>
+                        </msItem>
+                        <msItem xml:id="ms_i6">
+                            <locus from="59ra" to="59vb"/>
+                            <title>Unidentified text</title>
+                            <note>Unidentified text, according to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">77
+                                </citedRange></bibl> with invocation of possibly magical names, that are infact names of mountains known from the Bible: 
+                                <foreign xml:lang="gez">አአትብ፡ ገጸየ፡ ውስተ፡ ርእሰ፡ ሳኒር፡ ወኄርሜን። ርእሱ፡ ከመ፡ ሰሂን። ወኅሩይ፤ ከመ፡ ቂድሮስ። በምድረ፡ ዮርዳኖስ፡ በአርሞንዒ፡ በደብር፤ ንዑስ፡ 
+                                በፈለገ፡ ዮርዳኖስ፡ ወበላዕለ፡ ደብር። ወበቅድመ፡ ኵሎሙ፡ ሕዝብ፡ አብሐከ፡ ቃለ፡ አብ፡ ታቦር። ወአርሞንዒም። በስመ፡ ዚአከ፡ ይትፌሥሑ፡ በደብረ፡ ታቦር፡ ወበደብረ፡ ሲና። ተስብሐ፡ 
+                                ክርስቶስ፡ ከመ፡ ጠለ፡ አርሞንዒም። ወሕይወተ፤ እም፡ ይእዜ፡ ወእስከ፡ ለዓለም፡ አዘሬን፡ መሐቲን፡ ዝንቱ፤ አስማት፡ ዘአውጽኑሙ፡ ለ፫ደቂቅ።  እምእቶነ፡ እሳት። ከማሆሙ፡ አውጽኒ፡ 
+                                ሊተ፡ ለገብርከ፡ <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም።</persName> በ፭ቱ፡ ቅንዋተ፡ መስቀሉ፡ እለ፡ ቀነውዎ፡ ለሥጋከ። ሳዶር፡ አላዶር፡ ዳናት፡ አጼራ፡ ሮዳስ። 
+                                    በዝንቱ፤ አስማቲከ፡ ተማኅፀንኩ፤ አነ፤ ገብርከ። <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም።</persName> ለዓለመ፡ ዓለም፡ አሜን፡ ወአሜን፡ ለይኩን፤ ለይኩን። 
+                                    ለግብርከ፡ <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም።</persName> ጸሀፊሁ፤ ኃጥዕ፤ ወአባሲ፤ <gap reason="illegible"/></foreign></note>
+                        </msItem>
+                        <msItem xml:id="ms_i7">
+                            <locus from="60ra" to="78va"></locus>
+                            <title ref="LIT2246salotz"></title>
+                            <incipit xml:lang="gez">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡ ጸሎት፡ ዘእግዝእትነ፡ ማርያም፡ ወላዲተ፤ አምላክ፡ እንተ፡ ጸሐፋ፡ አብሮኮሮስ፤ ረድአ፡ 
+                                ዮሐንስ። ጸሎታ፡ ወበረከታ፡ የሃሉ፤ ምስለ፡ ገብራ፡ <persName ref="PRS0000">ኪዳነ፡ ማርያም።</persName> ለዓለመ፡ ዓለም፡ አሜን። ጸሎት፡ ዘጸለየት፡ ባቲ፡ 
+                                አመ፡ <date>፳ወ፩ለወርኃ፡ ሰኔ፡</date> በደብረ፤ ጎልጎታ፤ ዘውእቱ፡ መቃብረ፡ እግዚእነ፤ ኢየሱስ፡ ክርስቶስ፡ እንዘ፡ ትብል። ኦእግዚእየ፡ ወአምላኪየ። ወወልድየ፡ ወንጉሥየ፡ 
+                                ኢየሱስ፡ ክርስቶስ፡ ዘተወለድከ፤ በፈቃድከ። ወጠበውከ፤ ሀሊበ፤ እምአጥባትየ፡ እንዘ፡ ሰማይ፡ ኢያገምረከ። ወአጽናፈ፡ ዓለም፡ ኢየአክለከ። ወምድርኒ፡ ኢትክል፡ 
+                                ፀዊሮተከ፡ ከርሠ፡ ቀለያትኒ፤ ወእመቀ፡ አብሕርትኒ። </incipit>
+                            <explicit xml:lang="gez">ኦእግዝእትየ፡ ማርያም፡ ጸሎትኪ፤ ወሰዕለትኪ፡ ወምሕረተ፡ ወልድኪ። ቡሩክ፡ ይባርክነ፤ ለገብርኪ፡ <persName role="owner" ref="PRS13994KidanaMaryam">
+                                ኪዳነ፡ ማርያም።</persName> ጸሀፊሁ፡ ኃጥዕ፡ ወአባሲ፡ <persName role="scribe" ref="PRS13995TaklaMaryam">ተክለ፡ ማርያም።</persName></explicit>
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Codex">
+                            <supportDesc>
+                                <support><material key="parchment"></material></support>
+                                <extent>
+                                    <measure unit="leaf">80</measure>
+                                    <measure unit="leaf" type="blank">1</measure><locus target="#79v"></locus>
+                                    <dimensions unit="mm">
+                                        <height>153</height>
+                                        <width>110</width>                                        
+                                    </dimensions>
+                                </extent>
+                                <foliation>Numbered in pencil by a recent European hand on the bottom right. Folio <locus target="#63"/> numbered
+                                    twice and therefore the foliation of <locus from="64" to="80"/> does not match with the inscribed folio marks.
+                                </foliation>
+                                <collation>
+                                    <list>
+                                        <item xml:id="q1" n="1">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="1" to="10"/>
+                                        </item>
+                                        <item xml:id="q2" n="2"> 
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="11" to="20"/>
+                                        </item>
+                                        <item xml:id="q3" n="3">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="21" to="30"/>
+                                        </item>
+                                        <item xml:id="q4" n="4">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="31" to="40"/>
+                                        </item>
+                                        <item xml:id="q5" n="5">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="41" to="50"/>
+                                        </item>
+                                        <item xml:id="q6" n="6">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="51" to="60"/>
+                                        </item>
+                                        <item xml:id="q7" n="7">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="61" to="70"/>
+                                        </item>
+                                        <item xml:id="q8" n="8">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="71" to="80"/>
+                                        </item>
+                                    </list>
+                                </collation>
+                                <condition key="intact">
+                                </condition>
+                            </supportDesc>
+                            <layoutDesc><layout columns="2" writtenLines="16">
+                                <ab type="pricking">Pricking is visible</ab>
+                                <ab type="ruling">Ruling is visible</ab>
+                                <note>The number of written lines may vary between 15 and 16.</note>
+                            </layout>
+                            </layoutDesc>
+                        </objectDesc>
+                        <handDesc>
+                            <handNote xml:id="h1" script="Ethiopic">
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Incipits, sacred names and name of the owner</seg>
+                                <seg type="script">Script of the nineteenth century.</seg>
+                            </handNote>     
+                        </handDesc>
+                        <additions>
+                            <list>
+                                <item xml:id="a1">
+                                    <locus from="78v" to="79r"/>
+                                    <desc type="MagicText">Magic prayer of the type <title ref="LIT1824Mafteh"/>. Text ends abruptly.</desc>
+                                    <q xml:lang="gez">በስመ፡ አብ፡ ወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡ ጸሎት፡ በእንተ፡ መፍትሔ፡ ሥራይ፡ ሐመል፡ ዘተሰርቆ፡ በዓይነ፡ ጠባይ፡ እሳተዋ፡ ኢትሰግር፡ በሥራይ፡ 
+                                        ሰውር፡ ዘተሰርቆ፡ በዓይነ፡ ጠባይ፡ ይሰሞ፡ ይትረግር፡ በሥራይ፡ ማውዝ፡ ዘተስርቆ፡ ነፍሣዊ፡ በአይነ፡ ጠባይ፡ ይትረግር፡ በሥራይ፡ ሸርጣን፡ <gap reason="ellipsis"/>በሥራይ፡ 
+                                        ሁት፡ ዘተሰርቆ፡ በሥራይ፡ በእሉ፡ አስማቲከ፡ ሰክም፡ ክብት፡ ይቸታህ፡ ኩሉ፡ እምላእለነ፡ ፉ<gap reason="illegible"/>ብርከ፡ </q>
+                                </item>
+                                <item xml:id="a2">
+                                    <locus from="80r" to="80v"/>
+                                    <desc type="MagicText">Not identified magic text with animal names. Text ends abruptly.</desc>
+                                    <q xml:lang="gez">ሰለበዊት፡ ሰለብዎ፡ ኢትስልብ፡ ዝብ፡ ደደሰማ፡ አንበሳ፡ ጋማማ፡ ነምር፡ ጽፍራማ፡ አሞራ፡ ክንፍ፡ <gap reason="ellipsis"/> ዝእብ፡ ወነምር፡ ዘእንበለ፡ 
+                                        ኢጽልብ፡ ብዝቋለ፡ ደፈር፡ <gap reason="ellipsis"/> ቅዱስ፡ ዘየሐድርን፡ <gap reason="illegible"/>፯ጊዜ፡ ደግም፡ <gap reason="illegible"/>ደ፡ ቆመህ፡ 
+                                        ድግ <gap reason="illegible"/></q>
+                                </item>
+                                <item xml:id="e1">
+                                    <locus target="#10rb #20rb #30va #37vb #44va #52vb"/>
+                                    <desc>Indication of the days of the week for reading in the upper margins with red and black ink and surrounded by a frame: 
+                                        <foreign xml:lang="gez">ዘሠሉስ፡ </foreign> on <locus target="#10rb"/>
+                                        <foreign xml:lang="gez">ዘረቡዕ፡ </foreign> on <locus target="#20rb"/>
+                                        <foreign xml:lang="gez">ዘሐሙስ፡ </foreign> on <locus target="#30va"/>
+                                        <foreign xml:lang="gez">ዘዓርብ፡ </foreign> on <locus target="#37vb"/>
+                                        <foreign xml:lang="gez">ዘቀዳሚት፡ </foreign> on <locus target="#44va"/>
+                                        <foreign xml:lang="gez">ዘእሁድ፡ </foreign> on <locus target="#52vb"/>
+                                    </desc>
+                                </item>
+                            </list>
+                        </additions>
+                        <bindingDesc>
+                            <binding>
+                                <decoNote xml:id="b1" type="Boards">Two wooden boards, covered with leather.</decoNote>
+                                <decoNote xml:id="b2" type="SewingStations">4</decoNote>
+                                <decoNote xml:id="b3" type="bindingMaterial"><material key="wood"></material></decoNote>
+                                <decoNote xml:id="b4" type="SlipCase">Double housing of leather, the inner one with a strap that connects it to a 
+                                    transversal strip of the external. The external case with a support strap.</decoNote>
+                            </binding>
+                        </bindingDesc>
+                    </physDesc>
+                    <history> 
                     </history>
                     <additional>
                         <adminInfo>
@@ -65,11 +251,13 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
         <profileDesc>
-            <langUsage><language ident="en">English</language></langUsage>
+            <langUsage><language ident="en">English</language><language ident="gez">Gəʿəz</language></langUsage>
         </profileDesc>
         <revisionDesc>
             <change who="PL" when="2019-02-21">Created catalogue entry</change>
             <change when="2021-09-21" who="PL">added text from transkribus and facsimile with xi:include</change>
+            <change when="2023-03-27" who="CH">added physical description</change>
+            <change when="2023-03-30" who="CH">added content description</change>
         </revisionDesc>
     </teiHeader>
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" 
@@ -78,7 +266,6 @@ schematypens="http://relaxng.org/ns/structure/1.0"
             <!-- facsimile -->
         </xi:fallback>
     </xi:include>
-
             <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" 
                 href="transkribusText.xml">
                 <xi:fallback>

--- a/FlorenceBML/BMLacq720/BMLacq720.xml
+++ b/FlorenceBML/BMLacq720/BMLacq720.xml
@@ -46,10 +46,6 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                             <explicit xml:lang="gez">አነ፡ እሰምዖ፡ ወዘንተ፡ ይቤ፡ እግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ ሎቱ፡ ስብሐት፡ ወወላዲቱ፡ ድንግል፡ ወወሀባ፡ ሰላም። ወአርገ፡ ውስተ፡ 
                                 ሰማያት። በዓቢይ፤ ስብሐት፡ ሎቱ፡ ይደሉ፤ እስከ፡ ለዓለመ፤ ዓለም፡ አሚን፤ ወአሚን፤ ለይኩን፡ ለይኩን። </explicit>
                             <note>With insertion of magical names in the incipit.</note>
-                            <note>Name of the original owner unknown and erased various times, name of the new owner 
-                                <persName role="owner" ref="PRS13993GabraHanaCare">ገብረ፡ ሐና፡ ቸሬ፡ </persName> written over on <locus target="#8v #24ra #24rb"/>, 
-                                whose name again was frequently erased or crossed out and replaced by the name of the new owner
-                                <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም፡ </persName>.</note>
                         </msItem>
                         <msItem xml:id="ms_i2">
                             <locus from="30va" to="41vb"/>
@@ -100,7 +96,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                 ክርስቶስ፡ ከመ፡ ጠለ፡ አርሞንዒም። ወሕይወተ፤ እም፡ ይእዜ፡ ወእስከ፡ ለዓለም፡ አዘሬን፡ መሐቲን፡ ዝንቱ፤ አስማት፡ ዘአውጽኑሙ፡ ለ፫ደቂቅ።  እምእቶነ፡ እሳት። ከማሆሙ፡ አውጽኒ፡ 
                                 ሊተ፡ ለገብርከ፡ <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም።</persName> በ፭ቱ፡ ቅንዋተ፡ መስቀሉ፡ እለ፡ ቀነውዎ፡ ለሥጋከ። ሳዶር፡ አላዶር፡ ዳናት፡ አጼራ፡ ሮዳስ። 
                                     በዝንቱ፤ አስማቲከ፡ ተማኅፀንኩ፤ አነ፤ ገብርከ። <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም።</persName> ለዓለመ፡ ዓለም፡ አሜን፡ ወአሜን፡ ለይኩን፤ ለይኩን። 
-                                    ለግብርከ፡ <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም።</persName> ጸሀፊሁ፤ ኃጥዕ፤ ወአባሲ፤ <gap reason="illegible"/></foreign></note>
+                                    ለግብርከ፡ <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም።</persName> ጸሀፊሁ፤ ኃጥዕ፤ ወአባሲ፤ <gap reason="illegible"/></foreign></note>              
                         </msItem>
                         <msItem xml:id="ms_i7">
                             <locus from="60ra" to="78va"></locus>
@@ -126,8 +122,8 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                         <width>110</width>                                        
                                     </dimensions>
                                 </extent>
-                                <foliation>Numbered in pencil by a recent European hand on the bottom right. Folio <locus target="#63"/> numbered
-                                    twice and therefore the foliation of <locus from="64" to="80"/> does not match with the inscribed folio marks.
+                                <foliation>Folios numbered in pencil by a recent European hand on the bottom right. Folio <locus target="#64"/> numbered
+                                    "63bis" and therefore the foliation of <locus from="64" to="80"/> does not match with the inscribed folio marks.
                                 </foliation>
                                 <collation>
                                     <list>
@@ -177,6 +173,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         </objectDesc>
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
+                                <date notBefore="1800" notAfter="1899"/>
                                 <seg type="ink">Black, red.</seg>
                                 <seg type="rubrication">Incipits, sacred names and name of the owner</seg>
                                 <seg type="script">Script of the nineteenth century.</seg>
@@ -193,7 +190,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                 </item>
                                 <item xml:id="a2">
                                     <locus from="80r" to="80v"/>
-                                    <desc type="MagicText">Not identified magic text with animal names. Text ends abruptly.</desc>
+                                    <desc type="MagicText">Unidentified magic text with animal names. Text ends abruptly.</desc>
                                     <q xml:lang="gez">ሰለበዊት፡ ሰለብዎ፡ ኢትስልብ፡ ዝብ፡ ደደሰማ፡ አንበሳ፡ ጋማማ፡ ነምር፡ ጽፍራማ፡ አሞራ፡ ክንፍ፡ <gap reason="ellipsis"/> ዝእብ፡ ወነምር፡ ዘእንበለ፡ 
                                         ኢጽልብ፡ ብዝቋለ፡ ደፈር፡ <gap reason="ellipsis"/> ቅዱስ፡ ዘየሐድርን፡ <gap reason="illegible"/>፯ጊዜ፡ ደግም፡ <gap reason="illegible"/>ደ፡ ቆመህ፡ 
                                         ድግ <gap reason="illegible"/></q>
@@ -208,6 +205,15 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                         <foreign xml:lang="gez">ዘቀዳሚት፡ </foreign> on <locus target="#44va"/>
                                         <foreign xml:lang="gez">ዘእሁድ፡ </foreign> on <locus target="#52vb"/>
                                     </desc>
+                                </item>
+                                <item xml:id="e2">
+                                    <locus target="#1rb #4ra #4va #8vb #14va #15va #20ra #24ra #24rb #25ra #25rb #26rb #30va #33ra #34rb 
+                                        #34vb #35vb #36va #37ra #37vb #39ra #39vb #40va #40vb #41va #41vb #44va #44vb #49rb #50va #52va 
+                                        #52vb #53ra #55ra #55va #56rb #56va #57ra #58va #59ra #59va #59vb #60ra #66va #69va #78va"/>
+                                    <desc>Name of the original owner is unknown, since it has been erased elsewhere. The name of the new owner 
+                                        <persName role="owner" ref="PRS13993GabraHanaCare">ገብረ፡ ሐና፡ ቸሬ፡ </persName> to be identified on 
+                                        <locus target="#8v #24ra #24rb"/>, was again frequently erased and replaced by the name of the new owner
+                                        <persName role="owner" ref="PRS13994KidanaMaryam">ኪዳነ፡ ማርያም፡ </persName>.</desc>
                                 </item>
                             </list>
                         </additions>
@@ -234,8 +240,8 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                         </bibl>
                                     </listBibl>
                                 </source>
-                            </recordHist>
-                        </adminInfo>
+                             </recordHist>
+                        </adminInfo>                
                     </additional>
                 </msDesc>
             </sourceDesc>


### PR DESCRIPTION
Again the pagination is problematic, because the number 63 was given twice to folio 63 and 64. 
I created new IDs for the persons mentioned.
I was not sure, whether it was necessary to encode the dates of commemoration (21st Miyazya, 21st Maggabit and 21st Sane) and whether I did this appropriately and detailed enough. 
In seeking for the correct LIT, I came across EMML2133 and updated this record with the same narratives included.