### PR TITLE
Updated BMLacq776

### DIFF
--- a/FlorenceBML/BMLacq776.xml
+++ b/FlorenceBML/BMLacq776.xml
@@ -191,8 +191,8 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                     <explicit xml:lang="gez">ወወሀቦ፡ ለቤተ፡ ክርስቲያን፡ ወአግበረ፡ ፃሕለ፡ ዘቅዱስ፡ <hi rend="rubric">ሚካኤል፡</hi> ወነዳይኒ፡ ነሥአ፡ ሃምሳ፡ 
                                         ረ<pb n="42r"/>በሁ፡ አግበረ፡ ጽዋዓ፡ ለቤተ፡ ክርስቲያን፡ ዘቅዱስ፡ <hi rend="rubric">ሚኤል፡</hi> ወተዓረኩ፡ ፪ሆሙ፡ አምዓሜሃ፡ እለት፡ ዕሰሙ፡ ወፍቅሩ፡ 
                                         የሀሉ፡ ምስለ፡ ፍቁሩ፡ <gap reason="omitted" unit="chars" quantity="4"/> ለአለመ፡ ዓሚ፡ ከመ፡ </explicit>
-                                    <note>Anonymous here, but elsewhere as in <ref target="#">A 84 = N 137</ref> attributed to "Severus, patriarch of Alexandria"
-                                        or to a "Bishop of Aksum" as in <ref target="#EMML1433"></ref>.</note>
+                                    <note>Anonymous here, but elsewhere as in <ref type="mss" corresp="BNFabb84"/> attributed to "Severus, patriarch of Alexandria"
+                                        or to a "Bishop of Aksum" as in <ref type="mss" corresp="EMML1433"/>.</note>
                                 </msItem>
                                 <msItem xml:id="ms_i1.4.2">
                                     <locus from="42ra" to="45rb"/>

--- a/FlorenceBML/BMLacq776.xml
+++ b/FlorenceBML/BMLacq776.xml
@@ -76,7 +76,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                     <msItem xml:id="ms_i1.1.4">
                                         <locus from="12rb" to="13rb"></locus>
                                         <title ref="LIT1295Dersan#MiracleHedar"></title>
-                                        <note>Attested also in <ref target="#EMIP00016"/> on f. 9v to 13r.</note>
+                                        <note>Attested also in <ref type="mss" corresp="EMIP00016"/> on f. 9v to 13r.</note>
                                         <incipit xml:lang="gez"><hi rend="rubric">ተአምሪሁ፡</hi> ለቅዱስ፡ <hi rend="rubric">ሚካኤል፡ </hi> ክቡር፡ ሊቆሙ፡ 
                                             ለመላዕክት፡ በረከቱ፡ የሃሉ፡ ምስሌነ፡ ለዓ፡ ዓ፡ እከሰት፡ በምሳሊ፡ አፋየ፡ ወእንግር፡ አምሳለ፡ ዘእምትካት፡ ዘእም፡ ፍጥረተ፡ ዓለም፡ <pb n="12va"/>ወእፌክር፡ 
                                             ለክሙ፡ ውሑደ፡ ኃይሎ፡ ለመልአክ፡ ክቡር፡ ወልዑል፡ ሊቆሙ፡ ለመላእክት፡ ዘይትአጸፍ፡ ብርሃነ፡ ሕይወት፡ ወዘልፈ፡ ይስእሎ፡ ለእግር፡ አብሑር፡ በእንተ፡ ዘመደ፡ 
@@ -159,9 +159,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                         ወበአርብ፡ ፈጠረ፡ አዳምሃ፡ ምስለ፡ ኵለ፡ ዘሠርር፡ ወበሰኅቦት፡ አእረፈ፡ እምኩሉ፡ ግብሩ፡ ዘሎቱ፡ ሰብሐት፡ ወክብር፡ ለዓለመ፡ ዓለም፡ ዓማን፡ </explicit>
                                     <note>Homily on the angels and the child <persName ref="PRS11321Talafinos"/>, who was found at the sea. 
                                         Here anonymous, but elsewhere attributed to <persName ref="PRS3828Epiphani"/>. The story is a variant of 
-                                        <title ref="LIT4155MiraclesMichael"/> as found in <locus target="#ms_i1.5.1"/>; 
-                                        <title ref="LITLIT1295Dersan#CommemorativeSane"/> as found in <locus target="#ms_i1.8.2"/> and 
-                                        <title ref="LIT1295Dersan#HomilyHamle"/> as found in <locus target="#ms_i1.9.1"/> in this record. </note>
+                                        <ref type="work" corresp="LIT4155MiraclesMichael"/> as found in <ref target="#ms_i1.5.1"/>; 
+                                        <ref type="work" corresp="LITLIT1295Dersan#CommemorativeSane"/> as found in <ref target="#ms_i1.8.2"/> and 
+                                        <ref type="work" corresp="LIT1295Dersan#HomilyHamle"/> as found in <ref target="#ms_i1.9.1"/> in this record. </note>
                                 </msItem>
                                 <msItem xml:id="ms_i1.3.2">
                                     <locus from="35rb" to="35vb"/>
@@ -221,9 +221,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                     <note>
                                         Story about a child that was thrown into the sea by an evil rich man, saved by <persName ref="PRS7049Michael"/> and 
                                         found by a shepherd, who named him <persName ref="PRS11321Talafinos">ተላሶን፡ </persName>. The story is a variation 
-                                        of <title ref="LIT3959Homily"/> as in <locus target="#ms_i1.3.1"/>; 
-                                        <title ref="LIT1295Dersan#CommemorativeSane"/> as in <locus target="#ms_i1.8.2"/> and 
-                                        <title ref="LIT1295Dersan#HomilyHamle"/> as in <locus target="#ms_i1.9.1"/> in this record. 
+                                        of <ref type="work" corresp="LIT3959Homily"/> as in <ref target="#ms_i1.3.1"/>; 
+                                        <ref type="work" corresp="LIT1295Dersan#CommemorativeSane"/> as in <ref target="#ms_i1.8.2"/> and 
+                                        <ref type="work" corresp="LIT1295Dersan#HomilyHamle"/> as in <ref target="#ms_i1.9.1"/> in this record. 
                                         Often defined as Nagar, as it is the case here, but also frequently as Dərsān in some other manuscripts. 
                                         Usually attributed either to the month Ḥamle or to Miyāzyā but so far never attested in connection with the month of Maggābit,
                                         as it is the case here. 
@@ -395,9 +395,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                         </explicit>
                                     <note>Miracle of the temple built by <persName ref="PRS3137Cleopatr"/> and converted into a church by Mikāʾel
                                         attributed to the month of Sane as it is the case in the Sənkəssār. Taken from the history of Bāḥrān and very similar to 
-                                        the stories of Talafinos and Talason: <title ref="LIT3959Homily"/> as found in <locus target="#ms_i1.3.1"/>; 
-                                        <title ref="LIT4155MiraclesMichael"/> as found in <locus target="#ms_i1.5.1"/> and 
-                                        <title ref="LIT1295Dersan#HomilyHamle"/> as found in <locus target="#ms_i1.9.1"/> in this record.)</note>
+                                        the stories of Talafinos and Talason: <ref type="work" corresp="LIT3959Homily"/> as found in <ref target="#ms_i1.3.1"/>; 
+                                        <ref type="work" corresp="LIT4155MiraclesMichael"/> as found in <ref target="#ms_i1.5.1"/> and 
+                                        <ref type="work" corresp="LIT1295Dersan#HomilyHamle"/> as found in <ref target="#ms_i1.9.1"/> in this record.)</note>
                                 </msItem>
                                 <msItem xml:id="ms_i1.8.3">
                                     <locus from="84rb" to="86ra"/>
@@ -435,10 +435,10 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                         ኩሎሙ፡ ቅዱሳን፡ ሰማዕት፡ ጸድቃን፡ ነቢያት፡ ወሐዋርያት፡ ይምሐረነ፡ ወይሣህልነ፡ ለእመ፡ ረከብክሙ፡ ሀቡ፡ ወለእመ፡ ኢረከብክሙ፡ <cb n="90vb"/>ሀቡ፡ 
                                         ማ<add place="above">የ</add>ይ፡ በእንተ፡ ስሞሙ፡ <hi rend="rubric">ሚካኤል፡ ወገብርኤል፡</hi> ወይትኈለቅ፡ ለክሙ፡ ጽድቀ፡ 
                                         ሎቱ፡ ሰብሐት፡ ለዓለመ፡ ዓለ፡ ዓሜን፡ </explicit>
-                                    <note>Homily on <persName ref="PRS0000">Talāson</persName> similar to <title ref="LIT3959Homily"/> 
-                                        as found in <locus target="#ms_i1.3.1"/>; <title ref="LIT4155MiraclesMichael"/> as found in 
-                                        <locus target="#ms_i1.5.1"/> and <title ref="LIT1295Dersan#CommemorativeSane"/> as found in 
-                                        <locus target="#ms_i1.8.2"/> in this record.</note>
+                                    <note>Homily on <persName ref="PRS0000">Talāson</persName> similar to <ref type="work" corresp="LIT3959Homily"/> 
+                                        as found in <ref target="#ms_i1.3.1"/>; <ref type="work" corresp="LIT4155MiraclesMichael"/> as found in 
+                                        <ref target="#ms_i1.5.1"/> and <ref type="work" corresp="LIT1295Dersan#CommemorativeSane"/> as found 
+                                        in <ref target="#ms_i1.8.2"/> in this record.</note>
                                 </msItem>
                                 <msItem xml:id="ms_i1.9.2">
                                     <locus from="90vb" to="92rb"/>
@@ -455,7 +455,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                         መንክራቲሁ፡ ትንብልናሁ፡ የሃሉ፡ ምስለ፡ ገብሩ፡ ገብረ፡ <hi rend="rubric">ሚካኤል፡</hi>
                                         <gap reason="omitted" unit="chars" quantity="4"/></explicit>
                                     <note>Miracle of the Christian with withered hands and feet similar to the miracle of the month Miyāzyā in this record 
-                                        and in other witnesses as in <ref target="BAVet82#p1_i1.7.2"/>.</note>
+                                        and in other witnesses as in <ref type="mss" corresp="BAVet82#p1_i1.7.2"/>.</note>
                                 </msItem>
                                 <msItem xml:id="ms_i1.9.3">
                                     <locus from="92rb" to="92vb"/>
@@ -568,8 +568,6 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                     <title ref="LIT1295Dersan#SalamTeqemt"/>
                                 </msItem>
                             </msItem>
-                            <note>Spaces left free for owner names throughout except for <locus target="#52rb #105va #106ra"/>, where the name of the owner
-                                <persName ref="PRS14011GabraMikael"/> is written with a red ball point pen as <locus target="#e5"/>.</note>
                         </msItem>
                     </msContents>
                     <physDesc>
@@ -718,31 +716,35 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                  </bibl>, who considered some parts of <locus target="#55r"/> of the same hand as the first seven lines of 
                                      <locus target="#3va"/>.</note>
                              </item>
-                             <item xml:id="e1">
+                              <item xml:id="e1">
+                                  <desc type="OwnershipNote">Spaces left free for owner names throughout except for <locus target="#52rb #105va #106ra"/>, where the name of the owner
+                                      <persName ref="PRS14011GabraMikael"/> is written with a red ball point pen as <locus target="#e5"/>.</desc>
+                              </item>
+                             <item xml:id="e2">
                                  <desc type="StampExlibris">"Acq. Doni. 776" written in the centre on the inner side of the wooden board with a
                                      pen by a recent European hand and traced with a pencil by the same European hand as <ref target="#e2"/>.</desc>
                              </item>
-                              <item xml:id="e2">
+                              <item xml:id="e3">
                                   <locus target="#110v"/>
                                   <desc type="StampExlibris">"111368" written with pencil on the top left of the folio with the same European hand as
                                     <ref target="#e1"/></desc>
                               </item>
-                              <item xml:id="e3">
+                              <item xml:id="e4">
                                 <locus target="#78v #110v"/>
                                 <desc type="StampExlibris">Small round stamp on the bottom margin or on the bottom right with the inscription: 
                                     <foreign xml:lang="lat">BIBL. MED. LAUR. FLOR.</foreign>.</desc>
                              </item>
-                             <item xml:id="e4">
+                             <item xml:id="e5">
                                  <locus target="110v"/>
                                  <desc type="StampExlibris">Acquisition number stamped on the bottom right: "111368".</desc>
                              </item>
-                             <item xml:id="e5">
+                             <item xml:id="e6">
                                 <locus target="#35vb #36ra #52va #79va #102v #103ra #105va #106ra #107ra"/>
                                 <desc type="Correction">Addition of individual characters and words or highlighting of word separators as well as the 
                                     names of the owners <persName ref="PRS14010Ewostatewos" role="owner"/> and 
                                     <persName ref="PRS14011GabraMikael" role="owner"/> with a red ballpoint pen.</desc>
                             </item>
-                            <item xml:id="e6">
+                            <item xml:id="e7">
                                 <locus target="#49r"/>
                                 <desc type="MixedNote">Pen trial in black ink and an Ethiopian hand.</desc>
                             </item>    

--- a/FlorenceBML/BMLacq776.xml
+++ b/FlorenceBML/BMLacq776.xml
@@ -7,6 +7,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
             <titleStmt>
                 <title/>
                 <editor key="AB" role="generalEditor"/>
+                <editor key="CH"></editor>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
             <publicationStmt>
@@ -30,10 +31,731 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                     </msIdentifier>
                     <msContents>
                         <msItem xml:id="ms_i1">
-                            
                             <title ref="LIT1295Dersan"/>
