### PR TITLE
Update BMLacq680

### DIFF
--- a/FlorenceBML/BMLacq680/BMLacq680.xml
+++ b/FlorenceBML/BMLacq680/BMLacq680.xml
@@ -31,7 +31,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                     <msIdentifier>
                         <repository ref="INS0339BML"/>
                         <collection>Acquisizioni e doni</collection>
-                        <idno facs="Laurenziana/BML_015/BML_015-" n="307">BML Acq. e doni 680</idno>
+                        <idno facs="Laurenziana/BML_015/BML_015-" n="309">BML Acq. e doni 680</idno>
                         <altIdentifier>
                             <idno>Marrassini ms. 15</idno>
                         </altIdentifier>

--- a/FlorenceBML/BMLacq680/BMLacq680.xml
+++ b/FlorenceBML/BMLacq680/BMLacq680.xml
@@ -118,7 +118,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         </msItem>
                         <msItem xml:id="ms_i2">
                            <locus from="29ra" to="291ra"/>
-                            <title ref="LIT4033Senkessar"/>
+                            <title ref="LIT4035SenkessarDL"/>
                            <note>Synaxarion for the first part of the year beginning with the month Maskaram up to Yakkātit.</note>
                                 <msItem xml:id="ms_i2.1">
                                     <locus from="29ra" to="29rb"/>
@@ -216,7 +216,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                             </msItem>
                             <msItem xml:id="ms_i4">
                                 <locus from="291ra" to="291rb"/>
-                                <title ref="LIT0000">Salām</title> 
+                                <title ref="LIT6833Salam"/> 
                             </msItem>
                     </msContents>
                     <physDesc>

--- a/FlorenceBML/BMLacq680/BMLacq680.xml
+++ b/FlorenceBML/BMLacq680/BMLacq680.xml
@@ -536,14 +536,14 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                             <list>
                                 <item xml:id="a1">
                                     <locus target="2v"/>
-                                    <desc type="MixedNote">
-                                        <foreign xml:lang="gez"><hi rend="reversed"><hi rend="rubric">ብርዕ፡ ሠናይ፡ ዘፈተነ፡ በቀለመ፡ ወርቅ፡ ወጥቁር፡ </hi>
-                                        ብርዕ፡ ሠናይ፡ ዘፈተነ፡ በቀለመ፡ ጥቁር፡ </hi></foreign> written upside down on the top right side.</desc>
+                                    <desc type="MixedNote">Note written upside down on the top right side.</desc>
+                                    <q xml:lang="gez"><hi rend="reversed"><hi rend="rubric">ብርዕ፡ ሠናይ፡ ዘፈተነ፡ በቀለመ፡ ወርቅ፡ ወጥቁር፡ </hi>
+                                        ብርዕ፡ ሠናይ፡ ዘፈተነ፡ በቀለመ፡ ጥቁር፡ </hi></q>
                                 </item>
                                 <item xml:id="a2">
                                     <locus target="4v"/>
-                                    <desc type="MixedNote">Table of Contents:
-                                    <foreign xml:lang="am">መጽሐፈ።
+                                    <desc type="MixedNote">Table of Contents.</desc>
+                                    <q xml:lang="am">መጽሐፈ።
                                         <hi rend="rubric">አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ። </hi>
                                         ም፩የስነ፡ ፍጥረትን፡ ነገር፡ የሚያሰረዳ።
                                         ም፪ምሥጢረ፡ ሥጋዊ።
@@ -556,7 +556,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                         የሊቃውንቱም፡ ቃል፡ ያለ<sic resp="CH">በ</sic>ት፡ ነው።
                                         ዓለም፡ ከተፈ<sic resp="CH">ጠ</sic>ረ፡ ጀምሮ፡ ዓለም፡ እስኪያልፍ።
                                         በሃይማኖት፡ የመጣብህን፡ ጠላት፡ ትረታቦታለህ።
-                                        ለተመለከተውም፡ ሰው፡ ሃይማኖቱ፡ የጸና፡ ይሆናል።</foreign></desc>                             
+                                        ለተመለከተውም፡ ሰው፡ ሃይማኖቱ፡ የጸና፡ ይሆናል።</q>
                                 </item>
                                 <item xml:id="e1">
                                     <locus target="#27v #291r"/>

--- a/FlorenceBML/BMLacq680/BMLacq680.xml
+++ b/FlorenceBML/BMLacq680/BMLacq680.xml
@@ -7,6 +7,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
             <titleStmt>
                 <title/>
                 <editor key="AB" role="generalEditor"/>
+                <editor key="CH"></editor>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
             <editionStmt>
@@ -35,6 +36,572 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                             <idno>Marrassini ms. 15</idno>
                         </altIdentifier>
                     </msIdentifier>
