### PR TITLE
Updated BMLor148

### DIFF
--- a/FlorenceBML/BMLor148.xml
+++ b/FlorenceBML/BMLor148.xml
@@ -38,6 +38,800 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      <idno>Marrassini ms. 16</idno>
                   </altIdentifier>
                </msIdentifier>
+               <msContents>
+                  <msItem xml:id="ms_i1">
+                     <locus from="3ra" to="3rb"/><locus target="#4vb"/>
+                     <title>Monastery rule</title>
+                     <note>Document of the Ethiopian community of Jerusalem, dated to 524 year of mercy, i.e. to 1321/1322 AD, concerning rules
+                        of the convent, edited and translated in 
+                        <bibl><ptr target="bm:Cerulli19431947EtiopiI-II"/><citedRange unit="page">380-382</citedRange></bibl>.</note>
+                  </msItem>
+                  <msItem xml:id="ms_i2">
+                     <locus from="4ra" to="4va"/>
+                     <title ref="LIT6841MawArsima"/>
+                     <note>According to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">91</citedRange>
+                     </bibl> without any known parallel witnesses, but edited and translated in 
+                        <bibl><ptr target="bm:Cerulli1964LOriente"/><citedRange unit="page">34-40</citedRange></bibl>.</note>
+                     <incipit xml:lang="gez">
+                           <hi rend="rubric">መዋሥእት፡ ዘ<persName ref="PRS8126Rhipsime">አርሲማ፡</persName> ብፅዕት፡ ዘ፫</hi>መልዕልተ፡ ኰኵሕ፡ ዲበ፡ 
+                           ወርቅ፡ ሐነጸት፡ ቤታ፡ ነፋሳት፡ ዘኢይክሉ፡ አንቀልቅሎታ፡ ብፅዕት፡ አርሲማ፡ በስመ፡ ኢየሱስ፡ ጸንዐ፡ መሰረታ። ዘ፬፡ ረሰየት፡ ሥጋሃ፡ ከመ፡ ጽኑዕ፡ ሐመር፡ ዘኢይቀርቦ፡ ማዕበል፡ ካልእኒሃ፡ 
+                           ታስተጻንዕ፡ በገድል፡ እንዘ፡ ትየውሆሙ፡ በቃል። ዘ<hi rend="rubric">፲፬፡</hi> <add place="above">ኀ</add>በ፡ እቶነ፡ እሳት፡ ወረወት፡ ርእሳ፡ እማይ፡ 
+                           ወእመንፈስ፡ እሳተ፡ ለቢሳ፡ በከመ፡ ተጽሕፈ፡ በወንጌል፡ መጠወት፡ ነፍሳ። </incipit>
+                     <explicit xml:lang="gez">ተዝካሬ፡ <gap reason="illegible" unit="chars" quantity="6"/>ጋቢአነ፡ አሐቲ፡ 
+                           <gap reason="illegible" unit="chars" quantity="4"/>ን፡ እምኵ<gap reason="illegible" unit="chars" quantity="8"/><pb n="4va"/>ብ፡ 
+                           መዝገበ፡ ዘኢይማስን፡ በፃፄ፡ ወናምስጥ፡ እምዕፄ። <hi rend="rubric">ወዓዲ፡</hi> አልቦ፡ ዘይዐቢየ፡ እምኵሎን፡ አንስት፡ ዘእንበለ፡ ማርያም፡ ሙዳየ፡ ትንቢት፡ ዐቢይ፡ ስማ፡ 
+                           በመንግሥተ፡ ሰማያት፡ ንግበር፡ ተዝካራ፡ በስብሓት። ። ። ።
+                           ሱቀነ፡ ኢያስጥመነ፡ ሰርመ፡ ኃጢአት። በትንብልናሃ፡ ለ<persName ref="PRS8126Rhipsime">አርሲማ፡</persName> በፅዕት፡ ወእለ፡ ምስሌሃ፡ ስማዕት። 
+                           ክፍለነ፡ ነሀሉ፡ በቀዳሚ፡ ርስት፡ በዐሠርቱ፡ ምእት፡ ዓመት፡ አመ፡ ትነግሥ፡ ለሰማዕታት፡ በሀገር፡ ቅድስ<gap reason="illegible" unit="chars" quantity="1"/>፡ 
+                           በከመ፡ ብፅዕት፡ <persName ref="PRS8126Rhipsime">አርሲማ፡</persName> ዘአዕደዋ፡ እምባሕር፡ ሐዲፎ፡ በከመ፡ ብፅዕት፡ 
+                           <persName ref="PRS8126Rhipsime">አርሲማ፡</persName> እምነኪር፡ ይምሕኮ፡ ለአድኀኖ፡ ይፌኑ፡ መልአኮ። ከመ፡ 
+                           <persName ref="PRS8126Rhipsime">አርሲማ፡</persName> ዘያኀሦ፡ ጽሂቆ፡ በየማኑ፡ ይሰውቆ፡ ለዘ፡ ከመዝ፡ ያሰረጉ፡ 
+                           ጽድቆ<gap reason="illegible" unit="chars" quantity="1"/>፡ ብፅዕት፡ <persName ref="PRS8126Rhipsime">አርሲማ፡</persName>
+                           ወእለ፡ ምስሌሃ፡ ሰማዕት፡ ፈጸሙ፡ ገድሎሙ፡ ኀብስተ፡ እምሰማይ፡ ወሀቦሙ፡ ወመጠዎሙ፡ ጽዋዕ፡ ምሉአ፡ ማየ፡ ገነት፡ ፀዐዳ፡ በልዑ፡ ወጸግቡ፡ በመንፈስ፡ ቅዱስ፡ ጸንዑ፡ 
+                           በገ<add place="inline">ድ</add>ሎሙ፡ ሞኡ፡ ሀገሮሙ፡ ቦኡ፡ ይክፍለነ፡ ምስሌሆሙ፡ በሐዳስ፡ ምድር፡ መንግሥቶ፡ 
+                           ወጽ<add place="above">ድ</add>ቆ፡ በዳግም፡ ቀመር።</explicit>
+                  </msItem>
+                  <msItem xml:id="ms_i3">
+                     <title ref="LIT2317Senodo" type="incomplete"/>
+                     <note>According to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">90</citedRange>
+                     </bibl> and <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">92-93</citedRange></bibl>
+                        probably one of the oldest manuscripts containing this text. A relevant part is probably missing, given that the Canons are too 
+                        few in the codex.</note>
+                     <msItem xml:id="ms_i3.1">
+                        <locus from="5ra" to="17rb"/>
+                        <title ref="LIT2673CanonsAscension"/>
+                        <note>30 canons</note>
+                        <incipit xml:lang="gez"><hi rend="rubric">ዝንቱ፡ መጽሐፍ፡</hi> ዜናሆሙ፡ ለሐ<hi rend="rubric">ዋርያት፡ እምድ</hi>ኅረ፡ ዓርገ፡
+                           እግ<hi rend="rubric">ዚእነ፡ ወአምላ</hi>ክነ፡ ክርስቶስ፡ ዘአዘዙ፡ ሲኖዶስ፡ ዘጸሐፈ፡ ቀሌምንጦስ፡ 
+                           በእንተ፡ ሐዋርያት፡ ዘከመ፡ ሠርዑ፡ ለቤተ፡ ክርስቲያን፡ ቅድስት፡ እንተ፡ ተሣየጣ፡ በደሙ፡ ክቡር። ። ወወሀቡ፡ ለዘ፡ ተለዎሙ፡ ወቦአ፡ ውስተ፡ ጽዋዔሆሙ፡ ወአምነ፡ 
+                           በእግዚአብሔር፡ በእደዊሆሙ፡ እምኵሉ፡ አሕዛብ፡ ወአይሁድኒ። ። ወአዘዙ፡ መትልዎሙ፡ እምድኅሬሆሙ፡ ኤጲስ፡<cb n="5rb"/> 
+                           <hi rend="rubric">ቆጶሳት፡ እምቅድ</hi>መ፡ ጉባኤ፡ ዘ<placeName ref="LOC4993Nicaea">ኒቂ<hi rend="rubric">ያ፡</hi></placeName> 
+                           <hi rend="rubric">ዘሠርዑ፡ ሕገ፡</hi> እግዚአብሔር።</incipit>
+                        <explicit xml:lang="gez">ወአመ፡ በዝኁ፡ እለ፡ የአምኑ፡ በክርስቶስ፡ ወኮኑ፡ እምኔሆሙ፡ ሰባኪያነ፡ ወዜ<cb/>ናዊያነ፡ ወተፈቅደ፡ ይግበሩ፡ ትእዛዘ፡ ወሥርዓተ፡
+                           ለአርትዖ፡ ሕግ፡ ወተፍጻሜተ፡ ግብር፡ ወወሀብዎሙ፡ ሐዋርያት፡ ሶቤሃ፡ ዘንተ፡ ቀኖና፡ ዘይሰመይ፡ በነገረ፡ ጽርእ፡ በጥልሳት፡ በዘ፡ ኀበሩ፡ ቦቱ፡ 
+                           ሐዋር<add place="above">ያ</add>ቲሁ፡ ለክርስቶስ፡ ኄራን፡ ወጻድቃን፡ ወንጹሓን፡ መራሕያን፡ ወአዘዙ፡ ባቲ፡ ከመ፡ ይግበርዋ። ወይደልዎ፡ ዘተዐደዋ፡ ኵነኔ፡ 
+                           ወንሕነሂ፡ ንተሉ፡ አሰረ፡ ዚአሆሙ። ። ።</explicit>
+                        <note>According to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">94</citedRange>
+                        </bibl> on <locus from="5" to="14r"/>.</note>
+                     </msItem>
+                     <msItem xml:id="ms_i3.2">
+                        <locus from="17rb" to="38rb"/>
+                        <title ref="LIT2679ACAbt2"/>
+                        <note>81 Apostolic Canons of Clement, to be distinguished from other witnessed variants by the name 
+                           <foreign xml:lang="get">በጥልሳት፡</foreign> instead of the usually preferred forms <foreign xml:lang="">አብጥልሳት፡</foreign>
+                           or <foreign xml:lang="gez">ኤብጥልሳት፡</foreign>.</note>
+                        <incipit xml:lang="gez"><hi rend="rubric">ዝንቱ፡ ሴኖዶስ፡ ዘሐዋርያት፡ ቅዱሳን፡ ዘነገረ፡ ቃሌምንጦስ፡ ወይእቲ፡ በጥልሳት፡ ዘኀበሩ፡ ባቲ፡ አርዳኢሁ፡ 
+                           ለእግዚእነ፡<pb n="17va"/> ክርስቶስ፡ ወኆልቁ፡ ፹ወ፩፡ <add place="margin">፩</add>ትእዛዝ፡</hi> በእንተ፡ ሢመተ፡ ኤጲስ፡ ቆጶስ፡ ወሊቀ፡ 
+                           ጳጳሳት፡ ወስፍን፡ ይደሉ፡ የሀልዉ፡ ኤጲስ፡ ቆጶሳት፡ ለሢመተ፡ ሊቀ፡ ጳጳሳት። እስመ፡ ኢይትፈጸም፡ ዝንቱ፡ ዘእንበለ፡ በህላዌ፡ ጉባኤሆሙ፡ ለኤጲስ፡ ቆጶሳት፡ ወህላዌ፡ 
+                           መጥረብሊጥ፡ ዘውእቱ፡ ጳጳስ። ።</incipit>
+                        <explicit xml:lang="gez">ወእግዚአብሔር፡ አብ፡ ያቅርብክሙ፡ ኀበ፡ ፈሪሆቱ፡ በመንፈስ፡ ቅዱስ፡ ሕያው፡ ወንጽሕ፡ ጰራቅሊጦስ፡ 
+                           <add place="above">ወ</add>ያድኅንክሙ፡ ወይርዳእክሙ፡ ለገቢረ፡ ሠናይ። ወይረሲክሙ፡ ንጹሐነ፡ ወይሀብክሙ፡ ሕይወተ፡ ዘለዓለም፡ በትንብልናሁ፡ 
+                           ለኢያሱስ፡ ክርስቶስ፡ ምስለ፡ አቡሁ፡ ወመንፈስ፡ ቅዱስ፡ ለዓለመ፡ ዓለም፡ አሜን። ።</explicit>
+                        <note>The number of the Canons is indicated in the incipit with 81, however the treatises as indicated in the text run from 1 to 80.</note>
+                     </msItem>
+                     <msItem xml:id="ms_i3.3">
+                        <locus from="38va" to="55rb"/>
+                        <title type="complete" ref="LIT2639CanonsSimon1"/>
+                        <note>10 Canons, each with rubricated incipit.</note>
+                           <msItem xml:id="ms_i3.3.1">
+                              <locus from="38va" to="39vb"/>
+                              <title ref="LIT2704CanonsSimon"/>
+                              <incipit xml:lang="gez"><hi rend="rubric">ዝንቱ፡ ሴኖዶስ፡ ዘአበው፡ ቅዱሳን፡ ሐዋርያት፡ <add place="above">ንጹሓን፡ </add></hi> ሥርዓተ፡ ክህነት፡ 
+                                  ክህነት፡ ዘስምዖን፡ ቀነናዊ፡ በእንተ፡ ሥርዓተ፡ ቤተ፡ ክርስቲያን፡ ቅድስት፡ እንተ፡ ላዕለ፡ ኵሉ። <hi rend="rubric">ኤጲስ፡ ቆጶስ፡</hi> ይባርክ፡ ወኢይትባረክ፡ ወውእቱ፡ ያንብር፡ 
+                                  እዴሁ፡ ላዕለ፡ ርእሰ፡ ሰብእ፡ ወአልቦ፡ ዘያነብር፡ እዴሁ፡ ላዕለ፡ ርእሱ፡ ዘእንበለ፡ ሊቀ፡ ጳጳሳት፡ ወውእቱ፡ ይሢም፡ ቀሳውስት፡ ወዘይሠየም፡ በኀቤሁ፡ ይንሣእ፡ በኀቤሁ፡ በረከተ።</incipit>
+                              <explicit xml:lang="gez">ወኢይደልዎ፡ ለዲያቆን፡ ይክሥት፡ ጸሎተ፡ ቀዲሙ፡ ወኢየአዝዝ፡ በግብረ፡ ቤተ፡ ክርስቲያን፡ ዘእንበለ፡ ቀሲስ፡ ወይኩን፡ ቀሲስ፡ ዘይኤዝዝ፡ ባቲ።</explicit>
+                           </msItem>
+                           <msItem xml:id="ms_i3.3.2">
+                              <locus from="39vb" to="40va"/>
+                              <title ref="LIT2640CanonsMattSimon"/>
+                              <incipit xml:lang="gez"><hi rend="rubric">ዘአዙ</hi><add place="above">ዙ</add><hi rend="rubric">፡ ማቴዎስ፡ ወስምዖን፡ 
+                                 ሐዋርያት፡ በእንተ፡ ዓሥራት፡ ወበኵር፡</hi>ኵሉ፡ በኵር፡ ዘይበፅዑ፡ ለእግዚአብሔር፡ እምነ፡ ኵሉ፡ በኵር፡ አው፡ ወይን፡ አው፡ ባዕደ፡ ፍረያተ፡ ያምጽእዎ፡ ኀበ፡ ኤጲስ፡ 
+                                 ቆጶ<pb n="40"/>ስ፡ አው፡ ቀሲስ፡ አው፡ ዲያቆን፡ ኅቡረ፡ ምስሌሁ።</incipit>
+                              <explicit xml:lang="gez">ወከመዝ፡ አጠየቀነ፡ ወአርአየነ፡ መንፈስ፡ ቅዱስ፡ ጳራቅሊጦስ፡ ማሕየዊ።</explicit>
+                           </msItem>
+                           <msItem xml:id="ms_i3.3.3">
+                              <locus from="40va" to="40vb"/>
+                              <title type="complete" ref="LIT2643CanonsPaul"/>
+                              <incipit xml:lang="gez"><hi rend="rubric">ዘአዘዘ፡ ጳውሎስ፡ ሕርያ፡ ወይበ፡ </hi>ኵሉ፡ መሀየምን፡ ወመሀየምንት፡ ሶበ፡ ይከውን፡ ጽባሕ፡ ኢይግበሩ፡
+                                 ግብረ፡ ዘእንበለ፡ ይትኀፀቡ፡ ወ<add place="above">ይ</add>ጸለዩ፡ ለእግዚአብሔር፡ ፈጣሪሆሙ፡ በተጋንዩ።</incipit>
+                              <explicit xml:lang="gez">ወይነጽሩ፡ መሀየምናን፡ ውስተ፡ ግብሮሙ፡ በፍቅር፡ ወበየውሀት፡ በከመ፡ አዘዝነ፡ ወመሀርነ፡ በመለክትነ፡ ወነገርነ፡ በእንተ፡ ፈሪሆ፡ 
+                                 እግዚአብሔር፡ ወሕገጊሁ። </explicit>
+                           </msItem>
+                           <msItem xml:id="ms_i3.3.4">
+                              <locus from="40vb" to="43rb"/>
+                              <title type="complete" ref="LIT2641CanonsPeterPaul"/>
+                              <incipit xml:lang="gez"><hi rend="rubric">ትአዛዝ፡ ዘጴጥሮስ፡ ወጳውሎስ፡ በእንተ፡ ዕረፍተ፡ አግብርት፡ ዘይደሉ።</hi>
+                                 <add place="margin"><hi rend="rubric">፩</hi></add>ንሕነ፡ አዘዝነ፡ ከመ፡ ያዕርፉ፡ አግብርት፡ በበ፡ ስሙን፡ <hi rend="rubric">፪</hi>
+                                 ዕለት፡ ወእሙንቱ፡ ሳንበት፡ ወዕለተ፡ እሑድ። </incipit>
+                              <explicit xml:lang="gez">ወ<cb n="43rb"/>ለሰማዕት፡ ወለቅዱሳን፡ እስመ፡ ቀደሙ፡ አክብሮቶ፡ ለክርስቶስ፡ ወአብደቱ፡ ፍቅሮ፡ እምሕይወቶሙ።</explicit>
+                           </msItem>
+                           <msItem xml:id="ms_i3.3.5">
+                              <locus from="43rb" to="44va"/>
+                              <title type="complete" ref="LIT2642CanonsAp"/>
+                              <incipit><hi rend="rubric">ትአዛዝ፡ ዘሐዋርያት፡</hi> በእንተ፡ ዐቂበ፡ ጊዜ፡ ጸሎት።</incipit>
+                              <explicit>ምንተ፡ ደመሮ፡ ለጽልመት፡ ምስለ፡ ብርሃን፡ ወአይ፡ መሀይምን፡ ወመሀየምንት፡ ያወሳቡ፡ አግብርተ፡ ለይትገሐሡ፡ እምኔሆሙ፡ ወእመአኮ፡ ይሰደዱ፡
+                                 እምቅድስት፡ ቤተ፡ ክርስቲያኑ፡ ለእግዚአብሔር። ። </explicit>
+                           </msItem>
+                           <msItem xml:id="ms_i3.3.6">
+                              <locus from="44va" to="45ra"/>
+                              <title type="complete" ref="LIT2644CanonsPaul"/>
+                              <incipit xml:lang="gez"><hi rend="rubric">ትአዛዝ፡ ዘጳውሎስ፡ ሐዋርያ፡ በእንተ፡ እለ፡ ኖሙ፡</hi> ዘክመ፡ ይትገበር፡ ተዝካር፡ በሣልስት፡ ዕለት፡ 
+                                 ለእለ፡ ኖሙ፡ ተዝካረ፡ ምዉታን፡ በመዝሙር፡ ወጸሎት፡ እስመ፡ ክርስቶስ፡ ሞተ፡ ወተንሥአ፡ በሣልስት፡ ዕለት። </incipit>
+                              <explicit xml:lang="gez">ወኢይዔምፅ፡ በፍትሕ፡ ወኵሉ፡ የሐውር፡ ኀቤሁ፡ ወይፈድዮ፡ በከመ፡ ምግባሩ። ።</explicit>
+                           </msItem>
+                           <msItem xml:id="ms_i3.3.7">
+                              <locus from="45ra" to="46ra"/>
+                              <title type="complete" ref="LIT2645CanonW"/>
+                              <incipit xml:lang="gez"><hi rend="rubric">ወካዕበ፡ <add rend="overstrike">በእንተ፡ እለ፡ ተ</add>ጸውዑ፡ ውስተ፡ ምሳሕ፡ ወተዝካረ፡ ምውታን፡</hi></incipit>
+                              <explicit xml:lang="gez">ወይጐነዲ፡ ነቢረ፡ በሰቲዮታ፡ ረሐቁ፡ እመካነ፡ ዘአስተዳለው፡ ለስቴ፡ ወለትዝህርት፡ ወግበሩ፡ ዘይደልወክሙ፡ ወኢትግበሩ፡ ዘየሐሥመክሙ።</explicit>
+                           </msItem>
+                           <msItem xml:id="ms_i3.3.8">
+                              <locus from="46ra" to="46va"/>
+                              <title type="complete" ref="LIT2646CanonW"/>
+                              <incipit xml:lang="gez"><hi rend="rubric">ወካዕበ፡ ነገሮሙ፡ በእንተ፡ እለ፡ ይስደዱ፡ በእንተ፡ ሃይማኖት፡ ወይጕይዩ፡ እምሀገር፡ ውስተ፡ ሀገር።</hi></incipit>
+                              <explicit xml:lang="gez">ወመፍትው፡ ይርድእዎሙ፡ ለእለ፡ ከመዝ፡ ከመ፡ ይፈጽሙ፡ ትእዛዘ፡ ክር<pb n="46v"/>ስቶስ፡ ወይጽንዑ፡ ቦቱ።</explicit>
+                           </msItem>
+                           <msItem xml:id="ms_i3.3.9">
+                              <locus from="46va" to="51rb"/>
+                              <title type="complete" ref="LIT2647CanonsPeterPaul"/>
+                              <incipit xml:lang="gez"><hi rend="rubric">ነገር፡ ዘጴጥሮስ፡ ወጳውሎስ፡ ቅዱሳን፡ በእንተ፡ ዐቂበ፡ ማዓርገ፡ ክህነት። ።</hi></incipit>
+                              <explicit xml:lang="gez">ወተወክፉ፡ ክህነተ፡ እምሊቀ፡ ካህናት፡ ኢየሱስ፡ ክርስቶስ፡ ዘአልቦ፡ ዘይመስሎ፡ ወአልቦ፡ ዘይትዔረዮ፡ ዘሎቱ፡ ሰብሐት፡ ወክብር፡ አሜን። ።</explicit>
+                           </msItem>
+                           <msItem xml:id="ms_i3.3.10">
+                              <locus from="51rb" to="55rb"/>
+                              <title type="complete" ref="LIT2648CanonsPaul"/>
+                              <note>Subdivided into 29 parts and indicated with markings in the margins.</note>
+                              <incipit xml:lang="gez"><hi rend="rubric">ትእዛዝ፡ ወቀኖና፡ ዘጳውሎስ፡ ላእክ፡ በእንተ፡ እለ፡ ይመጽኡ፡ ኀበ፡<pb n="51v"/> ምስጢርነ፡
+                                 ሐዲስ፡ ወባዕድኒ።</hi></incipit>
+                              <explicit xml:lang="gez">ወእምዝ፡ ይወጥን፡ ምህሮ፡ ሰብእ፡ እስመ፡ ተብህለ፡ ወይኵኑ፡ ምሁራነ፡ በኀ<add place="above">በ</add>፡ እግዚአብሔር፡ 
+                                 ወመራኅያነ፡ ለሠናይ። ።</explicit>
+                           </msItem> 
+                     </msItem>
+                     <msItem xml:id="ms_i3.4">
+                        <locus from="55rb" to="57rb"/>
+                        <title ref="LIT2672SenodosInMe"/>
+                        <incipit xml:lang="gez"><hi rend="rubric">ዝንቱ፡ ሲኖዶሳት፡ ወቀኖና፡ ዘበትርጓሜሁ፡ ዘእግዚአብሔር፡ ዘይደሉ፡ ለክርስቲያን፡</hi> መልእክተ፡ 
+                           <add place="margin"> <hi rend="rubric">፩</hi></add> ሐዋርያት፡
+                           እምድኅረ፡ ዐርገ፡ እግዚእነ፡ ክርስቶስ፡ ውስተ፡ ሰማይ፡ ወዘከመ፡ ኮነ፡ ትእዛዞሙ፡ ወዘገብሩ፡ ቀኖና፡ ወፍትሐ። </incipit>
+                        <explicit xml:lang="gez"><hi rend="rubric">፲፫</hi>ሳድስ፡ ጉባኤ፡ በእንተ፡ መጽሐፍ፡ ዘኮነ፡ ዘሳርጊ፡ ወቆ<cb n="57rb"/>ርስ፡ ዘይበቍዕ፡
+                           ለመሀየምናን። ።</explicit>
+                     </msItem>
+                     <msItem xml:id="ms_i3.5">
+                        <locus from="57rb" to="67rb"/>
+                        <title ref="LIT2662Ancyra" type="incomplete"/>
+                        <note>24 Canons.</note>
+                        <incipit xml:lang="gez">ወገብሩ፡ ዘንተ፡ ትእዘዘተ፡ <hi rend="rubric">፳</hi>ወ <hi rend="rubric">፬</hi>ቀኖና። 
+                           <add place="margin"> <hi rend="rubric">፩</hi></add>በእንተ፡ ቀሳውስተ፡ እለ፡ ሦዑ፡ ለአማልክት። ።
+                           <add place="margin"> <hi rend="rubric">፪</hi></add>በእንተ፡ ዲያቆናት፡ እለ፡ ሦዑ፡ ለአማልክት። ።
+                        </incipit>
+                        <explicit xml:lang="gez">ዘአእመረ፡ እምአግዋሪሃ፡ <add place="overstrike">ወመቅርበ፡ ወኢነገረ፡ ለሰብእ፡ ዘኮነ፡ እምኔሃ፡ እምቅድመ፡ 
+                           ትግ</add>በር፡ ዘገብረት። ። ለይነስሕ፡ ምስ<add place="margin">፳</add>ለ፡ <add place="above">እለ፡</add> ይኔሳሑ፡ 
+                           <hi rend="rubric">፳፡</hi> ዓመት፡ አው፡ <hi rend="rubric">፲</hi>ዓመት፡ በከመ፡ ነገርነ፡ ውእቱኒ፡ ወእለ፡ አእመሩ፡ ዘንተ፡ ወኀብእዎ።
+                           ወይኩን፡ ነገሩ፡ ኀበ፡ እግዚአብሔር፡ እስመ፡ ተኃሥሦቱ፡ ለእግዚአብሔር፡ ወግብሩ፡ የዐቢ፡ እምግብሩ፡ ሰብእ፡ ወተኃሥሦቶሙ። ። 
+                           <hi rend="rubric">ተፈጸመ፡ ዘእንቅራ፡</hi></explicit>
+                        <note>Text beginning abruptly with the index of the subchapters.</note>
+                     </msItem>
+                     <msItem xml:id="ms_i3.6">
+                        <locus from="67ra" to="68ra"/>
+                        <title ref="LIT2682CanonsNCT"/>
+                        <note>Index of 14 canons.</note>
+                        <incipit xml:lang="gez"><add place="margin"><foreign xml:id="la">Consilium Casareense</foreign></add>
+                           <hi rend="rubric">ዝንቱ፡ ሲኖዶስ፡ ዘካ<add place="overstrike">ሳርያ፡</add> ኀበ፡ ተጋብኡ፡ ኃምሳ፡ ኤጲስ፡ ቆጶሳት፡ ወሠርዑ፡ ዓሠርተ፡ ወአርባዕተ፡
+                              ትእዛዘ፡</hi><add place="margin"> <hi rend="rubric">፩</hi></add>በእንተ፡ ዘአውሰበ፡ ቀሲስ፡ ካልእተ፡ አው፡ ዘመወ። ።
+                           <add place="margin"><hi rend="rubric">፪</hi></add>በእንተ፡ ዘአውሰበ፡ ክልኤተ፡ አኃተ፡ አው፡ ብእሲት፡ ዘአውሰበት፡ ክልኤተ፡ አኃወ።</incipit>
+                        <explicit xml:lang="gez"><add place="margin"><hi rend="rubric"> ፲፬</hi></add>በእንተ፡ ኍልቈ፡ ዲያቆናት። ።</explicit>
+                     </msItem>
+                     <msItem xml:id="ms_i3.7">
+                        <locus from="68ra" to="72vb"/>
+                        <title ref="LIT2661Canons"/>
+                        <note>14 canons.</note>
+                        <incipit xml:lang="gez"><hi rend="rubric">ትእዛዘ፡</hi> <add place="margin"><del rend="strikethrough">፲፭</del></add>
+                           በእንተ፡ ዘአውሰበ፡ <add place="margin"><hi rend="rubric">፩</hi></add>ቀሲሰ፡ አው፡ ዘመወ፡ እምድኅረ፡ ተወክፈ፡ ሢመተ፡ ክህነት። እስመ፡ 
+                           አረጋዊ፡ ኢይኩን፡ መርዓዌ፡ ወኢምሩዐ፡ በፍትወተ፡ ነፍሱ፡ ወባሕቱ፡ ብውሕ፡ ሎሙ፡ እውሰበ፡ እምቅድመ፡ ይንሥኡ፡ ዛተ፡ መዓርገ። </incipit>
+                        <explicit xml:lang="gez"><hi rend="rubric">ትእዛዘ፡ ፲፬፡</hi> በእንተ፡ ኍልቈ፡ ካህናት። ይደልዎሙ፡ ይኵኑ፡ ካህናት፡ ወዲያቆናት፡ ወቀሳውስተ፡ እለ፡ 
+                           ይቀውሙ፡ በጸሎት፡ ወበጊዜሁ፡ ወኵሎሙ፡ ምልእክተ፡ ቤተ፡ ክርስቲያን፡ ሰብዓቱ፡ ወይኩን፡ ሎሙ፡<cb n="67vb"/> ሲሳየ፡ እምንዋየ፡ ቤተ፡ ክርስቲያን፡ መብልዖሙ፡ 
+                           ወሰቴሆሙ፡ እምኔሃ፡ እስመ፡ ለእካኒሃ፡ እሙንቱ፡ ወኢይኵኑ፡ ዘይበዝኅ፡ እምኔሆሙ፡ ወእመሂ፡ ዓቢያት፡ ቤተ፡ ክርስቲያን፡ ወኮነ፡ ሀገሩ፡ ዐቢየ፡ እስመ፡ ውእቱ፡ ሥሩዕ፡ ወእሙር፡ 
+                           በመጽሐፈ፡ ግብሮሙ፡ ለሐዋርያት፡ ቅዱሳን። ።</explicit>
+                     </msItem>
+                     <msItem xml:id="ms_i3.8">
+                        <locus from="72vb" to="73vb"/>
+                        <title ref="LIT2683CanonsCouncilsT"/>
+                        <note>Index of 20 Canons.</note>
+                        <incipit xml:lang="gez"><hi rend="rubric">ዝንቱ፡ ሴኖዶስ፡ ሣልስ፡ እለ፡ ተጋብኡ፡ በ<placeName ref="LOC0000">ግንግራ፡</placeName> 
+                           ወኆልቆሙ፡ ፲ወ፭፡</hi> ኤጲስ፡ ቆጶሳት፡ ወሠርዑ፡ <hi rend="rubric">፳፡</hi> ትእዘዝ። ። <pb n="73ra"/>
+                           <add place="margin"><hi rend="rubric">፩</hi></add>በእንተ፡ ዘይትሔረም፡ አውስቦ። 
+                           <add place="margin"><hi rend="rubric">፪</hi></add>በእንተ፡ በሊዐ፡ ሥጋ። ። </incipit>
+                        <explicit xml:lang="gez"><add place="margin"><hi rend="rubric">፲፱</hi></add>በእንተ፡ ዘጾመ፡ አጽዋመ፡ ቤተ፡ ክርስቲያን። ። 
+                           <add place="margin"><hi rend="rubric">፳</hi></add>በእንተ፡ ዘይትቄጸብ፡ ማኅበረ፡ ቤተ፡ ክርስቲያን፡ እለ፡ 
+                           ይ<add place="above">ት</add>ጋብኡ፡ ለበዓለ። ።</explicit>
+                     </msItem>
+                     <msItem xml:id="ms_i3.9">
+                        <locus from="73vb" to="76vb"/><locus from="140ra" to="140rb"/>
+                        <title ref="LIT2651CanonsCouncils"/>
+                        <note>Canons Nos. 1 to 18 and the title of No. 19 can be found in <locus from="73v" to="76v"/>, while Nos. 19 and 20 in 
+                           <locus from="140ra" to="140rb"/>.</note>
+                        <incipit xml:lang="gez"><hi rend="rubric">፩ትእዛዝ።</hi> በእንተ፡ ዘይሐርም፡ አውስቦ። ። እመቦ፡ ብእሲ፡ ዘየኀርም፡ አውስቦ፡ ወያስተራኵሶ፡ ለሰብእ፡ 
+                           በእንተ፡ ሰኪበ፡ ምስለ፡ ብእሲ<add place="inline">ቱ</add>፡ እንዘ፡ መሀይምናን፡ እሙንቱ፡ ወንጹሓን፡ በአውስቦ፡ ወይብል፡ በእንተ፡ ሩካቤሆሙ፡ ርኵስ፡ ወሕሩም፡
+                           በእንተዝ፡ ኢይክሉ፡ በዊአ፡ መንግሥተ፡ ስማያት፡ ወስዱድ፡ እምቤተ፡ ክርስቲያኑ፡ ለእግዚአብሔር፡ ወይሐሊ፡ ዘንተ፡ <pb n="74ra"/>ነገረ፡ ውጉዝ፡ ውእቱ፡ በቃለ፡ 
+                           እግዚአብሔር፡ ጽኑዕ፡ ወፈጣሪ። ። </incipit>
+                        <explicit xml:lang="gez"><hi rend="rubric">፳ትእዛዝ፡</hi> በእንተ፡ ዘዎአ፡ ትዕቢት፡ እስከ፡ ይ<cb n="140rb"/>ሜንን፡ በዓልተ፡ ሰማዕት፡ እለ፡ 
+                           ተቀተሉ፡ በእንተ፡ ስሙ፡ ለእግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ ውጉዘ፡ ለይኩን። </explicit>
+                     </msItem>
+                     <msItem xml:id="ms_i3.10">
+                        <locus from="156vb" to="159rb"/>
+                        <title ref="LIT2685CanonsLaoT"/>
+                        <incipit xml:lang="gez"><hi rend="rubric">ዝንቱ፡ ሴኖዶስ፡ ዘ<placeName ref="LOC4254Laodic">ሎዎዶቅያ፡</placeName> አመ፡
+                           ተጋብኡ፡ ፳ወ፱፡ ኤጲስ፡ ቆጶሳት፡</hi> ወሠርዑ፡ <hi rend="rubric">፶፡</hi>ወ<hi rend="rubric">፱፡</hi> ትእዛዝ።<pb n="157ra"/> 
+                           <hi rend="rubric">፩፡</hi> በእንተ፡ ዘአውሰበ፡ ክልኤተ።
+                           <hi rend="rubric">፪፡</hi> በእንተ፡ <gap reason="lost" unit="chars" quantity="2"></gap> እለ፡ ይነስሑ፡ እምኃጢአት። ።</incipit>
+                        <explicit xml:lang="gez"><add place="margin"><hi rend="rubric">፶፱</hi></add>በእንተ፡ ዘይደሉ፡ ያንብቡ፡ ወይዜምሩ፡ በቤተ፡ 
+                           ክርስቲያን።</explicit>
+                     </msItem>
+                     <msItem xml:id="ms_i3.11">
+                        <locus from="159rb" to="162vb"/><locus from="77ra" to="87vb"/>
+                        <title ref="LIT2686CanonsLao"/>
+                        <note>Canons Nos. 1 to 19 can be found in <locus from="159rb" to="162vb"/>, while the final part of No. 19 and the Nos. 20 
+                           to 59 can be found in <locus from="77ra" to="87vb"/>.</note>
+                        <incipit xml:lang="gez"><add place="margin"><hi rend="rubric">፩</hi></add><hi rend="rubric">ትእዛዝ።</hi> በእንተ፡
+                           ዘአውሰበ፡ ክልኤተ። ።</incipit>
+                        <explicit xml:lang="gez">አላ፡ ያንብቡ፡ ወይትገባሩ፡ መጻሕፍተ፡ ዘሥርዐ፡ ዘሕገ፡ ቤተ፡ ክርስቲያን፡ ዘሠርዑ፡ ሐዋርያት፡ እመጻሕፍት፡ ብሉይ፡ ወሐዲስ፡ እንተ፡ ባቲ፡
+                           ብርሃነ፡ ጽድቅ፡ ወአፍላገ፡ ሕይወት፡ አሜን። ።</explicit>
+                     </msItem>
+                     <msItem xml:id="ms_i3.12">
+                        <locus from="87vb" to="88va"/>
+                        <title type="complete" ref="LIT2687CanonsNicaea1T"/>
+                        <note>Index of the 20 Canons.</note>
+                        <incipit xml:lang="gez"><hi rend="rubric">ዝንቱ፡ ሴኖ</hi><add place="above">ዶ</add><hi rend="rubric">ስ፡ ዘማኅበር፡ 
+                           ቅዱሳን፡ ፫፻፲ወ፰፡ ዘሠርዑ፡ በነቂያያ፡ <gap reason="lost" unit="chars" quantity="3"/>፳፡ ቀኖና፡ 
+                           <gap reason="lost" unit="chars" quantity="9"/></hi></incipit>
+                        <explicit xml:lang="gez"><add place="margin"><hi rend="rubric">፳</hi></add>በእንተ፡ ሰጊድ፡ በእሑድ፡ ወዘይመስሎ።</explicit>
+                     </msItem>
+                     <msItem xml:id="ms_i3.13">
+                        <locus from="88va" to="99va"/>
+                        <title type="complete" ref="LIT2650CanonsNicaea1" xml:lang="gez"/>
+                        <note>20 Canons.</note>
+                        <incipit xml:lang="gez"><add place="margin"><hi rend="rubric">፩</hi></add><hi rend="rubric">ቀኖና፡ </hi>
+                           በእንተ፡ ኀጽዋት፡ ወግዝረት። ።</incipit>
+                        <explicit xml:lang="gez">ወወሀበኒዮ፡ በደብረ፡ ዘይት፡ በዕለተ፡ ዕርገቱ፡ ውስተ፡ ስብሓቲሁ፡ አሜን። <hi rend="rubric">ተፈጸመ፡ ዘ፫፻፲ወ፰፡ ቅዱሳን።</hi>
+                           </explicit>
+                     </msItem>
+                     <msItem xml:id="ms_i3.14">
+                        <locus from="99va" to="103va"/>
+                        <title type="complete" ref="LIT2689CanonsNicaea2T"/>
+                        <note>Index to 84 Canons.</note>
+                        <incipit xml:lang="gez"><hi rend="rubric">ዝንቱ፡ ሲኖዶስ፡ ዘ፫፻፲፡ ወ፰፡ ር<cb n="99vb"/>ቱዓነ፡ ሃይማኖት።</hi> ዘሠርዑ፡ ማኅበር፡ ዐቢይ፡ መትልው፡ 
+                           ለውእቱ፡ ፹ወ፬ትእዛዝ፡</incipit>
+                        <explicit xml:lang="gez"><add place="margin"><hi rend="rubric">፹፬</hi></add>በእንተ፡ ቀዊመ፡ ድውያን፡ ወነዳያን።</explicit>
+                     </msItem>
+                     <msItem xml:id="ms_i3.15">
+                        <locus from="103va" to="134rb"/>
+                        <title type="complete" ref="LIT2688CanonsNicaea2" xml:lang="gez"/>
+                        <note>84 Canons.</note>
+                        <incipit xml:lang="gez"><add place="margin"><hi rend="rubric">፩</hi></add><hi rend="rubric">ትእዛዝ፡</hi> በእንተ፡ ከመ፡ 
+                           ኢይከውን፡ ካህን፡ ዘጋኔን። ።</incipit>
+                        <explicit xml:lang="gez">ተፈጸመ፡ ዘ<hi rend="rubric">፫፻፡፲</hi>ወ<hi rend="rubric">፰፡</hi> ርቱዓነ፡ ሃይማኖት፡ ስብሐት፡ ሃይማኖት፡
+                           ስብሐት፡ ለእግዚአብሔር፡ ለዝሉፍ። ።</explicit>
+                     </msItem>
+                     <msItem xml:id="ms_i3.16">
+                        <locus from="134rb" to="139vb"/><locus from="163ra" to="165rb"/>
+                        <title ref="LIT2680ClemPeter"/>
+                        <note>The first part of the Canons of Clement are to be found in <locus from="134rb" to="139vb"/>, the following in 
+                           <locus from="163ra" to="165rb"/>.</note>
+                        <incipit xml:lang="gez"><hi rend="rubric">ዝንቱ፡ ሲኖዶስ፡ ዘቃሌምንጦን፡ ዘጸሐፈ፡ ጴጥሮስ፡ ረድእ፡ ርእሰ፡ ሐዋርያት፡ ዘነገረ፡ በእንተ፡ እግዚእነ፡ ኢየሱስ፡
+                           ክርስቶስ፡</hi></incipit>
+                        <explicit xml:lang="gez">አእምር፡ ወልድየ፡ ከመ፡ ኵሎ፡ ዘአዘዝኪከ፡ በትእዛዘ፡ እግዚአብሔር፡ አዘዝኩከ፡ በእዴሁ፡ ጸሐፈ፡ ሊተ፡ ዘንተ፡ ትእዛዘ፡ ወወሀበኒዮ፡ በደብረ፡ 
+                           ዘይት፡ በዕለተ፡ ዕርገቱ፡ ውስተ፡ ስብሓቱ፡ አሜን። ።</explicit>
+                     </msItem>
+                     <msItem xml:id="ms_i3.17">
+                        <locus from="140rb" to="146ra"/>
+                        <title ref="LIT2652CanonsCouncils" type="complete"/>
+                        <note>21 Canons.</note>
+                        <incipit xml:lang="gez"><hi rend="rubric">ሴኖዶስ፡ ዘጉባኤ፡ ስርድቄ፡ ወኆልቆሙ፡ ፻ወ፵፡ ኤጲስ፡ ቆጶሳት፡</hi> 
+                           ወሠርዑ፡ <hi rend="rubric">፳፡</hi> ወ<hi rend="rubric">፬፡</hi> ትእዛዝ፡ ተጋቢኦሙ፡ እምርሑቅ፡ በሐውርት። ። <hi rend="rubric">፩ትእዛዝ፡</hi>
+                           ይቤ፡ ዋሳብርሰ፡ ኤጲስ፡ ቆጶስ። ይደሉ፡ ይሰርዎ፡ ለግብር፡ እኩይ፡ እስመ፡ ይአኪ፡ እምኩሉ፡ ለዘ፡ ይገብሮ፡ ወበእንተዝ፡ ኢይከውን፡ ያብሕዎ፡ ለኤጲስ፡ ቆጶስ። ይሖር፡ ኢምንእስት፡ 
+                           ሀገር፡ ኀ<pb n="140va"/>በ፡ እንተ፡ ተዓቢያ፡ በእንተ፡ አፍቅሮ፡ ሢመት፡ እስመ፡ ኢሠራዕነ፡ ለኤጲስ፡ ቆጶስ፡ ይፍልስ፡ እምሀገር፡ ዓባይ፡ ውስተ፡ ሀገር፡ እንተ፡ ትንእስ። </incipit>
+                        <explicit xml:lang="gez"><hi rend="rubric">፳፩፡ ትእዛዝ፡</hi> ይቤ፡ <sic>ዲጥኖስ፡</sic> ኤጲስ፡ ቆጶስ፡ ት፡ እለ፡ ይነብሩ፡ ውስተ፡ መካን፡ ኀበ፡ የኀልፍ፡ 
+                           ነግድ፡ ወለእመ፡ ኅለፈ፡ ኤጲስ፡ ቆጶስ፡ ይሴአሎ፡ በእንተ፡ ሑረቱ፡ ወኀበ፡ የሐውር፡ ወለእመ፡ ተረክበ፡ የሐውር፡ ኀበ፡ ትዕይንት፡ ይሴአሎ፡ በከመ፡ አቅደምነ፡ ነጊረ። ወለእመ፡ ተጻውዐ፡ 
+                           ኀበ፡ ትዕይንት፡ ኢይንበር፡ እምፍኖቱ። ወለእመ፡ ፈቀደ፡ ይሖር፡ እምፍኖ<pb n="146ra"/>ቱ፡ ኀበ፡ ትዕይንት፡ በአርአያ፡ በከመ፡ ትቤሉ፡ ወለገቢረ፡ መፍቅደ፡ ሰብእ፡ 
+                           ኢይትወከፍዎ፡ መጽሐፎ፡ ወአልቦ፡ ዘይሳተፎ፡ በኵሉ፡ ግሙራ፡ ወይቤሉ፡ ጉቡአን፡ ለይኩን፡ ዝኒ። ።</explicit>
+                     </msItem>
+                     <msItem xml:id="ms_i3.18">
+                        <locus from="146ra" to="146vb"/>
+                        <title ref="LIT2684CanonsCouncilsT"/>
+                        <note>Index ends abrubtly with number 11 on <locus target="#146rb"/>, while the back number indices once inscribed on 
+                           <locus target="#146va"/> have been erased and left blank - alone the last words of the last indexed number 25 are still visible 
+                           on <locus target="#146vb"/>.</note>
+                        <incipit xml:lang="gez"><hi rend="rubric">ዝንቱ፡ ሴኖዶስ፡ ዘማኅበረ፡ አንጾኪያ፡ ወኆልቆሙ፡ ፲ወ፫፡ ኤጲስ፡ ቆ<add place="above">ጶሳት፡</add></hi>
+                           ወሠርዑ፡ <hi rend="rubric">፳፡</hi> ወ<hi rend="rubric">፭፡</hi> ትእዛዝ። ። <add place="margin"><hi rend="rubric">፩</hi></add>
+                           በእንተ፡ ኀጽዋን፡ ወግዙራን። ። <add place="margin"><hi rend="rubric">፪</hi></add>በእንተ፡ ዘይበውእ፡ ቤተ፡ ክርስቲያን፡ ወይሰምዕ፡ መጻሕፍተ፡ 
+                           ወኢይቀርብ። ።</incipit>
+                        <explicit xml:lang="gez"><add place="margin"><hi rend="rubric">፲</hi></add>በእንተ፡ ዘይሠይሙ፡ ኤጲስ፡ ቆጶሳት። ።
+                           <add place="margin"><hi rend="rubric">፲፩</hi></add>በእንተ፡ ኤጲስ፡ ቆጶስ፡ ወቀሳውስት፡ እለ፡ ይሰ<pb n="146va"/>
+                           <gap reason="lost" unit="lines" quantity="23"/>ስ፡ ስሉጥ፡ ላዕለ፡ ከፈለ፡ ንዋየ፡ ቤተ፡ ክርስቲያን። ።</explicit>
+                     </msItem>
+                     <msItem xml:id="ms_i3.19">
+                        <locus from="146vb" to="156vb"/>
+                        <title ref="LIT2653CanonsCouncils"/>
+                        <note>25 Canons.</note>
+                        <incipit xml:lang="gez"><hi rend="rubric">፩፡ ትእዛዝ፡</hi>እመቦ፡ ብእሲ፡ ዘተኀበለ፡ ይሰዓር፡ ዘሠርዑ፡ ማኅበር፡ ዓቢይ፡ ቅዱሳን፡ 
+                           በ<placeName ref="LOC4993Nicaea">ንቅያ፡</placeName> እለ፡ ተጋብኡ፡ እንዘ፡ ሀሎ፡ ንጉሥ፡ መፍቀሬ፡ እግዚአብሔር፡ በእንተ፡ በዓል፡ ቅዱስ፡ 
+                           ዘንገብር፤ በእንተ፡ ሕማሙ፡ ለመድኀኒነ፡ ኢየሱስ፡ ክርስቶስ፡ ወዘወለጠ፡ ይሰደድ፡ እምቤተ፡ ክርስቲያን፡ ወኢይሳተፍ፡ በጸሎትነ፡ እንዘ፡ ሀሎ፡ በእኩይ፡ ምክሩ፡ ወይናፍቅ፡ 
+                           <pb n="145ra"/>በእንተ፡ ዘሠርዑ፡ አበው። ። </incipit>
+                        <explicit xml:lang="gez"><hi rend="rubric">ትእዛዝ፡ ፳፭፡</hi> በእንተ፡ ኤጲስ፡ ቆጶስ፡ ይኵን፡ ሰሉጥ፡ ላዕለ፡ ከፊለ፡ ንዋየ፡ ቤተ፡ ክርስቲያን። ኤጲስ፡ 
+                           ቆጶስ፡ <cb n="156rb"/><gap reason="ellipsis"/>ወያዐፅቡ፡ ለፅኑሳን፡ ወለነዳያን፡ ይትኀሠሥዎ፡ ሕዝብ፡ በከመ፡ ይደሉ፡ ወያረትዑ፡ በከመ፡ አዘዝነ፡ 
+                           ወአዘዘ፡ ሕግ፡ በከመ፡ ይሬእዩ። ተፈጸመ፡ ሲኖዶስ፡ ዘማኅበረ፡ <placeName ref="LOC1481Antioc">አንጾኪያ</placeName>።</explicit>
+                     </msItem>
+                  </msItem>
+                  <msItem xml:id="ms_i4">
+                     <locus from="166ra" to="173vb"/>
+                     <title ref="LIT2041Nagarb"/>
+                     <incipit xml:lang="gez"><hi rend="rubric">ነገር፡ በእንተ፡ እለ፡ ይክ</hi>ሕዱ፡ ትንሣኤ፡ ምው<hi rend="rubric">ታን፡ ወበእንተ፡ እለ፡ ይብ</hi>
+                        ሉ፡ ጻድቃን፡ ኢይትነሥ<hi rend="rubric">ኡ፡ እመሬት፡ እስመ፡ ሰ</hi>ማያዊያን፡ እሙንቱ፡ ወ<hi rend="rubric">ሥጋ፡ ሰማያዊያን፡ ይለብሱ።</hi>
+                           </incipit>
+                     <explicit xml:lang="gez">ወይቤሎ፡ እግዚእነ፡ ኅድጎሙ፡ ለምዉታን፡ ይቅበሩ፡ በድኖሙ፡ ወአንተሰ፡ ሖር፡ ስብክ፡ መንግሥተ፡ እግዚአብሔር። ።</explicit>
+                  </msItem>
+                  <msItem xml:id="ms_i5">
+                     <locus from="174" to="176r"/>
+                     <title>Chronological Computus to find Epact</title>
+                  </msItem>
+                  <msItem xml:id="ms_i6">
+                     <locus from="176" to="181"/>
+                     <title>Chronological computus</title>
+                     <note>According to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">90</citedRange>
+                     </bibl> the text on f. 181v ends abruptly, so that some folios or quires must be missing.</note>
+                  </msItem>
+                  <msItem xml:id="ms_i7">
+                     <locus target="182r"/>
+                     <title>Chronological Computus by Yāred</title>
+                  </msItem>
+                  <msItem xml:id="ms_i8">
+                     <locus from="182v" to="195"/>
+                     <title>Maṣḥafa ḥassāb</title>
+                     <note>According to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">90</citedRange>
+                     </bibl> the current folia <locus target="#186"/> and <locus target="#187"/> are wrongly integrated to the quire. Following 
+                        the text, the correct order must be <locus target="#185"/> followed by <locus target="#188"/> followed by 
+                        <locus target="#186"/> followed by <locus target="#187"/> followed by <locus target="#189"/>.</note>
+                  </msItem>
+                  <msItem xml:id="ms_i9">
+                     <locus from="196ra" to="199rb"/>
+                     <title>Unidentified</title>
+                     <note>Unidentified text, containing mainly moral teachings, addressed to an audience of monks. May be attributed among others 
+                        to <persName ref="PRS3828Epiphani"/>.</note>
+                     <incipit xml:lang="gez"><hi rend="rubric">በእንተ፡ ጰፋን</hi>ጢስ፡ ለባዊ፡ <hi rend="rubric">ወካልእሂ፡ ኮነ፡</hi> እንዘ፡ ያወጽእ፡ 
+                        <hi rend="rubric">እምነ፡ አሳዊት፡</hi> እምኀጢአ፡ ማዩ፡ ይሙት፡ ዘበእንተ፡ እስጢፋኖስ፡ ዘወድቀ፡ በእኪት፡ ምርዐት፡ ወበእንተ፡ አውቃርጲዮስ፡ ወበእንተ፡
+                        ሄሮን፡ እለ፡ ክስንድራዊ፡ ወበእንተ፡ ወላስ፡ ጳሌስጢናዊ፡ ወዘበእንተ፡ ጳጦሎሜዎስ፡ ዘበአስቂት፡ ግብጻዊ፡ ንሴእል፡ ምንተ፡ ነገሩ፡ ዘከመዝ፡ ሕያው፡ ሰብእ፡ ውስተ፡ በድው፡ 
+                        ቦእለ፡ ሰሐተ፡ ልቦሙ፡ ወቦእለ፡ ወድቁ፡ ውስተ፡ ዕረፍት፡ ዛቲ፡ እንከ፡ አውሥአነ፡ ጳፋኑጢስ፡ ለባዊ፡ </incipit>
+                     <explicit xml:lang="gez">እግዚኣ፡ ዮሴፍ፡ ወኒቆዲሞስ፡ አምላከ፡ ዕብራዊያን፡ አድኅነነ፡ እምዐላዊያን፡ ነዕቢ፡ ስመከ፡ በዛቲ፡ በዓል፡ እግዚኣ፡ ለስንበት፡ መሐር፡ ኪያነ፡
+                        ኃጥኣን። ።</explicit>
+                  </msItem>
+                  <msItem xml:id="ms_i10">
+                     <locus from="199v" to="203"/>
+                     <title>Five Computus tables to determine mobile feasts</title>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="Codex">
+                     <supportDesc>
+                        <support>
+                           <material key="parchment"></material>
+                           <p>Holes <locus target="#120 #131 #144 #167 #170"/> without textloss.</p>
+                        </support>
+                        <extent>
+                           <measure unit="leaf">1+203+1</measure>
+                           <measure unit="leaf" type="blank">5</measure><locus target="#i #ii #165v #iii #iv"/>
+                           <dimensions unit="mm">
+                              <height>290</height>
+                              <width>180</width>
+                           </dimensions>
+                           <note>The dimensions refers to the size of the boards and is taken from the notification in the scan images, what is different
+                              differs from the account in <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">90</citedRange>
+                              </bibl>, that most likely refers to the size of the folio pages.</note>
+                        </extent>
+                        <foliation>One protective leaf before and one after the textblock. Textblock leaves marked with folio numbers in pen by a rather 
+                           early European hand on top right. It is probably the hand of <persName ref="PRS10036Wansleb">Johann-Michael Wansleben</persName>
+                           who is possibly also responsible for some corrections and comments to the text, that are indicated in <ref target="#e4 #e5"/>.
+                           In this older folio numbering, the first two folios are not counted and numbers 100 and 137 have been skipped, while number 101 
+                           is numbered twice. Protective leafs marked with I and I' on the bottem left by a different recent European hand. 
+                        </foliation>
+                        <collation>
+                           <list>
+                              <item xml:id="q1" n="1"> 
+                                 <dim unit="leaf">5</dim>
+                                 <locus from="i" to="4"/>
+                                 s.l. 1, no stub
+                                 <note>According to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">90</citedRange>
+                                 </bibl> the binding of the initial binion has been reversed. The original order was <locus target="#2"/> followed by 
+                                    <locus target="#1"/> followed by <locus target="#4"/> followed by <locus target="#3"/>. An additional protective 
+                                    was attached as a single leave before the quire.</note>
+                              </item>
+                              <item xml:id="q2" n="2">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="5" to="12"/>
+                              </item>
+                              <item xml:id="q3" n="3">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="13" to="20"/>
+                                 s.l. 3, stub after 5
+                                 s.l. 6, stub after 2
+                              </item>
+                              <item xml:id="q4" n="4">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="21" to="28"/>
+                              </item>
+                              <item xml:id="q5" n="5">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="29" to="36"/>
+                              </item>
+                              <item xml:id="q6" n="6">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="37" to="44"/>
+                              </item>
+                              <item xml:id="q7" n="7">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="45" to="52"/>
+                              </item>
+                              <item xml:id="q8" n="8">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="53" to="60"/>
+                              </item>
+                              <item xml:id="q9" n="9">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="61" to="68"/>
+                                 s.l. 3, stub after 6
+                                 s.l. 6, stub after 3
+                              </item>
+                              <item xml:id="q10" n="10">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="69" to="76"/>
+                              </item>
+                              <item xml:id="q11" n="11">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="77" to="84"/>
+                              </item>
+                              <item xml:id="q12" n="12">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="85" to="92"/>
+                              </item>
+                              <item xml:id="q13" n="13">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="93" to="100"/>
+                                 s.l. 3, stub after 5
+                                 s.l. 6, stub after 2
+                              </item>
+                              <item xml:id="q14" n="14">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="101" to="107"/>
+                                 s.l. 6, stub after 1
+                              </item>
+                              <item xml:id="q15" n="15">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="108" to="115"/>
+                              </item>
+                              <item xml:id="q16" n="16">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="116" to="123"/>
+                              </item>
+                              <item xml:id="q17" n="17">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="124" to="131"/>
+                                 s.l. 3, stub after 6
+                                 s.l. 6, stub after 3
+                              </item>
+                              <item xml:id="q18" n="18">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="132" to="139"/>
+                                 s.l. 3, stub after 6
+                                 s.l. 6, stub after 3
+                              </item>
+                              <item xml:id="q19" n="19">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="140" to="146"/>
+                              </item>
+                              <item xml:id="q20" n="20">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="147" to="154"/>
+                              </item>
+                              <item xml:id="q21" n="21">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="155" to="162"/>
+                                 s.l. 2, stub after 7
+                                 s.l. 7, stub after 2
+                              </item>
+                              <item xml:id="q22" n="22">
+                                 <dim unit="leaf">3</dim>
+                                 <locus from="163" to="165"/>
+                                 s. l. 1, stub after 3
+                              </item>
+                              <item xml:id="q23" n="23">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="166" to="173"/>
+                              </item>
+                              <item xml:id="q24" n="24">
+                                 <dim unit="leaf">8</dim>
+                                 <locus from="174" to="181"/>
+                              </item>
+                              <item xml:id="q25" n="25">
+                                 <dim unit="leaf">10</dim>
+                                 <locus from="182" to="191"/>
+                                 <note>According to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">90</citedRange>
+                                 </bibl> the current folia <locus target="#186"/> and <locus target="#187"/> are wrongly integrated to the quire. Following 
+                                    the text, the correct order must be <locus target="#185"/> followed by <locus target="#188"/> followed by 
+                                    <locus target="#186"/> followed by <locus target="#187"/> followed by <locus target="#189"/>.</note>
+                              </item>
+                              <item xml:id="q26" n="26">
+                                 <dim unit="leaf">4</dim>
+                                 <locus from="192" to="195"/>
+                              </item>
+                              <item xml:id="q27" n="27">
+                                 <dim unit="leaf">9</dim>
+                                 <locus from="196" to="iv"/>
+                                 s.l. 9, stub before 1
+                              </item>
+                           </list>
+                        </collation>
+                        <condition key="good"> 
+                           Ripped lower corner on <locus target="#4"/>. Watershed with writing partly blurred and small pollutions throughout. Writing has 
+                           faded on <locus target="#4r"/>. Repairs with a thread on <locus target="#163 #169"/> including an extraordinarily fine work, 
+                           which was carried out with a very thin needle and without textloss on <locus target="#169"/>.
+                        </condition>
+                     </supportDesc>
+                     <layoutDesc><layout columns="2" writtenLines="24">
+                        <note>Number of written lines varies. In the middle part it is a less with mostly 21 or 22 written lines, but considerably higher in many folia
+                           on <locus from="4r" to="4v"> and on </locus> <locus from="166" to="199r"/> with maximum 40 written lines on 
+                           <locus target="#4v"/> and 45 written lines on <locus target="#188r"/>. As an exception the text on folio 
+                           <locus target="182r"/> was written in one column in the upper part of the page.</note>
+                        <ab type="pricking">Pricking is visible</ab>
+                        <ab type="ruling">Ruling is visible</ab>
+                     </layout>
+                     </layoutDesc>
+                  </objectDesc>
+                  <handDesc>
+                     <handNote xml:id="h1" script="Ethiopic">
+                        <locus target="#3r #4vb"/>
+                        <seg type="ink">Black.</seg>
+                        <seg type="script">Accurate script of the fifteenth century executed with a small pen and with relatively tall characters.</seg>
+                     </handNote>
+                     <handNote xml:id="h2" script="Ethiopic">
+                        <locus from="4ra" to="4va"/>
+                        <seg type="ink">Black, red.</seg>
+                        <seg type="rubrication">Incipits and chapter numbers.</seg>
+                        <seg type="script">Script of the fifteenth century.</seg>
+                     </handNote>
+                     <handNote xml:id="h3" script="Ethiopic">
+                        <locus from="5ra" to="38r"/><locus from="174r" to="199r"/>
+                        <seg type="ink">Black, red.</seg>
+                        <seg type="rubrication">Incipits and chapter numbers.</seg>
+                        <seg type="script">Well formed archaic script of the fifteenth century.</seg>
+                        <note>Slightly tilted to the left and more angular than the others. According to 
+                           <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">90</citedRange></bibl> 
+                           the shift of the laryngeal ə to a is not always observed. The numeral for "1", that is supposed to be expressed with
+                           <foreign xml:lang="gez">፩</foreign> is instead shaped in a rectangular form similiar to an 
+                           <foreign xml:lang="gez">፬</foreign>, while the numeral "4" is actually shaped like a triangle tapering downwards.
+                           The numeral for "6" can be distinguished from the "7" in that it is somewhat flattened and written a little smaller. On 
+                           the other hand, the 3rd and 5th order can be clearly distinguished in the handwriting, since the ticks of the 3rd and the 
+                           eyelets of the 5th order are designed differently.</note>
+                     </handNote>
+                     <handNote xml:id="h4" script="Ethiopic">
+                        <locus from="38v" to="44v"/>
+                        <seg type="ink">Black, red.</seg>
+                        <seg type="rubrication">Incipits and chapter numbers.</seg>
+                        <seg type="script">Well formed archaic script of the fifteenth century.</seg>
+                        <note>Slightly tilted to the right and more round than <ref target="h3"/>.</note>
+                     </handNote>
+                     <handNote xml:id="h5" script="Ethiopic">
+                        <locus from="45r" to="164va"/>
+                        <seg type="ink">Black, red.</seg>
+                        <seg type="rubrication">Incipits and chapter numbers.</seg>
+                        <seg type="script">Well formed archaic script of the fifteenth century.</seg>
+                        <note>More tilted to the right, more round and larger spaces between characters than the previous hands. Unusual form of ኍ with 
+                           vowel mark on top on <locus target="#68ra #72va"/>.</note>
+                     </handNote>
+                     <handNote xml:id="h6" script="Ethiopic">
+                        <locus from="164vb" to="165rb"/>
+                        <seg type="ink">Black, red.</seg>
+                        <seg type="rubrication">Incipit.</seg>
+                        <seg type="script">More mediocre archaic script of the fifteenth century.</seg>
+                        <note>More mediocre and less careful than the other hands.</note>
+                     </handNote>
+                     <handNote xml:id="h7" script="Ethiopic">
+                        <locus from="166ra" to="173vb"/>
+                        <seg type="ink">Black, red.</seg>
+                        <seg type="rubrication">Incipits and chapter numbers.</seg>
+                        <seg type="script">Well formed archaic script of the fifteenth century.</seg>
+                     </handNote>
+                  </handDesc>
+                  <decoDesc>
+                     <decoNote xml:id="d1" type="drawing">
+                        <locus target="#1v"/>
+                        <desc>Rough drawing with black ink covering the entire page showing two tall figures with halos standing and one small figure to be 
+                           identified as an angel as it possibly is having wings and wearing a halo as well. Several crosses and cross-like ornaments are at the top of the 
+                           drawing.</desc>
+                     </decoNote>
+                     <decoNote xml:id="d2" type="miniature">
+                        <locus target="#2r"/>
+                        <desc>Multicolored, unfinished picture covering the entire page, showing a the Lord enthroned surrounded by the symbols of the four 
+                           evangelists and, in the lower part, two human figures with halos and an angel.</desc>
+                     </decoNote>
+                     <decoNote xml:id="d3" type="drawing">
+                        <locus target="#2v"/><desc>Large picture of a cross covering the entire page, carefully executed with ornaments filling the body
+                           of the cross.</desc>
+                     </decoNote>
+                     <decoNote xml:id="d4" type="miniature">
+                        <locus target="#3v"/>
+                        <desc>Multicolored picture covering the entire page showing 13 male bearded figures with halos and elegant dresses.</desc>
+                     </decoNote>
+                     <decoNote xml:id="d5" type="drawing">
+                        <locus target="4r"/>
+                        <desc>Drawing of a cross in black ink on the top of the page, partially faded away.</desc>
+                     </decoNote>
+                     <decoNote xml:id="d6" type="headpieceBand">
+                        <locus target="4va"/>
+                        <desc>Ornamental band in black ink on top of the page, partially erased.</desc>
+                     </decoNote>
+                     <decoNote xml:id="d7" type="headpieceBand">
+                        <locus target="5ra"/>
+                        <desc>Ornamental band in black and red ink on top of the page.</desc>
+                     </decoNote>
+                     <decoNote xml:id="d8" type="ornamentation">
+                        <desc>Small ornaments in red ink, black ink or red and black ink in the margins indicating chapter numbers or chapter
+                           breaks throughout.</desc>
+                     </decoNote>
+                     <decoNote xml:id="d9" type="diagram">
+                        <locus target="#182r"/>
+                        <desc>Four small almost identical texts in black with red titles and numerals were written in a scheme of four circular text boxes. 
+                           The text boxes have been drawn in red and carry numerals. 
+                           The text in the first textbox on the upper right: <foreign xml:lang="gez"><hi rend="rubric">ጰጕሜን፡</hi> እምቀዳማይ፡ ዓመቱ፡ 
+                              ለአዳም፡ እስከ፡ <hi rend="rubric">፭፻፴፫</hi>፡ ዓመቱ፡ ለድዮቅልጥያኖስ፡ በበ<hi rend="rubric">፬፡</hi> ዓመት፡ አውደ፡ ቀመሩ፡ ለጳጕሜን፡ 
+                              ወይከውን፡ አንቀጽ፡ <hi rend="rubric">፲፻፭፻፺፮፡</hi> አሜሃ፡ ፪፭ጳጕሜን፡</foreign> This textbox is surrounded by a set of numbers 
+                           from 1 to 5: <foreign xml:lang="gez"><hi rend="rubric">፩ ፪ ፫ ፬ ፭፡</hi></foreign>.
+                           The text in the second textbox on the upper left is the following: <foreign xml:lang="gez"><hi rend="rubric">እንድቅትዮን፡</hi> 
+                              እምቀዳማይ፡ ዓመቱ፡ ለአዳም፡ እስከ፡ <hi rend="rubric">፭፻፴<gap reason="lost" unit="chars" quantity="1"/>፡</hi> ዓመቱ፡ 
+                              ለድዮቅልጥያኖስ፡ በበ፡ ዓመቱ፡ <hi rend="rubric">፲፭</hi>ዓመት፡ አውዳ፡ ቀመሩ፡ ለእንድቅዮን፡ ይከውን፡ አንቀጽ፡ <hi rend="rubric">፬፻፳፭፡</hi>
+                              ወዓመት፡ <hi rend="rubric">፲</hi>አሜሃ፡ እንድቅትዮን፡</foreign> This textbox is surrounded by a set of numbers from 6 to 15: 
+                           <foreign xml:lang="gez"><hi rend="rubric">፮ ፯ ፰ ፱ ፲ ፲ ፩ ፲ ፪ ፲ ፫ ፲ ፬ ፲ ፭።</hi></foreign>.
+                           The text in the third textbox on the bottom right is the following: <foreign xml:lang="gez"><hi rend="rubric">ጥንቴዮን፡</hi> 
+                              እምቀዳማይ፡ ዓመቱ፡ ለአዳም፡ እስከ፡ <hi rend="rubric">፭፻፴፫፡</hi> ዓመቱ፡ ለድቅልጥያኖስ፡ በበ፡ <hi rend="rubric">፯</hi>ዓመት፡ አውደ፡ ቀመሩ፡ 
+                              ለጥንቴዮን፡ ወይከውን፡ አንቀጽ፡ <hi rend="rubric">፲፻፬፻፱፡</hi> ወአሜሃ፡ <hi rend="rubric">፫፡</hi> ጥንቴዮን፡</foreign> This textbox is 
+                           surrounded by a set of numbers from 1 to 7: <foreign xml:lang="gez"><hi rend="rubric">፩ ፪ ፫ ፬ ፭ ፮ ፯ </hi></foreign>.
+                           The text in the fourth textbox on the bottom left is the following: <foreign xml:lang="gez"><hi rend="rubric">አጰቅት፡</hi> 
+                              እምዳግም፡ ዓመቱ፡ ለአዳም፡ እስከ፡ <hi rend="rubric">፭፻፴፫፡</hi> ዓመቱ፡ ለድዮቅልጥያኖስ፡ በበ፡ <hi rend="rubric">፲፱</hi>ዓመት፡ አውደ፡ 
+                              ቀመሩ፡ ለአጰቅቱ፡ ወይከውን፡ አንቀጽ፡ <hi rend="rubric"><gap reason="lost" unit="chars" quantity="4"/></hi> ወአሜሃ፡ አልቦ፡ አጰቅቴ፡</foreign> 
+                           This textbox is surrounded by a set of numbers from 7 to 19: 
+                           <foreign xml:lang="gez"><hi rend="rubric">፯ ፰ ፱ ፲ ፲ ፩ ፲ ፪ ፲ ፫ ፲ ፬ ፲ ፭ ፲ ፮ ፲ ፯ ፲ ፰ ፲ ፱</hi></foreign>.
+                        </desc>
+                     </decoNote>
+                     <decoNote xml:id="d10" type="diagram">
+                        <locus target="#189v"></locus>
+                        <desc>Big round diagram in red divided in 8 circles with 19 circle segments dividing each circle to a total of 152 textbox filled with
+                           words or numbers surrounding a middle field with a small text as follows: <foreign xml:lang="gez">መዋዕለ፡ ዓመታት፡ 
+                           ዘ<hi rend="rubric">፲፱፡</hi> ዓመታት፡ ዘበእንተ፡ <hi rend="rubric">፲፬፡</hi> ለወርኅ፡ ዘከመ፡ ተኣዘዘ፡ በወስተ፡ ሕገ፡ ኦሪት፡ ይግበሩ፡ ጳስካ፡ ወተጽሕፈ፡ 
+                           ዝንቱ፡ ማእድ፡ በወርኅ፡ ሮምስ፡ ወሱርስ፡ ወመቄዶን፡ ወግብጽ፡ ወዘአጋዕዚ፡ ወትውጥኑ፡ ዝንቱ፡ ዘ<hi rend="rubric">፲፱፡</hi>ዓመታት፡ ደደቅ፡ በሓሳበ፡ ግብጽ፡ 
+                           ወሮምስ፡ አመ፡ <hi rend="rubric">፯፡</hi> ቦኢጰ፡ <hi rend="rubric">፮፬</hi>፡ ዘገርጢየንስ፡ <hi rend="rubric">፭</hi>፡ ለለቍዮዶስስ፡ 
+                           <hi rend="rubric">፬</hi>። ።</foreign>.
+                        </desc>
+                     </decoNote>
+                     <decoNote xml:id="d11" type="diagram">
+                        <locus target="#195v"></locus>
+                        <desc>Big round diagram in red divided in 6 circles with 19 circle segments dividing each circle to a total of 152 pockets, that are 
+                           meant to be filled with text, but remained empty surrounding a middle field with a small text in red as follows: 
+                           <foreign xml:lang="gez"><hi rend="rubric">ኦደ፡ ቀመሩ፡ አበቅ፲፱፲፱ቴ፡ ዘውእቱ፡ ፀሐይ።</hi></foreign>.
+                        </desc>
+                     </decoNote>
+                     <decoNote xml:id="d12" type="diagram">
+                        <locus from="199v" to="203v"/>
+                        <desc>Calendaric tables to calculate Pagwəmen, Epact and specific days of the year possibly by the same hand as <ref target="h3"/>.</desc>
+                     </decoNote>
+                  </decoDesc>
+                  <additions>
+                     <list>
+                        <item xml:id="a1">
+                           <locus from="1ra" to="1rb"/>
+                           <desc type="GuestText"><title ref="LIT6847ZemmareHosana"/> written by a poorly trained hand on folio 1r, that used to be part 
+                              of one protective quire.</desc>
+                        </item>
+                        <item xml:id="a2">
+                           <locus target="#1rb"/>
+                           <desc type="GuestText"><title ref="LIT6848ZemmareDabraZa"/> written by a poorly trained hand on folio 1r, that used to be part 
+                              of a protective quire.</desc>
+                        </item>
+                        <item xml:id="a3">
+                           <locus from="164va" to="164vb"/>
+                           <desc type="ScribalNoteCompleting">Colophon, partly faded away: <foreign xml:lang="gez">ተፈጸመት፡ 
+                              ዛቲ፡ መጽሐፍ፡ ለጸሓፊሃ፡ ወአጽሐፊቱ፡ ይምሕሮሙ፡ እግዚአብሔር፡ በመንግሥተ፡ ሰማይ፡ አሜን፡ ወአሜን። ።</foreign></desc>
+                        </item>
+                        <item xml:id="e1">
+                           <locus target="#1r #203v"/>
+                           <desc type="StampExlibris">Large oval stamp of a library with coat of arms surrounded by an inscription: 
+                              <foreign xml:lang="la">BIBL. CAES. MED. PALAT.</foreign></desc>
+                        </item>
+                        <item xml:id="e2">
+                           <locus target="#1r #5r #33r #203v"/>
+                           <desc type="StampExlibris">Small round stamp of a library with coat of arms surrounded by an inscription:
+                              <foreign xml:lang="it">R. BIBLIOTECA MED. LAUR. FIRENZE</foreign></desc>
+                        </item>
+                        <item xml:id="e3">
+                           <desc type="StampExlibris">"Orient. 148" written in black pen on the inner front cover board and on the protective leaf 
+                              <locus target="#i"/>.</desc>
+                        </item>
+                        <item xml:id="e4">
+                           <desc type="StampExlibris">"58" written in red pen on the inner front cover board.</desc>
+                        </item>
+                        <item xml:id="e5">
+                           <desc type="Comment">Titles in Latin in the upper margins y a European hand by a European hand, that was probably the
+                              one of <persName ref="PRS10036Wansleb"/> as in <ref target="#e7"/>:
+                              <foreign xml:lang="la">Canones Clementis</foreign> on <locus target="#5r"/>,
+                              <foreign xml:lang="la">Comput temporum Abissinorum</foreign> on <locus target="#174r"/>.
+                           </desc>
+                        </item>
+                        <item xml:id="e6">
+                           <desc type="Comment">Comments in Italian by a European hand in the upper margin 
+                              <foreign xml:lang="it">Lingua Abissina</foreign> on <locus target="#5r"/>, 
+                              <foreign xml:lang="la">Trattato contro quelli che negano la resurrezione dei Morti</foreign> on <locus target="#166r"/>, 
+                              <foreign xml:lang="la">in Lingua Abissina</foreign> on <locus target="#166r"/>.</desc>
+                        </item>
+                        <item xml:id="e7">
+                           <desc type="Comment">Various comments in Latin in the margins by a European hand, that is most likely the one of 
+                              <persName ref="PRS10036Wansleb"/>, who collated this codex and who is indicated by the siglum "G. M." for "Giovanni 
+                              Michele (Wansleben)": 
+                              <foreign xml:lang="la">penta polim</foreign> on <locus target="#6vb"/>,
+                              <foreign xml:lang="la">Ieroboami</foreign> on <locus target="#49ra"/>,
+                              <foreign xml:lang="la">rufiano</foreign> on <locus target="#53rb"/>,
+                              <foreign xml:lang="la">Di quello chi bugara</foreign> on <locus target="#57vb"/>,
+                              <foreign xml:lang="la">Consilium Caesarense</foreign> on <locus target="#67va"/>,
+                              <foreign xml:lang="la">Didemus hic esse defectus nec enim bene sequuntur sequentia. </foreign> on <locus target="#136vb"/>,
+                              <foreign xml:lang="la">omnino hic est defectus</foreign> on <locus target="#139vb"/>,
+                              <foreign xml:lang="la">defectus hic est sed parum refert</foreign> on <locus target="#146va"/>,
+                              <foreign xml:lang="la">hic est defectus magnus. G. M.</foreign> on <locus target="#162vb"/>,
+                              <foreign xml:lang="la">antecedentia desunt. G. M.</foreign> on <locus target="#163ra"/>.
+                           </desc>
+                        </item>
+                        <item xml:id="e8">
+                           <locus target="#7ra #151va #152rb #153rb #162va"/>
+                           <desc type="Correction">Small corrections to the Ethiopic text by a European hand.</desc>
+                        </item>
+                        <item xml:id="e9">
+                           <desc type="Correction">Corrections by an Ethiopian hand throughout the text.</desc>
+                        </item>
+                        <item xml:id="e10">
+                           <locus target="#203v"/>
+                           <desc type="StampExlibris">"207746" written on the bottom margin.</desc>
+                        </item>
+                        <item xml:id="e11">
+                           <locus target="#182r"/>
+                           <desc type="Unclear">A line of ill-shaped Syriac characters: 
+                              <foreign xml:lang="syr">ܢܡܐܫܦ ܐܜܚܒܔܩܚܣܝܬܢܬ</foreign></desc>
+                        </item>
+                        <item xml:id="e12">
+                           <desc type="StampExlibris">"N. 58 III" written on the top of the spine and partially faded.</desc>
+                        </item>
+                        <item xml:id="e13">
+                           <desc type="StampExlibris">"Orient" written in pencil on the bottom of the spine.</desc>
+                        </item>
+                        <item xml:id="e14">
+                           <desc type="StampExlibris">"148" written in ink on the bottom of the spine.</desc>
+                        </item>
+                     </list>
+                  </additions>
+                  <bindingDesc>
+                     <binding>
+                        <decoNote xml:id="b1" type="Boards">European binding in leather.</decoNote>    
+                        <decoNote xml:id="b2" type="SewingStations">4</decoNote>
+                        <decoNote xml:id="b3" type="bindingMaterial"><material key="wood"></material></decoNote>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate evidence="internal-date">Year <date when="1426">ወኮነ፡ ኍልቈ፡ ዓመተ፡ ዘቅድመ፡ አይኅ፡ 
+                        <hi rend="rubrig">፷፻፡ ወ፬፻፡ ወ፷፰፡</hi> ዓመታቲሁ፡</date> mentioned on <locus target="#181rb" corresp="#ms_i6"/>
+                        refers to <date when="1426"/>.</origDate>
+                  </origin>
+                  <provenance>
+                     <note>According to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">92 and 95
+                     </citedRange></bibl>, most of the parts of the manuscript may have been copied to <ref type="mss" target="#BAVborget2"/>.
+                     </note>
+                  </provenance>
+               </history>
                <additional>
                   <adminInfo>
                      <recordHist>