+                            <msItem xml:id="ms_i1.1">
+                                <title ref="LIT1295Dersan#Ḫədār"/>
+                                    <msItem xml:id="ms_i1.1.1">
+                                        <locus from="1r" to="10"/>
+                                        <title ref="LIT1637Homily"/>
+                                        <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ።</hi> ድርሳን፡ ወነገር፡ ዘቅዱስ፡ አበ፡ 
+                                            <persName ref="PRS9523Timothy">ደማቲዎስ፡</persName> ሊቀ፡ ጳጳሳት፡ ዘለእስክንድርያ፡ ትነበብ፡ በበዓለ፡ ቅዱሰ፡ <hi rend="rubric">ሚካኤል፡ ሊቀ፡ መላእክት፡</hi> አመ፡ ፲ወ፪ለህዳር፡ 
+                                            <hi rend="rubric">ኣ</hi>ርፋ<hi rend="rubric">ታኤል፡</hi> አዘ<hi rend="rubric">ፋታኢ</hi>ል፡ 
+                                            <hi rend="rubric">ሕዝት</hi>ናኤ<hi rend="rubric">ል፡ ምርሜ</hi>ል፡ <hi rend="rubric">ስመ፡ አምላክ፡</hi> 
+                                            ኢየሱስ፡ ክርስቶስ፡ ቃል፡ ቀዳማዊ፡ ወልደ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ሕያው፡ ወወልደ፡ <hi rend="rubric">ማርያም፡ ሥግው፡</hi>
+                                            ያርኅቅ፡ እምኒነ፡ ኃይለ፡ ሳይግናት፡ ገሙናነ፡ መንፈስ፡ ወያድክም፡ ሀ<pb n="1v"/>ይሎሙ፡ ለመናፍስት፡ ርኩሳን፡ ወያርእየነ፡ 
+                                            እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ክብረ፡ ዓቢየ፡ ዘወሀቦ፡ ለቅዱስ፡ <hi rend="rubric">ሚካኤል፡ እምኩሎሙ፡ ቅዱሳን፡</hi> 
+                                            መላእክተ፡ በረክተ፡ ረድኤቱ፡ የሀሉ፡ ምስለ፡ ገብሩ፡ <gap reason="omitted"/> ለዓ፡ ዓሜን፡ </incipit>
+                                        <explicit xml:lang="gez">ወኢታንብሮ፡ ውስተ፡ ቢት፡ እኩይ፡ ከመ፡ እይኩን፡ ስላቀ፡ ሰሳይጣን፡ ኢትዝርዎ፡ ለአብዳን፡ ዘአልቦሙ፡ አሚን፡ ወኢጥሙቃን፡ 
+                                            አላ፡ እቀቦ፡ በተአምኖቱ፡ ለመልአካ፡ ምሕረት፡ ብርሃን፡ ኦቅዱስ፡ <gap reason="omitted"/> ሊቀ፡ መላእክት፡ ባልሖ፡ እመከራ፡ ሥጋ፡ ወነፍስ፡ 
+                                            ለጸሐፌ፡ ዝንቱ፡ ድሳን፡ ወለዘአጽሐፎ፡ <gap reason="omitted"/> ዓሜን፡ ወዓሜን፡ እይኩን፡ ለይኩ፡ </explicit>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.1.2">
+                                        <locus from="10v" to="11va"/>
+                                        <title ref="LIT1295Dersan#MiracleHedar"/>
+                                        <incipit xml:lang="gez"><hi rend="rubric">በስመአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩</hi>አምላክ። ንቀድም፡ በረዴዓተ፡ 
+                                            እ<pb n="11ra"/><hi rend="ligature">ግዚ</hi>አብሔር፡ ጽሒፈ፡ ተአምሪሁ፡ ለቅዱስ፡ <gap reason="omitted"/> ሊቀ፡ መላእክት፡ 
+                                            ትንብልናሁ፡ የሀሉ፡ ምስለ፡ ገብሩ፡ ለዓለ፡ ዓለ፡ ዓ፡ <gap reason="omitted"/> ውእቱ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ስብሕ፡ 
+                                            ወጥቀ፡ ልዑል፡ ዲበ፡ ኩሉ፡ ፍጥረት፡ ዝኢያገምሮ፡ ህሊና፡ ሰብእ፡ ወኢአምሮ፡ ዘመላእክት፡ ለፈጣሬ፡ ሰማያት፡ ወምድር፡ እስመ፡ ውእቱ፡ አዘዘ፡ በቃለ፡ ጥበቡ፡ 
+                                            ወአቀሞሙ፡ ለዓለም፡ ትእዝዝ፡ ወሀቦሙ፡ ወኢሃለፉ፡ </incipit>
+                                        <explicit xml:lang="gez">ወለእለ፡ ይትለአከዎ፡ ነደ፡ እሳት፡ ስልስ፡ ዲቤ፡ ዝያ፡ ትአቦን፡ መልአከ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ 
+                                            አውዶሙ፡ ለእለ፡ ይሪፈርህዎ፡ ወያድኅኖሙ፡ ጠአሙ፡ ወታእምሩ፡ ከመ፡ ሄር፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ወመንከር፡ ጥበብከ፡ 
+                                            <pb n="11va"/>እ<hi rend="ligature">ግዚ</hi>ኦ፡ ስብሐት፡ ለብ፡ ስብሐት፡ ለወልድ፡ ስብሐት፡ ለመንፈስ፡ ቅዱስ፡ ይዜኒ፡ ወዘልፈኒ፡ ወለአለመ፡ 
+                                            ዓ፡ ዓ፡ </explicit>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.1.3">
+                                        <locus from="11va" to="12rb"/>
+                                        <title ref="LIT1295Dersan#CommemorativeHedar"/>
+                                        <incipit xml:lang="gez"><hi rend="rubric">በስመአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ </hi>፩አምላክ፡ በዘቲ፡ እለት፡ አ፲፪ለሕዳር፡ ተዝካረ፡ በአሉ፡ 
+                                            ለመላክ፡ ክቡር፡ <hi rend="rubric">ሚካኤል፡ ሊ</hi>ቀ፡ መላእክት፡ ወርእሰ፡ ሰማያውያን፡ ወምድራውያን፡ መላእክት፡ መልአክ፡ መሐሪ፡ ለዘመደ፡ 
+                                            እጓለ፡ እመሕያው፡ ዝይቅውምም፡ ኩሎ፡ ጊዜ፡ ቅድመ፡ መንበረ፡ እባዩ፡ ለአብ፡ ይትነበል፡ በእንተ፡ ኩሉ፡ ፍጥረት፡ ዝንቱ፡ ዘአርአዩ፡ ለኢያሱ፡ </incipit>
+                                        <explicit xml:lang="gez">እስከ፡ ይፌጽሙ፡ ገድሎሙ፡ ወተገብረ፡ ሎቱ፡ ተዝካረ፡ ባወምጽዋታት፡ በእንተ፡ ስሙ፡ በበ፲ወ፪ቱ፡ ወርኅ፡ እስመ፡ ውእቱ፡ ይስእሎ፡ 
+                                            ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ በእንተ፡ ፍሬያተ፡ ምድር፡ ወበእንተ፡ ማያተ፡ አፍላግ፡ ወበእንተ፡ ነፍሳት፡ ሠናያን፡ ከመ፡ ይፈጽሞሙ፡ 
+                                            እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ለኩሎሙ፡ በርትሰ፡ ትንብልናሁ፡ ያሃሉ፡ ምስ፡ ገብ<del rend="strikethrough">ሩ</del>ሩ፡ 
+                                            <gap reason="omitted"/> ለዓለመ፡ ዓሜን፡ </explicit>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.1.4">
+                                        <locus from="12rb" to="13rb"></locus>
+                                        <title ref="LIT1295Dersan#MiracleHedar"></title>
+                                        <note>Attested also in <ref target="#EMIP00016"/> on f. 9v to 13r.</note>
+                                        <incipit xml:lang="gez"><hi rend="rubric">ተአምሪሁ፡</hi> ለቅዱስ፡ <hi rend="rubric">ሚካኤል፡ </hi> ክቡር፡ ሊቆሙ፡ 
+                                            ለመላዕክት፡ በረከቱ፡ የሃሉ፡ ምስሌነ፡ ለዓ፡ ዓ፡ እከሰት፡ በምሳሊ፡ አፋየ፡ ወእንግር፡ አምሳለ፡ ዘእምትካት፡ ዘእም፡ ፍጥረተ፡ ዓለም፡ <pb n="12va"/>ወእፌክር፡ 
+                                            ለክሙ፡ ውሑደ፡ ኃይሎ፡ ለመልአክ፡ ክቡር፡ ወልዑል፡ ሊቆሙ፡ ለመላእክት፡ ዘይትአጸፍ፡ ብርሃነ፡ ሕይወት፡ ወዘልፈ፡ ይስእሎ፡ ለእግር፡ አብሑር፡ በእንተ፡ ዘመደ፡ 
+                                            እጓለ፡ እመሑያው፡ ወይሠጠዎሙ፡ አስለ፡ ይጼውስዎ፡ ወይድኅኖሙ፡ እምንዳቤሆሙ፡ ነዋ፡ እንከ፡ ንዜንወክሙ፡ ዘኮነ፡ በቀዳሚ፡ ጌሡ፡ ብዙኃን፡ በአኅማር፡ 
+                                            እም፡ ብሔረ፡ ግብጽ፡ በማዕዶተ፡ ተካዚ፡ </incipit>
+                                        <explicit xml:lang="gez">ወስአል፡ ኃበ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ አምላክነ፡ በእንቲአነ፡ እስመ፡ ናሁ፡ ርኪናሃ፡ ለሞት፡ 
+                                            ወለኃጕል፡ ወለኃዉ፡ እንዘይብሉ፡ በአቢይ፡ ብካይ፡ መሪር፡ ውስተ፡ <add place="above">ጊ</add>ዜ፡ ርእዮ፡ አድኖተ፡ 
+                                            እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ወረዶ፡ እምሰማይ፡ ቅዱስ፡ <gap reason="omitted"/>ሊቀ፡ መላእክት፡ ወለሀበ፡ አሕማሪሆሙ፡ 
+                                            ወአውጽዖሙ፡ እንተ፡ የብስ፡ ወተለአሉ፡ ሕያዋኒሆሙ፡ ወኢነከዮሙ፡ ግምራ፡ ሕሱም፡ ወዚነዉ፡ ዘንተ፡ ተአምረ፡ ለብእ፡ ወነበሩ፡ እንዘ፡ ይባብሩ፡ ተዝካሮ፡ 
+                                            ለመልአክ፡ ክቡር፡ ለለኩሉ፡ አውራኅ፡ አመአ፲ወ፪እስከ፡ እሳተ፡ ሞቶሙ፡ ትንብልናሁ፡ የሃሉ፡ ምስለ፡ አመቱ፡ <gap reason="omitted"/> ለአለመ፡ ዓሜን፡ </explicit>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.1.5">
+                                        <locus from="13rb" to="13va"/>
+                                        <title ref="LIT1295Dersan#SalamHedar"/>                              
+                                    </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i1.2">
+                                <title ref="LIT1295Dersan#Tahsas"/>
+                                <msItem xml:id="ms_i1.2.1">
+                                    <locus from="13va" to="20ra"/>
+                                    <title ref="LIT1295Dersan#Tahsas"/>
+                                    <incipit xml:lang="gez"><hi rend="rubric">በስመአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡</hi> ድርሳን፡ ዘደረሰ፡ ርቱዓ፡ ሃይማኖት፡ 
+                                        <persName ref="PRS10425Yohanne">ዮሃንስ፡</persName> ጳጳስ፡ ዘይትነበብ፡ በበአለ፡ ቅዱስ፡ <hi rend="rubric">ሚካኤል፡ ሊቀ፡</hi> መላእክት፡ አመ፲ወ፪ለታኅሣሥ፡ ጸሎቱ፡ ወበረከቱ፡ ቦሃሰ፡ ምስለ፡ 
+                                        ገብሩ፡ ለዓለመ፡ ዓሜን፡ <hi rend="rubric">አውሎግሶን፡ አውለግሶን፡ ስምዑ፡</hi> ኩልክሙ፡ እለ፡ ትነብሩ፡ ውስተ፡ ዓለም፡ እድ፡ ወአንስት፡ እለ፡ 
+                                        ኀለውክሙ፡ ውስተ፡ ዝንቱ፡ ሕይወት፡ ከመ፡ ታእምሩ፡ ኃይሎ፡ ወተአምሪሁ፡ ዘገብረ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ከመ፡ ያርኢ፡ እበየ፡ 
+                                        ኃይሉ፡ ለቅዱስ፡ <hi rend="rubric">ሚካኤል፡ ሊቀ፡ መላእክት፡</hi> ይሰእል፡ ኩሎ፡ ጊዜ፡ ኃበ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ 
+                                        በእንተ፡ እለ፡ ይታመኑ፡ በጸቱ፡ ወሀሎ፡ ፩ብእሲ፡ ዘርቱዕ፡ ሃይማኖቱ፡ ወስሙ፡ <persName ref="PRS11306Deratewos">ዳራታዎስ፡</persName> 
+                                        ወስመ፡ ብእሲቱ፡ <persName ref="PRS11307Tewobesteya">ቴዎ፡ ብሳታ፡</persName> ወነበሩ፡ ውስተ፡ ሀገረ፡ 
+                                        <placeName ref="LOC6571Qalonya">ቆሎንያ፡</placeName> ወቦሙ፡ ብዙኅ፡ 
+                                        ወርቅ፡ ወብሩር፡ </incipit>
+                                    <explicit xml:lang="gez">መዊት፡ እምይጸራእ፡ በአሉ፡ ለለቅዱስ፡ <hi rend="rubric">ሚካኤል፡ ሊቀ፡ መላእክት፡ አጸራቃዎስ፡</hi> 
+                                        ወ<persName ref="PRS11307Tewobesteya">ቴዎብስታ፡</persName> ዓቢይ፡ ሃይማኖትክሙ፡ በሀበ፡ 
+                                        እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ዘኢየሐልቅ፡ ምሕረቱ፡ ወበረከቱ፡ ይድር፡ ለእሊክሙ፡ አሚን፡ ወዓሜን፡ ወከመዝ፡ ተናጊሮ፡ ቅዱስ፡ 
+                                        <hi rend="rubric">ሚካኤል፡ አርገ፡ ው</hi>ስተ፡ ሰማያት፡ በዓቢይ፡ ሰብሐት፡ <persName ref="PRS11306Deratewos">ደራታዎሰሰ፡</persName> 
+                                        ወብእሲቱ፡ አፈይሊዱ፡ ገቢረ፡ እም፡ ቀዳሚ፡ ተግባሮሙ፡ እስከ፡ እለተ፡ ሞቶሙ፡ ወኩሎሙ፡ ሕዝብ፡ አምኑ፡ በጸሎቶሙ፡ በረከቶሙ፡ 
+                                        ለ<persName ref="PRS11306Deratewos">ዳራታዎስ፡</persName> ወለ<persName ref="PRS11307Tewobesteya">ቴዎብስታ፡</persName> 
+                                        የሃሉ፡ ምስለ፡ ፍቍሮሙ፡ ገብ፡ ወ፡ <gap reason="omitted" unit="chars" quantity="4"/>ለዓለመ፡ ዓሜን። </explicit> 
+                                </msItem>
+                                <msItem xml:id="ms_i1.2.2">
+                                    <locus from="20ra" to="20vb"/>
+                                    <title ref="LIT1295Dersan#CommemorativeTahsas"/>
+                                    <incipit xml:lang="gez"><hi rend="rubric">በስመአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡ አመ</hi>፲ወ፪፡ ለታኅሣሥ፡ በዘቲ፡ እለት፡ 
+                                        እለተ፡ በአሉ፡ ለቅዱስ፡ <hi rend="rubric">ሚካኤል፡ ሊቀ፡ መላእክት፡ እስመ፡ </hi>በዛቲ፡ እለት፡ ፈነዎ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡
+                                        ሀበ፡ ሀገረ፡ በቢሎን፡ ወኮነ፡ ራብአየ፡ ገጽ፡ ምስለ፡ ፫ደቂቅ፡ <persName ref="PRS11288AnAzMi">አናንያ፡ ወአዛርያ፡ ወሚሰኤል፡</persName> 
+                                        ውስተ፡ እቶነ፡ እሳት፡ ሶበ፡ ገደሮሙ፡ ናቡ፡ ክዳነ፡ ጸር፡ ንጉሠ፡ ባቢሎን፡ ወተለአለ፡ ነበልባለ፡ እሳት፡ መጠነ፡ ፵ወ፱በእመት፡</incipit>
+                                    <explicit xml:lang="gez">ወበዝንቱ፡ ተነበዩ፡ ፴ወ፫፡ ቢዜ፡ ከመ፡ ክርስቶስ፡ ይነብር፡ ዲበ፡ ምድር፡ ፴ወ፫ዓመተ፡ ወበእንተዝ፡ ሠርዑ፡ አበዊነ፡ ሐዋርያት፡ ከመ፡ ይትገባር፡ 
+                                        በአሎ፡ ለቅዱስ፡ <hi rend="rubric">ሚካኤል፡ ሊቀ፡</hi> ሊቀ፡ መላእክት፡ በበ፡ ፲ወ፪እለት፡ ትኅብልናሁ፡ የሀሉ፡ ምስለ፡ ገብሩ፡ 
+                                        <gap reason="omitted" unit="chars" quantity="5"/> ለዓለ፡ </explicit>
+                                </msItem>
+                                <msItem xml:id="ms_i1.2.3">
+                                    <locus from="20va" to="21ra"/>
+                                    <title ref="LIT6822SalamLakaAqabi"/>
+                                </msItem>
+                                <msItem xml:id="ms_i1.2.4">
+                                    <locus from="21ra" to="22ra"/>
+                                    <title ref="LIT1295Dersan#MiracleTahsas"/>
+                                    <incipit xml:lang="gez"><hi rend="rubric">ተአምሪሁ፡ ለቅዱስ፡ ሚካኤል፡ ሊቀ፡ መላእክት፡ ትንብል</hi>ሁ፡ የሀሉ፡ ምስለ፡ ገብሩ፡ 
+                                        <gap reason="omitted" unit="chars" quantity="4"/> ለዓ፡ ወሀሎ፡ ፩ብእሲ፡ መሐይምን፡ ዘይሴፎ፡ ምሕረቶ፡ 
+                                        ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ ወትንብልናሁ፡ ለቅዱስ፡ <hi rend="rubric">ሚኤል፡</hi> ወይገብር፡ ተዝከሮ፡ 
+                                        አመአ፲ወ፪ሰለ፡ ኩለ፡ አውራኅ፡ ወግብሩ፡ ግብረ፡ ማሕረ፡ ወእምዝ፡ በአሐቲ፡ አመተ፡ በአሕለቀ፡ እፂ፡ ኩሎ፡ ፍሬ፡ ተግባሩ፡ ወኮነ፡ ነዳየ፡ ወኃጥአ፡ ሲሳየ፡ 
+                                        እለት፡ ወኢምንተኒ፡ ውስተ፡ ቤቱ፡ ወጽእቀ፡ በላእሊሁ፡ ተፅናሸ፡ ወእምብዝኃ፡ ኃዝኑ፡ ኮነ፡ እንቡዝ፡ ወጸከመ፡ ሕሊናሁ፡ በሀልዩ፡ ወበህየ፡ ኖመ፡ በአምሳለ፡ 
+                                        ምውት፡ ወአሜሃ፡ አስተርአዮ፡ ቅዱስ፡ <hi rend="rubric">ሚካኤል፡ ረዳኤ፡ ምገያ፡ በኅ፡</hi> ወይቤሎ፡ ኦ፡ ብእሲ፡ ብሩክ፡ ለመንት፡ ቀሐዝን፡ </incipit>
+                                    <explicit xml:lang="gez">ወነሥአ፡ እም፡ ውእቱ፡ ወርቅ፡ ወገብረ፡ ሰእሎ፡ ለቅዱስ፡ <hi rend="rubric">ሚካኤል፡ </hi>ወአንበሮ፡ ውስተ፡ 
+                                        ቤተ፡ ክርስቲያን፡ በክብር፡ ወእያኅተገ፡ ገቢረ፡ በዓሉ፡ ለመልአክ፡ ወባቢረ፡ ጽሎት፡ እስከ፡ እሳተ፡ ሞቱ፡ ትኅብልናሁ፡ የሀሉ፡ ምስለ፡ ገብሩ፡ ኅብለ፡ 
+                                        <gap reason="omitted" unit="chars" quantity="5"/> ለዓለመ፡ ዓለም፡ ዓ</explicit>
+                                </msItem>   
+                            </msItem>
+                            <msItem xml:id="ms_i1.3">
+                                <title ref="LIT1295Dersan#Terr"/>
+                                <msItem xml:id="ms_i1.3.1">
+                                    <locus from="22ra" to="35ra"/>
+                                    <title ref="LIT3959Homily"/>
+                                    <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡</hi> ሥሉስ፡ ዘኢይትሌለይ፡ ዕሩይ፡ ዘኢይስደቅ፡ 
+                                        ታ<hi rend="rubric">ሎት፡</hi> ዘኢትበአድ፡ ርድአነ፡ ከመ፡ ንንኅር፡ ዕበዮ፡ ለቅዱስ፡ <hi rend="rubric">ሚካኤል፡ ሊቀ፡ መላእክት፡</hi>
+                                        ዘውእቱ፡ መልአከ፡ ኃይል፡ ዘርዑስ፡ ላእለ፡ ኩሎሙ፡ ሠራዊተ፡ መላእክት፡ እሳታውያን፡ ዘውእቶሙ፡ አእላፈ፡ አእላፋት፡ ወትአልፊተ፡ አእላፋት፡ ዘይትነበብ፡ 
+                                        <hi rend="rubric">በወርኃ፡ ጥርቦሶላመ፡  እ<hi rend="ligature">ግዚ</hi>አብሔር፡ </hi>ዓሜን፡ መፍትው፡ እንከ፡ ትሰምእዎ፡ በፍርሐት፡ 
+                                        ከመ፡ ታአምሩ፡ አበዮ፡ ለቅዱስ፡ <hi rend="rubric">ሚካኤል፡ ሊቀ፡ መላ</hi>እክት፡ እም፡ አብያኢሁ፡ ሊቃነ፡ መላእክት፡ </incipit>
+                                    <explicit xml:lang="gez">ኦሪትኒ፡ ትቤ፡ ተፈጸመ፡ ኩሉ፡ በእንተ፡ ስቡዕ፡ ወንህነሂ፡ ተፈርነ፡ በእለተ፡ አርብ፡ ሠእር፡ ወሐመልማል፡ ፀሀይ፡ ወወርህ፡ ወክዋክብት፡ 
+                                        ሶበ፡ ርእየ፡ ሰኖሙ፡ ወብርሃኖሙ፡ ይቤ፡ አነብር፡ መንባርየ፡ ዲቤሆሙ፡ ወእትሜስሎ፡ ለኃይል፡ ወአሜሃ፡ ወድቀ፡ ወበሐሙስ፡ ፈወረ፡ ኩሉ፡ ዘይትሐወሰ፡ ምስለ፡ ሲሳዮሙ፡ 
+                                        ወበአርብ፡ ፈጠረ፡ አዳምሃ፡ ምስለ፡ ኵለ፡ ዘሠርር፡ ወበሰኅቦት፡ አእረፈ፡ እምኩሉ፡ ግብሩ፡ ዘሎቱ፡ ሰብሐት፡ ወክብር፡ ለዓለመ፡ ዓለም፡ ዓማን፡ </explicit>
+                                    <note>Homily on the angels and the child <persName ref="PRS11321Talafinos"/>, who was found at the sea. 
+                                        Here anonymous, but elsewhere attributed to <persName ref="PRS3828Epiphani"/>. The story is a variant of 
+                                        <title ref="LIT4155MiraclesMichael"/> as found in <locus target="#ms_i1.5.1"/>; 
+                                        <title ref="LITLIT1295Dersan#CommemorativeSane"/> as found in <locus target="#ms_i1.8.2"/> and 
+                                        <title ref="LIT1295Dersan#HomilyHamle"/> as found in <locus target="#ms_i1.9.1"/> in this record. </note>
+                                </msItem>
+                                <msItem xml:id="ms_i1.3.2">
+                                    <locus from="35rb" to="35vb"/>
+                                    <title ref="LIT1295Dersan#CommemorativeTerr">When Mikāʾel was sent to Yāʿqob.</title>
+                                </msItem>
+                                <msItem xml:id="ms_i1.3.3">
+                                    <locus target="#35vb"/>
+                                    <title ref="LIT1295Dersan#SalamTerr">Salām for the month Ṭərr</title>
+                                </msItem>
+                                <msItem xml:id="ms_i1.3.4">
+                                    <locus from="35vb" to="36va"/>
+                                    <title ref="LIT1295Dersan#MiracleTerr">Miracle of the rich woman</title>
+                                </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i1.4">
+                                <title ref="LIT1295Dersan#Yakkatit"/>
+                                <msItem xml:id="ms_i1.4.1">
+                                    <locus from="36vb" to="42ra"/>
+                                    <title ref="LIT1295Dersan#HomilyYakkatit">Homily on a poor man of great faith</title>
+                                    <incipit xml:lang="gez"><hi rend="rubric">በ<gap reason="lost" unit="chars" quantity="1"/> በስመአብ፡ ወወልድ፡ ወመንፈስ፡ ቅ፡</hi> 
+                                        ፩አምላክ፡ ድርሳን፡ ዘቀድሰ፡ <hi rend="rubric">ሚካኤል፡</hi> ሊቀ፡ መላእክት፡ ዘይትነበብ፡ አመ፲ወ፪፡ 
+                                        ለ<subst><del>ጥር</del><add rend="overstrike">የካ፡</add></subst> ቲት፡ በሰላመ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ 
+                                        ዓሜን፡ ወኮነ፡ ፩ዱ፡ ነዳይ፡ ውስተ፡ ፩ብሔር፡ ወዓቢይ፡ ሃይማኖቱ፡ ይጼሊ፡ መአልተ፡ ወሌሊተ፡ ወይብል፡ ኦ<gap reason="omitted" unit="chars" quantity="4"/> 
+                                        ሊቅየ፡ ወሊቆሙ፡ ለመላእክት፡ ተሣሃለኒ፡ እስመ፡ ሐካይ፡ ብእሲሁ፡ ወኢይወጽእ፡ እምነ፡ ቤቱ፡ ወአልቦቱ፡ ተግባር፡ ወኢስራኅ፡ ወኢየአምር፡ ንጊደ፡ ወእምዝ፡ ወእምዝ፡ 
+                                        መጽአ፡ ቅዱስ፡ <hi rend="rubric">ሚካኤል፡</hi> ወአስተርአዮ፡ በኅልም፡ ወይቤሎ፡ አንተ፡ ብእሲ፡ ሀካይ፡ ወኢትትገበር፡ አሐደ፡ እምግብርናት፡ ወትብለኒ፡ 
+                                        መአልተ፡ ወሌሊተ፡ ተሣሃለኒ፡ አይነ፡ </incipit>
+                                    <explicit xml:lang="gez">ወወሀቦ፡ ለቤተ፡ ክርስቲያን፡ ወአግበረ፡ ፃሕለ፡ ዘቅዱስ፡ <hi rend="rubric">ሚካኤል፡</hi> ወነዳይኒ፡ ነሥአ፡ ሃምሳ፡ 
+                                        ረ<pb n="42r"/>በሁ፡ አግበረ፡ ጽዋዓ፡ ለቤተ፡ ክርስቲያን፡ ዘቅዱስ፡ <hi rend="rubric">ሚኤል፡</hi> ወተዓረኩ፡ ፪ሆሙ፡ አምዓሜሃ፡ እለት፡ ዕሰሙ፡ ወፍቅሩ፡ 
+                                        የሀሉ፡ ምስለ፡ ፍቁሩ፡ <gap reason="omitted" unit="chars" quantity="4"/> ለአለመ፡ ዓሚ፡ ከመ፡ </explicit>
+                                    <note>Anonymous here, but elsewhere as in <ref target="#">A 84 = N 137</ref> attributed to "Severus, patriarch of Alexandria"
+                                        or to a "Bishop of Aksum" as in <ref target="#EMML1433"></ref>.</note>
+                                </msItem>
+                                <msItem xml:id="ms_i1.4.2">
+                                    <locus from="42ra" to="45rb"/>
+                                    <title>Miracle of the healing of a paralytic</title>
+                                    <incipit xml:lang="gez"><hi rend="rubric">ተአምሪሁ፡ ለቅዱስ፡ ሚካኤል፡ ዘሥዑል፡ በነበል፡</hi> ትኅብልናሁ፡ ወአስተብቍዖቱ፡ የሀሉ፡ ምስለ፡
+                                        ዓመቱ፡ <gap reason="omitted" unit="chars" quantity="5"/> ይድኅነነ፡ እሞተ፡ ኃጕል፡ ለደቂቅ፡ ዛቲ፡ መርጡል፡ ለዓለ፡ 
+                                        <gap reason="omitted" unit="chars" quantity="5"/> ተብሕለ፡ ከመ፡ ሀሎ፡ ፩ዱ፡ ብእሲ፡ በአሐቲ፡ ሀገር፡ ሬኄ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡
+                                        ወይ<add place="above">ገ</add>ብር፡ ምሕረተ፡ ለነዳየን፡ ወለ፡ ምስኪናን፡ በአእንተ፡ ስሙ፡ ለ<pb n="42v"/>ቅዱስ፡ <hi rend="rubric">ሚካኤል፡</hi>
+                                        ኵሎ፡ ጊዜ፡ ወሶበ፡ ርእየ፡ ሰይጣን፡ ጸላዔ፡ ሣናያት፡ ጸረ፡ ኵሉ፡ ትውልደ፡ አዳም፡ ቀንዓ፡ ላዕሌሁ፡ ወአጽንዓ፡ ደዌ፡ በሥጋሁ፡ ወኮነ፡ መባጕዓ፡ ወሐመ፡ ሕማመ፡ ብዙኃ፡ ወኮነ፡ የአወዩ፡ ብዝ፡ 
+                                        ዴዌ፡ እምጽንዓ፡ ሕማሙ፡ ዘላእሌሁ፡ </incipit>
+                                    <explicit xml:lang="gez">ወሰፍሐ፡ እዴሁ፡ ለዊህብ፡ ወኢያብጠለ፡ ገቢረ፡ በአሉ፡ አመ፡ ፲ወ፪፡ ለለ፡ ወርኁ፡ 
+                                        እ<gap reason="illegible" unit="chars" quantity="1"/>ከ፡ አመ፡ አእረፈ፡ ወቦአ፡ ውስተ፡ መንግሥተ፡ ስማያት፡ በሰእለቱ፡ ለቅዱሰ፡ 
+                                        <hi rend="rubric">ሚካኤል፡ መልአ</hi>ከ፡ ሣህል፡ ወምሕረት፡ ወለነኒ፡ ውሉደ፡ ጥምቀት፡ ይፈወሰነ፡ እም፡ ደዌ፡ ሥጋ፡ ትንብልናሁ፡ የሀሉ፡ ምስለ፡ ገብሩ፡ ለ</explicit>
+                                </msItem>
+                                <msItem xml:id="ms_i1.4.3">
+                                    <locus from="45va" to="45vb"/>
+                                    <title>When Mikāʾel was sent to Samson</title>
+                                </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i1.5">
+                                <title ref="LIT1295Dersan#Maggabit"/>
+                                <note>Without any indication of the month.</note>
+                                <msItem xml:id="ms_i1.5.1">
+                                    <locus from="46ra" to="52va"/>
+                                    <title ref="LIT4155MiraclesMichael"/>
+                                    <note>
+                                        Story about a child that was thrown into the sea by an evil rich man, saved by <persName ref="PRS7049Michael"/> and 
+                                        found by a shepherd, who named him <persName ref="PRS11321Talafinos">ተላሶን፡ </persName>. The story is a variation 
+                                        of <title ref="LIT3959Homily"/> as in <locus target="#ms_i1.3.1"/>; 
+                                        <title ref="LIT1295Dersan#CommemorativeSane"/> as in <locus target="#ms_i1.8.2"/> and 
+                                        <title ref="LIT1295Dersan#HomilyHamle"/> as in <locus target="#ms_i1.9.1"/> in this record. 
+                                        Often defined as Nagar, as it is the case here, but also frequently as Dərsān in some other manuscripts. 
+                                        Usually attributed either to the month Ḥamle or to Miyāzyā but so far never attested in connection with the month of Maggābit,
+                                        as it is the case here. 
+                                        Usually attributed to <persName ref="PRS10425Yohanne"/> as it can be observed in the incipit here as well.</note>
+                                    <incipit xml:lang="gez"><hi rend="rubric">በስመአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አ</hi>ምላክ፡ ነገር፡ በእንተ፡ 
+                                        <persName ref="PRS10425Yohanne">ዮሐንስ፡ </persName>ወሀሎ፡ በአኃቲ፡ ሀገር፡ ፩ብእሲ፡
+                                        ወልቡ፡ ጸዋግ፡ ከመ፡ ፈርዖን፡ ወኢየአምር፡ ጾመ፡ ወጸሎተ፡ ወ፩ብእሲ፡ ነዳይ፡ ነብር፡ በሳረቤቱ፡ ወርቱእ፡ ሃይማኖቱ፡ ምስለ፡ ብእሲቱ፡ ወይጸመድምዎ፡ 
+                                        ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ ወይገብሩ፡ ተዝካሮ፡ ለቅ<hi rend="rubric">ዱስ፡ ሚካኤል፡</hi> ወይርተቡ፡ ኩሎ፡ ዘረከቡ፡ ለዳያን፡ 
+                                        ወለመስኪናን፡ <pb n="46va"/> ወሶበ፡ ርእየ፡ መኰን፡ ዘሀሎ፡ በጐሮሙ፡ ያንጐረጕር፡ ላዕሌሆሙ፡ ወይብል፡ እንዘ፡ ነዳያን፡ አልቦሙ፡ ዘይበልዑ፡ </incipit>
+                                    <explicit xml:lang="gez">ወይሰረድ፡ ለነ፡ ኃጢአተነ፡ ነገርኩ፡ ከሙ፡ አነ፡ ዮሐንስ፡ አቡክሙ፡ ዘርኢኩ፡ አንትሙኒ፡ አሐውይ፡ ጸልዩ፡ ከመ፡ ንርከብ፡ ሣህለ፡ በቅድሜሁ፡
+                                        ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ ወበስእለታ፡ ለእግዝእትነ፡ <hi rend="rubric">ማርያም፡</hi> ወበስእለቱ፡ 
+                                        ለ<persName ref="PRS5720JohnChr">ዮሐንስ፡ አፈወርቅ፡</persName> ወስእለቶሙ፡ ለጻዳቃን፡ ወስማዕት፡ ያድኅኖ፡ ለገብሩ፡ 
+                                        <hi rend="rubric"><persName ref="PRS14011GabraMikael">ገብረ፡ ሚካኤ፡</persName></hi> ሰብሐ <pb n="52va"/>ት፡ 
+                                        ለአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ይእዜኒ፡ ወዘልፈነ፡ ወለዓለመ፡ ዓለም፡ ዓ</explicit>
+                                </msItem>
+                                <msItem xml:id="ms_i1.5.2">
+                                    <locus from="52va" to="55ra"/>
+                                    <title>Miracle of the woman, who was suffering from elephantiasis</title>
+                                    <incipit xml:lang="gez">ተአምረሁ፡ ዐመአክ፡ ክቡር፡ <gap reason="omitted" unit="chars" quantity="4"/><cb n="52rb"/>
+                                        ሊቀ፡ መላእክት፡ ትንብልናሁ፡ የሀሉ፡ ምስለ፡ ገብሩ፡ ገብ<gap reason="omitted" unit="chars" quantity="6"/> ወሀለወት፡ አሐቲ፡ ብእሲት፡ በእልት፡ 
+                                        ጥቀ፡ ወትገብር፡ ተዝካሩ፡ ለቅዱስ፡ <hi rend="rubric">ሚካኤል፡</hi> ሊቀ፡ መላእክት፡ ወአኃዛ፡ ሕማመ፡ ዝልጋሲ፡ ወሐብጠ፡ ኵሉ፡ ሥሃ፡ ወኃጥዑ፡ አታብያነ፡ 
+                                        ሥጌይ፡ ፈውስታ፡ ወኩነ፡ ኩሉ፡ ሰጋ<pb n="53ra"/>ሃ፡ ከመ፡ ዓሣ፡ ዘበሰለ፡ በእሰተ፡ ወአሕለቆት፡ ንዋይ፡ ወሶበ፡ ኢረከበት፡ ጢኢና፡ ሰእለት፡ ኃበ፡ 
+                                        እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ሕያው</incipit>
+                                    <explicit xml:lang="gez">ወይፈውስ፡ ሕማመነ፡ ሞተ፡ ንፍሰ፡ ኢያርእየነ፡ ለለሰዑ፡ የሐውፅነ፡ ሐዝነ፡ ዘመን፡ ኢያቲኀቅነነ፡ ወበሣህሉ፡ ይሱቀነ፡ ለገቢረ፡ በአሉ፡ 
+                                        እለ፡ ተጋባእነ፡ ቃለ፡ ፍሥሐ፡ ይስምዓነ፡ ለዓለመ፡ ዓለም፡ ዓሜን፡ </explicit>
+                                </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i1.6">
+                                <title ref="LIT1295Dersan#Miyazya"/>
+                                <msItem xml:id="ms_i1.6.1">
+                                    <locus from="55ra" to="61rb"/>
+                                    <title ref="LIT3962Homily"/>
+                                    <note>Author not mentioned here, but elsewhere usually attributed to <persName ref="PRS10425Yohanne"/></note>
+                                    <incipit xml:lang="gez"><hi rend="rubric">በስመአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱ</hi> ፩አምላክ፡ ድርሳን፡ ዘቅዱስ፡ <hi rend="rubric">ሚካአል፡</hi> 
+                                        ሊቀ፡ መላእክት፡ ዘይትነበብ፡ አመ፡ ፲ወ<add place="below">፪</add>ሰንዪ፡ <add place="above">አ</add>ወርኃ፡ ሚዝያ፡ 
+                                        ትኅብልናሁ፡ ያሀሉ፡ ምስለ፡ ገብሩ፡ ዘለዓለመ፡ ዓለ፡ ንሄድራንስ፡ አድርያስ፡ አብርያስ፡ መፍትው፡ እንከ፡ አሐውየ፡ 
+                                        ከመ፡ ንዘከር፡ እበዩ፡ ዘአብ፡ ወኂሩት፡ ዘወልድ፡ ወክብረ፡ ዘመንፈስ፡ ቅዱስ፡ ኢስመ፡ በህብረተ፡ ሥላሴ፡ ተትበፈ፡ ዓለም፡ ስማይ፡ ወምድር፡ እስመ፡ ይቤ፡ መድኃኒነ፡ በከመ፡ በሰማይ፡ 
+                                        ከማ<pb n="55va"/>ሁ፡ በምድር፡ ንቀደም፡ እንከ፡ ጠይቁ፡ ዘበሰማይ፡ ንለቡ፡ እንከ፡ ዘበ፡ ምድር፡ እሰሚ፡ ቀዳሚ፡ ገብረ፡ 
+                                        እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ሰማየ፡ ወምድረ፡ ወኩሉ፡ ፍጥረት፡ ዘዚአሁ፡ </incipit>
+                                    <explicit xml:lang="gez">ወካእበ፡ አመ፡ አሐዘ፡ ሄሮድስ፡ ለጰጥሮስ፡ ወአጽንዖ፡ በሞቱ፡ <gap reason="illegible" unit="chars" quantity="1"/>
+                                        ወረደ፡ መልአከ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ወአንቅሖ፡ ወይቤሎ፡ ትንት፡ ሐቄከ፡ ወነአ፡ ትልወኒ፡ ወጽአ፡ ወወድቃ፡ መዋቅሕቲሁ፡ እም፡ እደዊሁ፡ 
+                                        ወበጽሐ፡ ኀበ፡ ኆኅተ፡ ኃሂን፡ ወተርህጠት፡ ለሊሃ፡ ወሶቤሃ፡ ዲቤ፡ ጰጥሮስ፡ በአማን፡ አእመርኩ፡ ከመ፡ ፈነወ፡ ከመ፡ ፈነወ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ 
+                                        መልአኮ፡ ወአድኃነኒ፡ እምእዴሁ፡ ለሄሮድስ፡ ወይእዜኒ፡ ጸሊ<gap reason="illegible" unit="chars" quantity="2"/> ከመ፡ ናስምሮ፡ 
+                                        ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ ወንርከብ፡ ምገ፴፡ በቅድሜሁ፡ በግዓምት፡ እለት፡ ምስለ፡ ኩሎሙ፡ ቅዳሳን፡ ዘሎት፡ ሰብሐት፡ ወክብር፡ ለአብ፡ ወወልድ፡ 
+                                        ወመንፈሶ፡ ቅዱስ፡ ይእዜኒ፡ ወዘልፈኒ፡ ወለዓለመ፡ ዓለም፡ ዓሜን፡ </explicit>
+                                </msItem>
+                                <msItem xml:id="ms_i1.6.2">
+                                    <locus from="61rb" to="62rb"/>
+                                    <title ref="LIT1295Dersan#CommemorativeMiyazya"/>
+                                </msItem>
+                                <msItem xml:id="ms_i1.6.3">
+                                    <locus from="62ra" to="62rb"/>
+                                    <title ref="LIT1295Dersan#SalamMiyazya"/>
+                                </msItem>
+                                <msItem xml:id="ms_i1.6.4">
+                                    <locus from="62rb" to="64rb"/>
+                                    <title ref="LIT1295Dersan#MiracleMiyazya"/>
+                                    <incipit xml:lang="gez">ተአምሪሁ፡ ለቅዱስ፡ ሚካኤል፡ ሊቀ፡ መላእክት፡ ትንብልናሁ፡ የሃሉ፡ ምስለ፡ ገብሩ፡ 
+                                        <gap reason="omitted" unit="chars" quantity="4"/> ለአለዓለመ፡ ዓ፡ ተብህለ፡ ከመ፡ ሀሎ፡ ፩ብእሲ፡ 
+                                        አረማየዊ፡ ባዕል፡ ጥቀ፡ በንዋየ፡ ዝንቱ፡ ዓለም፡ ኃላፊ፡ ወርቅ፡ ወብሩር፡ ወበአሐቲ፡ እለት፡ እንዘ፡ የሐውር፡ ውስተ፡ ብሔረ፡ ሮሜ፡ <pb n="62va"/>ወረከበ፡ 
+                                        ብእሲ፡ አረማዊ፡ <add place="above">ዘርትትያናዊ፡</add> ቀዳሚ፡ ነበረ፡ ባዕለ፡ ወድኅረ፡ ነድየ፡ ወኃጥአ፡ ሲሳየ፡ እለት፡ ወእንዘ፡ የኃውር፡ ለኃሢሠ፡ 
+                                        ሲሳየ፡ እለት፡ ይቤሎ፡ ዝኩ፡ አረማዊ፡ ነአ፡ ተገበር፡ ሊተ፡ ወእኁበከ፡ ፻ተ፡ ደናጊ፡ ወርቅ፡ ከመ፡ ታርብህ፡ ሊተ፡ ወነአ፡ ንሁር፡ ኀበ፡ ቤተ፡ ክርስቲያኑ፡ ለቅዱስ፡ 
+                                        <hi rend="rubric">ሚካአል፡ ሊቀ፡ መላእክት፡</hi> ወመሐል፡ ሊተ፡ ከመ፡ ኢትእልወኒ፡ ወዝኩ፡ ክርስቲያናዊ፡ መሐል፡ ከመ፡ እይኢምጽንዋዮ፡ 
+                                        ወወሀቦ፡ በከመ፡ ፈቀዳ፡ ወሐረ፡ ውስተ፡ ተግባሩ፡ ከመ፡ ይንግጸ፡ ወይርብህ፡ በብሔረ፡ ባእድ፡ </incipit>
+                                    <explicit xml:lang="gez">ወናሁ፡ እምይእዜሰ፡ ኢይፍር፡ መሐላ፡ በኃሰት፡ በስመ፡
+                                        <hi rend="rubric"> እ<hi rend="ligature">ግዚ</hi>አብሔር፡</hi> ወበጊዜሃ፡ ተሣሃሎ፡ ወአሕየዎ፡ ወይቤሎ፡ ናሁ፡ ኃይውከ፡ እኅከ፡ 
+                                        ወኢተ፡ አብሰ፡ ደሃመ፡ ወዘንተ፡ ብሂ<cb n="64rb"/>ሎ፡ ተሰወረ፡ እምኔሁ፡ ወዝኩ፡ አረማዊት፡ ተጠምቀ፡ ወተወፈየ፡ አረቦነ፡ ጸጋ፡ ወክርስትና፡ ወኮነ፡ 
+                                        መሐይምነ፡ ወነበሩ፡ ሕቡረ፡ እንዘ፡ ይትለእኩ፡ ለቤተ፡ ክርስቲያኑ፡ ለቅዱስ፡ <hi rend="rubric">ሚካአል፡ ሊቀ፡</hi> መላእክት፡ በኩሉ፡ መዋዕለ፡ 
+                                        ሕይወቶሙ፡ እንዘ፡ ይዜንዉ፡ ዕበየ፡ መንክሩ፡ ዘገብረ፡ በእንቲአሆሙ፡ ትንብልናሁ፡ የሃሉ፡ ምስለ፡ ኩልነ፡ ሰ፡ ማዕየኅ፡ ለዓለመ፡</explicit>
+                                    <note>Similar to the miracle of Mikāʾel for the month of Ḥamle in <locus target="#ms_i1.9.2"/>.</note>
+                                </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i1.7">
+                                <title ref="LIT1295Dersan#Genbot"/>
+                                <msItem xml:id="ms._i1.7.1">
+                                    <locus from="64va" to="66va"/>
+                                    <title ref="LIT3963Homily"/>
+                                    <note>Homily on <persName ref="PRS3899Eudoxia"/>, wife of Emperor <persName ref="PRS2016Arcadius"/> 
+                                        and on <persName ref="PRS5720JohnChr"/>, attributed to <persName ref="PRS10382Yohanne"/> (perhaps 
+                                        an error instead of <persName ref="PRS5720JohnChr"/>).</note>
+                                    <incipit xml:lang="gez"><hi rend="rubric">በስመአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡ ድርሳን፡</hi> ዘቅዱስ፡ 
+                                        <hi rend="rubric">ሚካአል፡ </hi> ዘኅቡእ፡ ወገሃድ፡ ኢየሱስ፡ <hi rend="rubric">ክርስቶስ፡ ኢሎ</hi>ሂ፡
+                                        <hi rend="rubric">ኢ</hi>ሎ<hi rend="rubric">ሂ፡</hi> ኢ<hi rend="rubric">ሎ</hi>ሂ፡ 
+                                        ያ<hi rend="rubric">ዊ፡</hi>ያ<hi rend="rubric">ዊ፡</hi>ያ<hi rend="rubric">ዊ</hi>፡
+                                        <hi rend="rubric">ጸባ</hi>ት፡ ፍጹም፡ ምሉእ፡ ሰማያተ፡ ወድረ፡ ቅድስተ፡ ሰብሐቲከ፡ አፍላቶስ፡ አፍላናታ፡ 
+                                        <hi rend="rubric">ሚካአል፡ ወገብርኢል፡ ሱራፌል፡ ወኪሩቤል፡</hi> ሰራዊተ፡ ሰደቅይል፡ 
+                                        <hi rend="rubric">ሰድ</hi>ታኤ<hi rend="rubric">ል፡</hi> ሰድ<hi rend="rubric">ቃአ</hi>ል፡ 
+                                        <hi rend="rubric">ሰልት</hi>ኤል፡ <hi rend="rubric">ሰልት</hi>ኤል፡ 
+                                        አፍ<hi rend="rubric">ላታኢል፡</hi> መግረሬ፡ ፀር፡ ድርሳን፡ ዘቅዱስ፡ <hi rend="rubric">ሚካኤል፡ ሊቀ፡</hi> 
+                                        መላኢክ<cb n="64vb"></cb>ት፡ ሰአሊ፡ ምሕረት፡ ወመተነብል፡ ይሰአል፡ ለነ፡ ወይለተሰሪ፡ ኃጢአተነ፡ ለዒለመ፡ ዓለም፡ ዓሚን፡ ነገር፡ በእንተ፡
+                                        <persName ref="PRS10382Yohanne">ዮሐንስ፡</persName> ጳጳስ፡ ዘኢትዮጵያ፡ ዘመጽአ፡ እምድኅረ፡ አቡነ፡ ይስሐቅ፡ ከመ፡ ያየድዕ፡ 
+                                        አበዮ፡ ለወኃይሎ፡ ለቅዱስ፡ <hi rend="rubric">ሚካአል፡</hi> መ<add resp="CH">ላ</add>እክት፡ 
+                                        ዘይት<add resp="CH">ነ</add>በብ፡ በወርኃ፡ ግንቦት፡ በረከቱ፡ የኃሉ፡ ምስለ፡ ግብሩ፡ 
+                                        <gap reason="omitted" unit="chars" quantity="3"/> ለዓለመ፡ <pb n="65ra"/>
+                                        <hi rend="rubric">ወኮነ፡ በመዋ</hi>ዕሊሁ፡ ለ<persName ref="PRS2016Arcadius">አርቃዲዎስ፡ </persName>ወልደ፡ 
+                                        ለ<persName ref="PRS9479Theodosi">ቴዎደስዮስ፡ </persName> ንጉሥ፡ ርቱዓ፡ ሃይማኖት፡ ዘሀገረ፡ 
+                                        <placeName ref="LOC2196Consta">ቍስጥንጥያ፡ ወዘአጶሊ፡ </placeName>ወበ፡ እብሬቱ፡ ለዮሐንስ፡ ጳጳስ፡ 
+                                        ዘውእቱ፡ <persName ref="PRS5720JohnChr">አፈወርቅ፡</persName> ወሃለወት፡ ብእሲቱ፡
+                                        ለ<persName ref="PRS2016Arcadius">አርቃዴዎስ፡</persName> ዘስማ፡ 
+                                        <persName ref="PRS3899Eudoxia">አውዶክስያ፡</persName> 
+                                        መፍቀሪተ፡ ንዋይ፡ ወሶበ፡ ርእያ፡ ዮሐንስ፡ ከመ፡ ታፈቅር፡ ንዋየ፡ ይምዕዳ፡ ወይጊስፃ፡ </incipit>
+                                    <explicit xml:lang="gez">ወቀደሰ፡ <persName ref="PRS10382Yohanne">ዮሐንስ፡</persName> ጳጳስ፡ ወሢመ፡ ሎሙ፡ ቁሳውሶተ፡ 
+                                        ወደያቅናተ፡ ወአእረፈ፡ አመ፡ ፲ወ፪ለግንቦት፡ ወነሥአ፡ አክሊለ፡ ክብር፡ ወቦዓ፡ ውስተ፡ መንግሥተ፡ ስማያት፡ ምስለ፡ ጸድቃን፡ ወሰማዕት፡ ወዝንቱ፡ ዘኮነ፡ በስእለቱ፡ 
+                                        ለቅዱስ፡ <hi rend="rubric">ሚካአል፡ ሊቀ፡ መ</hi>ላእክት፡ ትንብልናሁ፡ የሀሉ፡ ምስለ፡ ገብሩ፡ 
+                                        <gap reason="omitted" unit="chars" quantity="4"/> ለመ፡ ዓሜን፡</explicit>
+                                </msItem>
+                                <msItem xml:id="ms_i1.7.2">
+                                    <locus from="66va" to="67ra"/>
+                                    <title ref="LIT1295Dersan#CommemorativeGenbot"/>
+                                </msItem>
+                                <msItem xml:id="ms_i1.7.3">
+                                    <locus from="67ra" to="67rb"/>
+                                    <title ref="LIT1295Dersan#SalamGenbot"/>
+                                </msItem>
+                                <msItem xml:id="ms_i1.7.4">
+                                    <locus from="67rb" to="68vb"/>
+                                    <title ref="LIT1295Dersan#MiracleGenbot"/>
+                                    <incipit xml:lang="gez"><hi rend="rubric">ተአምር፡ ዘገብረ፡ እ<hi rend="ligature">ግዚ</hi>እነ፡ በእዴሁ፡ ለመልአክ፡</hi>
+                                        ክቡር፡ <hi rend="rubric">ሚካአል፡</hi> ሊቀ፡ መላእክት፡ ትንብልናሁ፡ የሃሉ፡ ገብሩ፡ ገብ<gap reason="omitted" unit="chars" quantity="3"/> 
+                                        ለዓለመ፡ ዓ፡ ዓ፡ <gap reason="omitted" unit="chars" quantity="2"/>ተብህለ፡ ከመ፡ ህሎ፡ ፩ብእሲ፡ ክርስቲያናዊ፡ ዕም፡ ዓበይተ፡ ሮሜ፡ 
+                                        ወብ<pb n="67va"/>እሲቱ፡ መካን፡ ወኢወለደት፡ ግሙራ፡ ወነበሩ፡ እንዘ፡ የሐዝኑ፡ በእንተ፡ ዘአልቦሙ፡ ወይጸልዪ፡ ኀበ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡
+                                        መአልተ፡ ወሌሊተ፡ ከመ፡ የሀቦሙ፡ ውሉደ፡ </incipit>
+                                    <explicit xml:lang="gez">እንዘ፡ ትብል፡ እ<hi rend="ligature">ግዚ</hi>እየ፡ ሊቀ፡ መ<cb n="68vb"/>ላእክት፡ 
+                                        <hi rend="rubric">ሚካአል፡</hi> እሕዎ፡ ለወልድየ፡ እምዝንቱ፡ ዳዌ፡ ዕፁብ፡ አድኅኖ፡ እምይእዜ፡ ይትለአክ፡ ውስተ፡ ቤተ፡ ክርስቲያንከ፡ ወሰቤሃ፡ ሐይወ፡ ወልዳ፡
+                                        እምደዌሁ፡ ወይእቲ፡ ብእሲት፡ ነበጊት፡ እንዘ፡ ትዜኑ፡ ሰበዐ፡ ኃይሉ፡ ዘገብረ፡ በእንቲአሃ፡ ወበእንተ፡ ወልዳ፡ ትንብልናሁ፡ የሀሉ፡ ምስለ፡ ገብሩ፡ 
+                                        <gap reason="omitted" unit="chars" quantity="3"></gap>ለዓለመ።</explicit>
+                                </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i1.8">
+                                <title ref="LIT1295Dersan#Sane"/>
+                                <msItem xml:id="ms_i1.8.1">
+                                    <locus from="68vb" to="77vb"/>
+                                    <title ref="LIT1295Dersan#HomilySane"/>
+                                    <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈ፡ ቅዱስ፡ ፩<pb n="69ra"/>አምላክ፡</hi> 
+                                        ድርሳን፡ ዘቅዱስ፡ <hi rend="rubric">ሚካአል፡ ሊቀ፡ ሠራዊተ፡</hi> ሰማያት፡ ሰአለ፡ ምሕረት፡ አን<hi rend="rubric">ኰራ፡</hi> 
+                                        ኳራ<hi rend="rubric">ኤል፡</hi> አጕለ፡ <hi rend="rubric">ቶዳይኅ፡</hi>
+                                        ሠተር<hi rend="rubric">ሪናኤል</hi>ዮና፡
+                                        <hi rend="rubric">ፓፓኢል፡</hi> ተብል፡ በእኅቲአነ፡ ኦ<hi rend="rubric">ሚካኤል፡</hi> ኀበ፡ 
+                                        እ<hi rend="ligature">ግዚ</hi>አብሔር፡ እመላክክ፡ ዝንቱ፡ ነገር፡ ዘደረሰ፡ ጳጳስ፡ ዘብሔረ፡ 
+                                        <placeName ref="LOC7363Aksum">አኩሳም፡</placeName> ቀዳሚተ፡ ኩሎን፡ አብያተ፡ ክርስቲያናት፡ 
+                                        ዘቅዱስ፡ <hi rend="rubric">ሚካል፡ ሊ፡</hi> ወይፈርሆ፡ ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ በውእቱ፡ 
+                                        መካ<cb n="69ra"/>ን፡ በረካቱ፡ ትኩን፡ ምስለ፡ ገብሩ፡ ገብረ፡<gap reason="omitted" unit="chars" quantity="5"></gap> ዓሜን፡ 
+                                        ወሀሎ፡ ፩በሲ፡ መኰንን፡ ርቱዓ፡ ሃይማኖት፡ ዘስሙ፡ <persName ref="PRS14018Astaraniqos">አስተራኒቆስ፡</persName> ወብእሲቱ፡ 
+                                        <persName ref="PRS14019Euphemia">አፈምያ፡</persName> ወክልኤሆሙ፡ የኢቅርዎ፡ ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡
+                                        ወለቅዱስ። <hi rend="rubric">ሚካኤል፡ ሊቀ፡</hi> መላእክት፡ ወይገብሩ፡ በአሎ፡ ከመ፡ ፲ወ፪ለለ፡ ወርኁ፡ ወይምሕሩ፡ ነዳያነ፡ ወምስኪናነ፡ </incipit>
+                                    <explicit xml:lang="gez">ወቦአ፡ ውስተ፡ ቤተ፡ ክር<pb n="77va"/>ስቲያን፡ ወተሰቀለ፡ ውስተ፡ ቤተ፡ መቅደስ፡ ዘቅዱስ፡ 
+                                        <hi rend="rubric">ሚካኤል፡ ሊቀ፡ መላእክ</hi>ት፡ ዘእንበለ፡ ሀብል፡ ወሶቤሃ፡ አውጽአ፡ ሥአለ፡ ቈጹለ፡ ወፈረየ፡ ዘይተ፡ ወኮነ፡ ፈውሰ፡ ለድሙያን፡ 
+                                        ወለለ፡ አጋንት፡ ርኩሳን፡ እስመ፡ ዓቢይ፡ መንክራት፡ ኮነ፡ በውስቱ፡ ሀገር፡ በእለቱ፡ ለቅዱስ፡ <hi rend="rubric">ሚካኤል፡ ሊቀ፡</hi> መላእክት፡ እስመ፡ 
+                                        ውእቱ፡ ይትነብል፡ በእንተ፡ ኩሉ፡ ፍጥረት፡ ት<cb n="77vb"/>ንብልናሁ፡ የሃሉ፡ ምስለ፡ ገብሩ፡ <gap reason="omitted" unit="chars" quantity="5"/> 
+                                        ለዓለመ፡</explicit>
+                                    <note>Homily on <persName ref="PRS14018Astaraniqos"/> and <persName ref="PRS14019Euphemia"/> of 
+                                        <placeName ref="LOC2177Cilici"/> by <persName ref="PRS13526Yohannes"/>, whose name is omitted in this 
+                                        codex</note>
+                                </msItem>
+                                <msItem xml:id="ms_i1.8.2">
+                                    <locus from="77vb" to="84rb"/>
+                                    <title ref="LIT1295Dersan#CommemorativeSane"/>
+                                    <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡</hi> አመ፡ ፲ወሰ፪ለሰኔ፡ በዛቲ፡ እለት፡ ያብእሉ፡ 
+                                        ተዝካረ፡ በከሉ፡ ለመልአክ፡ ክቡር፡ <hi rend="rubric">ሚካኤል፡</hi> መላእክት፡ ወምክንክንያቱስ፡ 
+                                        ዘያብዕሉ፡ ቦቱ፡ እስመ፡ ሐሎ፡ በ<placeName ref="LOC1338Alexan">እስከንድርያ፡</placeName> ምኩራብ፡ ዓቢይ፡ ኰነት፡ 
+                                        <persName ref="PRS3137Cleopatr">እክላኡ፡ በጥራ፡ </persName>ንገሥት፡ ወለተ፡ <persName ref="PRS14020Ptolemy">በጥሊሞስ፡</persName> 
+                                        ንጉሥ፡ ዘ<placeName ref="LOC2804Egypt">ግብጽ፡ </placeName>ሀነጸት፡ በስመ፡ ኮከብ፡ ዙሐል፡ ወገ<pb n="78ra"/>ብሩ፡ ሎቱ፡ 
+                                        በሃሰ፡ አመ፡ ፲ወሰ፪ለሰኔ፡ ወኮነ፡ ምኩራብ፡ ጣዖት፡ ዘወርቅ፡ ወዘብሩር፡ ግሩም፡ ፈድፋደ፡ </incipit>
+                                    <explicit xml:lang="gez">ወንስአል፡ ምሕረተ፡ ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ በትንብልናሁ፡ ለቅዱስ፡ 
+                                        <hi rend="rubric">ሚካኤል፡ ሊቀ፡ መላእሕ፡</hi> ከመ፡ የድኅነ፡ እመሣገሪሁ፡ ለሰይጣን፡ ርጉም፡ ወያርኀቅ፡ እምኔነ፡ ኩሎ፡ ሕማመ፡ ወቡድብደ፡ 
+                                        ወያብብዝኅ፡ ፍሬ፡ ምድ<cb n="84rb"/>ርነ፡ ወያጽንዓነ፡ ለገቢረ፡ ፈቃዱ፡ ወይደስረይ፡ ለነ፡ ኃጠውኢነ፡ ለዓለመ፡ ዓሜን። 
+                                        <hi rend="rubric">ለ</hi>ለ<hi rend="rubric">ሚካኤል፡ መሐሪ፡</hi> ውእቱ፡ ወተአዘዚ፡ ዕዕብእ፡ በዲበ፡ ሰናይይቱ፡ ለቀርነ፡ ዝንቱ፡ 
+                                        መልአክ፡ በድምየ፡ ዓፍሐቱ፡ በከመ፡ ቀዳሚ፡ ኮነ፡ ውስተ፡ ሰማያት፡ አርባቱ፡ ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ ይከውን፡ ዳግመ፡ ምጽአቱ።
+                                        </explicit>
+                                    <note>Miracle of the temple built by <persName ref="PRS3137Cleopatr"/> and converted into a church by Mikāʾel
+                                        attributed to the month of Sane as it is the case in the Sənkəssār. Taken from the history of Bāḥrān and very similar to 
+                                        the stories of Talafinos and Talason: <title ref="LIT3959Homily"/> as found in <locus target="#ms_i1.3.1"/>; 
+                                        <title ref="LIT4155MiraclesMichael"/> as found in <locus target="#ms_i1.5.1"/> and 
+                                        <title ref="LIT1295Dersan#HomilyHamle"/> as found in <locus target="#ms_i1.9.1"/> in this record.)</note>
+                                </msItem>
+                                <msItem xml:id="ms_i1.8.3">
+                                    <locus from="84rb" to="86ra"/>
+                                    <title ref="LIT1295Dersan#MiracleSane"/>
+                                    <incipit xml:lang="gez"><hi rend="rubric">ተአምሪሁ፡ ለቅዱስ፡ ሚካኤል፡ </hi>ሊቀ፡ መላአክት፡ የሀሉ፡ ምስለ፡ ገብሩ፡ 
+                                        <gap reason="omitted" unit="chars" quantity="3"/>ወሀሎ፡ ፩ብእሲ፡ ክርስቲያናዊ፡ <pc n="84va"/>ዘይፈርሆ፡ 
+                                        ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ ወይትአምን፡ በጸሎቱ፡ ለቅዱስ፡ <hi rend="rubric">ሚካኤል፡ ሊቀ፡ መላእት፡</hi>
+                                        ወሀለየ፡ ከመ፡ ይሕንጽ፡ ቤተ፡ ክርስቲነ፡ ውስተ፡ ደሴተ፡ <placeName ref="LOC2206Cyprus">ቆጵሮስ፡</placeName> በስሙ፡ ለቅዱስ፡ 
+                                        <hi rend="rubric">ሚካኤል፡ ሊቀ፡ መላእክት፡</hi> 
+                                        ወሀነጸ፡ ወፈጸማ፡ ወአሰርገዋ፡ በኩሉ፡ ሠርጕ፡ ሠናይ፡ ወሶበ፡ ፈጸመመ፡ ሊኦከ፡ ኃበ፡ ኢጲስ፡ ቆጶስ፡ ወሀበ፡ ካህናት፡ ከመ፡ ይምምጽዑ፡ ለቅዳሴ፡ ቤተ፡ 
+                                        ክርስቲያን፡ ዘቅዱስ፡ <hi rend="rubric">ሚካኤ<cb n="84vb"/>ል፡ ሊቀ፡ መላእክ</hi>ት፡ ወገብረ፡ መቅድሃ፡ ለቤተ፡ ክርስቲያን፡ 
+                                            </incipit>
+                                    <explicit xml:lang="gez">ወነበረ፡ በርትእት፡ ሃይማኖት፡ እንዘ፡ ይትለአክ፡ በቤተ፡ ክርስቲያኑ፡ ለቅዱስ፡ 
+                                        <hi rend="rubric">ሚ<pc n="86ra"/>ካኤል፡</hi> ሊቀ፡ መበኩሉ፡ መዋዕለ፡ ሕይወቱ፡ ወነበረ፡ እንዘ፡ ይዚኑ፡ መንክራቲሁ፡ ለቅዱስ፡ 
+                                        <hi rend="rubric">ሚካኤል፡</hi> ሊቀ፡ መላእክት፡ ወበርሃ፡ ጽልመተ፡ ዑረቱ፡ ዘነበረ፡ ቀዲሙ፡ በከመ፡ ይቤ፡ ነቢይ፡ ሕዝብ፡ ዘይንብር፡ ውስተ፡ 
+                                        ጽልመት፡ ወጽላሎተ፡ ሞት፡ ሠረቀ፡ ሎሙ፡ ብርሃነ፡ ንቢየ፡ ትኅብልናሁ፡ የሃሉ፡ ምስ፡ ገብሩ፡ 
+                                        <gap reason="omitted" unit="chars" quantity="4"/>። </explicit>
+                                </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i1.9">
+                                <title ref="LIT1295Dersan#Hamle"/>
+                                <msItem xml:id="ms_i1.9.1">
+                                    <locus from="86ra" to="90vb"/>
+                                    <title ref="LIT1295Dersan#HomilyHamle"/>
+                                    <incipit xml:lang="gez"><hi rend="rubric">በስመአብ፡ ወልድ፡ ወመንፈስ፡ ቅዱስ፡</hi> ፩አምላክ፡ ድርሳን፡ ዘቅዱስ፡ 
+                                        <hi rend="rubric">ሚካኤል፡</hi> ሊቀ፡ መላእክት፡ ዘይትነበብ፡ በውርኃ፡ ኃምሌ፡ ዘተናገረ፡ 
+                                        <persName ref="PRS10382Yohanne">ዮሃንስ፡</persName>ጳጳስ፡ ዘብሔረ፡ 
+                                        <placeName ref="LOC3010Ethiop">ኢትዮጵያ፡</placeName> 
+                                        በ<placeName ref="LOC7363Aksum">አኩሰም፡</placeName> ትንብልናሁ፡ የሀሉ፡ 
+                                        <gap reason="omitted" unit="chars" quantity="5"/>ወነበረ፡ ፩ብሲ፡ ጸዋግ፡ ከመ፡ ፈርዖን፡ ወኢየ፡ አምር፡ ጾመ፡ ወጽሎተ፡ ወፅኑእ፡ ልቡ፡ 
+                                        ከመ፡ አብነ፡ አየ፡ ማሰ፡ ወበጥቃሁ፡ ይንብር፡ ነደ፡ ዘአልቦቱ፡ ሲሳየ፡ እለተ፡ ወርቱዕ፡ ሃይማኖቱ፡ ምስለ፡ ብእሲቱ፡ ወይጸመድዎ፡  
+                                        ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ ወይገብሩ፡ ተካሮ፡ ለቅዱስ፡ <hi rend="rubric">ሚካኤል፡ ወይሁቡ፡ እምዘ፡</hi>
+                                        ረከቡ፡ ለነዳያን፡ ወለምኪናን፡ </incipit>
+                                    <explicit xml:lang="gez">ወበጸሎቱ፡ ለዮሐንስ፡ መጥምቅ፡ ወቦ፡ ስለቶሙ፡ <hi rend="rubric">ሚካኤል፡ ወገብርኤል፡</hi> ወበ፡ ጸሎተ፡ 
+                                        ኩሎሙ፡ ቅዱሳን፡ ሰማዕት፡ ጸድቃን፡ ነቢያት፡ ወሐዋርያት፡ ይምሐረነ፡ ወይሣህልነ፡ ለእመ፡ ረከብክሙ፡ ሀቡ፡ ወለእመ፡ ኢረከብክሙ፡ <cb n="90vb"/>ሀቡ፡ 
+                                        ማ<add place="above">የ</add>ይ፡ በእንተ፡ ስሞሙ፡ <hi rend="rubric">ሚካኤል፡ ወገብርኤል፡</hi> ወይትኈለቅ፡ ለክሙ፡ ጽድቀ፡ 
+                                        ሎቱ፡ ሰብሐት፡ ለዓለመ፡ ዓለ፡ ዓሜን፡ </explicit>
+                                    <note>Homily on <persName ref="PRS0000">Talāson</persName> similar to <title ref="LIT3959Homily"/> 
+                                        as found in <locus target="#ms_i1.3.1"/>; <title ref="LIT4155MiraclesMichael"/> as found in 
+                                        <locus target="#ms_i1.5.1"/> and <title ref="LIT1295Dersan#CommemorativeSane"/> as found in 
+                                        <locus target="#ms_i1.8.2"/> in this record.</note>
+                                </msItem>
+                                <msItem xml:id="ms_i1.9.2">
+                                    <locus from="90vb" to="92rb"/>
+                                    <title ref="LIT1295Dersan#MiracleMiyazya">Miracle of the Christian with withered hands and feet</title>
+                                    <incipit xml:lang="gez"><hi rend="rubric">ተአምሪሁ፡ ለመል</hi>አክ፡ ክቡር፡ <hi rend="rubric">ሚካኤል፡</hi>
+                                        ሊቀ፡ መላእክት፡ ትንብልናሁ፡ የሀሉ፡ ምስለ፡ ገብሩ፡ ገብረ፡ <hi rend="rubric">ሚካኤል፡</hi> ለዓ፡ 
+                                        <gap reason="omitted" unit="chars" quantity="3"/> ተብህለ፡ ከመ፡ ሀሎ፡ ፩ብእሲ፡ አረማዊ፡ ባዕል፡ ጥቀ፡ በንዋዝ፡ ዓለም፡ ኃላፊ፡ 
+                                        ወአኃዘ፡ የሐውር፡ በህገ፡ አበዊሁ፡ ረከበ፡ ብእሲ፡ ከርስታናዌ፡ እ<pb n="91ra"/>ሑየ፡ ልደቱ፡ ተሀውር፡ ወይቤሎ፡ አህር፡ ውስተ፡ ተግባርየ፡ ወይቤ፡ 
+                                        አረማዊ፡  ነአ፡ ተገበር፡ እምኔየ፡ ኡሁበከ፡ ወርቅ፡ ከመ፡ ታርብህ፡ ሊተ፡ ወነአ፡ ንኁር፡ ኃበ፡ ቤተ፡ ክርስቲያኑ፡ ለቅዱስ፡ 
+                                        <hi rend="rubric">ሚካኤል</hi>፡ መላእክት፡ ከመ፡ ትምሐል፡ ወኢትአልወኒ፡ ወሁሩ፡ ወእምሀሎ፡ ወወሀቦ፡ ወርቀ፡ </incipit>
+                                    <explicit xml:lang="gez">ወዘንተ፡ ቢሔሎ፡ ተሰወረ፡ እምኔሁ፡ ወዝኩ፡ ብእሲ፡ ነቅሐ፡ ወሐይወ፡ አእከቶ፡ 
+                                        <hi rend="rubric">እ<hi rend="ligature">ግዚ</hi>አብሔር፡</hi> ወነበሩ፡ ሀቡራ፡ ምስለ፡ ዘተጠምቀ፡ አረማዊ፡ እንዘ፡ ይትለአኵ፡
+                                        ውስተ" ቤተ፡ ክርስቲያኑ፡ ለቅዱስ፡ <hi rend="rubric">ሚካኤል፡</hi> ሊቀ፡ መላእክት፡ በኩሉ፡ መዋዕሊ፡ ሕይወቶሙ፡ እንዘ፡ ይዜንዉ፡ 
+                                        መንክራቲሁ፡ ትንብልናሁ፡ የሃሉ፡ ምስለ፡ ገብሩ፡ ገብረ፡ <hi rend="rubric">ሚካኤል፡</hi>
+                                        <gap reason="omitted" unit="chars" quantity="4"/></explicit>
+                                    <note>Miracle of the Christian with withered hands and feet similar to the miracle of the month Miyāzyā in this record 
+                                        and in other witnesses as in <ref target="BAVet82#p1_i1.7.2"/>.</note>
+                                </msItem>
+                                <msItem xml:id="ms_i1.9.3">
+                                    <locus from="92rb" to="92vb"/>
+                                    <title ref="LIT1295Dersan#CommemorativeHamle">When Mikaʾel was sent to Sennacherib</title>
+                                </msItem>
+                                <msItem xml:id="ms_i1.9.4">
+                                    <locus target="92vb"/>
+                                    <title ref="LIT1295Dersan#SalamHamle"/>
+                                </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i1.10">
+                                <title ref="LIT1295Dersan#Nahase"/>
+                                <msItem xml:id="ms_i1.10.1">
+                                    <locus from="92vb" to="96r"/>
+                                    <title ref="LIT1295Dersan#HomilyNahase"/>
+                                    <incipit xml:lang="gez"><hi rend="rubric">ዘነሐሴ፡ በስመ፡ <add place="above">ገነሐ፡</add> አብ፡ ወወልድ፡ ወመንፈስ፡ 
+                                        ቅዱስ፡ ፩አምላክ፡</hi> ድርሳን፡ ዘቅዱስ፡ <hi rend="rubric">ሚካኤል፡</hi> ሊቀ፡ መላእክት፡ ዘይትነበብ፡ አመ፡ ፲ወ፪፡ ለነሐሴ፡ ኃይለ፡ ጸሎቱ፡ 
+                                        ይባልሖነ፡ እምሕማመ፡ ዘልጋሴ፡ ወይሰውረነ፡ እም፡ ዓለም፡ ድምስሱ፡ በረከቱ፡ ወሀብተ፡ ረድኤቱ፡ ይኩነነ፡ ቅዳሴ፡ ስዓ፡ ዓለ፡ ዓ፡ 
+                                        <hi rend="rubric">ዛቲ፡</hi> መጽሐፍ፡ ዘወፅአት፡ እት፡ እም፡ <placeName ref="LOC3957Jerusa">እየሩሳሌም፡</placeName> 
+                                        ከመ፡ ትንግር፡ እብዮሙ፡ ለቅዱሳን፡ <hi rend="rubric">ሚካኤ፡ ወገብርኤል፡ ሱራፌ፡</hi> ወኪሩቤል፡ ፬እንስስ፡ ፩ወ፬፡ ካህናት፡ ሰማይ፡ ዘማርያን፡ 
+                                        በሰብሐት፡ በመንፈሰ፡ ቅዱስ፡ ፍጹማን፡ በርእቶሙ፡ ወበበ፡ ሚመት፡ ወአቀብያን፡ በሃይማኖት፡ ብሩሃን፡</incipit>
+                                    <explicit xml:lang="gez">ወሰገዱ፡ ላቲ፡ ወ፪ተ፡ ረበኃ፡ ረብሐት፡ ዘበምድረ፡ መንገሥ፡ ት፡ ወዘበሰማይ፡ ገነት፡ በስእለቱ፡ ለቅዱስ፡ 
+                                        <hi rend="rubric">ሚካኤል፡ ይድኅን፡</hi> ኵሉ፡ ፍጥረት፡ ወአንትሙኒ፡ ሀቡ፡ ምጽዋተ፡ ለነዳያን፡ ወለምስኪናን፡ መእንተ፡ ስሙ፡ እንዘ፡ ትትአመኑ፡ 
+                                        ኪያሁ፡ አስትዩ፡ ጹሙአ፡ ወአልብሱ፡ እሩቀ፡ ወእብልዑ፡ ርኁበ፡ ከመ፡ ያኀብክሙ፡ <hi rend="rubric">ክርስቶስ፡ ኅብስት፡</hi> ሕይወት፡ በሰማያት፡ 
+                                        ሎቱ፡ ስብሐት፡ ለዓለመ፡ ዓለም። </explicit>
+                                </msItem>
+                                <msItem xml:id="ms_i1.10.2">
+                                    <locus from="96ra" to="96vb"/>
+                                    <title ref="LIT1295Dersan#MiracleNahase"/>
+                                </msItem>
+                                <msItem xml:id="ms_i1.10.3">
+                                    <locus from="96vb" to="97ra"/>
+                                    <title ref="LIT1295Dersan#CommemorativeNahase"/>
+                                </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i1.11">
+                                <title ref="LIT1295Dersan#Maskaram"/>
+                                <msItem xml:id="ms_i1.11.1">
+                                    <locus from="97rb" to="100ra"/>
+                                    <title ref="LIT1295Dersan#HomilyMaskaram"/>
+                                    <note>Erroneously attributed to Naḥāse, but always either attributed to Maskaram or to Ṭəqəmt in other 
+                                        manuscripts.</note>
+                                    <incipit xml:lang="gez"><hi rend="rubric">በስመአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱ፡</hi> ድርሳን፡ ዘሊቀ፡ 
+                                        <hi rend="rubric">ሚካኤል፡</hi> ሊቀ፡ መላእክት፡ ዘይትነበብ፡ በወርኅ፡ ነሐሴ፡ ኃይለ፡ ጸሎቱ፡ ያድህነነ፡ እምሕመ፡ ዝልጋሴ፡ ምስለ፡ 
+                                        ገብሩ፡ ለዓ፡ <gap reason="ellipsis" unit="chars" quantity="3"/> ይቤ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ 
+                                        ኢታምልኩ፡ ባዕደ፡ አምላከ፡ ዘእንበሊየ፡ ወዘእንበለ፡ መላእክትየ፡ <hi rend="rubric">ወማርያም፡ እምየ፡</hi> ነበያትየ፡ ወሐዋርያ፡ 
+                                        ወሰማዕት፡ ጻድቃን፡ ይሰአሉ፡ በእንቲአክሙ፡ ወአነሂ፡ እስምዖሙ፡ </incipit>
+                                    <explicit xml:lang="gez">ወክቡራን፡ ሥርግዋን፡ በወርቅ፡ ወበብሩር፡ አንትሙኒ፡ ትከውኑ፡ ከማሆሙ፡ ኢትፍርሁ፡ ሞተ፡ ዘበምድር፡ ጸላ፡ ፍርሁ፡ 
+                                        ሞተ፡ ዘበሰማይ፡ እንተ፡ አልቦቱ፡ ሙጻእ፡ ውምጉያይ፡ ወይእዜኒ፡ ድልዋኒ፡ ክሙ፡ ንበሩ፡ ወሀበ፡ ምጽዎተ፡ በእንተ፡ 
+                                        <hi rend="rubric">ሚኬል፡</hi> ወ<hi rend="rubric">ገብርአ፡</hi>
+                                        ሱ<hi rend="rubric">ሬሬል፡</hi> <hi rend="rubric">ሀ</hi> ወኪ<hi rend="rubric">ኪ</hi>ሩ፡ 
+                                        <hi rend="rubric">ወ፳</hi>፳<hi rend="rubric">ወ፬</hi>ካህናተ፡ ሰማይ፡ ወ፬እንስሳ፡ ከመ፡ ይኩንክሙ፡ ረዳኢያነ፡ አመ፡ 
+                                        ትትመነዳቡ፡ ወትመውቱ፡ ጸሎቶሙ፡ ወሰእለቶሙ፡ የሀሉ፡ መስለ፡ ገብሮሙ፡ ገብረ፡ 
+                                        <gap reason="omitted" unit="chars" quantity="11"/></explicit>
+                                </msItem>
+                                <msItem xml:id="ms_i1.11.2">
+                                    <locus from="100ra" to="101va"/>
+                                    <title>Miracle of the poor man, who became a rich man</title>
+                                    <incipit xml:lang="gez"><hi rend="rubric">ተአምሪሁ፡</hi> ለመልአክ፡ ክቡር፡ ሊቀ፡ መላእክት፡ <hi rend="rubric">ሚካኤል፡</hi>
+                                        ትንብልናሁ፡ የሀሉ፡ ምስለ፡ ገብሩ፡ <gap reason="omitted" unit="chars" quantity="4"/> ተብህለ፡ ከመ፡ ነበረ፡ ፩ነዳይ፡ በጥቃሁ፡ ትነብር፡ 
+                                        ቤተክርስቲያን፡ ዘተሀንጸት፡ በስሙ፡<gap reason="omitted" unit="chars" quantity="3"/> ሊቀ፡ መላኢክት፡ ወይሰአል፡ ኃቤሃ፡ መእልተ፡ 
+                                        ወሌ<cb n="100rb"/>ሊተ፡ በእንበለ፡ ወይብል፡ ሊቆሙ፡ ለመላእክት፡ ወሊቀየ፡ ሰአል፡ ሊተ፡ ኀበ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ 
+                                        ከመ፡ የሀበኒ፡ ሲሳየ፡ ወአራዘ፡ ወነበረ፡ ከመዝ፡ ብዙኃ፡ መዋዕለ፡ ወበ፡ ፩እመዋዕል፡ መጽአ፡ ኃቤሁ፡ ሊቀ፡ መላእክት፡ ወይቤሉ፡ ኦ፡ ገብር፡ ህካይ፡ ወፅሩእ፡ ለምንት፡ 
+                                        ትስእለኑ፡ ከመዝ፡ ወኢትገብር፡ ተግባረ፡ አትፃሙ፡ ከመ፡ እባርከ፡ ለከ፡ ወኢትነግጽ፡ ወኢተዘርእ፡ ከመ፡ እባርክ፡ ለከ፡ ወዮምኒ፡ ሑር፡ ኀበ፡ አቃቤ፡ ቤተክርስቲያን፡ 
+                                        ወሰአ<pb n="100va"/>ል፡ እምኔሁ፡ ወርቀ፡ ወንግድ፡ </incipit>
+                                    <explicit xml:lang="gez">ወአስኰቶ፡ ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ ወገነየ፡ ለቅዱስ፡ 
+                                        <gap reason="omitted" unit="chars" quantity="4"/>ሊቀ፡ መላእክት፡ ወይቤሎ፡ ኦብእሲ፡ ፈራኄ፡ 
+                                        እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ወመንፈሰ፡ ቅዱስ፡ ህዱር፡ ላእሌከ፡ ወሬድዲቱ፡ 
+                                        ለ<gap reason="omitted" unit="chars" quantity="4"/>  የሃሉ፡ ምስሌከ፡ ወሊተኒ፡ ተዘከረኒ፡ በጸሎትከ፡ ወነበሩ፡ ፪ሆሙ፡ ህቡረ፡ በፍቅር፡ እንዘ፡ 
+                                        ይዜንዉ፡ ትአምሪሁ፡ ልቅዱስ፡ <gap reason="omitted" unit="chars" quantity="3"/>መተንብል፡ ቅድመ፡ 
+                                        እ<hi rend="ligature">ግዚ</hi>አብሔር፡ በእንተ፡ ዘመደ፡ እጓለ፡ እመሕያው፡ ረድኢቱ፡ የሀሉ፡ ምስለ፡ ገብሩ፡ ገብረ፡ 
+                                        <gap reason="omitted" unit="chars" quantity="11"/></explicit>
+                                </msItem>
+                                <msItem xml:id="ms_i1.11.3">
+                                    <locus from="101va" to="101vb"/>
+                                    <title ref="LIT1295Dersan#CommemorativeMaskaram"/>
+                                </msItem>
+                                <msItem xml:id="ms_i1.11.4">
+                                    <locus from="101vb" to="102ra"/>
+                                    <title ref="LIT1295Dersan#SalamMaskaram"/>
+                                </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i1.12">
+                                <title ref="LIT1295Dersan#Teqemt"/>
+                                <msItem xml:id="ms_i1.12.1">
+                                    <locus from="102ra" to="105va"/>
+                                    <title ref="LIT1295Dersan#HomilyTeqemt"/>
+                                    <incipit xml:lang="gez"><hi rend="rubric">በስመአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡ ድርሳን፡</hi> ዘቅዱስ፡ 
+                                        <gap reason="omitted" unit="chars" quantity="3"/>ሊቀ፡ መላእክት፡ ዘይትነበብ፡ አመ፡ ፲ወ፪ለጥቅምት፡ ትንብልናሁ፡ ምስለ፡ ገብሩ፡ 
+                                        <gap reason="omitted" unit="chars" quantity="3"/> ሰምዑ፡ ሕዝበ፡ ወንጌል፡ ነፍስ፡ ዘኢኃሠሠት፡ ዋሕሠ፡ በህይወታ፡ ኢተረክብ፡ ዋህሰ፡ 
+                                        በጊዜ፡ መታ፡ ወከመዝ፡ ኮነ፡ ፳<cb n="102rb"/>ብእሲ፡ ዘቦቱ፡ ሸዳ፡ ወኃጥአ፡ ዘይፈዪ፡ ኃሣሥዎ፡ አኃዝዎ፡ ዘወሀብዎ፡ 
+                                        <add place="above">ኒ የ</add>ወበማዕከለ፡ አውድ፡ ወኃጥአ፡ ዘይፈድዮሙ፡ </incipit>
+                                    <explicit xml:lang="gez">ንዑ፡ ኃቤየ፡ እኁበ፡ ክብረ፡ ወምንተ፡ ትሂል<pb n="105va"/>ዉ፡ ምስሌየ፡ በትፍሥሕት፡ ወበሕማት፡ ወኢይሂሱ፡ 
+                                        ቃልየ፡ በረከቱ፡ ወኃብተ፡ ለቅዱስ፡ <hi rend="rubric">ሚካኤል፡ ሊቀ፡ መላእክት፡</hi> ወበረከታ፡ 
+                                        ለእ<hi rend="ligature">ግዚ</hi>እትነ፡ <hi rend="rubric">ማርያም፡ ወላዲተ፡ አምላክ፡</hi> በረከተ፡ ነቢያት፡ ወሐዋርያት፡ ጻድቃን፡ 
+                                        ወሰምዕት፡ የሃሉ፡ ምስለ፡ ገብሩ፡
+                                        <hi rend="rubric"><persName ref="PRS14011GabraMikael" role="owner">ገብሚካኤል፡ </persName></hi>
+                                            </explicit>
+                                </msItem>
+                                <msItem xml:id="ms_i1.12.2">
+                                    <locus from="105va" to="106ra"/>
+                                    <title>Miracle of the rich man who recovers his possessions.</title>
+                                </msItem>
+                                <msItem xml:id="ms_i1.12.3">
+                                    <locus from="106ra" to="107ra"/>
+                                    <title ref="LIT1295Dersan#CommemorativeTeqemt"/>
+                                </msItem>
+                                <msItem xml:id="ms_i1.12.4">
+                                    <locus target="#107r"/>
+                                    <title ref="LIT1295Dersan#SalamTeqemt"/>
+                                </msItem>
+                            </msItem>
+                            <note>Spaces left free for owner names throughout except for <locus target="#52rb #105va #106ra"/>, where the name of the owner
+                                <persName ref="PRS14011GabraMikael"/> is written with a red ball point pen as <locus target="#e5"/>.</note>
                         </msItem>
                     </msContents>
