### PR TITLE
Update bdlaethe39

### DIFF
--- a/OxfordBodleian/Juel-Jensen/BDLaethe39.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe39.xml
@@ -62,11 +62,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <note corresp="#leafdim">Data on leaves dimensions taken from <locus target="#12r"/>.</note>
                                 </extent> 
                                 <condition key="deficient">
-                                    <!-- What follows is the condition of the entire MS -->
-                                    The manuscript is in bad condition. Tears, losses, and insect droppings are present, especially along the external margins.
-                                    Most folia are unevenly distorted, stained, and darkened along the margins.
-                                    The sewing is broken throughout. Most bifolia became separated and the single folia are stitched
-                                    to strips of parchment or textile placed around the quires.
+                                    The two codicological units forming the manuscript seem to share the same conservation history. Most folia are unevenly distorted, stained, and darkened along the margins,
+                                    and present tears and lacunas. The sewing is broken throughout. Most bifolia became separated and the single folia are stitched to strips of parchment or textile placed
+                                    around the quires. A protective strip of textile is sewn around <ref target="#q5 #q7 #q9 #q11 #q12 #q13 #q14 #q17 #q18"/>. A parchment support has been added around <ref target="#q1"/>.
+                                    <ref target="#q19 originates from another codex and is currently held together very precariously by means of one running stitch. One or more leaves are missing after <locus target="#88"/>,
+                                    with loss of text. All leaves are stained with dirt and some portions of text are illegible due to faded ink.
                                 </condition>
                             </supportDesc>                                                
                         </objectDesc>
@@ -463,7 +463,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <support>
                                         <material key="parchment"/>                                     
                                         <p>Holes, presumably resulting from parchment making, are found on e.g. <locus target="#1 #52 #83"/>.
-                                            A tear has been repaired on <locus target="#63"/>
+                                            A tear has been repaired on <locus target="#63"/>.
                                         </p>
                                     </support>
                                     <foliation>Pencil foliation in the upper right corner carried out by the Bodleian Library in January 2020.</foliation>
@@ -557,16 +557,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             </item>
                                         </list>
                                     </collation>
-                                    <condition key="deficient">
-                                        <!-- What follows is the condition of the first codicological unit -->
-                                        The quires are held together precariously: only one loose thread is found between <locus target="#56"/> and <locus target="#57"/>. 
-                                        A protective strip of textile is sewn around <ref target="#q5 #q7 #q9 #q11 #q12 #q13 #q14 #q17 #q18"/>.
-                                        A parchment support has been added around <ref target="#q1"/>.
-                                        Many leaves from <ref target="#q5 #q7 #q9 #q11 #q13"/> are detached and sewn together.
-                                        The margins of some leaves have been damaged possibly by rodents (e.g. <locus target="#12"/>). Some leaves are slightly stained with water, 
-                                        e.g. on <locus from="44vb" to="45ra"/> and <locus from="55vb" to="56ra"/>, or wax, e.g. on <locus target="#113v #49ra #49vb"/>. 
-                                        The text on some leaves is occasionally illegible, e.g. on <locus target="#56vb #73rb #80va"/>.
-                                    </condition>
+                                
                                 </supportDesc>
                     
                                 <layoutDesc>
@@ -769,12 +760,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             </item>
                                         </list>
                                     </collation>
-                                    <condition key="deficient">
-                                        <!-- What follows is the condition of the second codicological unit -->
-                                        The quire originates from another codex and is currently held together very precariously by means of one running stitch.
-                                        One or more leaves are missing after <locus target="#88"/>, with loss of text.  
-                                         All leaves are stained with dirt and some portions of text are illegible due to faded ink.
-                                    </condition>
+                                   
                                 </supportDesc>
                                 
                                 <layoutDesc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethe39.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe39.xml
@@ -62,11 +62,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <note corresp="#leafdim">Data on leaves dimensions taken from <locus target="#12r"/>.</note>
                                 </extent> 
                                 <condition key="deficient">
+                                    <!-- What follows is the condition of the entire MS -->
                                     The manuscript is in bad condition. Tears, losses, and insect droppings are present, especially along the external margins.
-                                  Most folia are unevenly distorted, stained, and darkened along the margins.
-                                  The sewing is broken throughout. Most bifolia became separated and the single folia are stitched
-                                  to strips of parchment or textile placed around the quires.
-                                  </condition>
+                                    Most folia are unevenly distorted, stained, and darkened along the margins.
+                                    The sewing is broken throughout. Most bifolia became separated and the single folia are stitched
+                                    to strips of parchment or textile placed around the quires.
+                                </condition>
                             </supportDesc>                                                
                         </objectDesc>
                         
@@ -557,6 +558,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </list>
                                     </collation>
                                     <condition key="deficient">
+                                        <!-- What follows is the condition of the first codicological unit -->
                                         The quires are held together precariously: only one loose thread is found between <locus target="#56"/> and <locus target="#57"/>. 
                                         A protective strip of textile is sewn around <ref target="#q5 #q7 #q9 #q11 #q12 #q13 #q14 #q17 #q18"/>.
                                         A parchment support has been added around <ref target="#q1"/>.
@@ -768,6 +770,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </list>
                                     </collation>
                                     <condition key="deficient">
+                                        <!-- What follows is the condition of the second codicological unit -->
                                         The quire originates from another codex and is currently held together very precariously by means of one running stitch.
                                         One or more leaves are missing after <locus target="#88"/>, with loss of text.  
                                          All leaves are stained with dirt and some portions of text are illegible due to faded ink.
@@ -883,7 +886,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <change who="DR" when="2020-02-18">Added dimensions and layout</change>
             <change who="SH" when="2020-04-22">Added editors</change>
             <change who="MV" when="2022-10-24">Textual description</change>
-            <change who="MV" when="2022-10-24">Added binding, extra, p2, additiones</change
+            <change who="MV" when="2022-10-24">Added binding, extra, p2, additiones</change>
             <change who="EDS" when="2022-12-03">Updated conditions, added binding description</change>
           </revisionDesc>
     </teiHeader>


### PR DESCRIPTION
Ciao Eliana,
questa è l'unica PR problematica con un conflitto tra le parti.
Si tratta di un manoscritto composito, e al momento ha diverse sezioni `<condition/>` in cui è descritto lo stato di conservazione: una parte generale all'inizio (ho mantenuto qui il testo scritto da te) e due parti, una per ciascuna unità codicologica, all'interno di p1 e p2 (qui troverai il testo scritto indipendentemente da me).
L'idea era di distinguere ciò che riguardasse lo stato generale del MS da ciò che si riferisce a ciascuna delle singole unità codicologiche. Si può sistematizzare l'informazione tra le diverse sezioni `<condition/>` o, se credi, anche eliminare le due relative a p1 e p2 se sono ridondanti.
Grazie!