@@ -46,6 +840,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               <bibl>
                                  <ptr target="bm:Marrassini1987manoscrittietiopici"/>
                                  <citedRange unit="page">90-97</citedRange>
+                              </bibl>
+                           </listBibl>
+                           <listBibl type="secondary">
+                              <bibl>
+                                 <ptr target="bm:MauroLeonessa1942ConcilioNicea"/>
+                                 <citedRange unit="page">31</citedRange>
                               </bibl>
                            </listBibl>
                         </source>
@@ -63,7 +863,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="it">Italian</language>
+            <language ident="gez">Gəʿəz</language>
+            <language ident="la">Latin</language>
+            <language ident="syr">Syriac</language>
+         </langUsage>
       </profileDesc>
       <revisionDesc>
          <change who="PL" when="2016-11-17">Created XML record from Ethio authority google spreadsheet</change>
@@ -71,7 +877,35 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
       <body>
-         <ab/>
+         <div type="edition" corresp="a1" xml:lang="gez">
+            <ab><add place="above">ሀዘ</add>ዝማሬ፡ ዘሆሳዕና፡ ግዕዝ፡ ንዜኑ፡ ክብራ፡ ለዐድግት፡ እስመ፡ ተጻዕነ፡ ለዕሌሃ፡ ነደ፡ እሳት፡ ነበልበለ፡ ኀይል። አትሕትና፡ ዘእንበለ፡ 
+               መስፈርት፡ አትሕትና፡ ዘእንበለ፡ ዐቅም። ለርኁባን፡ ኅብስት፡ ለጽሙዐን፡ አነቅዕት። ኦ። ተቀበልዎ፡ ነሲኦሙ፡ አዕጹቀ፡ በቀልት፡ ደቂቅ፡ አዕሩግ፡ ወሕፃናት። ኦ። ተጽኢኖ፡ ዲበ፡ አድግ፡
+               ወእዋለ፡ ቡአ፡ እየሩሳሌም፡ በእንተ፡ ሰንበት፡ ወይቤሉ፡ ሆሳዕና፡ በአርያም። ኦ። በከመ፡ ነስአ፡ አብርሃም፡ አዕጽቀ፡ በቀልት፡ ሰብሐ፡ ወዘመረ፡ በ<cb n="1rb"/>በእለተ፡ ሰንበት።
+               ኦ።<add place="above">እም</add>ተጽዕነ፡ ዲበ፡ ዕዋል፡ ዘይጼዐን፡ ለዕለ፡ <persName ref="PRS13936Kirubel">ኪሩ፡ ቤል፡ </persName>
+               </ab>          
+         </div>
+         <div type="edition" corresp="a2" xml:lang="gez">
+            <ab>ዝማሪ፡ ዘደብረ፡ ዘይት፡ እንዘ፡ ይነብር፡ እግዚእነ፡ ውስተ፡ ደብረ፡ ዘይት፡ ተስእልዎ፡ 
+               አርዳኢሁ፡ ወይቤልዎ፡ ማእዜ፡ ይከውን፡ ምጽእትከ፡ ወለሕልቀተ፡ ዓለም፡ ወይ<gap reason="illegible" unit="chars" quantity="2"/>ሙ፡ ለአርዳኢሁ፡ እምበለስ፡
+               አእምሩ፡ አዕጹቀሁ፡ ወይትነሥአ፡ አሕዝብ፡ ለዕለ፡ ሕዝብ፡ ወይከውን፡ ብድብደ፡ ወድልቅልቅ፡ በበብሔር፡ ዝኵሉ፡ ለእመ፡ ኮነ፡ አሚሀ፡ ኬ፡ ምጽአቱ፡ ለወልደ፡ እጓለ፡ እምሕያው፡ 
+               ምስለ፡ ኵሉ፡ ኀይለ፡ ሰማይት፡ አሜሃ፡ ይውሕዝ፡ <gap reason="illegible" unit="chars" quantity="2"/>ዝ፡ እሳት፡ 
+               ወ<gap reason="illegible" unit="chars" quantity="4"/>ብሱ፡ አብሕርተ፡ እሳት፡ ወይትረወጹ፡ መላእክት፡ ለአሣተ፡ ጋብአ፡</ab>
+         </div>
+         <div type="edition" corresp="ms_i1" xml:lang="gez">
+            <ab>እመካን፡ ኢይንሣእ፡ ዘእንበለ፡ መጻሕፍቲሁ፡ ወአልባሲሁ፡ ወለእመቦ፡ ዘኀብአ፡ እንግዳ፡ እመሂ፡ ወርቅ፡ ወእመሂ፡ ብሩር፡ ይሰደድ፡ ወይኩን፡ ውፁአ፡ 
+               እማኅበረ፡ ቅዱሳን፡ ወለአበ፡ ምኔት፡ ወለረበይታ፡ ይትአዙ፡ ወይንበሩ፡ በፍቅር፡ ወለእመ፡ ቦ፡ ዘአበየ፡ ተአዝዞ፡ ለቅዱሳን፡ ወለአበ፡ ምኔት፡ ይሰደድ፡ ወእግዚአብሔር፡ ይባርክ፡ ላዕለ፡ ኵልነ፡ 
+               ወይረስየነ፡ ድልዋነ፡ ለመንግሥቱ፡ በጸሎታ፡ ለማርያም፡ እግዝእትነ፡ ወላዲተ፡ አምላክ፡ ወበጸሎተ፡ ኵሎሙ፡ ቅዱሳን፡ ጻድቃን፡ ወሰማዕት፡ ለዓለመ፡ ዓለም፡ አሜን። ወአሜን። ወለእመቦ፡ 
+               ዘተዓደወ፡ በእዴሁ፡ ይጹም፡ ፺ዕለተ፡ እስከ፡ ዕርባተ፡ ፀሓይ፡ <cb n="3rb"/>ይ፡ በኀብስት፡ ወፄው፡ ወማይ፡ ወባዓልት፡ ምእት፡ ይስግድ፡ ወበሌሊት፡ ምእት፡ ይስግድ፡ ወለእመቦ፡ 
+               ዘፀረፈ፡ ላዕለ፡ እኁሁ፡ በቃሉ፡ ይጹም፡ ፴፡ ዕለተ፡ እስከ፡ ዕርባተ፡ ፀሐይ፡ በኅብስት፡ ወፄው፡ ወይስግድ፡ በሌሊት፡ ምእት፡ ወበመዓልት፡ ምእት፡ ከመ፡ ካልኣን፡ ርኢዮሙ፡ ይፈርሁ። ጸለዩ፡ 
+               ለዘ፡ ጽሐፈ፡ ለሠረቀ፡ ብርሃን፡ ነዳይ፡ ወኢትርግሙኒ፡ ለእኁክሙ፡ ለኃጥእ፡ ወለአባሲ፡ ወሰላም፡ ለክሙ፡ አባዊየ፡ ወአኃዊየ፡ ተዘከሩኒ፡ በጸሎትክሙ፡ ጸልዩ፡ 
+               ለ<persName ref="PRS0000">ገብረ፡ ክርስቶስ፡</persName> ለዘ፡ አጽሐፈ፡ ዘንተ፡ በሕብረተ፡ ቅዱሳን፡ <pb n="4vb"/>በአኰቴተ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ 
+               ቅዱስ። በ<date>፭፻፳፬ዓመተ፡ ምሕረት፡</date> ሠራዕነ፡ ማኅባረ፡ 
+               በ<placeName ref="LOC3957Jerusa">ኢየሩሳሌም፡</placeName> አመ፡ ፲ወ፬፡ ለመስከረም፡ ፰፡ ካህናት፡ ወ፰፡ ዲያቆናት፡ ወ፯አበው፡ ተጋቢአነ፡ አጽሐፍነ፡ ዘንተ፡ 
+               ወዘቀዳሚ፡ ግዘተ፡ ኅቢረነ፡ ዓቢይ፡ ወንኡስ፡ ተባዕት፡ ወአንስት፡ ኃቢረነ፡ ካላእነ፡ ዘአልቦ፡ ጋእዛ፡ ወዘአልቦ፡ ናቃፌ፡ በከመ፡ ሥርዓተ፡ 
+               <persName ref="PRS1962Anthony">እንጦንስ፡</persName> ወ<persName ref="PRS6427Macarius">መቃርስ፡</persName> 
+               ከመ፡ ንንበር፡ ተባዕተ፡ ወአንስተ፡ በበ፡ መካናቲነ፡ ወለእመ፡ መጽአ፡ እንግዳ፡ ይትወካፍዎ፡ ፫፡ ዕለተ፡ ወለእመ፡ ቦአ፡ ወገብአ፡ ኃበ፡ መይዳ፡ ያግብእ፡ ኵሎ፡ ዘሀለዎ፡ ብሩር፡ ወወርቅ፡ ኃበ፡ 
+               ቤተ፡ ማኅበር፡ ኃበ፡ ቅዱሳን፡ ወለእመ፡ ኢገብአ፡ ኃበ፡ ማኅበር፡ ይግበር፡ በዓለ፡ ወይሖር፡ ወለእመቦ፡ ዘወፅአ፡ </ab>
+         </div>
       </body>
    </text>
 </TEI>