+                    <physDesc>
+                        <objectDesc form="Codex">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"></material>
+                                    <p>Holes in <locus target="#57 #60 #63 #64 #99"/> without textloss.</p>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf">110</measure>
+                                    <measure unit="leaf" type="blank">4</measure><locus target="#107rb #107v #108 #109 #110"/>
+                                    <dimensions unit="mm">
+                                        <height>134</height>
+                                        <width>110</width>                                        
+                                    </dimensions>
+                                </extent>
+                                <foliation> 
+                                    Marked folio numbers in pencil by a recent European hand on the bottom right.
+                                </foliation>
+                                <collation>
+                                    <list>
+                                        <item xml:id="q1" n="1">
+                                            <dim unit="leaf">8</dim>
+                                            <locus from="1" to="8"/>
+                                        </item>
+                                        <item xml:id="q2" n="2"> 
+                                            <dim unit="leaf">8</dim>
+                                            <locus from="9" to="16"/>
+                                        </item>
+                                        <item xml:id="q3" n="3">
+                                            <dim unit="leaf">8</dim>
+                                            <locus from="17" to="24"/>
+                                        </item>
+                                        <item xml:id="q4" n="4">
+                                            <dim unit="leaf">8</dim>
+                                            <locus from="25" to="32"/>
+                                        </item>
+                                        <item xml:id="q5" n="5">
+                                            <dim unit="leaf">8</dim>
+                                            <locus from="33" to="40"/>
+                                        </item>
+                                        <item xml:id="q6" n="6">
+                                            <dim unit="leaf">8</dim>
+                                            <locus from="41" to="48"/>
+                                            <note>Second and third bifolium are considerably smaller than the rest of the quire and the rest of the codex.</note>
+                                        </item>
+                                        <item xml:id="q7" n="7">
+                                            <dim unit="leaf">8</dim>
+                                            <locus from="49" to="56"/>
+                                        </item>
+                                        <item xml:id="q8" n="8">
+                                            <dim unit="leaf">8</dim>
+                                            <locus from="57" to="64"/>
+                                        </item>
+                                        <item xml:id="q9" n="9">
+                                            <dim unit="leaf">8</dim>
+                                            <locus from="65" to="72"/>
+                                        </item>
+                                        <item xml:id="q10" n="10">
+                                            <dim unit="leaf">5</dim>
+                                            <locus from="73" to="78"/> 
+                                            s.l. 3, stub after 3, s.l. 4, stub after 2
+                                            <note>Contrary to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">77</citedRange>
+                                                </bibl>, who considered the quire originally a quadernion, whose two middle bifolia are lost and replaced by just
+                                                only one additional single leaf.</note>
+                                            <note>Two additional sewing stations have been added to keep this quire fixed, so the number of sewing stations for 
+                                                this quire is six and thus different as for the rest of the codex.</note>
+                                        </item>
+                                        <item xml:id="q11" n="11">
+                                            <dim unit="leaf">8</dim>
+                                            <locus from="79" to="86"/>
+                                        </item>
+                                        <item xml:id="q12" n="12">
+                                            <dim unit="leaf">8</dim>
+                                            <locus from="87" to="94"/>
+                                        </item>
+                                        <item xml:id="q13" n="11">
+                                            <dim unit="leaf">8</dim>
+                                            <locus from="95" to="102"/>
+                                        </item>
+                                        <item xml:id="q14" n="11">
+                                            <dim unit="leaf">8</dim>
+                                            <locus from="103" to="110"/>
+                                        </item>
+                                    </list>
+                                </collation>
+                                <condition key="good">Some leaves are dirty and possibly affected by mold or insects. Few instances of minor 
+                                    watersheds.</condition>
+                            </supportDesc>
+                            <layoutDesc><layout columns="2" writtenLines="17">
+                                <note>Number of written lines may vary between 14 and 18 lines on <locus from="1r" to="54r"/> and <locus target="#55r #55v"/>, 
+                                    but with 19 lines on <locus target="#56r #56v #70r"></locus> and 20 to 22 lines or even 23 or 24 lines in the back of the 
+                                    codex on <locus from="57r" to="110"/>.</note>
+                                <ab type="pricking">Pricking is visible</ab>
+                                <ab type="ruling">Ruling is visible</ab>
+                            </layout>
+                            </layoutDesc>
+                        </objectDesc>
+                        <handDesc>
+                            <handNote xml:id="h1" script="Ethiopic">
+                                <locus from="1r" to="54r"/>
+                                <locus from="55r" to="107va"/>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Incipits, sacred names and owner.</seg>
+                                <seg type="script">Oblique script of the 19th to 20th centuries by a rather skilled hand with a broad pen, except for 
+                                    <locus target="#51r"/> as well as the rubricated words, that were written with a smaller pen.</seg>
+                                <note>Height of letters and ink saturation alternating considerably. Ligature used for 
+                                    <foreign xml:lang="gez"><hi rend="ligature">ግዚ</hi></foreign> throughout. Rare form of 
+                                    <foreign xml:lang="gez">ሎ</foreign> with a short right leg instead of a loop as a mark for the 
+                                    seventh order on <locus target="#13vb"/>.</note>
+                                <note>Contrary to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">77</citedRange>
+                                </bibl>, who considered <locus from="41r" to="50r"/>, <locus from="50r" to="55r"/>, some lines on 
+                                    <locus target="#55r"/> and <locus from="65r" to="107ra"/> for different hands.</note>
+                            </handNote>
+                            <handNote xml:id="h2" script="Ethiopic">
+                                <locus target="#54v"/>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Sacred names.</seg>
+                                <seg type="script">More upright and more schematic script of the 19th to 20th centuries, executed with a smaller pen.</seg>
+                                <note>Contrary to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">77</citedRange>
+                                </bibl>, who considered <locus target="#54v"/> of the same hand as <locus from="41r" to="54r"/> and <locus target="#55r"/>.
+                                        </note>
+                            </handNote>
+                        </handDesc>
+                        <decoDesc>
+                            <decoNote xml:id="d1" type="band"><locus target="#13va"/><desc>Symmetric ornamental band in black and red in the
+                                middle of the first column, marking the beginning of a new chapter.</desc></decoNote>
+                            <decoNote xml:id="d2" type="band"><locus target="#22ra"/><desc>Symmetric ornamental band in black and red in the
+                                middle of the first column, marking the beginning of a new chapter.</desc></decoNote>
+                            <decoNote xml:id="d3" type="band"><locus target="#35rb"/><desc>Symmetric ornamental band in black and red on top 
+                                of the second column, marking the beginning of a new chapter.</desc></decoNote>
+                            <decoNote xml:id="d4" type="band"><locus target="#36vb"/><desc>Symmetric ornamental band in black and red ink 
+                                on top of the second column, marking the beginning of a new chapter with added red color from a red ballpoint pen similar
+                                to the corrections on <locus target="#35vb #36ra"/>.</desc></decoNote>
+                            <decoNote xml:id="d5" type="band"><locus target="#96vb"/><desc>Symmetric ornamental band in black and red in the
+                                middle of the second column, marking the beginning of a new chapter.</desc></decoNote>
+                        </decoDesc>
+                        <additions>
+                          <list>
+                             <item xml:id="a1">
+                                 <locus target="3va"/>
+                                 <desc type="Correction">Insertion of 7 lines in the first column in a more schematic and higher script with a smaller 
+                                     pen.</desc>
+                                 <note>Contrary to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">77</citedRange>
+                                 </bibl>, who considered some parts of <locus target="#55r"/> of the same hand as the first seven lines of 
+                                     <locus target="#3va"/>.</note>
+                             </item>
+                             <item xml:id="e1">
+                                 <desc type="StampExlibris">"Acq. Doni. 776" written in the centre on the inner side of the wooden board with a
+                                     pen by a recent European hand and traced with a pencil by the same European hand as <ref target="#e2"/>.</desc>
+                             </item>
+                              <item xml:id="e2">
+                                  <locus target="#110v"/>
+                                  <desc type="StampExlibris">"111368" written with pencil on the top left of the folio with the same European hand as
+                                    <ref target="#e1"/></desc>
+                              </item>
+                              <item xml:id="e3">
+                                <locus target="#78v #110v"/>
+                                <desc type="StampExlibris">Small round stamp on the bottom margin or on the bottom right with the inscription: 
+                                    <foreign xml:lang="lat">BIBL. MED. LAUR. FLOR.</foreign>.</desc>
+                             </item>
+                             <item xml:id="e4">
+                                 <locus target="110v"/>
+                                 <desc type="StampExlibris">Acquisition number stamped on the bottom right: "111368".</desc>
+                             </item>
+                             <item xml:id="e5">
+                                <locus target="#35vb #36ra #52va #79va #102v #103ra #105va #106ra #107ra"/>
+                                <desc type="Correction">Addition of individual characters and words or highlighting of word separators as well as the 
+                                    names of the owners <persName ref="PRS14010Ewostatewos" role="owner"/> and 
+                                    <persName ref="PRS14011GabraMikael" role="owner"/> with a red ballpoint pen.</desc>
+                            </item>
+                            <item xml:id="e6">
+                                <locus target="#49r"/>
+                                <desc type="MixedNote">Pen trial in black ink and an Ethiopian hand.</desc>
+                            </item>    
+                          </list>
+                        </additions>
+                        <bindingDesc>
+                            <binding>
+                                <decoNote xml:id="b1" type="Boards">Two wooden boards.</decoNote>    
+                                <decoNote xml:id="b2" type="SewingStations">4</decoNote>
+                                <decoNote xml:id="b3" type="bindingMaterial"><material key="wood"/></decoNote>
+                            </binding>
+                        </bindingDesc>
+                    </physDesc>
                     <history>
                     </history>
                     <additional>