+                    <msContents>
+                        <summary/>
+                        <msItem xml:id="ms_i1">
+                            <locus from="5ra" to="27v"/>
+                            <title>Theological texts in Amharic</title>
+                            <note>Preceded by an index by another hand as noted in <ref target="#a2"/>.</note>
+                            <msItem xml:id="ms_i1.1">
+                                <locus from="5ra" to="6v"/>
+                                <title>No. 1 - Explaining the Creation</title>
+                                <incipit xml:lang="am"><hi rend="rubric"><add place="above">ምዕራፍ፡ ፩፡</add> በመጀመሯ፡ እግዚአብሔር፡ ሰማይና፡ ምድርን፡ ብር</hi>ሃንና፡ 
+                                    መላእክትን፡ ፈጠረ። እግዚአብሔር፡ ጨለማንና፡ ብርሃንን፡ ለየ፡ ብ<hi rend="rubric">ርሃኑን፡ ቀን፡ አለው፡ ጨለማውን፡ ሊት፡ አለው። ማ</hi>ታም፡ ሆነ፡ ጧትም፡ ሆነ፡ 
+                                    ፩ዱ፡ ቀን። </incipit>
+                            </msItem> 
+                            <msItem xml:id="ms_i1.2">
+                                <locus from="6v" to="9ra"/>
+                                <title>No. 2 - The Mystery of the Human Body</title>
+                                <incipit xml:lang="am">ምዕራፍ፡ ፪። እንደምን፡ ነው፡ ቢሉ፡ ፪ተኛው፡ አከል፡ አዳም፡ ቀዳማዊ፡ ወልድ፡ ባባቱ፡ ሥምረትና፡ በመንፈስ፡ ቅዱስ፡ ፈቀድ፡ 
+                                    ከመቤታችን፡ ከንጹሕ፡ ሥጋዋ፡ ሥጋ፡ ከነፍሷ፡ ነፍስ፡ ነሥቶ፡ ሰው፡ ነው። </incipit>
+                                <explicit xml:lang="am">ሕዝብና፡ ነገድ፡ ልሳናትም፡ ሁሉ፡ ያመልኩታል፡ አለ፡ አስተውል፤ ሐዋርያት፡ ወደ፡ ሰማይ፡ ሲያርግ፡ ያዩት፡ አምላክ፡ የሆነ፡ ሥጋ፡ 
+                                    አይደለምን። ረቂቁ፡ አምላክማ፡ መውጣት፡ መውረድ፡ የታለበት፡ ወጣ፡ ወረደ፡ ማለት፡ አምላክ፡ ለሆነ፡ ሥጋ፡ ነው፡ ከዚሁ፡ ከክቡር፡ ሥላሲ፡ ምስክርነት፡ ወዲህ፡ 
+                                    አላምንም፡ የሚል፡ መናፍቅ፡ ነው። </explicit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.3">
+                                <locus from="9ra" to="12vc"/>
+                                <title>No. 3 - On the Beliefs of the Unbelievers</title>
+                                <incipit xml:lang="am"><hi rend="rubric"><add place="overstrike">ምዕራፍ፡ ፫፡</add> በተዋህዶ፡ ሃይማኖት፡ ያላመኑ፡ ሰዎች፡ 
+                                    ፩ባሕርይ፡ አለማ</hi>ለታችን፡ ሥላሲ፡ ሥጋ፡ ሆነ። ሥጋ፡ ሥላሲ፡ ሆነ፡ ማለት፡ እንዳሆን፡ <add place="above">ብን፡</add> ብለን፡ ብንፈራ፡ ነው፡ 
+                                    ይላሉ። </incipit>
+                                <explicit xml:lang="am">እርሱም፡ በእግዚአብሔር፡ ይኖራል። ደግሞ፡ ም፡ ፭፡ ቁ፡ ፲፡ በእግዚአብሔር፡ ልጅ፡ የሚያምን፡ ምስክር፡ ለነፍሱ፡ አለው፡ 
+                                    በእግዚአብሔር፡ ልጅ፡ የሚያምን፡ ምስክር፡ ለነፍሱ፡ አለው፡ በእግዚአብሔር፡ ልጅ፡ የማያምን፡ ሐሰተኛ፡ አደረገው፡ እግዚአብሔር፡ ሰለ፡ ልጁ፡ በመሰከረለት፡ 
+                                    ምሰክር፡ አላመነምና፡ አለ። ይሕነን፡ የሐዋርያውን፡ ቃል፡ ማሳበል፡ አይቻለውም፡ ይመሰለኛል። </explicit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.4">
+                                <locus from="12vc" to="18va"/>
+                                <title>No. 4 - On the unseen ascension of the body</title>
+                                <incipit xml:lang="am"><hi rend="rubric"><add place="overstrike">ምዕ፡ ራፍ፡ ፬፡</add> እግዚአብሔር፡ አብ፡ ለኢየ</hi>ሱስ፡ 
+                                    የባሕርይ፡ ልጂ፡ ነው፡ ብሎ፡ ስንት፡ ጊዜ፡ መሰከረ፡ ፪ጊዜ፡ ነው፡ መጀመሯ፡ በ<pb n="13r"/>ዮሐንስ፡ እጅ፡ ሲጠመቅ፡ ከሰማይ፡ ድምጽ፡ መጣ፡ እንዲህ፡ ሲል፡ 
+                                    ይህ፡ ነው፡ ልጂ፡ የምወደው፡ በርሱ፡ ይሰታዬን፡ የማይበት። ማቴዎስ፡ ም፡ ፫፡ ቁ፡ ፲፯፡ ፬ተኛም፡ በደብረ፡ ታቦር፡ ልይ፡ ከደመና፡ ድምፅ፡ መጣ፡ እንዲህ፡ ሲል፡ ይህ፡ ነው፡ 
+                                    የምወደው፡ ልጂ፡ እርሱን፡ ስሙት።</incipit>
+                                <explicit xml:lang="am">ጌታ፡ ከመቃብር፡ በተነሣ፡ ጊዜ፡ በማይታበል፡ ቃሉ፡ እጄንና፡ እግሬን፡ እዩ፡ ጐኒንም፡ ዳሱኝ፡ ነፍስ፡ ሥጋና፡ አጥንት፡ የለውምና። 
+                                    እንድታዩ፡ ለኔ፡ እንዳለኝ። ብሎ፡ ሲመሰክር፡ ጊዜ፡ ረቆ፡ ተነሣ፡ የሚሉ፡ ሰዎች። ረቆ፡ ተነሣማ፡ ካሉ፡ ዮእንደ፡ ሰብአ፡ ዓድረት፡ መሆናችው፡ ነው። </explicit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.5">
+                                <locus from="18va" to="21rb"/>
+                                <title>No. 5 - On the Holy Spirit, that did not descend from the son</title>
+                                <incipit xml:lang="am"><hi rend="rubric"><add place="above">ምዕራፍ፡ ፭፡</add>ዳግሞ፡ በተዋህዶ፡ ሃይ</hi>ማኖት፡ ያላመኑ፡ 
+                                    ሰዎች፡ መንፈስ፡ ቅዱስ፡ ከአብ፡ ብቻ፡ አይደለም፡ የሚሰርፀው፡ ከወልድም፡ ይሠርፃል፡ ይላሉ፡ ከብሉይና፡ ከሐዲሰ፡ የለ፡ ከምን፡ አግኝተውት፡ ነው፤ መንፈስ፡ ቅዱስ፡ 
+                                    ከአብ፡ ብቻ፡ እንዳ፡ ሠረፀ፡ እንደ፡ ቅዱስ፡ ወንጌል። ትእዛዝ፡ እምናልሁ። <placeName ref="LOC2804Egypt">ግብፅ</placeName>ና፡ 
+                                    <hi rend="rubric">ኢትዮጵያ፡</hi> ብቻ፡ አይደለም፡ ዳግሞ፡ እንደዚህ፡ ያለ፡ እምነት፡ የሚይምኑ፡ የመሰኮብና፡ 
+                                    የ<placeName ref="LOC3607Greece">ዮናኒ፡</placeName> ቤተ፡ ክርስቲያን፡ 
+                                    <placeName ref="LOC0000">ኢርመን</placeName>ና፡ <placeName ref="LOC5833Syria">ሶርያ፡</placeName> 
+                                    ናቸው። </incipit>
+                                <explicit xml:lang="am">ከዚህም፡ በኋላ፡ ሔዋንን፡ ከጐኑ፡ ፈጠረ። ግን፡ ፈጠራት፡ ስላልነ። እንደ፡ አዳም፡ ሕያው፡ ነፍስ፡ ነፋባት፡ ብሎ፡ መጽሐፍ፡ ቅዱስ፡ 
+                                    አልነገረንም። ስለሆን፡ ከባት፡ ከናት፡ ነፍስ፡ ስለተፈጠረች፡ ከዘር፡ ጋራ፡ ትከፋፈላለች፡ ተብሎ፡ አይደለም፤ ግዙፍ፡ ከ<add place="above">ግ</add>ዙፍ፡ 
+                                    እንዲከፈል፡ እንዲሁም፡ ረቂቁ፡ ከረቂቅ፡ ይከፈላል።</explicit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.6">
+                                <locus from="21rb" to="24rb"/>
+                                <title>No. 6 - Acts of the Apostles</title>
+                                <incipit xml:lang="am"><hi rend="rubric"><add place="above">ምዕራፍ፡ ፮፡</add>የሐዋርያት፡ ትእዛዝ፡ ስን</hi>ት፡ ነው።
+                                    ያዘዙት፡ ትእዛዝ፡ ብዙ፡ ነው። ዳሩ፡ ግን፡ ዋና፡ ዋናው፡ እሊህ፡ ናቸው። እሁድን፡ አክብረን፡ ቤተ፡ ክርስቲያን፡ ሂዳን፡ ቅዳሴ፡ መሰማት። የጌታ፡ በዓላትን፡ መጠበቅ።
+                                    በሠራነው፡ ኃጢአት፡ መናዘዝ። ሥጋ፡ ወደሙ፡ መቀበል። </incipit>
+                                <explicit xml:lang="am">በራሳችንም፡ ብንፈርድ፡ በልተፈረደብነም፡ ቢፈረድብነም፡ እግዚአብሔር፡ የሚገሥፅ፡ ነው፡ ከአለም፡ ጋራ፡ 
+                                    እን<add place="above">ዳን</add>ኰንን። ቁ፡ ፴፴፩፴፪ብሏልና፡ ተጠንቅቀን፡ መቀበል፡ ይገባናል፡ ይፍሮ፡ መቀበል፡ ሞተ፡ ነፍስ፡ ብቻ፡ አይደለም፡ ሞተ፡ 
+                                    ሥጋም፡ ጭምር፡ ይመጣብናል፡ እንጂ። </explicit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.7">
+                                <locus from="24rb" to="27va"/>
+                                <title>No. 7 - The secret of the priesthood</title>
+                                <note>Contrary to the indication in the aforementioned index in <ref target="#a2"/></note>
+                                <incipit xml:lang="am"><hi rend="rubric"><add place="above">ምዕራፍ፡ ፯፡</add>የክህነት፡ ምሥጢር፡ የክህነት፡ ምሥጢር፡ ማለት፡
+                                    ምን፡ ማለት፡ ነው።</hi> በካህናት፡ አለቆች፡ አንብሮ፡ እድና፡ በመንፈስ፡ ቅዱስ፡ ኃይል፡ የሚፈጽም፡ ስጦታ፡ ነው። በዚህ፡ <cb n="24rc"/>ምሥጢር፡ የቤተ፡ 
+                                    ክርስቲያን፡ የመንፈሳዊ፡ ሥራ፡ ሁሉ፡ ይፈጸምበታል፡ የቤተ፡ ክርስቲያን፡ የመንፈሳዊ፡ መንፈሳዊ፡ ሥራ፡ እንደምንድነው፡ መቀደስ፡ ማጥመቅ፡ ንሥሐ፡ የገቡትን፡ 
+                                    ከኃጢኦት፡ ምፍታት፡ ምዕመናን፡ ማስተማር፡ ነው። </incipit>
+                                <explicit xml:lang="am">የዚያን፡ ጊዜ፡ ጸድቃን፡ ብርሃን፡ ትሸልመው፡ የዘለዓለምን፡ ክብር፡ ይውርሳሉ። ኃጥዓንም፡ ኃፍረት፡ ለብሰው፡ ገሃነም፡ ተፈርይባቸው፡ 
+                                    ፈቃዱን፡ በሠሩለት፡ ከሰይጣን፡ ጋራ፡ ዘለዓለም፡ ሲሣቀዮ፡ ይኖራሉ። ከዚህ፡ ሃይማኖት፡ አያናውጸን፡ አሜን። ዝመጽሐፍ፡ ዘደጃዝማች፡ 
+                                    <persName ref="PRS14025Balca" role="owner">ባልቻ</persName>፡ ወስመ፡ ጥምቀቱ፡ 
+                                    <persName ref="PRS14025Balca" role="owner">ተክለ፡ ሚካኤል፡</persName> 
+                                    ዘወጽአ፡ እምብሉይ፡ ወሐዲስ።</explicit>
+                            </msItem>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                           <locus from="29ra" to="291ra"/>
+                           <title ref="LIT2375Synaxa"/>
+                           <note>Synaxarion for the first part of the year beginning with the month Maskaram up to Yakkātit.</note>
+                                <msItem xml:id="ms_i2.1">
+                                    <locus from="29ra" to="29rb"/>
+                                    <title>Introduction</title>
+                                    <note>Introduction to the Synaxarion with the date of the original Egyptian version to the year 963 era of martyrs.</note>
+                                </msItem>
+                                <msItem xml:id="ms_i2.2">
+                                    <locus from="29rb" to="69vc"/>
+                                    <title>For Maskaram</title>
+                                    <incipit xml:lang="gez">ዝንቱ፡ ወር<hi rend="rubric">ኃ፡ መስከረም፡ ቡሩክ፡ ውእቱ፡ ርእሰ፡ አውራኃ፡ ዓመ</hi>ታት፡ ዘግብፅ፡ ወዘኢትዮጵያሂ፡ 
+                                        መዓልቱ፡ ለዝንቱ፡ ወርኅ፡ ውእቱ፡ ፲ወ፪ሰዓቱ፡ ወእምዝ፡ የሐፅፅ። አመ፡ ፩ለወርኃ፡ መስከረም፡ በእንተ፡ ውእቱ፡ ርእሰ፡ ዓውደ፡ ዓመት፡ ቡርክት፡ ዘግብጽ፡ ወዘኢትዮጵያ።
+                                        ወይእዜኒ፡ ይደልወነ፡ ከመ፡ ንግበር፡ ባቲ፡ በዓለ፡ ዓቢየ፡ በኵሉ፡ ንጽሕና፤ እስመ፡ ይእቲ፡ ዕለት፡ ቅድስት፡ ወቡርክት።</incipit>
+                                    <explicit xml:lang="gez">ወሶበ፡ ርእዩ፡ ጐቡዓን፡ ዘንተ፡ መንክረ፡ ጸርሑ፡ እንዘ፡ ይብሉ፡ ኪርያላይሶን፡ ፫፻ጊዜ፡ ወለይእቲ፡ ቆብዕ፡ ረከብዋ፡ ግድፍተ፡ ወአንበርዋ፡ 
+                                        ውስተ፡ ቤተ፡ ክርስቲያን፡ በዓቢይ፡ ክብር፡ ወነበረት፡ እንዘ፡ ትገብር፡ ተአምረ፡ ወመንክረ፡ ወትፌውሰ፡ ድውያነ። ወሶበ፡ ሰምዓ፡ ሊቀ፡ ጳጳሳት፡ ፈቀደ፡ ይንስአ፡ ለይእቲ፡ 
+                                        ቆብዕ። ከመ፡ ይትባረክ፡ እምኔሃ። ወለለ፡ ይወሰድዋ፡ ትትመየጥ፡ ውስተ፡ ደብር፡ ወከመዝ፡ ኮነ፡ ፫ጊዜ። ወዝኩኒ፡ መነኮስ፡ እምድኅረ፡ ብዙኅ፡ መዋዕል፡ በከመ፡ 
+                                        በዛቲ፡ ዕለት፡ አዕረፈ፡ በሰላም፡ እግዚአብሔር፡ ይምሐሮ፡ በጸሎቱ፡ ለፍቁሩ፡ 
+                                        <hi rend="rubric"><persName ref="PRS14025Balca" role="owner">ተክለ፡ ሚካኤል፡</persName></hi> ለዓለመ፡ ዓለም። 
+                                        አሜን።
+                                        <hi rend="rubric">ሰላም፡</hi> ለአብ፡ ሣሉስ፡ ጥበቦ፡ ዘሠወረ። መሲሆ፡ በነግህ፡ እንዘ፡ ይጸውም፡ ድራረ። አኅድጎተ፡ ዝንቱ፡ ልማድ፡ ሶበ፡ አበ፡ ምኔት፡ መከረ።
+                                        ዘቤጦ፡ በቆብዑ፡ ዓረፍተ፡ መቅደሰ፡ ሰቈረ። ወእንተ፡ ህየ፡ ወፂኦ፡ እምዓለም። ሖረ። </explicit>
+                                </msItem>
+                                <msItem xml:id="ms_i2.3">
+                                    <locus from="70ra" to="109vc"/>
+                                    <title>For Ṭəqəmt</title>
+                                    <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አ</hi>ምላክ፡ ወርኃ፡ ጥቅምት፡ ቡሩክ፡ መዓልቱ፡ 
+                                        ፲<hi rend="rubric">ወ፩ሰዓቱ። ወእምዝ፡ የሐፅፅ፡ አመ፡ ፩ለጥ</hi>ቅምት፡ በዛቲ፡ ዕለት፡ ኮነት፡ ቅድስት፡ 
+                                        <persName ref="PRS12248Anestasya">አንስጣስያ፡</persName> ሰማዕት፡ ዛቲ፡ መስተጋድልት፡ 
+                                        ኮነት፡ <hi rend="rubric">እምሰብአ፡ ሀገረ፡ ሮሜ፡ ወኮኑ፡ አበዊሃ፡ ክ</hi>ርስቲያነ፡ ወሐፀንዋ፡ በኵሉ፡ ክብር፡ ወሠናይ፡ ሥርዓት፡ በትምህርት፡ በቋዒት፡ 
+                                        ለነፍስ፡ ወሥጋ፡ ወበትምህርተ፡ ቤተ፡ <sic resp="CH">ክርስቲን።</sic></incipit>
+                                    <explicit xml:lang="gez">ወበዛቲ፡ ዕለት፡ ካዕበ፡ ተዝካሮሙ፡ ለፋሊቡና፡ ወካይና፡ ወአስተርእዮተ፡ ርእሱ፡ 
+                                        ለ<persName ref="PRS5741Johnthe">ዮሐንስ፡ መጥምቅ፡</persName> ወመቴስ፡ ወማርሰ፡ እግዚአብሔር፡ 
+                                        <add place="margin">ይምሐረነ፡ ወ</add>ይምሐሮ<del rend="erasure" unit="chars" quantity="1"/>፡ በጸሎቶሙ፡ 
+                                        ለፍቁ<add place="overstrike">ሮሙ፡ </add>
+                                        <hi rend="rubric"><persName ref="PRS14025Balca" role="owner">ተክለ፡ ሚካኤል፡</persName></hi> ለዓለመ፡ 
+                                        <cb n="109vc"/> ዓለም፡ አሜን። 
+                                        <hi rend="rubric">ሰላም፡ ለከ፡ </hi>ዲማትርዮስ፡ ሰማዕት። ርጉዘ፡ ገቦ፡ በኵናት። እስእለከ፡ ሕጽረኒ፡ በጽጌ፡ ቅዱሳት። ኢያመዓርዕር፡ ጕርኤየ፡ ጸቃውዓ፡ ዘማ፡ ኅሥርት።
+                                        ፈዳዬ፡ ስሑል፡ መጥባሕት፡ ወመሪር፡ <del rend="erasure">ሐ</del>ሞት። ሰላም፡ እብል፡ ለሰማዕት፡ ሰቅጥር። ፍቁረ፡ ደማትርዮስ፡ ማር። ወሰላም፡ ለረድኡ፡ እንተ፡ ድኅሬሁ፡ 
+                                        ምቱር። በልብሱ፡ ወኅልቀቱ፡ ጥ<add place="overstrike">መ</add>ዳነ፡ ደሙ፡ ክቡር። ገባሬ፡ ኃይል፡ ዓቢይ፡ ወእፁብ፡ መንክር። </explicit>
+                                </msItem>
+                                <msItem xml:id="ms_i2.4">
+                                    <locus from="110ra" to="150vc"/>
+                                    <title>For Ḫədār</title>
+                                    <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አ</hi>ምላክ፡ ወርኃ፡ ኅዳር፡ ቡሩክ፡ መዓልቱ፡ ፲ቱ፡ 
+                                        ሰዓት፡ ወእምዝ፡ የሐፅፅ። አመ፡ <hi rend="rubric">፩ለኅዳር፡ በዛቲ፡ ዕለት፡ ኮኑ፡ ቅዱሳን፡ መስተጋድላን፡</hi> ሰማዕታት፡ 
+                                        መክሲሞስ፡ ወመንፍዮስ፡ ወፊቅጦር፡ ወፊልጶስ። እሉ፡ መስተጋ<add place="above">ድ</add>ላ<add place="inline">ን</add>፡ 
+                                        ቅዱሳን፡ ኮኑ፡ እምሰብአ፡ ሀገረ፡ አፍራቅያ። ወእሙንቱሰ፡ አኃው፡ በመንፈስ፡ ቅዱስ። ወአኮ፡ በሥጋ፡ ወተጋብኡ፡ ኅቡረ፡ በበናቲሆሙ፡ በእንተ፡
+                                        <hi rend="rubric">ፍቅሩ፡ ለክርስቶስ፡ ወኮነ፡ መዋዕሊሁ፡ ለዳኬዎስ፡</hi> ከሐዲ።</incipit>
+                                    <explicit xml:lang="gez">ተፈጸመ፡ ምንባብ፡ ዘወርኃ፡ ኅዳር፡ ለኂሩቱ፡ ወሣህሉ፡ ለእግዚአብሔር፡ ዘሎቱ፡ ይደሉ፡ ክብር፡ ወስብሐት፡ እስከ፡ ለዓለመ፡ ዓለም፡
+                                        አሜን። ኦአምላክ፡ ጻድቃን፡ ወሰማዕት፡ ኢታኅጥአነ፡ ተስፋ፡ ለእለ፡ ፃመውነ፡ በጽሒፈ፡ ዝንቱ፡ መጽሐፍ፡ በዝ፡ ዓለም፡ ወበዘይመጽእ።</explicit>
+                                </msItem>
+                                <msItem xml:id="ms_i2.5">
+                                    <locus from="151ra" to="201va"/>
+                                    <title>For Tāḫśāś</title>
+                                    <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩</hi>ምላክ። ወርኃ፡ ታኅሣሥ፡ ቡሩክ፡ መዓልቱ፡ 
+                                        <hi rend="rubric">ወ፱ሰዓቱ፡ ወእምዝ፡ ይትዌሰክ፡ አመ፡ አሚ</hi>ሩ፡ በዛቲ፡ ሰለት፡ አስተርአየ፡ ኤልያስ፡ ነቢይ፡ ቅድመ፡ እስራኤል፡ እስመ፡ ዝንቱ፡
+                                        ኢልያስ፡ ቀናኢ።</incipit>
+                                    <explicit xml:lang="gez"><hi rend="rubric">ወበዛቲ፡ ዕለት፡ ካዕበ፡</hi> ያብዕሉ፡ ሰብአ፡ ኢትዮጵያ። ተዝካረ፡ ሕፃናት፡ ዘቤተ፡ ልሔም፡ 
+                                        ዘቀተሎሙ፡ ሄሮድስ፡ ዓላዊ። ወዜናሆሙሰ፡ ጽሁፍ፡ አመ፡ ፫ለጥር፡ ጸሎቶሙ፡ ወበረከቶሙ፡ የሃሉ፡ ምስለ፡ ፍቁሮሙ፡ 
+                                        <persName ref="PRS14025Balca" role="owner">ተ<hi rend="rubric">ክለ፡ ሚካኤል፡</hi></persName> ለዓለመ፡ 
+                                        ዓለም፡ አሜን። <hi rend="rubric">ሰላም፡</hi> እብል፡ ለለ፡ ፩፩ዱ። ዘክልዔ፡ ዓመታት፡ ወዘይውኅዱ። በእንተ፡ ልደቱ፡ ለቃል፡ አመ፡ በሳይፍ፡
+                                        ተገምዱ። ሕፃናት፡ ንጹሐን፡ ወጽሩያን፡ ነገዱ። ከመ፡ እምአንስት፡ እሙንቱ፡ ተወልዱ። ተፈጸመ፡ ምንባብ፡ ዘወርኃ፡ ታሕሣሥ።</explicit>
+                                </msItem>
+                                <msItem xml:id="ms_i2.6">
+                                    <locus from="202ra" to="255rb"/>
+                                    <title>For Ṭərr</title>
+                                    <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አም</hi>ላክ፡ ወርኃ፡ ጥር፡ ቡሩክ፡ መዓልቱ፡ ዓሠርቱ፡
+                                        ሰዓቱ፡ ወእምዝ፡ ይትዌ<add place="overstrike">ሰክ፡</add> አመ፡ ፩ለጥር። በዛ<hi rend="rubric">ቲ፡ ዕለት፡ ኮነ፡ ቅዱስ፡ ሐዋርያ፡ 
+                                        እጢፋኖስ፡ ሊ</hi>ቀ፡ ዲያቆናት፡ ወቀዳሜ፡ ሰማዕት፡ ለዝንቱ፡ ቅዱስ፡ መጽሐፈ፡ ግብረ፡ ሐዋርያት። ስምዓ፡ ኮነ፡ ሎቱ፡ ወበእንቲአሁ፡ እስመ፡ ውእቱ፡ ኮነ፡ ምሉዓ፡
+                                        ጸጋ፡ በመንፈስ፡ ቅዱስ፡ ወኃይል፡ ወይገብር፡ ተአምራተ፡ ወመንክራተ፡ በውስተ፡ አሕዛብ። </incipit>
+                                    <explicit xml:lang="gez"><hi rend="rubric">ለዘጸሐፎ፡</hi> በክርተስ፤ ወለዘአጽሐፎ፡ እንዘ፡ ይደርስ። ለዘአንበቦ፡ ወለዘተርጐሞ፡ በልሳን፡ 
+                                        ሐዲስ። ወለዘስምዓ፡ ቃሎ፡ በዕዝነ፡ መንፈስ። በጸሎተ፡ እሙ፡ <hi rend="rubric">ማርያም፡</hi> አራቂተ፡ ኵሉ፡ እምባዕስ። ኅቡረ፡ ይምሐረነ፡ ኢየሱስ፡ 
+                                        <hi rend="rubric">ክርስቶስ፡</hi> ስብሐት፡ ለእግዚእየ፡ ወአምላኪየ፡ ዘአፈጸመኒ፡ በዕላም፡ ይእዜኒ፡ ጸግወኒ፡ እምብዙኅ፡ ሣህልከ፡ ሊተ፡ ለኃጥእ፡ ገበርከ። 
+                                            </explicit>
+                                </msItem>
+                                <msItem xml:id="ms_i2.7">
+                                    <locus from="256ra" to="291ra"/>
+                                    <title>For Yakkātit</title>
+                                    <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡ ወ</hi>ወርኃ፡ የካቲት፡ ቡሩክ፡ መዓልቱ፡ ፲ወ፩ዱ፡ 
+                                        ሰዓቱ፡ ወእ<hi rend="rubric">ምዝ፡ ይትዌሰክ፡ ወየሐጽፅ፡ አመ፡ ፩ለየካቲት፡ ወበዛቲ፡</hi> ዕለት፡ ኮነ፡ ጉባኤ፡ ማኅበረ፡ አበው፡ ቅዱሳን፡ ፻ወ፶ኤጲስ፡ ቆጶሳት፡
+                                        እለ፡ ተጋብኡ፡ በሀገረ፡ <placeName ref="LOC2196Consta">ቍስጥንጥንያ፡</placeName> በመዋዕለ፡ መንግሥቱ፡ 
+                                        ለ<persName ref="PRS9479Theodosi">ቴዎዶስዮስ፡</persName> ንጉሥ፡ ዘየዓቢ፡ ወኮነ፡ ተጋብኦቶሙ፡ በእንተ፡ 
+                                        <persName ref="PRS6432Macedoni">መቅዶንዮስ፡</persName> ሊቀ፡ ጳጳሳት፡ ዘኮነ፡ ላዕለ፡ ሀገረ፡ 
+                                        <placeName ref="LOC2196Consta">ቍስጥንጥንያ፡</placeName>። </incipit>
+                                    <explicit xml:lang="gez">ወአዘዞሙ፡ ከመ፡ ያዕርጉ፡ ርእሶ፡ ቅድስተ፡ ወአዕረግዋ፡ እምውስተ፡ ውእ<pb n="291ra"/>ቱ፡ መካን፡ ወፆርዋ፡ ወወለድዋ፡ ኀበ፡ 
+                                        ቤቶሙ፡ ምስሌሆሙ፡ ወእክበርዋ፡ ክብረ፡ ዓቢየ፡ ትንብልናሁ፡ የሃሉ፡ ምስለ፡ ፍቁሩ። 
+                                        <hi rend="rubric"><persName ref="PRS14025Balca" role="owner">ተክለ፡ ሚካኤል፡</persName></hi> ለዓለመ፡ ዓለም፡ አሜን። 
+                                        ወበዛቲ፡ ዕለት፡ ካዕበ። ተዝካሩ፡ ለአፃ፡ ሚናስ፡ ሊቀ፡ ጳጳሳት፡ ዘሀገረ፡ እስክንድርያ፡ ጸሎቱ፡ ወበረከቱ፡ የሃሉ፡ ምስለ፡ ፍቁሩ፡ 
+                                        <hi rend="rubric"><persName ref="PRS14025Balca" role="owner">ተክለ፡ ሚካኤል፡</persName></hi> ለዓለመ፡ ዓለም፡ አሜን።
+                                            </explicit>
+                                </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i3">
+                                <locus target="#291ra"/>
+                                <title ref="LIT4630Zaaqrabku"/>
+                            </msItem>
+                            <msItem xml:id="ms_i4">
+                                <locus from="291ra" to="291rb"/>
+                                <title ref="LIT0000">Salām</title> 
+                            </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Codex">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"></material>
+                                    <p>Holes in e.g. <locus target="#43 #45 #59 #81 #86 #93 #94"/> without textloss.</p>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf">293</measure>
+                                    <measure unit="leaf" type="blank">15</measure><locus target="#1r #1v #2r #2v #3r #3v #4r #28r #28v #255r #291v #292r #292v #293r #293v"/>
+                                    <dimensions unit="mm">
+                                        <height>455</height>
+                                        <width>317</width>                                        
+                                    </dimensions>
+                                </extent>
+                                <foliation>Number of folios with pencil on the bottom left of every recto.</foliation>
+                                <collation>
+                                    <list>
+                                        <item xml:id="q1" n="A">
+                                            <dim unit="leaf">4</dim>
+                                            <locus from="1" to="4"/>
+                                        </item>
+                                        <item xml:id="q2" n="1"> 
+                                            <dim unit="leaf">11</dim>
+                                            <locus from="5" to="15"/>
+                                            s.l. 10, stub after 1
+                                        </item>
+                                        <item xml:id="q3" n="2">
+                                            <dim unit="leaf">13</dim>
+                                            <locus from="16" to="28"/>
+                                            s.l. 2, stub after 12
+                                        </item>
+                                        <item xml:id="q4" n="3">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="29" to="38"/>
+                                        </item>
+                                        <item xml:id="q5" n="4">
+                                            <dim unit="leaf">12</dim>
+                                            <locus from="39" to="50"/>
+                                        </item>
+                                        <item xml:id="q6" n="5">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="51" to="60"/>
+                                        </item>
+                                        <item xml:id="q7" n="6">
+                                            <dim unit="leaf">9</dim>
+                                            <locus from="61" to="69"/>
+                                            s.l. 3, stub after 7
+                                        </item>
+                                        <item xml:id="q8" n="7">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="70" to="79"/>
+                                            s.l. 3, stub after 7
+                                            s.l. 8, stub after 3
+                                        </item>
+                                        <item xml:id="q9" n="8">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="80" to="89"/>
+                                        </item>
+                                        <item xml:id="q10" n="9">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="90" to="99"/>
+                                        </item>
+                                        <item xml:id="q11" n="10">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="100" to="109"/>
+                                            s.l. 2, stub after 9
+                                            s.l. 9, stub after 2
+                                        </item>
+                                        <item xml:id="q12" n="11">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="110" to="119"/>
+                                        </item>
+                                        <item xml:id="q13" n="12">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="120" to="129"/>
+                                        </item>
+                                        <item xml:id="q14" n="13">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="130" to="139"/>
+                                        </item>
+                                        <item xml:id="q15" n="14">
+                                            <dim unit="leaf">11</dim>
+                                            <locus from="140" to="150"/>
+                                            s.l. 3, stub after 8
+                                            s.l. 8, stub after 3
+                                            s.l. 10, stub after 1
+                                        </item>
+                                        <item xml:id="q16" n="15">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="151" to="160"/>
+                                        </item>
+                                        <item xml:id="q17" n="16">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="161" to="170"/>
+                                            s.l. 3, stub after 7
+                                            s.l. 8, stub after 2
+                                        </item>
+                                        <item xml:id="q18" n="17">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="171" to="180"/>
+                                            s.l. 3, stub after 7
+                                            s.l. 8, stub after 2
+                                        </item>
+                                        <item xml:id="q19" n="18">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="181" to="190"/>
+                                        </item>
+                                        <item xml:id="q20" n="19">
+                                            <dim unit="leaf">11</dim>
+                                            <locus from="191" to="201"/>
+                                            s.l. 5, stub after 7
+                                        </item>
+                                        <item xml:id="q21" n="20">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="202" to="211"/>
+                                        </item>
+                                        <item xml:id="q22" n="21">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="212" to="221"/>
+                                        </item>
+                                        <item xml:id="q23" n="22">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="222" to="231"/>
+                                        </item>
+                                        <item xml:id="q24" n="23">
+                                            <dim unit="leaf">12</dim>
+                                            <locus from="232" to="243"/>
+                                            s.l. 3, stub after 10
+                                            s.l. 5, stub after 8
+                                            s.l. 8, stub after 5
+                                            s.t. 10, stub after 3
+                                        </item>
+                                        <item xml:id="q25" n="24">
+                                            <dim unit="leaf">12</dim>
+                                            <locus from="244" to="255"/>
+                                        </item>
+                                        <item xml:id="q26" n="25">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="256" to="265"/>
+                                        </item>
+                                        <item xml:id="q27" n="26">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="266" to="275"/>
+                                        </item>
+                                        <item xml:id="q28" n="27">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="276" to="285"/>
+                                        </item>
+                                        <item xml:id="q29" n="28">
+                                            <dim unit="leaf">8</dim>
+                                            <locus from="286" to="293"/>
+                                        </item>
+                                    </list>
+                                </collation>
+                                <condition key="intact">With smaller watersheds in the margins and on the textblock on several folia.</condition>
+                            </supportDesc>
+                            <layoutDesc><layout columns="3" writtenLines="35">
+                                <ab type="pricking">Pricking is visible</ab>
+                                <ab type="ruling">Ruling is visible</ab>
+                            </layout>
+                            </layoutDesc>
+                        </objectDesc>
+                        <handDesc>
+                            <handNote xml:id="h1" script="Ethiopic">
+                                <locus from="5r" to="15v"/>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Titles, incipits, sacred names and name of the owner.</seg>
+                                <seg type="script">Careful script of the nineteenth or early 20th century.</seg>
+                                <note>Contrary to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">87</citedRange>
+                                </bibl>, who considered <ref target="h1"/>, <ref target="h2"/> and <ref target="h3"/>to be made by the same hand.</note>
+                            </handNote>
+                            <handNote xml:id="h2" script="Ethiopic">
+                                <locus from="16r" to="23ra"/>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Titles, incipits, sacred names and name of the owner.</seg>
+                                <seg type="script">Careful script of the nineteenth or early 20th century.</seg>
+                                <note>Contrary to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">87</citedRange>
+                                </bibl>, who considered <ref target="h1"/>, <ref target="h2"/> and <ref target="h3"/>to be made by the same hand.</note>
+                            </handNote>
+                            <handNote xml:id="h3" script="Ethiopic">
+                                <locus from="23ra" to="27va"/><locus from="47rb" to="50vc"/><locus from="181ra" to="190vc"/>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Titles, incipits, sacred names and name of the owner.</seg>
+                                <seg type="script">Careful script of the nineteenth or early 20th century.</seg>
+                                <note>Contrary to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">87</citedRange>
+                                </bibl>, who considered <ref target="h1"/>, <ref target="h2"/> and <ref target="h3"/>to be made by the same hand.
+                                    Contains <hi rend="ligature">ግዚ</hi> and <hi rend="ligature">ብሔ</hi> in <locus target="#48ra"/>.
+                                    Possibly the same hand as table of contents on <ref target="a1"/></note>
+                            </handNote>
+                            <handNote xml:id="h4" script="Ethiopic">
+                                <locus from="28ra" to="45rc"/>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Titles, incipits, sacred names and name of the owner.</seg>
+                                <seg type="script">Careful script of the nineteenth or early 20th century.</seg>
+                                <note>Contrary to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">87</citedRange>
+                                </bibl>, who considered <ref target="h1"/>, <ref target="h2"/> and <ref target="h3"/>to be made by the same hand.</note>
+                            </handNote>
+                            <handNote xml:id="h5" script="Ethiopic">
+                                <locus from="45rc" to="47rb"/>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Titles, incipits, sacred names and name of the owner.</seg>
+                                <seg type="script">Careful script of the nineteenth or early 20th century.</seg>
+                                <note>Contains <hi rend="ligature">ግዚ</hi> throughout.</note>
+                            </handNote>
+                            <handNote xml:id="h6" script="Ethiopic">
+                                <locus from="51ra" to="60vc"/>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Titles, incipits, sacred names and name of the owner.</seg>
+                                <seg type="script">Careful script of the nineteenth or early 20th century.</seg>
+                            </handNote>
+                            <handNote xml:id="h7" script="Ethiopic">
+                                <locus from="61ra" to="69vc"/><locus from="129rc" to="129vc"/>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Titles, incipits, sacred names and name of the owner.</seg>
+                                <seg type="script">Careful script of the nineteenth or early 20th century.</seg>
+                            </handNote>
+                            <handNote xml:id="h8" script="Ethiopic">
+                                <locus from="70ra" to="109vc"/>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Titles, incipits, sacred names and name of the owner.</seg>
+                                <seg type="script">Careful script of the nineteenth or early 20th century.</seg>
+                                <note>Contrary to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">87</citedRange>
+                                </bibl>, who considered <locus from="102r" to="109v"/> to be made by the subsequent hand <ref target="h9"/>.</note>
+                            </handNote>
+                            <handNote xml:id="h9" script="Ethiopic">
+                                <locus from="110ra" to="129rb"/>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Titles, incipits, sacred names and name of the owner.</seg>
+                                <seg type="script">Careful script of the nineteenth or early 20th century.</seg>
+                            </handNote>
+                            <handNote xml:id="h10" script="Ethiopic">
+                                <locus from="129rb" to="129rc"/>
+                                <seg type="ink">Black.</seg>
+                                <seg type="script">Very small and squat script of the nineteenth or early 20th century.</seg>
+                            </handNote>
+                            <handNote xml:id="h11" script="Ethiopic">
+                                <locus from="130ra" to="150vc"/>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Titles, incipits, sacred names and name of the owner.</seg>
+                                <seg type="script">Careful script of the nineteenth or early 20th century.</seg>
+                                <note>Contrary to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">87</citedRange>
+                                </bibl>, who considered <locus from="149r" to="150v"/> to be made by the subsequent hand <ref target="h12"/>.</note>
+                            </handNote> 
+                            <handNote xml:id="h12" script="Ethiopic">
+                                <locus from="151ra" to="180vc"/>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Titles, incipits, sacred names and name of the owner.</seg>
+                                <seg type="script">Careful script of the nineteenth or early 20th century in comparison to the others with less high and more 
+                                    wide characters.</seg>
+                                <note>Contrary to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">87</citedRange>
+                                    </bibl>, who considered <locus from="153r" to="153v"/> and <locus from="154r" to="180v"/> to be made by other hands.</note>
+                                <note>Occurence of <foreign rend="gez">ዠ</foreign> in a specific form with dashes at all ends on 
+                                    <locus target="#152rc"/>. <hi rend="ligature">ግዚ</hi> on <locus target="#153rb"/>.</note>
+                            </handNote>
+                            <handNote xml:id="h13" script="Ethiopic">
+                                <locus from="191ra" to="210ra"/>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Titles, incipits, sacred names and name of the owner.</seg>
+                                <seg type="script">Careful script of the nineteenth or early 20th century.</seg>
+                                <note>Contrary to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">87</citedRange>
+                                </bibl>, who considered <locus from="210v" to="221r"/> to be made by another hand.</note>
+                            </handNote>
+                            <handNote xml:id="h14" script="Ethiopic">
+                                <locus from="210ra" to="221vc"/>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Titles, incipits, sacred names and name of the owner.</seg>
+                                <seg type="script">Careful script of the nineteenth or early 20th century.</seg>
+                            </handNote>
+                            <handNote xml:id="h15" script="Ethiopic">
+                                <locus target="#213ra"/>
+                                <seg type="ink">Black.</seg>
+                                <seg type="script">Careful script of the nineteenth or early 20th century.</seg>
+                                <note>Text of the lower third of the first column erased and superscribed by another hand, that is very similar to 
+                                    <ref target="h3"/>.</note>
+                            </handNote>
+                            <handNote xml:id="h16" script="Ethiopic">
+                                <locus from="222ra" to="231vc"/>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Titles, incipits, sacred names and name of the owner.</seg>
+                                <seg type="script">Careful script of the nineteenth or early 20th century.</seg>
+                                <note>Contrary to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">87</citedRange>
+                                </bibl>, who considered <locus from="229v" to="231v"/> to be made by the same hand as <ref target="h17"/>.</note>
+                            </handNote>
+                            <handNote xml:id="h17" script="Ethiopic">
+                                <locus from="232ra" to="255rb"/>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Titles, incipits, sacred names and name of the owner.</seg>
+                                <seg type="script">Careful script of the nineteenth or early 20th century.</seg>
+                            </handNote>    
+                            <handNote xml:id="h18" script="Ethiopic">
+                                <locus from="256ra" to="275vc"/>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Titles, incipits, sacred names and name of the owner.</seg>
+                                <seg type="script">Careful script of the nineteenth or early 20th century.</seg>
+                                <note>Contrary to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">87</citedRange>
+                                    </bibl>, who considered <locus target="#273r"/> to be made by another hand and and <locus from="273r" to="275v"/>
+                                    to be made by the same hand as <ref target="h19"/>.</note>
+                            </handNote>
+                            <handNote xml:id="h19" script="Ethiopic">
+                                <locus from="276ra" to="291ra"/>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Titles, incipits, sacred names and name of the owner.</seg>
+                                <seg type="script">Careful, more rounded script of the nineteenth or early 20th century.</seg>
+                            </handNote>
+                            <handNote xml:id="h20" script="Ethiopic">
+                                <locus from="291ra" to="291rb"/>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Titles, incipits, sacred names and name of the owner.</seg>
+                                <seg type="script">Careful, more rounded script with a smaller pen of the nineteenth or early 20th century.</seg>
+                            </handNote>
+                        </handDesc>
+                        <additions>
+                            <list>
+                                <item xml:id="a1">
+                                    <locus target="2v"/>
+                                    <desc type="MixedNote">
+                                        <foreign xml:lang="gez"><hi rend="reversed"><hi rend="rubric">ብርዕ፡ ሠናይ፡ ዘፈተነ፡ በቀለመ፡ ወርቅ፡ ወጥቁር፡ </hi>
+                                        ብርዕ፡ ሠናይ፡ ዘፈተነ፡ በቀለመ፡ ጥቁር፡ </hi></foreign> written upside down on the top right side.</desc>
+                                </item>
+                                <item xml:id="a2">
+                                    <locus target="4v"/>
+                                    <desc type="MixedNote">Table of Contents:
+                                    <foreign xml:lang="am">መጽሐፈ።
+                                        <hi rend="rubric">አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ። </hi>
+                                        ም፩የስነ፡ ፍጥረትን፡ ነገር፡ የሚያሰረዳ።
+                                        ም፪ምሥጢረ፡ ሥጋዊ።
+                                        ም፫በተዋህዶ፡ ሃይማኖት፡ ላላመኑ፡ ሰዎች።
+                                        ም፬በሥጋ፡ ኢየታየ፡ እንዳረገ።
+                                        ም፭መንፈስ፡ ቅዱስ፡ ከወልድ፡ እንዳልሠረፀ።
+                                        ም፮የሐዋርያት፡ ትእዛዝ።
+                                        ም፯መለኮት፡ በአካል፡ ፫እንዳይባል። 
+                                        ይህ፡ መጽሐፍ፡ የሰማንያ፡ አንድ፡ መጽሐፍ፡ ቃል።
+                                        የሊቃውንቱም፡ ቃል፡ ያለ<sic resp="CH">በ</sic>ት፡ ነው።
+                                        ዓለም፡ ከተፈ<sic resp="CH">ጠ</sic>ረ፡ ጀምሮ፡ ዓለም፡ እስኪያልፍ።
+                                        በሃይማኖት፡ የመጣብህን፡ ጠላት፡ ትረታቦታለህ።
+                                        ለተመለከተውም፡ ሰው፡ ሃይማኖቱ፡ የጸና፡ ይሆናል።</foreign></desc>                             
+                                </item>
+                                <item xml:id="e1">
+                                    <locus target="#27v #291r"/>
+                                    <desc type="StampExlibris">Big oval stamp of Daǧǧazmāčč <persName ref="PRS14025Balca" role="owner"/> 
+                                        with floral elements as well as with an ornament depicting the earth with buildings standing on it, with canons and with 
+                                        an inscription with the name of the owner in reversed fidal script: <foreign rend="am">ባልቻ፡</foreign>.</desc>
+                                </item>
+                                <item xml:id="e2">
+                                    <locus target="#2v #34r #291v"/>
+                                    <desc type="StampExlibris">Small round stamp with the inscription 
+                                        <foreign rend="lat">BIBL. MED. LAUR. FLOR.</foreign>.</desc>
+                                </item>
+                                <item xml:id="e3">
+                                    <locus target="1r"/>
+                                    <desc type="StampExlibris">"64928" written in pencil by a recent European hand on top left.</desc>
+                                </item>
+                                <item xml:id="e4">
+                                    <locus target="1r"/>
+                                    <desc type="StampExlibris">"A. D. 680" written in pencil by a recent European hand on top left, probably by 
+                                        another hand as <ref target="e5"/> and <ref target="e6"></ref>.</desc>
+                                </item>
+                                <item xml:id="e5">
+                                    <locus target="1r"/>
+                                    <desc type="StampExlibris">"Acq. e Doni 680" written by a recent European hand in the central part of the page, 
+                                        probably by the same hand as <ref target="e6"/>, but by another as <ref target="e4"/>.</desc>
+                                    </item>
+                                <item xml:id="e6">
+                                    <locus target="2r"/>
+                                    <desc type="MixedNote"><foreign rend="it">"Manoscritto amarico in 290 carte membran."</foreign>
+                                        written in pencil by a recent European hand in the central part of the page, probably by the same hand as 
+                                        <ref target="e5"/>, but by another as <ref target="e4"/></desc>
+                                </item>
+                            </list>
+                        </additions>
+                        <bindingDesc>
+                            <binding>
+                                <decoNote xml:id="b1" type="Boards">Two wooden boards, covered with brown leather, decorated 
+                                    with cross and geometric designs on the entire external surface; 
+                                    boards covered with blue fabric with floral decoration from the inside, over which the leather of the
+                                    cover is folded.</decoNote>    
+                                <decoNote xml:id="b2" type="SewingStations">5</decoNote>
+                                <decoNote xml:id="b3" type="bindingMaterial"><material key="wood"></material></decoNote>
+                            </binding>
+                        </bindingDesc>
+                    </physDesc>
                     <history>
                     </history>
                     <additional>