--- a/FlorenceBML/BMLor148.xml
+++ b/FlorenceBML/BMLor148.xml
@@ -42,9 +42,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <msItem xml:id="ms_i1">
                      <locus from="3ra" to="3rb"/><locus target="#4vb"/>
                      <title>Monastery rule</title>
-                     <note>Document of the Ethiopian community of Jerusalem, dated to 524 year of mercy, i.e. to 1321/1322 AD, concerning rules
-                        of the convent, edited and translated in 
-                        <bibl><ptr target="bm:Cerulli19431947EtiopiI-II"/><citedRange unit="page">380-382</citedRange></bibl>.</note>
+                     <note>Document of the Ethiopian community of Jerusalem, dated to <date when-custom="524" calendar="grace">524 
+                        year of mercy</date>, i.e. to <date notBefore="1321" notAfter="1322"/>, concerning rules of the convent, edited and 
+                        translated in <bibl><ptr target="bm:Cerulli19431947EtiopiI-II"/><citedRange unit="page">380-382</citedRange></bibl>.
+                     </note>
                   </msItem>
                   <msItem xml:id="ms_i2">
                      <locus from="4ra" to="4va"/>
@@ -378,7 +379,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      <locus from="176" to="181"/>
                      <title>Chronological computus</title>
                      <note>According to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">90</citedRange>