@@ -64,15 +786,214 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
         <profileDesc>
-            <langUsage><language ident="en">English</language></langUsage>
+            <langUsage><language ident="en">English</language><language ident="gez">Gəʿəz</language><language ident="la">Latin</language></langUsage>
         </profileDesc>
         <revisionDesc>
             <change who="PL" when="2019-02-21">Created catalogue entry</change>
+            <change when="2023-04-19" who="CH">Added physical description and content description</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">
-        <body>
-            <ab/>
+       <body>
+            <div type="edition" subtype="textpart" corresp="#ms_i1.1.5" xml:lang="gez">
+                <ab>
+                    <hi rend="rubric">ሰላም፡ እብ</hi>ልኪያከ፡ መልአከ፡ ርኀሩኃ፡ ልብ፡ ለኩሉ፡ እንተ፡ ኢኮንክ፡ ድሩከ፡ 
+                    <pb n="13va"/><hi rend="rubric">ሚካኤል፡ <del rend="strikethrough">ሊ</del>ቀየ፡ </hi>እለ፡ 
+                    እቤለከ፡ ኅብአኒ፡ በጽላሎትከ፡ ነግሐ፡ ወሰርከ፡ እስመ፡ እምንዕስየ፡ እፈርህ፡ ኃከከ።
+                </ab>
+            </div>
+           <div type="edition" subtype="textpart" corresp="#ms_i1.2.3" xml:lang="gez">
+               <ab>
+                   <hi rend="rubric">ሰላም፡ ለካ፡</hi> አቃቢ፡ ቅዱሳን፡ እምተሐውኮ፡ ወለፀረ፡ ነፍሶሙ፡ ዘሞቃሕኮ፡ አመ፡ መጽአ፡ ወልድ፡ 
+                   ዘአፈ፡ ነቢያት፡ ሰበኮ፡ ከመ፡ ያስተፋኑ፡ ሐራ፡ መልአኮ፡ እስከ፡ መጽጋኣት፡ ሐምሰ፡ <hi rend="rubric">ሚካኤል፡ </hi> ተለውኮ። 
+               </ab>
+           </div>
+           <div type="edition" subtype="textpart" corresp="#ms_i1.3.2" xml:lang="gez">
+               <ab>
+                   <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡</hi> አመ፡ ፲ወ፪፡ ለጥር፡ በዛቲ፡ እለት፡ ተዝካረ፡ በአሉ፡ ለመልአክ፡ ቡር፡ 
+                   <hi rend="rubric">ሚካኤል፡</hi> እስመ፡ በዛቲ፡ እለት፡ ፈነዎ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ለ<hi rend="rubric">ሚካኤ፡</hi> 
+                   ሊቀ፡ መላእክት፡ ኃበ፡ ያእቆብ፡ <choice><sic>እ፳ኢለዊ፡ </sic><corr resp="CH">እስራኤላዊ፡ </corr></choice> እንዘ፡ ይፈርህ፡ እም፡ 
+                   እኁሁ፡ ኤሳው፡ ወአድኃኖ፡ ወአእደዎ፡ ፈለገ፡ ዮርዳኖስ፡ ወበጽሖ፡ ዐበ፡ ላባ፡ እኁሃ፡ ለእሙ፡ ወአስተዋሰበ፡ ፪ኢ፡ አዋልዲሁ፡ ልያ፡ ወራኅየል፡ ወአግብኦ፡ እንዘ፡ ይጸይህ፡ 
+                   ፍኖት፡ በደህና፡ ወበሰላም፡ ምስለ፡ ንዋዪወውልዱ፡ ወተቀበሎ፡ አኁሁ፡ ኢሳው፡ በፍቅር፡ ወበሰላም፡ ወበእንተዝ፡ ኮነ፡ ተዝካረ፡ በዓሉ፡ ለ፡ 
+                   <hi rend="rubric">ሚካኤል፡</hi> ሊቀ፡ መላእክት፡ ትንብልናሁ፡ የሀሉ፡ ምስለ፡ ገብሩ፡ ገብ<hi rend="rubric">ረ፡ 
+                       <persName ref="PRS14010Ewostatewos" role="owner">ኤዎስጣቴዎስ፡ </persName></hi>
+               </ab>
+           </div>
+           <div type="edition" subtype="textpart" corresp="#ms_i1.3.3" xml:lang="gez">
+               <ab>
+                   <hi rend="rubric">ሰላም፡ </hi>ለከ፡ <hi rend="rubric">ሚካኤል፡</hi> ፩ዱ፡ እምነ፡ ሊቃናት፡ ልዑላን፡ 
+                   ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ ጸማዱ፡ አመ፡ ተፈኖከ፡ ትኩን፡ ረዲዖተ፡ ቲዎድሮሰ፡ ጊዜ፡ ምራይ፡ ከመ፡ ቈጽል፡ እምነፋስ፡ ሰብአ፡ ቍዝ፡ ርአዱ፡ ሶበ፡ መጥባትከ፡ 
+                   ነጸፉ፡ በእዱ፡
+               </ab>
+           </div>
+           <div type="edition" subtype="textpart" corresp="#ms_i1.3.4" xml:lang="gez">
+               <ab>
+                   <hi rend="rubric">ተአምሪሁ፡ </hi>ለሊቀ፡ መላእክት፡ 
+                   <add place="above"><hi rend="rubric">ሚካኤል፡</hi></add> ትንብልናሁ፡ የሀሉ፡ ምስለ፡ አመቱ፡ 
+                   <hi rend="rubric">ወለተ፡ <add change="overstrike">ኪዳን፡</add></hi> ወበሎ፡ ፩ብእሲ፡ ኢራኃ፡ 
+                   እ<hi rend="ligature">ግዚ</hi>አብ፡ ወጥቀ፡ ይፈቅሮ፡ ለቅዱስ፡ <hi rend="rubric">ሚካኤል፡</hi> ሊቀ፡ መላእክት፡ ወሶበ፡ በጽሐ፡ 
+                   በአሉ፡ ለሊቀ፡ መላእክት፡ <hi rend="rubric">ሚካኤል፡</hi> ዘይእቲ፡ አመት፡ ወኢያስተሐመመ፡ ለበአል፡ ይግበር፡ በከመ፡ ልማዱ፡ እስመ፡ ኃጥኦ፡ 
+                   ኢስየ፡ እለተ፡ ሶበ፡ ተዘከረ፡ ከመ፡ በኃጢእ፡ ረስኦ፡ ብጽአቶ፡ ወሶቤሃ፡ ተንሥአ፡ ወገብረ፡ በከመ፡ ክሂሎቱ፡ ዘይዳሉ፡ በምሂረ፡ ነዳያን፡ ወምስኪናን፡ ለእቤራት፡ ወለእጓለ፡ 
+                   ማውከመ፡ እይትኃምል፡ በአለ፡ መልአክ፡ <hi rend="rubric">ሚካኤል፡</hi> እስመ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ መሐሪ፡ 
+                   ወመስተሣህል፡ ሶበ፡ ነጸረ፡ ኂሩቶ፡ ለውእቱ፡ ብእሲ፡ ሜጠ፡ ሎቱ፡ ዘቀዳሚ፡ ብእለ፡ ወክብረ፡ ቤቱ፡ ዘትካት፡ ውእቱኒ፡ አፈድፈደ፡ ገቢረ፡ ተዝካሩ፡ ወስፍሃ፡ እዴሁ፡ ለዊሂብ፡ 
+                   ወኢያብጣለ፡ በኵሉ፡ ጊዜ፡ ውሂበ፡ ምጽዋት፡ ለነዳያን፡ በእንተ፡ ስሙ፡ <hi rend="rubric">ሚካኤል፡</hi> ሊቀ፡ መላእክት፡ እስከ፡ እለተ፡ ሞቱ፡ ትንብልናሁ፡ 
+                   የሃሉ፡ ምስለ፡ ገብ፡
+               </ab>
+           </div>
+           <div type="edition" subtype="textpart" corresp="#ms_i1.4.3" xml:lang="gez">
+               <ab>
+                   <hi rend="rubric">በስመአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡</hi> ወበዛቲ፡ እለት፡ ፈነዎ፡ 
+                   እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ለ<hi rend="rubric">ሚካኤል፡ ሀበ፡ ስሙ፡ </hi> ሶበ፡ ተመክነዩ፡ ፳ኤል፡ በብእሲቱ፡ ይቅትልዎ፡ 
+                   ወወወሀቦ፡ ሀይለ፡ ወምዖሙ፡ ወበመንሰከ፡ አድግ፡ ፹እልፍ፡ ወበእንተ፡ ዝ፡ አዘዙነ፡ መምሕራነ፡ ቤተ፡ ክርስቲያን፡ ከመ፡ ንግበር፡ በአሉ፡ ለቅዱስ፡ 
+                   <hi rend="rubric">ሚካኤል፡ ለለ፡ ወርሁ፡ </hi> ትኅብልናሁ፡ የሀሉ፡ ምስለ፡ ገብሩ፡ ለዓለ፡ ዓለ፡ ዓ
+               </ab>
+           </div>
+           <div type="edition" subtype="textpart" corresp="#ms_i1.6.2" xml:lang="gez">
+               <ab>
+                   <hi rend="rubric">በስመአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡ አመ፡ ፲ወ፪፡</hi> ለሚያዝያ፡ በዛቲ፡ እለት፡ ፈነዎ፡ 
+                   እ<pb n="61va"/><hi rend="ligature">ግዚ</hi>አብሔር፡ ለ፡ <hi rend="rubric">ሚካአል፡ ኃበ፡</hi> 
+                   <persName ref="PRS5680Jeremiah">ኤርምያስ፡</persName> ነቢይ፡ ወአድኃኖ፡ 
+                   ስሞቅሕ፡ ዐባብ፡ ዘአምአም፡ እስመ፡ ተምሃ፡ ሰደቅያስ፡ ንጕሥ፡ ወአውጽአ፡ ለበመልየክ፡ ኢትዮጵያዊ፡ ገብሩ፡ በሲቀ፡ ሐራሁ፡ ለንጕሥ፡ ወሶቤሃ፡ ባረከ፡ 
+                   <persName ref="PRS5680Jeremiah">ኢርምያስ፡</persName> ወይቤሎ፡ 
+                   ከመ፡ አይር<gap reason="illegible" unit="chars" quantity="1"></gap>አይ፡ ብድወታ፡ 
+                   <placeName ref="LOC3957Jerusa"><add place="above">አ</add>ለ<cb n="61vb"/>የሩሳሌም፡</placeName> ወእይርአይ፡ 
+                   ምሪረ፡ ጺዋዊ፡ ወኰነ፡ ከማሁ፡ ወኖመ። ፳ወ፮ዓመተ፡ ዐምሳሊሁ፡ ወዳን፡ ወበለሰ፡ ወኢመሰነ፡ እስከ፡ ተመይጡ፡ ደቁቀ፡ ፳ኢል፡ እምጺዋዊ፡ ወአውጽእ፡ እምወዶን፡ ወበለሰ፡ 
+                   ወወሀበ፡ ለኢርምያስ፡ ነቢይ፡ ወበእንተእዝ፡ አዘዙነ፡ መምሕራነ፡ ቤተ፡ ክርስቲያ<pb n="62ra"/>ን፡ ከመ፡ ንግበር፡ በአሎ፡ 
+                   ለ<add place="margin">መ</add>መልአክ፡ ክቡር፡ ሊቀ፡ መላእክት፡ <hi rend="rubric">ሚካአል፡ አመ፡</hi> አ፲ወ፪፡ 
+                   ለ<add place="margin">ለ</add>ወርኃ። ትንብልናሁ፡ የሀሉ፡ ምስለ፡ ፍቁሩ፡ <gap reason="omitted" unit="chars" quantity="3"/> ለዓለ፡ 
+               </ab>
+           </div>
+           <div type="edition" subtype="textpart" corresp="#ms_i1.6.2" xml:lang="gez">
+               <ab>
+                   <hi rend="rubric">ሰላም፡ ለ</hi>ከ፡ ዘረሰየከ፡ በክብር፡ መልአከ፡ ኪዳኑ፡ ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ 
+                   <hi rend="rubric">ሚካአል፡ ረ</hi>ዳኢ፡ ለእለ፡ ውስተ፡ የብስ፡ ወበህር፡ ረድአትከሰ፡ ለዘየአጽቦ፡ ነገር፡ አልቦ፡ በሰማይ፡ ወአልቦ፡ በምድር፡ 
+               </ab>
+           </div>
+           <div type="edition" subtype="textpart" corresp="#ms_i1.7.2" xml:lang="gez">
+               <ab>
+                       <hi rend="rubric">በስመአብ፡ ወወልድ፡ ወመንፈስ፡ <cb n="66vb"/> ቅዱስ፡ ፩አምላክ፡</hi> አመ፡ 
+                       ፲ወ፪ለግንቦት፡ በዛቲ፡ እለት፡ ፈነዎ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ለሚካ<hi rend="rubric">ኤል፡ ሊቀ፡ መላእክት፡</hi>
+                       ኃበ፡ <persName ref="PRS4914Habakkuk">እንባቆም፡</persName> ነቢይ፡ ዘሀገረ፡ 
+                       <placeName ref="LOC3957Jerusa">ኢየሩሳሌም፡ </placeName>እንዘ፡ ይጸውር፡ ሲሳየ፡ ብርሰኅ፡ ወይፈቅድ፡ ይሰድ፡ ለእለ፡ የአጽዱ፡ 
+                       ውስተ፡ ገራኅቱ፡ ወአሐዘ፡ <hi rend="rubric">ሚካኤል፡ በ</hi>ድማሁ፡ እንዘ፡ ይጸው<add place="above">ር፡</add> ሲሳየ፡ ወአብጽሖ፡ 
+                       ሀቦ፡ ሃገረ፡ <placeName ref="LOC1692Babylo">በቢሎን፡</placeName> ወወሀበ፡ ለዳንኤ<pb n="67ra"/>ል፡ እም፡ ውእቱ፡ መብልእ፡ 
+                       ወእምድኅረ፡ በልዓ፡ ወለዩ፡ <hi rend="rubric">ሚካኤል፡ </hi> ለ<persName ref="PRS4914Habakkuk">እንባቆም፡</persName>
+                       ነብይ፡ ወአብጽሖ፡ ኃበ፡ እለ፡ የአጽዱ፡ ወሲሳይ፡ ምሰሊሁ፡ ወለዳንኤለም፡ አፈ፡ አናብስት፡ ወበእንተዝ፡ አዘዙነ፡ መምሕራነ፡ ቤተ፡ ክርስቲያን፡ ከመ፡ ንግበር፡ ተዝከሮ፡ 
+                       ለመልከ፡ ክቡር፡ <hi rend="rubric">ሚካኤል፡</hi> ሊቀ፡ መላእክት፡ አመ፡ አሰሩ፡ ወሰንዪ፡ ለለ፡ ወርኁ፡ ትንብልናሁ፡ የሀሉ፡ ምስለ፡ ገብሩ፡ 
+                       <gap reason="omitted" unit="chars" quantity="2"/> ለዓ፡
+               </ab>
+           </div>
+           <div type="edition" subtype="textpart" corresp="#ms_i1.7.3" xml:lang="gez">
+               <ab>
+                   <hi rend="rubric">ሰላም፡</hi> ለሕላዌከ፡ ዘምሥውዓ፡ አብ፡ መቅደስ፡ ከመ፡ ታእርግ፡ ህየ፡ ጸሎተ፡ ቅዱሳን፡ ጢስ፡ ኢትርአይ፡ በድንጋፄ፡ እንዘ፡ ታንቃአዱ፡ 
+                    ዘልፈ፡ <hi rend="rubric">ነፍሰ፡ ሚካኤል፡</hi> አጽነንከ፡ ወአትሐትከ፡ ርእሰ፡
+               </ab>
+           </div>
+           <div type="edition" subtype="textpart" corresp="#ms_i1.9.3" xml:lang="gez">
+               <ab>
+                       <hi rend="rubric">በስመአብ፡ ወወልድ፡ ወመንፈስ፡ ዱስ፡ ፩አምላክ፡</hi> አመ፡  ፲ወ፪ለሐምሌ፡ በዛቲ፡ እለት፡ 
+                       ፈነዎ፡ <hi rend="rubric">እ<hi rend="ligature">ግዚ</hi>አሔር፡</hi>ለ<hi rend="rubric">ሚካኤል</hi>፡ ሊቀ፡ 
+                       መላእክት፡ ኃበ፡ ትእይንቱ፡ ለ<persName ref="PRS8762Sennache">ሰናክሬም፡</persName><pb n="92va"/> ንጉሠ፡ ፋርስ፡ 
+                       ወቀተለ፡ እምኔሁ፡ ፲ወ፰ተ፡፼ሶበ፡ አጋታ፤ ለ<placeName ref="LOC3957Jerusa">ኢየኢሩስሌም፡</placeName> ወፈነወ፡ ላእካነ፡ ኃበ፡ 
+                       <persName ref="/PRS5330Hezekiah">ሕዝቅያስ፡ </persName>ንጉሥ፡ እንዘ፡ ይጸርፍ፡ ላዕሌሁ፡ ወላዕለ፡ 
+                       እ<hi rend="ligature">ግዚ</hi>አሔር፡ እንዘ፡ ይብል፡ መኑ፡ ያድኅነከ፡ እም፡ እዴየ፡ ወኃዘነ፡ 
+                       <persName ref="/PRS5330Hezekiah">ሕዝቅያስ፡ </persName> ለብሰ፡ ስቀ፡ ወቦአ፡ ውስተ፡ 
+                       <hi rend="rubric">እ<hi rend="ligature">ግዚ</hi>አሔር፡ በካየ፡ ወ</hi>ሰአለ፡ ከመ፡ ያድኅኖ፡ ወያድኅን፡ ሀገሮ፡ 
+                       <placeName ref="LOC3957Jerusa">ኢየኢሩስሌም፡</placeName>ሃ፡ ወተወክፈ፡ እ<hi rend="ligature">ግዚ</hi>አሔር፡ 
+                       ስእለቶ፡ ወፈነዎ፡ ለ<hi rend="rubric">ሚካኤል፡</hi> ሊቀ፡ መላእክት፡ ኃበ፡ ትእይንተ፡ 
+                       <persName ref="PRS8762Sennache">ሰናክሬም፡</persName> ወገብረ፡ ዓቢየ፡ ተአምረ፡ ወአድኃኖ፡ እምእዴሁ፡ ወኢየሩሳሌም፡ 
+                       ሀገሩ፡ ወኩሉ፡ ሰብዑ፡ ወበእንተዝ፡ እዘዜነ፡ መሥሕራነ፡ ቤተ፡ ክርስቲያን፡ ከመ፡ ንግበር፡ በአሎ፡ ለመልአክ፡ ክቡር፡ 
+                       <hi rend="rubric">ሚካኤል፡ ሊቀ፡ መላእክት፡</hi> ትንብልናሁ፡ የሀሉ፡ ምስ፡ ገብሩ፡ ገበሩ፡ 
+                       <gap reason="omitted" unit="chars" quantity="3"/>
+               </ab>
+           </div>
+           <div type="edition" subtype="textpart" corresp="ms_i1.9.4" xml:lang="gez">
+               <ab>
+                       <hi rend="rubric">ሰላም</hi>፡ ለከ፡ ረዳኤ፡ ቅዱሳን፡ <add place="above">ወስማእት፡ ሐዊየ፡</add> እምተሐውኮ፡ 
+                       <add place="above">አዳው፡ ጸድን፡ በውስተ፡ </add>ወአጸረ፡ ነፍሶሙ፡ ዘ<add place="above">ይጣከካ፡ አራበሀይጤ፡</add>
+                       ምቃሕከ፡ ቁያንትሐኒ፡ ወጆንስአኒ፡ እምዳግመ፡ ሞት፡ ውስተ፡ ክነፈኒከ፡ ዘሀሎ፡ ሕይወት፡ <gap reason="omitted" unit="chars" quantity="3"/>
+               </ab>
+           </div>
+           <div type="edition" subtype="textpart" corresp="ms_i1.10.2" xml:lang="gez">
+               <ab>
+                       <hi rend="rubric">ተአምሪሁ፡ ለቅዱስ፡ ሚካኤል፡</hi> ሊቀ፡ መላእክት፡ ትንብልናሁ፡ የሃሉ፡ ምስለ፡ ገብሩ፡ ገረ፡ 
+                       <hi rend="rubric">ወሀሎ፡ ፩ብእሲ፡</hi> ክርስቲያናዊ፡ ዘረከቦ፡ ደዌ፡ እጹበ፡ ወዖራ፡ ፪ሆን፡ ዓዕይንቲሁ፡ ወሶበ፡ ኮነ፡ በአሉ፡ ለቅዱስ፡ 
+                       <hi rend="rubric">ሚካኤል፡</hi> ሊቀ፡ መላእክት፡ ዝውእቱ፡ አመ፡ ፲ወ፪፡ ለህዳር፡ መጽአ፡ ዝ፡ ብእሴ፡ ውስተ፡ ቤተ፡ ክርስቲያን፡ ዘቅዱስ፡ 
+                       <hi rend="rubric">ሚካኤል፡ ሊቀ፡ መላእክት፡ ምስለ፡ ሕዝብ፡</hi> ወሶበ፡ ኮነ፡ አንብባተ፡ ወንጌል፡ በካይ፡ ዝኩ፡ ብእሲ፡ ወበጽአ፡ 
+                       ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ እንዘ፡ ይብል፡ እ<hi rend="ligature">ግዚ</hi>እየ፡ ሊቀ፡ መላእክት፡ 
+                       <hi rend="rubric">ሚካኤል፡</hi> ዘታብተብቍዕ፡ ኩሎ፡ ጊዜ፡ ቅድመ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ 
+                       ሰአል፡ ሊቀ፡ ከመ፡ ይጸግወኑ፡ ብርሃነ፡ ለዓዕይንትየ፡ አነ፡ እኁብ፡ ለቤተ፡ ክርስቲያንከ፡ አምሐ፡ ብዙሐ፡ ወእገብር፡ ተዝካረከ፡ ለለወርሁ፡ በበአልከ፡ ወንተ፡ ብሂለ፡ 
+                       ሰከበ፡ ቅድመ፡ ሰእለ፡ ለመልአከ፡ ወከዊኖ፡ መንፈቀ፡ ሌሊትት፡ አስተርአዮ፡ ቅዱስ፡ <hi rend="rubric">ሚካኤል፡ አን</hi>ቅሐ፡ ወይቤሎ፡ ኦብእሲ፡ 
+                       ኢትርሳእ፡ ዘበጸእከ፡ ብሂሎ፡ አንበረ፡ እዴሁ፡ ዲበ፡ ዓዕይንቲሁ፡ ወወድቀ፡ እም፡ ዓዕንቲሁ፡ ወበጊዜሃ፡ ሐይወ፡ አም፡ ዑረቅ፡ ወርእየ፡ ብርሃነ፡ ወተፈሰ፡ ወአንኮሩ፡ 
+                       አለ፡ ርእዩ፡ ወሰምዑ፡ ዘንተ፡ ተአምረ፡ ዘገብረ፡ ሎቱ፡ <hi rend="rubric">እ<hi rend="ligature">ግዚ</hi>አብሔር፡</hi> በእደዊሁ፡ 
+                       ለቅዱስ፡ <hi rend="rubric">ሚካኤል፡ ሊቀ፡ መላእክ</hi>ት፡ ወነበረ፡ እንዘ፡ የአቍቶ፡ ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ 
+                       ወይዜኑ፡ ኂሩቶ፡ ለቅዱስ፡ <hi rend="rubric">ሚካኤል፡</hi> እከ፡ እለተ፡ ሞቱ፡ ትንብልናሁ፡ የሀሉ፡ ምስለ፡ ገብሩ፡ ገብረ፡ 
+                       <gap reason="omitted" unit="chars" quantity="3"/>ለዓለመ፡ ዓለ፡ ዓሜ።
+               </ab>
+           </div>
+           <div type="edition" subtype="textpart" corresp="ms_i1.10.3" xml:lang="gez">
+               <ab>
+                       <hi rend="rubric">በስመአብ፡ ወወወልድ፡ ወመንፈስ፡ ቅዱስ፡</hi> ፩አምላክ፡ ድርሳን፡ ዘቅዱስ፡ ወክቡር፡ ሊቀ፡ 
+                       መላእክት፡ ወበዛቲ፡ እለት፡ ፈነዎ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ለሚ<hi rend="rubric">ካኤል፡</hi> ኀበ፡ 
+                       <persName ref="PRS3175Constant">ቈስጤጤኖስ፡</persName> ጻድቅ፡ ንጉሥ፡ ሮሜ፡ ወወሀቦ፡ ኃይለ፡ ወምዖሙ፡ ለጸላአቱ፡ እስከ፡ 
+                       ጸንአ፡ መንግሥቱ፡ ወነሐዕ፡ ጣዖታተ፡ ወሐነጸ፡ አብያተ፡ ክርስቲያናት፡ በእንተዝ፡ አዘዙነ፡ መምሕራነ፡ ቤተ፡ ከመ፡ ንግበር፡ በአሎ፡ ለቅዱስ፡ 
+                       <hi rend="rubric">ሚካኤል፡</hi> ሊቀ፡ ምለእክት፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ይምሐሮ፡ ለገብሩ፡ ገብረ፡ 
+                       <gap reason="omitted" unit="chars" quantity="5"/> ለከ፡ ረዳኤ፡ ቅዱሳን፡
+               </ab>
+           </div>
+           <div type="edition" subtype="textpart" corresp="ms_i1.11.3" xml:lang="gez">
+               <ab>
+                   <hi rend="rubric">በስመአብ፡ ወወልድ፡ <cb n="101vb"/>ወመንፈስ፡ ቅዱስ፡</hi> ፩አምላክ፡ አመ፡ 
+                       ፲ወ፪ለመስከረም፡ በዛቲ፡ እለት፡ ተዝካረ፡ በእሉ፡ ለመልአክ፡ ክቦር፡ <gap reason="omitted" unit="chars" quantity="4"/> ሊቀ፡ መላእክት፡ 
+                       እስመ፡ በዛቲ፡ እለት፡ ፈነዎ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ሎቱ፡ ስብሐት፡ ኃበ፡ 
+                       <persName ref="PRS5584Isaiah">ኢሰይይስ፡</persName> ወልደ፡ አሞጽ፡ ወተሣሃለ፡ ላእሌሁ፡ ወመሐር፡ እመቅስፍ፡ ዘተምአ፡ ለእሊሁ፡ 
+                       ፳ወ፰ዓመተ፡ ወአዘዘ፡ ከመ፡ ይሁር፡ ኃበ፡ <persName ref="PRS5330Hezekiah">ሕዝቅያስ፡</persName> ንጉሥ፡ ወዜነዎ፡ ከመ፡ 
+                       እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ፈወሶ፡ እምዳዌሁ፡ ወወሰኮ፡ ዲበ፡ ዓመታቲሁ፡ ፲ወ፪ተ፡ ዓመተ፡ እስከ፡ ወለደ፡ ምናሴሃ፡ 
+                       እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ይምሕሮ፡ ለገብሩ፡ <gap reason="omitted" unit="chars" quantity="5"/>
+               </ab>
+           </div>
+           <div type="edition" subtype="textpart" corresp="ms_i1.11.4" xml:lang="gez">
+               <ab>
+                       <hi rend="rubric">ሰላም፡</hi><pb n="102ra"/> ለምቅዋምከ፡ ዘልዑል፡ መአርጋ፡ እምቅመ፡ አእላፍ፡ ዕንግልጋ፡ 
+                       <gap reason="omitted" unit="chars" quantity="5"/> መንፈሰ፡ እንበለ፡ ሥጋ፡ ታድኅን፡ ዘተመንደበ፡ ለማዕበለ፡ ባህር፡ እምፁጋ፡ 
+                       ወለእሶ፡ በየብስ፡ ትባልህ፡ በጸጋ። 
+               </ab>
+           </div>
+           <div type="edition" subtype="textpart" corresp="ms_i1.12.2" xml:lang="gez">
+               <ab>
+                       <hi rend="rubric">ተአምሪሁ፡ ለ</hi>መልአክ፡ ክቡር፡ <hi rend="rubric">ሚካኤል፡</hi> ል፡ 
+                       ሊቀ፡ መላእክት፡ ትንብልናሁ፡ የሃሉ፡ ምስለ፡ ገብሩ፡ ወሀሎ፡ ፩ብእሲ፡ <hi rend="strikethrough">ፋ</hi>ፈራኄ፡ 
+                       እ<hi rend="ligature">ግዚ</hi><cb n="105vb"/>አብሔር፡ ዘያፈቅር፡ ለቅዱስ፡ <hi rend="rubric">ሚካኤል፡</hi> ሊቀ፡ 
+                       መላእክት፡ ወግብሩ፡ ሐረስ፡ ወበአሐቲ፡ ዓመት፡ ተገበረ፡ ወዘርዓ፡ ገራኅቶ፡ ወአኅለቆ፡ ፅጼ፡ ወኃልቀ፡ ማዕረሩ፡ ወሐጥዓ፡ ዘይበልዕ፡ ወዝ፡ ዘረከበ፡ በእንተ፡ ዘኢገብረ፡ 
+                       በአሉ፡ ሉ፡ ለመልአክ፡ ወተዝከረ፡ ከመ፡ ረስአ፡ ወታንሥዓ፡ ፍጡነ፡ በጕጕዓ፡ ወገብረ፡ ተዝካሮ፡ ለመልአከ፡ <hi rend="rubric">ክቡር፡ ሚካኤል፡</hi>
+                       በምሑረ፡ ነዳያን፡ ወምስኪናን፡ ለኅቡራት፡ ወለ፡ ኦ፡ ነአ፡ ማውታ፡ በእንተ፡ ስሙ፡ እስመ፡ 
+                       እ<hi rend="ligature">ግዚ</hi>አብ<pb n="106ra"/>ሔር፡ መሐሪ፡ ወመሰት፡ ሣህል፡ ሰዐ፡ ነጸሒሩቶ፡ ሚጠ፡ ሎቱ፡ ዝቀዳሚ፡ ብእሱ፡ ወክብረ፡ 
+                       ቤቱ፡ ዘትካት፡ ወአፈድፈዳ፡ ውሂበ፡ መጽዎት፡ እስከ፡ እለተ፡ ሞቱ፡ ትንብልናሁ፡ ምስለ፡ ገብሩ፡ 
+                       <hi rend="rubric"><persName ref="PRS14011GabraMikael" role="owner">ገብረሚካ፡ </persName></hi>ለዓለመ፡ ዓሜን፡
+               </ab>
+           </div>
+           <div type="edition" subtype="textpart" corresp="ms_i1.12.3" xml:lang="gez">
+               <ab>
+                   <hi rend="rubric">በስመአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡</hi> አመ፡ ፲ወ፪ለጥቅምት፡ በዛቲ፡ እለት፡ 
+                       ተዝካረ፡ ሰአሉ፡ ለምል፡ ክቡር፡ <hi rend="rubric">ሚካኤል፡</hi> ሊቀ፡ መላእክክት፡ ወበዛቲ፡ እለት፡ ፈነዎ፡ 
+                       እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ለ<hi rend="rubric">ሚካኤል፡ ሊቀ፡ መላእክት፡ </hi>ኃበ፡ ሳሙኤል፡ ነቢይ፡ እንዘ፡ ሀሉ፡ 
+                       ውስተ፡ ቤተ፡ መቅደስ፡ ወአዘዘ፡ ይሁር፡ ውስተ፡ ቤተ፡ እሴይ፡ ወአንገሣ፡ ሰደዊት፡ ለደቅቂቀ፡ ፳ኤል፡ ሕይገቲሁ፡ ለስውሰል፡ ወልደ፡ ቂስ፡ ወሖረ፡ ሳሙኤል፡ ኃበ፡ 
+                       እሲ፡ ወይቤሎሙ፡ አምጽኖሙ፡ ለደቅቅከ፡ ወአምጸክሙ፡ ዘእንበለ፡ ዳዊት፡ ወሶበ፡ አልአለ፡ ሰሙኤል፡ ቀርነ፡ ቅብዕ፡ ወኢሰምረ፡ ቦሙ፡ 
+                       እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ወይቤሎ፡ ስሙ፡ ዘተርፈ፡ እምውራዱከ፡ ወይቤሎ፡ ለሲደ፡ አወ፡ ሀሎ፡ ዘድንእሰ፡ ወየአቅብ፡ ዓበግዓ፡ 
+                       ውስተ፡ መርህብ፡ ወይቤሎ፡ እስኩ፡ አሞጽ፡ ኦ፡ ወሶበ፡ አሞጽኒ፡ ወአልአለ፡ ቀርነ፡ ቅብሸ፡ ለእለ፡ ዳዊት፡ ፈልኃ፡ ቀርነ፡ ቅብዕ፡ ዘነባሥት፡ ወሠምረ፡ 
+                       እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ሳእለ፡ ዳዊት፡ ወነግሦ፡ ላእለ፡ ፳ኢል፡ ወካዕበ፡ ፈነዎ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ 
+                       ለ<hi rend="rubric">ሚካኤል፡ ኃ</hi>በ፡ ዳዊት፡ ወቀተሉ፡ ለጕልያድ፡ ረአይታዊ፡ ወረድአ፡ ኃይለ፡ ወአድኃኖሙሙ፡ ለ፳ኤል፡ እምቅንያቱ፡ 
+                       ለጐልያድ፡ ወስልበ፡ በአሉ፡ ለማቴዎስ፡ ሐዋርያ፡ ወበእንተዝ፡ አዘዙነ፡ መምሕራነ፡ ቤተ፡ ክርስቲያን፡ ከመ፡ ንግበር፡ በአሎ፡ ለመልአ፡ ክቡር፡ 
+                       <hi rend="rubric">ሚካኤል፡ ሊቀ፡ መላእክት፡ ለቀ፡ መላእ</hi>ክት፡ አመ፡ ፲ወ፪ለለ፡ ወርኅ። ትንብልናሁ፡ የሃሉ፡ ምስለ፡ ገብሩ፡ ገብረ፡
+               </ab>
+           </div>
+           <div type="edition" subtype="textpart" corresp="ms_i1.12.4" xml:lang="gez">
+               <ab>
+                       <hi rend="rubric">ሰላም፡</hi> ለከ፡ ዘገነተ፡ ጽባህ፡ ዖፍ፡ ምሕረተ፡ ኃጥኣን፡ ዘትነቅ፡ በዘኢያረምም፡ ኦፍ፡ 
+                       <hi rend="rubric">ሚካኤል፡ ንሳአኒ፡</hi> ወሕቀፈኒ፡ በክንፍ፡ እይትከየጽ፡ ቅድመ፡ ፀርየ፡ ጊዜ፡ ልስሐ፡ ፄው፡ የዱፍ፡ ወኢደቅ፡ እምክብርይ፡
+                       ከመ፡ ጽጊ፡ ንጕ። <persName role="owner" ref="PRS14011GabraMikael">ገብረሚካኤል</persName>
+               </ab>
+           </div>
         </body>
     </text>
 </TEI>