@@ -65,24 +632,42 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
         <profileDesc>
-            <langUsage><language ident="en">English</language></langUsage>
+            <langUsage><language ident="en">English</language><language ident="gez">Gəʿəz</language>
+                <language ident="am">Amharic</language><language ident="la">Latin</language><language ident="it">Italian</language></langUsage>
         </profileDesc>
         <revisionDesc>
             <change who="PL" when="2019-02-21">Created catalogue entry</change>
             <change when="2021-09-20" who="PL">added text from transkribus and facsimile with xi:include</change>
+            <change when="2023-05-12" who="CH">Added Contents and physical description</change>
         </revisionDesc>
     </teiHeader>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" 
-        href="facsimile.xml">
-        <xi:fallback>
-            <!-- facsimile -->
-        </xi:fallback>
-    </xi:include>
-
-            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" 
-                href="transkribusText.xml">
-                <xi:fallback>
-                    <!-- transkribus text -->
-                </xi:fallback>
-            </xi:include>
+    <text xml:base="https://betamasaheft.eu/">
+        <body>
+            <div type="edition" subtype="textpart" corresp="#ms_i2.1" xml:lang="gez">
+                <ab><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላ</hi>ክ፡ ንዌጥን፡ በረድኤተ፡ እግዚአብሔር። ወበሠናይ፡ ሀብቱ፡ ጽሒፈ፡ 
+                    መጽ<hi rend="rubric">ሐፈ፡ ስንክሣር፡ ዘበትርጓሜሁ፡ ጉባኤ፡ ዘቀዱሕዎ፡</hi> አበዊነ፡ ቅዱሳን፡ መምህራን፡ ዘቤተ፡ ክርስቲያን፡ አብ፡ ክቡር፡ 
+                    <persName ref="PRS0000">አባ፡ ሚካኤል፡</persName> ኤጲስ፡ ቆጶስ፡ ዘሀገረ፡ <placeName ref="LOC0000">አትሪብ፡ </placeName>
+                    ወ<placeName ref="LOC0000">መሊግ</placeName>። ወአብ፡ ክቡር፡ <persName ref="PRS0000">አባ፡ ዮሐንስ፡</persName> 
+                    ኤጲስቆጶስ፡ ዘሀገረ፡ <placeName ref="LOC0000"></placeName>ቡርልስ። ወካላንሂ፡ አበው፡ ቅዱሳን፡ ወክቡራን፡ እለ፡ አስተጋብእዎ፡ ለዝንቱ፡ መጽሐፍ፤
+                    እምነ፡ ገድላት፡ ዘመላእክት፡ ወዘነቢያት፡ ወዘሐዋርያት። ዘጻድቃን፡ ወዘሰማዕታት፡ ወሊቃነ፡ <hi rend="rubric">ጳጳሳት፡ ወቅዱሳን፡ ወገዳማውያን፡ 
+                    ወመነኮሳት፡ ከ</hi>መ፡ ይግበሩ፡ ተዝካሮሙ፡ ወያንብቡ፡ ገድሎሙ፡ ኵሎ፡ አሚረ፡ እምሠርቀ፡ አሚሩ፡ ለመስከረም፡ እስከ፡ ዓመት፡ ወተፍጻሜቱ። ወኮነ፡ 
+                    አስተጋብኦቶሙ፡ ለዝንቱ፡ በ፱፻፷ወ፫ዓመተ፡ ሰማዕታት፡ ንጹሐን፡ ጸሎቶሙ፡ ወሀብተ፡ ረድኤቶሙ፡ 
+                    ቦሃ<hi rend="rubric">ሉ፡ ምስለ፡ ፍቁሮሙ፡ <persName ref="PRS14025Balca">ተክለ፡ ሚካኤል፡</persName></hi> ለዓለመ፡ ዓለም፡ 
+                    አሜን፡ ወአሜን፡ ለይኩን፡ ለይኩን። </ab>
+            </div>
+            <div type="edition" corresp="#ms_i3" xml:lang="gez">
+                <ab><hi rend="rubric">ዘአቅረብኩ፡</hi> ማኅሌተ፡ አዘኪርየ፡ አዕላፈ። እምእለ፡ ተፀምዱከ፡ ዘልፈ። ለለአነብብ፡ ተወከፍ፡ ዘንዴትየ፡ መጽሐፈ። 
+                    እንተ፡ ረሰይከ፡ እግዚአ፡ ጸሪቀ፡ መበለት፡ ውኩፈ። እምእለ፡ አብኡ፡ ብዑላን፡ ተረፈ። <hi rend="rubric">ነቢያት፡</hi> ቅዱሳን፡ ወሐዋርያት፡ ሰባክያን። 
+                    ሰማዕት፡ ወጸድቃን፡ ወመላእክት፡ ትጉሃን። ደናግል፡ ዓዲ፡ ወመነኮሳት፡ ኂራን፤ ባርኮ፡ ባርኩ፡ ጉባዒ፡ ዛቲ፡ መካን። እስከ፡ አረጋዊ፡ ልሂቅ፡ እምንዑስ፡ ሕፃን።</ab>
+            </div>
+            <div type="edition" corresp="#ms_i4" xml:lang="gez">
+                <ab><hi rend="rubric">ሰላም፡</hi> ለክሙ፡ ጻድቃን፡ ወሰማዕት። እለ፡ አዕረፍክሙ፡ በዛቲ፡ ዕለት። መዋዕያነ፡ ዓለም፡ <cb n="291rb"/>አንትሙ፡ 
+                    በብዙኅ፡ ትዕግሥት። ሰአሉ፡ ቅድመ፡ ፈጣሪ፡ በኵሉ፡ ሰዓት። እንበለ፡ ንስሐ፡ ኪያነ፡ ኢይንሣእ፡ ሞት። <hi rend="rubric">ለዘጸሐሮ፡</hi> በክርታስ። ወለዘአጽሐፎ፡
+                    እንዘ፡ ይደርስ። ለዘአንበቦ፡ ወለዘተርጐሞ፡ በልሳን፡ ሐዲስ። ወለዘሰምዓ፡ ቃሎ፡ በዕዝነ፡ መንፈስ። በጸሎተ፡ እሙ፡ <hi rend="rubric">ማርያም፡</hi> ዓራቂተ፡ ኵሉ፡ 
+                    እምባዕስ። ኅቡረ፡ ይምሐረነ፡ ኢየሱስ፡ ክርስቶስ። ዝመጽሐፍ፡ ዘደጃዝማች፡ <persName ref="PRS14025Balca" role="owner">ባልቻ፡</persName>
+                    ወስመ፡ ጥምቀቱ፡ <hi rend="rubric"><persName ref="PRS14025Balca" role="owner">ተክለ፡ ሚካኤል፡</persName></hi> ዘወሀባ፡ 
+                    ለሀገረ፡ ሰላም፡ ኪዳነ፡ ምሕረት፡ ዘሠረቆ፡ ወዘፈሐቆ፡ በሥልጣነ፡ ጴጥሮስ፡ ወጳውሎስ፡ ውጉዘ፡ ለይኩን።</ab>
+            </div>
+        </body>
+    </text>
 </TEI>