-                     </bibl> the text on f. 181v ends abruptly, so that some folios or quires must be missing.</note>
+                     </bibl> the text on <locus target="#181v"/> ends abruptly, so that some folios or quires must be missing.</note>
                   </msItem>
                   <msItem xml:id="ms_i7">
                      <locus target="182r"/>
@@ -423,15 +424,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               <height>290</height>
                               <width>180</width>
                            </dimensions>
-                           <note>The dimensions refers to the size of the boards and is taken from the notification in the scan images, what is different
-                              differs from the account in <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">90</citedRange>
-                              </bibl>, that most likely refers to the size of the folio pages.</note>
+                           <note>The dimensions are taken from the indication in the scan images.</note>
                         </extent>
-                        <foliation>One protective leaf before and one after the textblock. Textblock leaves marked with folio numbers in pen by a rather 
-                           early European hand on top right. It is probably the hand of <persName ref="PRS10036Wansleb">Johann-Michael Wansleben</persName>
-                           who is possibly also responsible for some corrections and comments to the text, that are indicated in <ref target="#e4 #e5"/>.
+                        <foliation>One protective leaf before and one after the textblock. Two different sets of foliation marks throughout in the textblock.
+                           The earlier folio numbers are written in pen by a rather early European hand on top right containing a number of mistakes. It is 
+                           probably the hand of <persName ref="PRS10036Wansleb">Johann-Michael Wansleben</persName>, who is possibly also 
+                           responsible for some corrections and comments to the text, that are indicated in <ref target="#e4 #e5"/>.
                            In this older folio numbering, the first two folios are not counted and numbers 100 and 137 have been skipped, while number 101 