--- a/VaticanBAV/et/BAVet82.xml
+++ b/VaticanBAV/et/BAVet82.xml
@@ -452,7 +452,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <title type="complete" ref="LIT1295Dersan#CommemorativeSane"/>
                               <incipit xml:lang="gez">
                                  በስመ፡ አብ፡ <gap reason="omitted" extent="unknown" resp="PRS4805Grebaut PRS9530Tisseran"/> አመ፡ ፲ወ፪ለሰኔ፤ በዛቲ፡ ዕለት፤ ያብዕሉ፡ ለቅዱስ፡ ሚካኤል፡ 
-                                 ወምክንያት፤ ዘያብዕሉ፡ ሎቱ፡ ሀሎ፡ በሀገረ፡ እስክንድርያ፡ ዓቢይ፡ ምኵራብ፡ ዘሐነፀቶ፡ አክላቡ፤ ባጥራ፡ ንግሥት፡ ወለተ፡ በጥሊሞስ፤
+                                 ወምክንያት፤ ዘያብዕሉ፡ ሎቱ፡ ሀሎ፡ በሀገረ፡ እስክንድርያ፡ ዓቢይ፡ ምኵራብ፡ ዘሐነፀቶ፡ <persName ref="PRS3137Cleopatr">አክላቡ፤ ባጥራ፡</persName> ንግሥት፡ ወለተ፡ በጥሊሞስ፤
                               </incipit>
                               <explicit xml:lang="gez">
                                  ወበዛቲ፡ <supplied reason="omitted">ዕለት፡</supplied>