--- a/FlorenceBML/BMLacq680/BMLacq680.xml
+++ b/FlorenceBML/BMLacq680/BMLacq680.xml
@@ -229,6 +229,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                 <extent>
                                     <measure unit="leaf">293</measure>
                                     <measure unit="leaf" type="blank">15</measure><locus target="#1r #1v #2r #2v #3r #3v #4r #28r #28v #255r #291v #292r #292v #293r #293v"/>
+                                    <note>Folios <locus from="6v" to="7r"/> and <locus from="179v" to="180r"/> are not digitized.</note>
                                     <dimensions unit="mm">
                                         <height>455</height>
                                         <width>317</width>                                        

--- a/FlorenceBML/BMLacq680/BMLacq680.xml
+++ b/FlorenceBML/BMLacq680/BMLacq680.xml
@@ -142,7 +142,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                 </msItem>
                                 <msItem xml:id="ms_i2.3">
                                     <locus from="70ra" to="109vc"/>
-                                    <title>For Ṭəqəmt</title>
+                                    <title>For Ṭǝqǝmt</title>
                                     <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አ</hi>ምላክ፡ ወርኃ፡ ጥቅምት፡ ቡሩክ፡ መዓልቱ፡ 
                                         ፲<hi rend="rubric">ወ፩ሰዓቱ። ወእምዝ፡ የሐፅፅ፡ አመ፡ ፩ለጥ</hi>ቅምት፡ በዛቲ፡ ዕለት፡ ኮነት፡ ቅድስት፡ 
                                         <persName ref="PRS12248Anestasya">አንስጣስያ፡</persName> ሰማዕት፡ ዛቲ፡ መስተጋድልት፡ 