-                           is numbered twice. Protective leafs marked with I and I' on the bottem left by a different recent European hand. 
+                           is numbered twice. The later foliation marks are written by pencil and consistent. Protective leafs are marked with I and I' on the 
+                           bottom left in pen by a different recent European hand. 
                         </foliation>
                         <collation>
                            <list>
@@ -442,7 +443,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                  <note>According to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">90</citedRange>
                                  </bibl> the binding of the initial binion has been reversed. The original order was <locus target="#2"/> followed by 
                                     <locus target="#1"/> followed by <locus target="#4"/> followed by <locus target="#3"/>. An additional protective 
-                                    was attached as a single leave before the quire.</note>
+                                    leaf was attached as a single leaf before the quire.</note>
                               </item>
                               <item xml:id="q2" n="2">
                                  <dim unit="leaf">8</dim>
@@ -499,7 +500,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                  s.l. 6, stub after 2
                               </item>
                               <item xml:id="q14" n="14">
-                                 <dim unit="leaf">8</dim>
+                                 <dim unit="leaf">7</dim>
                                  <locus from="101" to="107"/>
                                  s.l. 6, stub after 1
                               </item>
@@ -570,14 +571,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            </list>
                         </collation>
                         <condition key="good"> 
-                           Ripped lower corner on <locus target="#4"/>. Watershed with writing partly blurred and small pollutions throughout. Writing has 
+                           Ripped lower corner on <locus target="#4"/>. Watershed with writing partly blurred and small stains throughout. Writing has 
                            faded on <locus target="#4r"/>. Repairs with a thread on <locus target="#163 #169"/> including an extraordinarily fine work, 
                            which was carried out with a very thin needle and without textloss on <locus target="#169"/>.
                         </condition>
                      </supportDesc>
                      <layoutDesc><layout columns="2" writtenLines="24">