### PR DESCRIPTION
Because Marrassini gave a very detailed description of the contents of this manuscript, I wanted to be precise as well. Unfortunately, I was not able to identify the works or individual textparts of LIT1295 in some cases: 

ms_i1.4.2
ms_i1.4.3 (described as "Michael sent to Samson" by Marrassini)
ms_1.5.2
ms_1.11.2
ms_1.12.2

It is likely that in fact these parts can be found in other witnesses of Homily of Mikāʾel, but I could not check in manuscripts but relied on the quoted incipits for BAVet82 and EMIP00016, because I had no access to images for these two or for other related manuscripts. 

I do not understand which manuscript was indicated by Marrassini with A 84 = N 137 in ms.i1.4.1. It is not mentioned in the introductory text. If this note is not very important, it can also deleted. Also I am not sure, whether I encoded the references to manuscripts correctly. 

In describing the quire structure, I differ from Marrassini in quire 10. His account does not match the total number of folios. 

Even more important is another difference in the description of hands. Marrassini thought, there are at least five hands visible, but according to my opinion, there are only two. For the larger part of the manuscript, the size of the pen changes frequently as well as the saturation of the ink, but special features of hand 1 remains constant throughout the codex. It would be nice, if somebody else may have a look to it and may confirm or falsify my judgement! 

Marrassini also gave a lot of general information on other manuscripts, that I did not record. 

A number of new IDs for works and for persons, related to this manuscript will follow in a minute.