@@ -160,7 +160,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                 </msItem>
                                 <msItem xml:id="ms_i2.4">
                                     <locus from="110ra" to="150vc"/>
-                                    <title>For Ḫədār</title>
+                                    <title>For Ḫǝdār</title>
                                     <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አ</hi>ምላክ፡ ወርኃ፡ ኅዳር፡ ቡሩክ፡ መዓልቱ፡ ፲ቱ፡ 
                                         ሰዓት፡ ወእምዝ፡ የሐፅፅ። አመ፡ <hi rend="rubric">፩ለኅዳር፡ በዛቲ፡ ዕለት፡ ኮኑ፡ ቅዱሳን፡ መስተጋድላን፡</hi> ሰማዕታት፡ 
                                         መክሲሞስ፡ ወመንፍዮስ፡ ወፊቅጦር፡ ወፊልጶስ። እሉ፡ መስተጋ<add place="above">ድ</add>ላ<add place="inline">ን</add>፡ 
@@ -183,7 +183,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                 </msItem>
                                 <msItem xml:id="ms_i2.6">
                                     <locus from="202ra" to="255rb"/>
-                                    <title>For Ṭərr</title>
+                                    <title>For Ṭǝrr</title>
                                     <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አም</hi>ላክ፡ ወርኃ፡ ጥር፡ ቡሩክ፡ መዓልቱ፡ ዓሠርቱ፡
                                         ሰዓቱ፡ ወእምዝ፡ ይትዌ<add place="overstrike">ሰክ፡</add> አመ፡ ፩ለጥር። በዛ<hi rend="rubric">ቲ፡ ዕለት፡ ኮነ፡ ቅዱስ፡ ሐዋርያ፡ 
                                         እጢፋኖስ፡ ሊ</hi>ቀ፡ ዲያቆናት፡ ወቀዳሜ፡ ሰማዕት፡ ለዝንቱ፡ ቅዱስ፡ መጽሐፈ፡ ግብረ፡ ሐዋርያት። ስምዓ፡ ኮነ፡ ሎቱ፡ ወበእንቲአሁ፡ እስመ፡ ውእቱ፡ ኮነ፡ ምሉዓ፡