-                        <note>Number of written lines varies. In the middle part it is a less with mostly 21 or 22 written lines, but considerably higher in many folia
-                           on <locus from="4r" to="4v"> and on </locus> <locus from="166" to="199r"/> with maximum 40 written lines on 
+                        <note>Number of written lines varies. In the middle part it is mostly 21 or 22 written lines, but considerably higher in many folia
+                           as on <locus from="4r" to="4v"/> and on <locus from="166" to="199r"/> with maximum 40 written lines on 
                            <locus target="#4v"/> and 45 written lines on <locus target="#188r"/>. As an exception the text on folio 
                            <locus target="182r"/> was written in one column in the upper part of the page.</note>
                         <ab type="pricking">Pricking is visible</ab>
@@ -589,19 +590,20 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      <handNote xml:id="h1" script="Ethiopic">
                         <locus target="#3r #4vb"/>
                         <seg type="ink">Black.</seg>
-                        <seg type="script">Accurate script of the fifteenth century executed with a small pen and with relatively tall characters.</seg>
+                        <seg type="script">Accurate script of the <date notBefore="1400" notAfter="1500">fifteenth century</date>, executed with a 
+                           small pen and with relatively tall characters.</seg>
                      </handNote>
                      <handNote xml:id="h2" script="Ethiopic">
                         <locus from="4ra" to="4va"/>
                         <seg type="ink">Black, red.</seg>
                         <seg type="rubrication">Incipits and chapter numbers.</seg>
