### PR TITLE
Eth 205 223 343

### DIFF
--- a/ParisBNF/et/BNFet205.xml
+++ b/ParisBNF/et/BNFet205.xml
@@ -5,7 +5,8 @@ schematypens="http://relaxng.org/ns/structure/1.0"
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-             <title>Maṣḥafa Falāsfā Ṭabibān, Physiologus, Excerpts of Ethiopian history, Ṭǝbāba Sābelā, Sentences of the wise philosophers, Fǝkkāre ʾIyasus, Biblical chronology, Baralām wa-Yǝwāsǝf</title>
+             <title>Maṣḥafa Falāsfā Ṭabibān, Physiologus, Excerpts of Ethiopian history, Ṭǝbāba Sābelā, Sentences of the wise philosophers, 
+                 Fǝkkāre ʾIyasus, Biblical chronology, Baralām wa-Yǝwāsǝf</title>
             <editor key="MV"/>
             <editor key="AB" role="generalEditor"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -26,7 +27,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                     <collection>Manuscrits orientaux</collection>
                     <collection>Fonds éthiopien</collection>
                     <collection>Collection Mondon-Vidailhet</collection>
-                    <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b52504823x">BnF Éth. 205</idno>
+                    <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b52504823x">BnF Éthiopien 205</idno>
                     <altIdentifier>
                         <idno>Mondon-Vidailhet 19</idno>
                     </altIdentifier>
@@ -180,8 +181,18 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                             <listRelation>
                                 <relation name="betmas:formerlyAlsoListedAs" active="BNFet205" passive="BNFmon19"/>
                             </listRelation>
+                            <listBibl type="catalogue">
+                                <bibl>
+                                    <ptr target="bm:Chaine1913Mondon"/>
+                                    <citedRange unit="page">10-11</citedRange> 
+                                    <citedRange unit="number">19 (205)</citedRange>
+                                </bibl>
+                                
+                            </listBibl>
                         </source>
+                         
                      </recordHist>
+                      
                   </adminInfo>
                </additional>
             </msDesc>
@@ -204,6 +215,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
            <change who="MV" when="2018-02-15">Created catalogue entry</change>
            <change who="DR" when="2022-04-11">Added link to images</change>
            <change who="DR" when="2023-10-09">Added relation to deleted BNFmon19</change>
+           <change who="DR" when="2023-10-09">Added bibliography</change>
        </revisionDesc>
    </teiHeader>
     <text xml:base="https://betamasaheft.eu/">

--- a/ParisBNF/et/BNFet223.xml
+++ b/ParisBNF/et/BNFet223.xml
@@ -5,7 +5,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Gadla Takla Hāymānot, Amharic notes on French grammar</title>
+            <title>Vita of Takla Hāymānot, Amharic notes on French grammar</title>
             <editor key="DR"/>
             <editor key="AB" role="generalEditor"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -26,11 +26,25 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                      <collection>Manuscrits orientaux</collection>
                      <collection>Fonds éthiopien</collection>
                      <collection>Collection Mondon-Vidailhet</collection>
-                     <idno>BnF Éth. 223</idno>
+                     <idno>BnF Éthiopien 223</idno>
                      <altIdentifier>
                         <idno>Mondon-Vidailhet 37</idno>
                      </altIdentifier>
                   </msIdentifier>
+               <msContents>
+                  <summary/>
+                  <msItem xml:id="ms_i1">
+                     <locus from="1r"/>
+                     <title type="complete" ref="LIT3969GadlaTHW"/>
+                     <textLang mainLang="gez"/>
+                  </msItem>
+                     
+                     <msItem xml:id="ms_i2">
+                        <locus from="18r"/>
+                        <title type="complete">Notes on French grammar in Amharic</title>
+                        <textLang mainLang="am"/>                    
+                  </msItem>
+               </msContents>
                   <additional>
                      <adminInfo>
                         <recordHist>
@@ -39,6 +53,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                  <bibl>
                                  <ptr target="bm:Chaine1913Mondon"/>
                                  <citedRange unit="page">24</citedRange>
+                                    <citedRange unit="number">37 (223)</citedRange>
                               </bibl>
                               </listBibl>
                               <listRelation>
@@ -67,6 +82,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
       <revisionDesc>
          <change who="DR" when="2016-10-31">Created catalogue entry</change>
          <change who="DR" when="2023-10-09">Added relation to deleted BNFmon37</change>
+         <change who="DN" when="2023-10-11">Added bibliography and content description</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">

--- a/ParisBNF/et/BNFet343.xml
+++ b/ParisBNF/et/BNFet343.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <title>Hagiographic dossier of Takla Hāymānot</title>
+                <title>Vita and Miracles of Takla Hāymānot</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="DR"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -35,6 +35,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <adminInfo>
                             <recordHist>
                                 <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Grebaut1941GriauleII"/>
+                                            <citedRange unit="page">20-25</citedRange>                                           
+                                        </bibl>
+                           
+                                    </listBibl>
                                  <listRelation>
                                      <relation name="betmas:formerlyAlsoListedAs" active="BNFet343" passive="BNFgriaule343"/>
                                  </listRelation>
@@ -73,6 +80,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
     <text xml:base="https://betamasaheft.eu/">
         <body>
             <div type="bibliography"/>
+            
          <!---->
         </body>
     </text>


### PR DESCRIPTION
Minor changes (shelfmarks, bibliography). Only one record exists for each of MSS et 205 - mondon 19, et 223 - mondon 37, and et 343 - griaule 39 (doublets have been deleted by Dorothea).  Note that now found Griaule and Mondon are in the through numbering starting with Ethiopien (all saved in one folder, together with the older Ethiopien ... from Zotenberg), but Fond Abbadie obviously does not have that abbadie descriptions placed separately.