@@ -638,7 +638,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
         <profileDesc>
-            <langUsage><language ident="en">English</language><language ident="gez">Gəʿəz</language>
+            <langUsage><language ident="en">English</language><language ident="gez">Gǝʿǝz</language>
                 <language ident="am">Amharic</language><language ident="la">Latin</language><language ident="it">Italian</language></langUsage>
         </profileDesc>
         <revisionDesc>

--- a/FlorenceBML/BMLacq680/BMLacq680.xml
+++ b/FlorenceBML/BMLacq680/BMLacq680.xml
@@ -86,7 +86,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                     ከአብ፡ ብቻ፡ እንዳ፡ ሠረፀ፡ እንደ፡ ቅዱስ፡ ወንጌል። ትእዛዝ፡ እምናልሁ። <placeName ref="LOC2804Egypt">ግብፅ</placeName>ና፡ 
                                     <hi rend="rubric">ኢትዮጵያ፡</hi> ብቻ፡ አይደለም፡ ዳግሞ፡ እንደዚህ፡ ያለ፡ እምነት፡ የሚይምኑ፡ የመሰኮብና፡ 
                                     የ<placeName ref="LOC3607Greece">ዮናኒ፡</placeName> ቤተ፡ ክርስቲያን፡ 
-                                    <placeName ref="LOC0000">ኢርመን</placeName>ና፡ <placeName ref="LOC5833Syria">ሶርያ፡</placeName> 
+                                    <placeName ref="LOC7374Armenia">ኢርመን</placeName>ና፡ <placeName ref="LOC5833Syria">ሶርያ፡</placeName> 
                                     ናቸው። </incipit>
                                 <explicit xml:lang="am">ከዚህም፡ በኋላ፡ ሔዋንን፡ ከጐኑ፡ ፈጠረ። ግን፡ ፈጠራት፡ ስላልነ። እንደ፡ አዳም፡ ሕያው፡ ነፍስ፡ ነፋባት፡ ብሎ፡ መጽሐፍ፡ ቅዱስ፡ 
                                     አልነገረንም። ስለሆን፡ ከባት፡ ከናት፡ ነፍስ፡ ስለተፈጠረች፡ ከዘር፡ ጋራ፡ ትከፋፈላለች፡ ተብሎ፡ አይደለም፤ ግዙፍ፡ ከ<add place="above">ግ</add>ዙፍ፡ 