-                        <seg type="script">Script of the fifteenth century.</seg>
+                        <seg type="script">Script of the <date notBefore="1400" notAfter="1500">fifteenth century</date>.</seg>
                      </handNote>
                      <handNote xml:id="h3" script="Ethiopic">
                         <locus from="5ra" to="38r"/><locus from="174r" to="199r"/>
                         <seg type="ink">Black, red.</seg>
                         <seg type="rubrication">Incipits and chapter numbers.</seg>
-                        <seg type="script">Well formed archaic script of the fifteenth century.</seg>
+                        <seg type="script">Well formed archaic script of the <date notBefore="1400" notAfter="1500">fifteenth century</date>.</seg>
                         <note>Slightly tilted to the left and more angular than the others. According to 
                            <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">90</citedRange></bibl> 
                            the shift of the laryngeal ə to a is not always observed. The numeral for "1", that is supposed to be expressed with
@@ -615,14 +617,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <locus from="38v" to="44v"/>
                         <seg type="ink">Black, red.</seg>
                         <seg type="rubrication">Incipits and chapter numbers.</seg>
-                        <seg type="script">Well formed archaic script of the fifteenth century.</seg>
+                        <seg type="script">Well formed archaic script of the <date notBefore="1400" notAfter="1500">fifteenth century</date>.</seg>
                         <note>Slightly tilted to the right and more round than <ref target="h3"/>.</note>
                      </handNote>
                      <handNote xml:id="h5" script="Ethiopic">
                         <locus from="45r" to="164va"/>
                         <seg type="ink">Black, red.</seg>
                         <seg type="rubrication">Incipits and chapter numbers.</seg>
-                        <seg type="script">Well formed archaic script of the fifteenth century.</seg>
+                        <seg type="script">Well formed archaic script of the <date notBefore="1400" notAfter="1500">fifteenth century</date>.</seg>
                         <note>More tilted to the right, more round and larger spaces between characters than the previous hands. Unusual form of ኍ with 
                            vowel mark on top on <locus target="#68ra #72va"/>.</note>
                      </handNote>
@@ -630,14 +632,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <locus from="164vb" to="165rb"/>
                         <seg type="ink">Black, red.</seg>
                         <seg type="rubrication">Incipit.</seg>
-                        <seg type="script">More mediocre archaic script of the fifteenth century.</seg>
+                        <seg type="script">More mediocre archaic script of the <date notBefore="1400" notAfter="1500">fifteenth century</date>.</seg>
                         <note>More mediocre and less careful than the other hands.</note>
                      </handNote>
                      <handNote xml:id="h7" script="Ethiopic">
                         <locus from="166ra" to="173vb"/>
                         <seg type="ink">Black, red.</seg>
                         <seg type="rubrication">Incipits and chapter numbers.</seg>