@@ -111,15 +111,14 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                     ክርስቲያን፡ የመንፈሳዊ፡ ሥራ፡ ሁሉ፡ ይፈጸምበታል፡ የቤተ፡ ክርስቲያን፡ የመንፈሳዊ፡ መንፈሳዊ፡ ሥራ፡ እንደምንድነው፡ መቀደስ፡ ማጥመቅ፡ ንሥሐ፡ የገቡትን፡ 
                                     ከኃጢኦት፡ ምፍታት፡ ምዕመናን፡ ማስተማር፡ ነው። </incipit>
                                 <explicit xml:lang="am">የዚያን፡ ጊዜ፡ ጸድቃን፡ ብርሃን፡ ትሸልመው፡ የዘለዓለምን፡ ክብር፡ ይውርሳሉ። ኃጥዓንም፡ ኃፍረት፡ ለብሰው፡ ገሃነም፡ ተፈርይባቸው፡ 
-                                    ፈቃዱን፡ በሠሩለት፡ ከሰይጣን፡ ጋራ፡ ዘለዓለም፡ ሲሣቀዮ፡ ይኖራሉ። ከዚህ፡ ሃይማኖት፡ አያናውጸን፡ አሜን። ዝመጽሐፍ፡ ዘደጃዝማች፡ 
-                                    <persName ref="PRS14025Balca" role="owner">ባልቻ</persName>፡ ወስመ፡ ጥምቀቱ፡ 
-                                    <persName ref="PRS14025Balca" role="owner">ተክለ፡ ሚካኤል፡</persName> 
-                                    ዘወጽአ፡ እምብሉይ፡ ወሐዲስ።</explicit>
+                                    ፈቃዱን፡ በሠሩለት፡ ከሰይጣን፡ ጋራ፡ ዘለዓለም፡ ሲሣቀዮ፡ ይኖራሉ። ከዚህ፡ ሃይማኖት፡ አያናውጸን፡ አሜን። ዝመጽሐፍ፡ 
+                                    ዘ<persName ref="PRS2435Balcasa" role="owner"><roleName type="title">ደጃዝማች፡</roleName> ባልቻ፡</persName> 
+                                    ወስመ፡ ጥምቀቱ፡ <persName ref="PRS2435Balcasa" role="owner">ተክለ፡ ሚካኤል፡</persName> ዘወጽአ፡ እምብሉይ፡ ወሐዲስ። </explicit>
                             </msItem>
                         </msItem>
                         <msItem xml:id="ms_i2">
                            <locus from="29ra" to="291ra"/>
-                           <title ref="LIT2375Synaxa"/>
+                            <title ref="LIT4033Senkessar"/>
                            <note>Synaxarion for the first part of the year beginning with the month Maskaram up to Yakkātit.</note>
                                 <msItem xml:id="ms_i2.1">
                                     <locus from="29ra" to="29rb"/>
@@ -136,7 +135,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                         ውስተ፡ ቤተ፡ ክርስቲያን፡ በዓቢይ፡ ክብር፡ ወነበረት፡ እንዘ፡ ትገብር፡ ተአምረ፡ ወመንክረ፡ ወትፌውሰ፡ ድውያነ። ወሶበ፡ ሰምዓ፡ ሊቀ፡ ጳጳሳት፡ ፈቀደ፡ ይንስአ፡ ለይእቲ፡ 
                                         ቆብዕ። ከመ፡ ይትባረክ፡ እምኔሃ። ወለለ፡ ይወሰድዋ፡ ትትመየጥ፡ ውስተ፡ ደብር፡ ወከመዝ፡ ኮነ፡ ፫ጊዜ። ወዝኩኒ፡ መነኮስ፡ እምድኅረ፡ ብዙኅ፡ መዋዕል፡ በከመ፡ 
                                         በዛቲ፡ ዕለት፡ አዕረፈ፡ በሰላም፡ እግዚአብሔር፡ ይምሐሮ፡ በጸሎቱ፡ ለፍቁሩ፡ 
-                                        <hi rend="rubric"><persName ref="PRS14025Balca" role="owner">ተክለ፡ ሚካኤል፡</persName></hi> ለዓለመ፡ ዓለም። 
+                                        <hi rend="rubric"><persName ref="PRS2435Balcasa" role="owner">ተክለ፡ ሚካኤል፡</persName></hi> ለዓለመ፡ ዓለም። 
                                         አሜን።
                                         <hi rend="rubric">ሰላም፡</hi> ለአብ፡ ሣሉስ፡ ጥበቦ፡ ዘሠወረ። መሲሆ፡ በነግህ፡ እንዘ፡ ይጸውም፡ ድራረ። አኅድጎተ፡ ዝንቱ፡ ልማድ፡ ሶበ፡ አበ፡ ምኔት፡ መከረ።
                                         ዘቤጦ፡ በቆብዑ፡ ዓረፍተ፡ መቅደሰ፡ ሰቈረ። ወእንተ፡ ህየ፡ ወፂኦ፡ እምዓለም። ሖረ። </explicit>
@@ -149,11 +148,11 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                         <persName ref="PRS12248Anestasya">አንስጣስያ፡</persName> ሰማዕት፡ ዛቲ፡ መስተጋድልት፡ 
                                         ኮነት፡ <hi rend="rubric">እምሰብአ፡ ሀገረ፡ ሮሜ፡ ወኮኑ፡ አበዊሃ፡ ክ</hi>ርስቲያነ፡ ወሐፀንዋ፡ በኵሉ፡ ክብር፡ ወሠናይ፡ ሥርዓት፡ በትምህርት፡ በቋዒት፡ 
                                         ለነፍስ፡ ወሥጋ፡ ወበትምህርተ፡ ቤተ፡ <sic resp="CH">ክርስቲን።</sic></incipit>
-                                    <explicit xml:lang="gez">ወበዛቲ፡ ዕለት፡ ካዕበ፡ ተዝካሮሙ፡ ለፋሊቡና፡ ወካይና፡ ወአስተርእዮተ፡ ርእሱ፡ 
-                                        ለ<persName ref="PRS5741Johnthe">ዮሐንስ፡ መጥምቅ፡</persName> ወመቴስ፡ ወማርሰ፡ እግዚአብሔር፡ 
+                                    <explicit xml:lang="gez">ወበዛቲ፡ ዕለት፡ ካዕበ፡ ተዝካሮሙ፡ ለ<persName ref="PRS14034FalibulaKayna">ፋሊቡና፡ ወካይና፡</persName> 
+                                        ወአስተርእዮተ፡ ርእሱ፡ ለ<persName ref="PRS5741Johnthe">ዮሐንስ፡ መጥምቅ፡</persName> ወመቴስ፡ ወማርሰ፡ እግዚአብሔር፡ 
                                         <add place="margin">ይምሐረነ፡ ወ</add>ይምሐሮ<del rend="erasure" unit="chars" quantity="1"/>፡ በጸሎቶሙ፡ 
                                         ለፍቁ<add place="overstrike">ሮሙ፡ </add>
-                                        <hi rend="rubric"><persName ref="PRS14025Balca" role="owner">ተክለ፡ ሚካኤል፡</persName></hi> ለዓለመ፡ 
+                                        <hi rend="rubric"><persName ref="PRS2435Balcasa" role="owner">ተክለ፡ ሚካኤል፡</persName></hi> ለዓለመ፡ 
                                         <cb n="109vc"/> ዓለም፡ አሜን። 
                                         <hi rend="rubric">ሰላም፡ ለከ፡ </hi>ዲማትርዮስ፡ ሰማዕት። ርጉዘ፡ ገቦ፡ በኵናት። እስእለከ፡ ሕጽረኒ፡ በጽጌ፡ ቅዱሳት። ኢያመዓርዕር፡ ጕርኤየ፡ ጸቃውዓ፡ ዘማ፡ ኅሥርት።
                                         ፈዳዬ፡ ስሑል፡ መጥባሕት፡ ወመሪር፡ <del rend="erasure">ሐ</del>ሞት። ሰላም፡ እብል፡ ለሰማዕት፡ ሰቅጥር። ፍቁረ፡ ደማትርዮስ፡ ማር። ወሰላም፡ ለረድኡ፡ እንተ፡ ድኅሬሁ፡ 
@@ -178,7 +177,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                         ኢልያስ፡ ቀናኢ።</incipit>
                                     <explicit xml:lang="gez"><hi rend="rubric">ወበዛቲ፡ ዕለት፡ ካዕበ፡</hi> ያብዕሉ፡ ሰብአ፡ ኢትዮጵያ። ተዝካረ፡ ሕፃናት፡ ዘቤተ፡ ልሔም፡ 
                                         ዘቀተሎሙ፡ ሄሮድስ፡ ዓላዊ። ወዜናሆሙሰ፡ ጽሁፍ፡ አመ፡ ፫ለጥር፡ ጸሎቶሙ፡ ወበረከቶሙ፡ የሃሉ፡ ምስለ፡ ፍቁሮሙ፡ 
-                                        <persName ref="PRS14025Balca" role="owner">ተ<hi rend="rubric">ክለ፡ ሚካኤል፡</hi></persName> ለዓለመ፡ 
+                                        <persName ref="PRS2435Balcasa" role="owner">ተ<hi rend="rubric">ክለ፡ ሚካኤል፡</hi></persName> ለዓለመ፡ 
                                         ዓለም፡ አሜን። <hi rend="rubric">ሰላም፡</hi> እብል፡ ለለ፡ ፩፩ዱ። ዘክልዔ፡ ዓመታት፡ ወዘይውኅዱ። በእንተ፡ ልደቱ፡ ለቃል፡ አመ፡ በሳይፍ፡
                                         ተገምዱ። ሕፃናት፡ ንጹሐን፡ ወጽሩያን፡ ነገዱ። ከመ፡ እምአንስት፡ እሙንቱ፡ ተወልዱ። ተፈጸመ፡ ምንባብ፡ ዘወርኃ፡ ታሕሣሥ።</explicit>
                                 </msItem>
@@ -205,9 +204,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                         <placeName ref="LOC2196Consta">ቍስጥንጥንያ፡</placeName>። </incipit>
                                     <explicit xml:lang="gez">ወአዘዞሙ፡ ከመ፡ ያዕርጉ፡ ርእሶ፡ ቅድስተ፡ ወአዕረግዋ፡ እምውስተ፡ ውእ<pb n="291ra"/>ቱ፡ መካን፡ ወፆርዋ፡ ወወለድዋ፡ ኀበ፡ 
                                         ቤቶሙ፡ ምስሌሆሙ፡ ወእክበርዋ፡ ክብረ፡ ዓቢየ፡ ትንብልናሁ፡ የሃሉ፡ ምስለ፡ ፍቁሩ። 
-                                        <hi rend="rubric"><persName ref="PRS14025Balca" role="owner">ተክለ፡ ሚካኤል፡</persName></hi> ለዓለመ፡ ዓለም፡ አሜን። 
+                                        <hi rend="rubric"><persName ref="PRS2435Balcasa" role="owner">ተክለ፡ ሚካኤል፡</persName></hi> ለዓለመ፡ ዓለም፡ አሜን። 
                                         ወበዛቲ፡ ዕለት፡ ካዕበ። ተዝካሩ፡ ለአፃ፡ ሚናስ፡ ሊቀ፡ ጳጳሳት፡ ዘሀገረ፡ እስክንድርያ፡ ጸሎቱ፡ ወበረከቱ፡ የሃሉ፡ ምስለ፡ ፍቁሩ፡ 
-                                        <hi rend="rubric"><persName ref="PRS14025Balca" role="owner">ተክለ፡ ሚካኤል፡</persName></hi> ለዓለመ፡ ዓለም፡ አሜን።
+                                        <hi rend="rubric"><persName ref="PRS2435Balcasa" role="owner">ተክለ፡ ሚካኤል፡</persName></hi> ለዓለመ፡ ዓለም፡ አሜን።
                                             </explicit>
                                 </msItem>
                             </msItem>
@@ -589,6 +588,12 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                         written in pencil by a recent European hand in the central part of the page, probably by the same hand as 
                                         <ref target="e5"/>, but by another as <ref target="e4"/></desc>
                                 </item>
+                                <item xml:id="e7">
+                                    <locus target="#232rb"/>
+                                    <desc type="OwnershipNote">Name of the previous owner <foreign xml:lang="gez">አስካለ፡ ማርያም፡</foreign>, 
+                                        that is probably empress <persName ref="PRS10671Zawditu"/> with her baptismal name, that was erased and
+                                        followed by the name of the later owner <persName ref="PRS2435Balcasa"/>.</desc>
+                                </item>
                             </list>
                         </additions>
                         <bindingDesc>
@@ -646,13 +651,14 @@ schematypens="http://relaxng.org/ns/structure/1.0"
             <div type="edition" subtype="textpart" corresp="#ms_i2.1" xml:lang="gez">
                 <ab><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላ</hi>ክ፡ ንዌጥን፡ በረድኤተ፡ እግዚአብሔር። ወበሠናይ፡ ሀብቱ፡ ጽሒፈ፡ 
                     መጽ<hi rend="rubric">ሐፈ፡ ስንክሣር፡ ዘበትርጓሜሁ፡ ጉባኤ፡ ዘቀዱሕዎ፡</hi> አበዊነ፡ ቅዱሳን፡ መምህራን፡ ዘቤተ፡ ክርስቲያን፡ አብ፡ ክቡር፡ 
-                    <persName ref="PRS0000">አባ፡ ሚካኤል፡</persName> ኤጲስ፡ ቆጶስ፡ ዘሀገረ፡ <placeName ref="LOC0000">አትሪብ፡ </placeName>
-                    ወ<placeName ref="LOC0000">መሊግ</placeName>። ወአብ፡ ክቡር፡ <persName ref="PRS0000">አባ፡ ዮሐንስ፡</persName> 
-                    ኤጲስቆጶስ፡ ዘሀገረ፡ <placeName ref="LOC0000"></placeName>ቡርልስ። ወካላንሂ፡ አበው፡ ቅዱሳን፡ ወክቡራን፡ እለ፡ አስተጋብእዎ፡ ለዝንቱ፡ መጽሐፍ፤
+                    <persName ref="PRS7054Michael">አባ፡ ሚካኤል፡</persName> ኤጲስ፡ ቆጶስ፡ ዘሀገረ፡ 
+                    <placeName ref="LOC7373Atrib">አትሪብ፡ </placeName>ወ<placeName ref="LOC7375Malig">መሊግ</placeName>። 
+                    ወአብ፡ ክቡር፡ <persName ref="PRS14031John"><roleName type="title">አባ፡ </roleName>ዮሐንስ፡</persName> 
+                    ኤጲስቆጶስ፡ ዘሀገረ፡ <placeName ref="LOC7372Paralos">ቡርልስ</placeName>። ወካላንሂ፡ አበው፡ ቅዱሳን፡ ወክቡራን፡ እለ፡ አስተጋብእዎ፡ ለዝንቱ፡ መጽሐፍ፤
                     እምነ፡ ገድላት፡ ዘመላእክት፡ ወዘነቢያት፡ ወዘሐዋርያት። ዘጻድቃን፡ ወዘሰማዕታት፡ ወሊቃነ፡ <hi rend="rubric">ጳጳሳት፡ ወቅዱሳን፡ ወገዳማውያን፡ 
                     ወመነኮሳት፡ ከ</hi>መ፡ ይግበሩ፡ ተዝካሮሙ፡ ወያንብቡ፡ ገድሎሙ፡ ኵሎ፡ አሚረ፡ እምሠርቀ፡ አሚሩ፡ ለመስከረም፡ እስከ፡ ዓመት፡ ወተፍጻሜቱ። ወኮነ፡ 
                     አስተጋብኦቶሙ፡ ለዝንቱ፡ በ፱፻፷ወ፫ዓመተ፡ ሰማዕታት፡ ንጹሐን፡ ጸሎቶሙ፡ ወሀብተ፡ ረድኤቶሙ፡ 
-                    ቦሃ<hi rend="rubric">ሉ፡ ምስለ፡ ፍቁሮሙ፡ <persName ref="PRS14025Balca">ተክለ፡ ሚካኤል፡</persName></hi> ለዓለመ፡ ዓለም፡ 
+                    ቦሃ<hi rend="rubric">ሉ፡ ምስለ፡ ፍቁሮሙ፡ <persName ref="PRS2435Balcasa">ተክለ፡ ሚካኤል፡</persName></hi> ለዓለመ፡ ዓለም፡ 
                     አሜን፡ ወአሜን፡ ለይኩን፡ ለይኩን። </ab>
             </div>
             <div type="edition" corresp="#ms_i3" xml:lang="gez">
@@ -664,8 +670,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                 <ab><hi rend="rubric">ሰላም፡</hi> ለክሙ፡ ጻድቃን፡ ወሰማዕት። እለ፡ አዕረፍክሙ፡ በዛቲ፡ ዕለት። መዋዕያነ፡ ዓለም፡ <cb n="291rb"/>አንትሙ፡ 
                     በብዙኅ፡ ትዕግሥት። ሰአሉ፡ ቅድመ፡ ፈጣሪ፡ በኵሉ፡ ሰዓት። እንበለ፡ ንስሐ፡ ኪያነ፡ ኢይንሣእ፡ ሞት። <hi rend="rubric">ለዘጸሐሮ፡</hi> በክርታስ። ወለዘአጽሐፎ፡
                     እንዘ፡ ይደርስ። ለዘአንበቦ፡ ወለዘተርጐሞ፡ በልሳን፡ ሐዲስ። ወለዘሰምዓ፡ ቃሎ፡ በዕዝነ፡ መንፈስ። በጸሎተ፡ እሙ፡ <hi rend="rubric">ማርያም፡</hi> ዓራቂተ፡ ኵሉ፡ 
-                    እምባዕስ። ኅቡረ፡ ይምሐረነ፡ ኢየሱስ፡ ክርስቶስ። ዝመጽሐፍ፡ ዘደጃዝማች፡ <persName ref="PRS14025Balca" role="owner">ባልቻ፡</persName>
-                    ወስመ፡ ጥምቀቱ፡ <hi rend="rubric"><persName ref="PRS14025Balca" role="owner">ተክለ፡ ሚካኤል፡</persName></hi> ዘወሀባ፡ 
+                    እምባዕስ። ኅቡረ፡ ይምሐረነ፡ ኢየሱስ፡ ክርስቶስ። ዝመጽሐፍ፡ 
+                    ዘ<persName ref="PRS2435Balcasa" role="owner"><roleName type="title">ደጃዝማች፡</roleName> ባልቻ፡</persName>
+                    ወስመ፡ ጥምቀቱ፡ <hi rend="rubric"><persName ref="PRS2435Balcasa" role="owner">ተክለ፡ ሚካኤል፡</persName></hi> ዘወሀባ፡ 
                     ለሀገረ፡ ሰላም፡ ኪዳነ፡ ምሕረት፡ ዘሠረቆ፡ ወዘፈሐቆ፡ በሥልጣነ፡ ጴጥሮስ፡ ወጳውሎስ፡ ውጉዘ፡ ለይኩን።</ab>
             </div>
         </body>


### PR DESCRIPTION
The images of BMLacq680 are not complete. The scan images for folio 6v-7r (after scan page 8) as well as for folio 179v-180r (after scan 180). It can be discerned from the folio marks (bottom left) and from the text, that is not fitting.

In encoding the quire structure and the description of hands, I differed a lot from P. Marrassini. As well the last textpart (ms_i3 and ms_i4) are encoded independently contrary to Marrassinis account (See also Issue  #2367). Also I treated the index on f. 4v, I as an addition because it is by another hand as most of ms_i1 but not as the incipit of ms_i1, as Marrassini did.