-                        <seg type="script">Well formed archaic script of the fifteenth century.</seg>
+                        <seg type="script">Well formed archaic script of the <date notBefore="1400" notAfter="1500">fifteenth century</date>.</seg>
                      </handNote>
                   </handDesc>
                   <decoDesc>
@@ -649,12 +651,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      </decoNote>
                      <decoNote xml:id="d2" type="miniature">
                         <locus target="#2r"/>
-                        <desc>Multicolored, unfinished picture covering the entire page, showing a the Lord enthroned surrounded by the symbols of the four 
-                           evangelists and, in the lower part, two human figures with halos and an angel.</desc>
+                        <desc>Multicolored, unfinished picture covering the entire page, showing a the Lord enthroned surrounded by the symbols of 
+                           the four evangelists and, in the lower part, two human figures with <term key="halo">halos</term> and an 
+                           <term key="angel"/>.</desc>
                      </decoNote>
                      <decoNote xml:id="d3" type="drawing">
-                        <locus target="#2v"/><desc>Large picture of a cross covering the entire page, carefully executed with ornaments filling the body
-                           of the cross.</desc>
+                        <locus target="#2v"/><desc>Large picture of a <term key="cross"/> covering the entire page, carefully executed with ornaments 
+                           filling the body of the cross.</desc>
                      </decoNote>
                      <decoNote xml:id="d4" type="miniature">
                         <locus target="#3v"/>
@@ -726,8 +729,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      <list>
                         <item xml:id="a1">
                            <locus from="1ra" to="1rb"/>
-                           <desc type="GuestText"><title ref="LIT6847ZemmareHosana"/> written by a poorly trained hand on folio 1r, that used to be part 
-                              of one protective quire.</desc>
+                           <desc type="GuestText"><title ref="LIT6847ZemmareHosana"/> written by a poorly trained hand on <locus target="#1r"/>,
+                              that used to be part of one protective quire.</desc>
                         </item>
                         <item xml:id="a2">
                            <locus target="#1rb"/>
@@ -737,7 +740,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <item xml:id="a3">
                            <locus from="164va" to="164vb"/>
                            <desc type="ScribalNoteCompleting">Colophon, partly faded away: <foreign xml:lang="gez">ተፈጸመት፡ 
-                              ዛቲ፡ መጽሐፍ፡ ለጸሓፊሃ፡ ወአጽሐፊቱ፡ ይምሕሮሙ፡ እግዚአብሔር፡ በመንግሥተ፡ ሰማይ፡ አሜን፡ ወአሜን። ።</foreign></desc>
+                              ዛቲ፡ መጽሐፍ፡ ለጸሓፊሃ፡ ወአጽሐፊቱ፡ ይምሕሮሙ፡ እግዚአብሔር፡ በመንግሥተ፡ ሰማይ፡ አሜን፡ ወአሜን። ።</foreign> The palaeographic style is very similar, but the characters
+                              are standing more apart from each other than the main text indicating a later addition. The characters have faded away,
+                              probably because of the poorer quality of the ink, that was used.</desc>
                         </item>
                         <item xml:id="e1">
                            <locus target="#1r #203v"/>
@@ -822,14 +827,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </physDesc>
                <history>
                   <origin>
-                     <origDate evidence="internal-date">Year <date when="1426">ወኮነ፡ ኍልቈ፡ ዓመተ፡ ዘቅድመ፡ አይኅ፡ 
-                        <hi rend="rubric">፷፻፡ ወ፬፻፡ ወ፷፰፡</hi> ዓመታቲሁ፡</date> mentioned on <locus target="#181rb" corresp="#ms_i6"/>
+                     <origDate evidence="internal-date">Year <date when="1426" when-custom="6468" calendar="creation">ወኮነ፡ ኍልቈ፡ ዓመተ፡ 
+                        ዘቅድመ፡ አይኅ፡ <hi rend="rubric">፷፻፡ ወ፬፻፡ ወ፷፰፡</hi> ዓመታቲሁ፡</date> mentioned on <locus target="#181rb" corresp="#ms_i6"/>
                         refers to <date when="1426"/>.</origDate>
                   </origin>
                   <provenance>
                      <note>According to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">92 and 95
-                     </citedRange></bibl>, most of the parts of the manuscript may have been copied to <ref type="mss" target="#BAVborget2"/>.
-                     </note>
+                     </citedRange></bibl>, most parts of the manuscript are also found in <ref type="mss" target="#BAVborget2"/> with a number 
+                        of common errors indicating that both have been produced in the same context.</note>
                   </provenance>
                </history>
                <additional>
@@ -898,8 +903,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                ዘተዓደወ፡ በእዴሁ፡ ይጹም፡ ፺ዕለተ፡ እስከ፡ ዕርባተ፡ ፀሓይ፡ <cb n="3rb"/>ይ፡ በኀብስት፡ ወፄው፡ ወማይ፡ ወባዓልት፡ ምእት፡ ይስግድ፡ ወበሌሊት፡ ምእት፡ ይስግድ፡ ወለእመቦ፡ 
                ዘፀረፈ፡ ላዕለ፡ እኁሁ፡ በቃሉ፡ ይጹም፡ ፴፡ ዕለተ፡ እስከ፡ ዕርባተ፡ ፀሐይ፡ በኅብስት፡ ወፄው፡ ወይስግድ፡ በሌሊት፡ ምእት፡ ወበመዓልት፡ ምእት፡ ከመ፡ ካልኣን፡ ርኢዮሙ፡ ይፈርሁ። ጸለዩ፡ 
                ለዘ፡ ጽሐፈ፡ ለሠረቀ፡ ብርሃን፡ ነዳይ፡ ወኢትርግሙኒ፡ ለእኁክሙ፡ ለኃጥእ፡ ወለአባሲ፡ ወሰላም፡ ለክሙ፡ አባዊየ፡ ወአኃዊየ፡ ተዘከሩኒ፡ በጸሎትክሙ፡ ጸልዩ፡ 
-               ለ<persName ref="PRS0000">ገብረ፡ ክርስቶስ፡</persName> ለዘ፡ አጽሐፈ፡ ዘንተ፡ በሕብረተ፡ ቅዱሳን፡ <pb n="4vb"/>በአኰቴተ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ 
-               ቅዱስ። በ<date>፭፻፳፬ዓመተ፡ ምሕረት፡</date> ሠራዕነ፡ ማኅባረ፡ 
+               ለ<persName ref="PRS14047GabraKrestos">ገብረ፡ ክርስቶስ፡</persName> ለዘ፡ አጽሐፈ፡ ዘንተ፡ በሕብረተ፡ ቅዱሳን፡ <pb n="4vb"/>በአኰቴተ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ 
+               ቅዱስ። በ<date when-custom="524" calendar="grace" notBefore="1321" notAfter="1322">፭፻፳፬ዓመተ፡ ምሕረት፡</date> ሠራዕነ፡ ማኅባረ፡ 
                በ<placeName ref="LOC3957Jerusa">ኢየሩሳሌም፡</placeName> አመ፡ ፲ወ፬፡ ለመስከረም፡ ፰፡ ካህናት፡ ወ፰፡ ዲያቆናት፡ ወ፯አበው፡ ተጋቢአነ፡ አጽሐፍነ፡ ዘንተ፡ 
                ወዘቀዳሚ፡ ግዘተ፡ ኅቢረነ፡ ዓቢይ፡ ወንኡስ፡ ተባዕት፡ ወአንስት፡ ኃቢረነ፡ ካላእነ፡ ዘአልቦ፡ ጋእዛ፡ ወዘአልቦ፡ ናቃፌ፡ በከመ፡ ሥርዓተ፡ 
                <persName ref="PRS1962Anthony">እንጦንስ፡</persName> ወ<persName ref="PRS6427Macarius">መቃርስ፡</persName> 

--- a/FlorenceBML/BMLor148.xml
+++ b/FlorenceBML/BMLor148.xml
@@ -98,7 +98,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <locus from="17rb" to="38rb"/>
                         <title ref="LIT2679ACAbt2"/>
                         <note>81 Apostolic Canons of Clement, to be distinguished from other witnessed variants by the name 
-                           <foreign xml:lang="get">በጥልሳት፡</foreign> instead of the usually preferred forms <foreign xml:lang="">አብጥልሳት፡</foreign>
+                           <foreign xml:lang="gez">በጥልሳት፡</foreign> instead of the usually preferred forms <foreign xml:lang="gez">አብጥልሳት፡</foreign>
                            or <foreign xml:lang="gez">ኤብጥልሳት፡</foreign>.</note>
                         <incipit xml:lang="gez"><hi rend="rubric">ዝንቱ፡ ሴኖዶስ፡ ዘሐዋርያት፡ ቅዱሳን፡ ዘነገረ፡ ቃሌምንጦስ፡ ወይእቲ፡ በጥልሳት፡ ዘኀበሩ፡ ባቲ፡ አርዳኢሁ፡ 
                            ለእግዚእነ፡<pb n="17va"/> ክርስቶስ፡ ወኆልቁ፡ ፹ወ፩፡ <add place="margin">፩</add>ትእዛዝ፡</hi> በእንተ፡ ሢመተ፡ ኤጲስ፡ ቆጶስ፡ ወሊቀ፡ 
@@ -757,7 +757,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <desc type="StampExlibris">"58" written in red pen on the inner front cover board.</desc>
                         </item>
                         <item xml:id="e5">
-                           <desc type="Comment">Titles in Latin in the upper margins y a European hand by a European hand, that was probably the
+                           <desc type="Comment">Titles in Latin in the upper margins by a European hand by a European hand, that was probably the
                               one of <persName ref="PRS10036Wansleb"/> as in <ref target="#e7"/>:
                               <foreign xml:lang="la">Canones Clementis</foreign> on <locus target="#5r"/>,
                               <foreign xml:lang="la">Comput temporum Abissinorum</foreign> on <locus target="#174r"/>.
@@ -766,8 +766,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <item xml:id="e6">
                            <desc type="Comment">Comments in Italian by a European hand in the upper margin 
                               <foreign xml:lang="it">Lingua Abissina</foreign> on <locus target="#5r"/>, 
-                              <foreign xml:lang="la">Trattato contro quelli che negano la resurrezione dei Morti</foreign> on <locus target="#166r"/>, 
-                              <foreign xml:lang="la">in Lingua Abissina</foreign> on <locus target="#166r"/>.</desc>
+                              <foreign xml:lang="it">Trattato contro quelli che negano la resurrezione dei Morti</foreign> on <locus target="#166r"/>, 
+                              <foreign xml:lang="it">in Lingua Abissina</foreign> on <locus target="#166r"/>.</desc>
                         </item>
                         <item xml:id="e7">
                            <desc type="Comment">Various comments in Latin in the margins by a European hand, that is most likely the one of 
@@ -823,7 +823,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <history>
                   <origin>
                      <origDate evidence="internal-date">Year <date when="1426">ወኮነ፡ ኍልቈ፡ ዓመተ፡ ዘቅድመ፡ አይኅ፡ 
-                        <hi rend="rubrig">፷፻፡ ወ፬፻፡ ወ፷፰፡</hi> ዓመታቲሁ፡</date> mentioned on <locus target="#181rb" corresp="#ms_i6"/>
+                        <hi rend="rubric">፷፻፡ ወ፬፻፡ ወ፷፰፡</hi> ዓመታቲሁ፡</date> mentioned on <locus target="#181rb" corresp="#ms_i6"/>
                         refers to <date when="1426"/>.</origDate>
                   </origin>
                   <provenance>

--- a/LondonBritishLibrary/orient/BLorient481.xml
+++ b/LondonBritishLibrary/orient/BLorient481.xml
@@ -249,7 +249,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            
                            
                            <msItem xml:id="ms_i3.5.5">
-                              <locus from="168r" to="168r"/>
+                              <locus from="168r" to="168v"/>
                               <title type="complete" ref="LIT2642CanonsAp"/>
                               <incipit xml:lang="gez">በእንተ፡ ዓቀበ፡ ጊዜ፡ አ ቅዱሙ፡ ጸሎተ።</incipit>
                            </msItem>

--- a/LondonBritishLibrary/orient/BLorient794.xml
+++ b/LondonBritishLibrary/orient/BLorient794.xml
@@ -325,7 +325,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                        <textLang mainLang="gez"></textLang>
                      </msItem>
                      <msItem xml:id="ms_i1.12.16">
-                       <locus from="138r" to="151v"></locus>
+                       <locus from="138r" to="151r"></locus>
                        <title type="complete" ref="LIT2688CanonsNicaea2" xml:lang="gez">
                        ሲኖዶስ፡ ዘኒቅያ፡</title>
                        <textLang mainLang="gez"></textLang>


### PR DESCRIPTION
I updated BMLor148. 

Again the description of quires and the description of hands is different from Marrassinis descriptions. 

For the description of ms_i3 (Senodos) I took BLorient481 and BLorient794 as examples and for this reason encoded the Indices of some canons seperately, although I think, that this is not the perfect way of encoding it. It might be better to include the Indices to each of the records of the canons, but this would require a reworking of all Senodos manuscript record so far encoded.

I obstained from encoding any Clement in ms_i3 as discussed in Issue #2387.

The astronomical treatises in the back part of the manuscript (ms_i5, ms_i6, ms_i7, ms_i8, ms_i10) I did only a minimal record and left a more precise description to @DenisNosnitsin1970, who asked me to leave this to him, since he is dealing with a number of calendaric works in manuscript at the moment. However I already encoded some diagrams as decorations as demonstrated already in Issue #2378.

Similarly to Marrassini, I could not identify the moral teaching in ms_i9.

I still need to check the volume in the HLC-library for the Mawāśəʾət za-ʾArsima in ms_i2, that is adressed in Issue #2381.

I encoded two new sets of Zəmmāre Chants as additions a1 and a2 as discussed in Issue #2381.

For the line of Syriac characters I kept a very minimal record in e11 as discussed in Issue #2377.