### PR TITLE
Tanasee1

### DIFF
--- a/Tanasee/Tanasee1.xml
+++ b/Tanasee/Tanasee1.xml
@@ -336,7 +336,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </decoNote>
                             <decoNote xml:id="d11" type="miniature">
                                 <locus target="#11r"/>
-                                <desc>Finely executed full-page <ref type="authFile" target="AT1034Tempietto"/> depicting a pavillon with a number of birds including two 
+                                <desc>Finely executed full-page <ref type="authFile" corresp="AT1034Tempietto"/> depicting a pavillon with a number of birds including two 
                                     peacocks accompanied by two gazelles representing the Fountain of Life with some words added: 
                                     <foreign xml:lang="gez">ባቡላ</foreign>, <foreign xml:lang="gez">ኑባሬ፡ ሥርዓት።</foreign> and 
                                     <foreign xml:lang="gez">ባዙላ</foreign>. This miniature was described and reproduced 
@@ -582,7 +582,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <locus target="#4vb"/>
                                     <desc type="MixedNote">Commemorative note (Tazkār) on a person named 
                                         <persName ref="PRS14080SardaMaryam">ሠርፀ፡ ማርያም፡</persName>, who donated to the church of Māryām by
-                                        a similar hand as <ref target="#a14 #a15"/>.</desc>
+                                        a similar hand as <ref target="#a14"/> and <ref target="#a15"/>.</desc>
                                     <q xml:lang="gez">ለዘ፡ እምዘ፡ ብእሲ፡ አዕብይዎ፡ ወአክብርዎ፡ በሕይወቱ። ወእምድኅረ፡ ሞቱሂ፡ ግበሩ፡ ሎቱ፡ ተዝካሮ፡ ከመ፡ አባ፡ 
                                         <persName ref="PRS14078GabraKrestos">ገብረ፡ ክርስቶስ፡</persName> 
                                         ወ<persName ref="PRS14079GabraAmlak">ገብረ፡ አምላክ</persName>። ወዘንተ፡ ኵሎ፡ ዘወሀበ፡ 
@@ -600,7 +600,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <item xml:id="a16">
                                     <locus target="#5ra"/>
                                     <desc type="Inventory">Note on church utensils, that nǝburaʾǝd <persName ref="PRS14081TanseaKrestos"/> 
-                                        donated to <placeName ref="LOC4042Kebran "/> by a similar hand as <ref target="#a13 #a18"/>.</desc>
+                                        donated to <placeName ref="LOC4042Kebran "/> by a similar hand as <ref target="#a13"/> and <ref target="#a18"/>.</desc>
                                     <q xml:lang="gez">ወዘንተ፡ ንዋየ፡ ቤተ፡ ክርስቲያን፡ ዘወሀበ፡ ንቡረ፡ እድ፡ <persName ref="PRS14081TanseaKrestos">ተንሥአ፡ ክርስቶስ፡</persName> 
                                         ለመካነ፡ ገብርኤል፡ ወለማርያም፡ ፪አጽሕልት፡ ዘወርቅ፡ ወ፪፡ ጽዋዕ፡ ዘወርቅ። <gap reason="ellipsis" unit="lines" quantity="16"/></q>
                                 </item>
@@ -611,7 +611,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <item xml:id="a18">
                                     <locus from="5va" to="5vb"/>
                                     <desc>Order of <persName ref="PRS6229LebnaDe"/> for the distribution of land when he celebrated Easter in 
-                                        <placeName ref="LOC5733Sima"/> by a similar hand as <ref target="#a13 #a14"/>.</desc>
+                                        <placeName ref="LOC5733Sima"/> by a similar hand as <ref target="#a13"/> and <ref target="#a14"/>.</desc>
                                     <q xml:lang="gez">በአኰቴተ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ እጕለትኩ፡ አ<add resp="CH">ፄ፡ </add>
                                         <persName ref="PRS6229LebnaDe">ወናግ፡ ሰገድ፡</persName> 
                                         ንጉሥ፡ እንዘ፡ ሀላውኩ፡ በ<placeName ref="LOC3549Gojjam">ጐዣም፡</placeName> አመ፡ ወዐልኩ፡ 
@@ -789,7 +789,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <item xml:id="a30">
                                     <locus target="#184ra"/>
                                     <desc type="LandGrant">Short note on a land grant. The word <foreign xml:lang="gez">ዘአጉልቶ</foreign> was
-                                        added later by another hand, that is also attested in <ref target="a31"/> directly below.</desc>
+                                        added later by another hand, that is also attested in <ref target="#a31"/> directly below.</desc>
                                     <q xml:lang="am">አጼ፡ <persName ref="PRS8550sardaDe">ሰርጸ፡ ድ<add place="above">ን</add>ግል፡</persName>
                                         ዘወሀብዎ፡ ለመቅደስ፡ ገብርኤል፡ ምድረ፡ <placeName ref="LOC7399Dazma">ይዝማ፡</placeName> የዟመረው፡ ሰረው፡ 
                                         የ<placeName ref="LOC3549Gojjam">ጎጃም፡</placeName> ነጋሽ፡
@@ -798,7 +798,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </item>
                                 <item xml:id="a31">
                                     <locus target="#184ra"/>
-                                    <desc type="LandGrant">Note by another hand as <ref target="a30"/>, but apparently refers to regular taxes that
+                                    <desc type="LandGrant">Note by another hand as <ref target="#a30"/>, but apparently refers to regular taxes that
                                         had to be paid by the inhabitants of the aforementioned fiefdom of <placeName ref="LOC7399Dazma"/> to
                                         <placeName ref="LOC4042Kebran"/>.</desc>
                                     <q xml:lang="gez">ወጉልቶሙሂ፡ ወሀበ፡ ለመቅደሰ፡ ገብርኤል፡ ዘ<placeName ref="LOC4042Kebran">ክብራን፡</placeName>
@@ -1084,7 +1084,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <desc type="ScribalNoteCommissioning">Scribal note, that mentions <persName ref="PRS6229LebnaDe"/> and 
                                             also <persName ref="PRS14077FereKrestos"/> and <persName ref="PRS14088TaklaSyon"/>, two dignitaries, 
                                             who are also mentioned in <ref target="#a44"/> that can be dated to the early 16th century. 
-                                            Written by a hand similar to <ref target="#a52 #a53"/>.</desc>
+                                            Written by a hand similar as <ref target="#a52"/> and <ref target="#a53"/>.</desc>
                                         <q xml:lang="gez">ዛቲ፡ መጽሐፍ፡ ዘአጽሐፈ፡ 
                                             <persName ref="PRS14144GabraKrestosRWN" role="donor">ገብረ፡ ክርስቶስ፡ ራሴ፡ ወልደ፡ ኖብ፡</persName> 
                                             በ፭አልሕምት፡ ዘተሣየጠ፡ ለ<persName ref="PRS14145TabotSeyon" role="donor">ታቦት፡ ጽዮን፡</persName>

--- a/Tanasee/Tanasee1.xml
+++ b/Tanasee/Tanasee1.xml
@@ -791,7 +791,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <desc type="LandGrant">Short note on a land grant. The word <foreign xml:lang="gez">ዘአጉልቶ</foreign> was
                                         added later by another hand, that is also attested in <ref target="a31"/> directly below.</desc>
                                     <q xml:lang="am">አጼ፡ <persName ref="PRS8550sardaDe">ሰርጸ፡ ድ<add place="above">ን</add>ግል፡</persName>
-                                        ዘወሀብዎ፡ ለመቅደስ፡ ገብርኤል፡ ምድረ፡ <placeName ref="LOC7399Dazma">ደዝማ፡</placeName> የዟመረው፡ ሰረው፡ 
+                                        ዘወሀብዎ፡ ለመቅደስ፡ ገብርኤል፡ ምድረ፡ <placeName ref="LOC7399Dazma">ይዝማ፡</placeName> የዟመረው፡ ሰረው፡ 
                                         የ<placeName ref="LOC3549Gojjam">ጎጃም፡</placeName> ነጋሽ፡
                                         <persName ref="PRS12219Hara">ሐራ፡</persName> ነው፡ <add place="above">ዘአጉልቶ፡</add> ወለቍልቢጥ፡ አባሂ፡ 
                                         መሪው፡ ሰሪው፡ <persName ref="PRS14200MarawSarawWG">ወልደ፡ ጊዮርጊስ፡</persName> ነው፡ </q>

--- a/Tanasee/Tanasee1.xml
+++ b/Tanasee/Tanasee1.xml
@@ -1041,7 +1041,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <locus from="236ra" to="236va"/>
                                         <desc type="LandGrant">Landgrant of King <persName ref="PRS10342Yeshaq">Yəsḥaq</persName> with a 
                                             very similar incipit and by a similar hand as <ref target="#a51"/> directly above.</desc>
-                                        <q xml:lang="gez">በስመ፡ እግዚአብሔር፡ አበ፡ ኢየሱስ፡ ክርስቶስ፡ አበ፡ ሣህል፡ <gap reason="ellipsis" unit="lines" quantity="5"/> አጽሐፍኩ፡ 
+                                        <q xml:lang="gez">በስመ፡ እግዚአብሔር፡ አበ፡ ኢ<supplied reason="omitted">የ</supplied>ሱስ፡ ክርስቶስ፡ አበ፡ ሣህል፡ 
+                                            <gap reason="ellipsis" unit="lines" quantity="5"/> አጽሐፍኩ፡ 
                                             ዘንተ፡ መጽሐፈ፡ አነ፡ <persName ref="PRS10342Yeshaq">ይስሐቅ፡</persName> ወስመ፡ መንግሥትየ፡ 
                                             <persName ref="PRS10342Yeshaq">ገብረ፡ መስቀል፡ ሠርፀ፡ እስራኤል፡</persName> እምቤተ፡ አብርሃም፡
                                             <gap reason="ellipsis" unit="lines" quantity="1"/> እዕሎኩ፡ ዘንተ፡ መጽሐፈ፡ ውስተ፡ ዛቲ፡ ወንጌለ፡ ጸጋሁ፡ ለእግዚእነ፡ 
@@ -1055,7 +1056,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             ወእንዘ፡ ቀስ፡ ሐፄ፡ <persName ref="PRS14212BatsagaQirqos">በፀጋ፡ ቂርቆስ</persName>።
                                             ወእንዘ፡ ሊቀ፡ ዲያቆናት፡ <persName ref="PRS14213Yosef">ዮሴፍ፡</persName>
                                             ወእንዘ፡ ኢቃቂታት፡ <persName ref="PRS14214GabraKrestos">ገብረ፡ ክርስቶስ</persName>።
-                                            ወእንዘ፡ ቀላበስ፡ ዛን፡ <persName ref="PRS14215Hash">ሐሽ፡</persName> 
+                                            ወእንዘ፡ ቀላባስ፡ ዛን፡ <persName ref="PRS14215Hash">ሐሽ፡</persName> 
                                             ወእንዘ፡ ይትመጻኔ፡ መዋዔ።
                                             ወእንዘ፡ መጌምድር፡ <persName ref="PRS14168Delmangasa">ድልመንገሣ፡</persName> ወአፈ፡ መጌምድር፡ ይትአኰት፡ ስሙ፡ 
                                             ወእንዘ፡ <persName ref="PRS14217ShebherZanane">ሽብሕር፡ ዘናኔ፡</persName> ወእንዘ፡ ስዩመ፡ 
@@ -1118,7 +1119,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <gap reason="lost" unit="chars" quantity="1"/>
                                             መባሕተ፡ አበውየ፡ ቅዱሳ<gap reason="lost" unit="chars" quantity="1"/>፡
                                             ምድረ፡ <placeName ref="LOC7383Qwebitsa">ቍቢጻ፡</placeName> ከመ፡ ይኩኖ፡ ርስተ፡ 
-                                            ለ<persName ref="PRS14151Zaiyasus">ዘኢየሱስ፡ </persName>ዐቃቢ። እመሂ፡ ንቡረ፡ እድ፡ ወእመሂ፡ ቂስ፡ ገበዝ፡ እመሂ፡ 
+                                            ለ<persName ref="PRS14151Zaiyasus">ዘኢየሱስ፡ </persName>ዐቃቢ። እመሂ፡ ንቡረ፡ እድ፡ ወእመሂ፡ ቄስ፡ ገበዝ፡ እመሂ፡ 
                                             ሊቀ፡ ዲያቆን፡ ወራቅማሰራሂ፡ ዘቦአ፡ በተአድዎ፡ ይኩን፡ ውጉዘ፡ በአፈ፡ ሥሉስ፡ ቅዱስ፡ ወበአፈ፡ እግዝእትነ፡ ማርያም፡
                                             <gap reason="ellipsis" unit="lines" quantity="4"/>ሰባክያነ፡ ወንጌል፡ ሐዲስ፡ እሱረ፡ ይኩኑ፡ ለዓለመ፡ ዓለም፡ አሜን። ። ።</q>
                                     </item>

--- a/Tanasee/Tanasee1.xml
+++ b/Tanasee/Tanasee1.xml
@@ -36,44 +36,144 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <idno>Kǝbrān 1</idno>
                         </altIdentifier>
                     </msIdentifier>
-                    <msContents>
-                        <summary>Gospels</summary>
-                        <msItem xml:id="ms_i1">
-                            <locus from="6r" to="7r"/>
-                            <title ref="LIT1349EpistlEusebius"/>
-                            <incipit xml:lang="gez">አውሴብስ፡ ለቃርጲያኖስ፡ ለዘ፡ ኣፈቅር፡ እኁየ፡ ፍሥሓ፡ ወዳኅና፡ ለከ፡ እምኀበ፡ እግዚአብሔር፡ እምንስ፡ አንከ፡ አሌክስንድርያዊ፡ በብዙኅ፡ 
-                                አስተሐምሞ፡ </incipit>
-                           <explicit xml:lang="gez">ኢያሱስ፡ ክርስቶስ፡ ወኀበሂ፡ አዘዘ፡ ወኀበሂ፡ ገሠጸ፡ ወኀበሂ፡ መሀረ፡ ወኀበሂ፡ ነበረ፡ ወትአምርት፡ ኀበ፡ ማዕተበ፡ መስቀል። </explicit> 
-                            <note>Decorated with in finely <ref target="#d1 #d2 #d3">illuminated frames</ref>.</note>
-                        </msItem>
-                        <msItem xml:id="ms_i2">
-                            <locus from="7v" to="10v"/>
-                            <title ref="LIT1224Canons"/>
-                            <note>Decorated with finely <ref target="#d4 #d5 #d6 #d7 #d8 #d9 #d10">illuminated frames</ref> bearing the 
-                                headline <foreign xml:lang="gez">ሥርዐት። ። ዘኀብሩ፡ አርባዕቱ። ።</foreign>.</note>
-                        </msItem>
-                        <msItem xml:id="ms_i3">
-                            <locus from="22va" to="22vb"/>
-                            <title>Treatise on the four Evangelists and their symbols</title> 
-                            <incipit xml:lang="gez">እስመ፡ ኵሎሙ፡ ጸሐፉ፡ ዘከመ፡ ርእዩ፡ ወስምዑ፡ ዜና፡ ስብከቱ፡ ለኢያሱስ፡ ክርስቶስ፡ ወንጌል፡ ቅዱስ።</incipit>
-                            <explicit xml:lang="gez">ወንሕነኒ፡ ተማሕፀነ፡ በወንጌለ፡ መላኮትከ፡ ከመ፡ ትምሐረነ፡ ለዓለመ፡ ዓለም፡ አሜን። ።</explicit>
-                        </msItem>
-                        <msItem xml:id="ms_i4">
-                            <locus from="23ra" to="230vb"/>
-                            <title ref="LIT1560Gospel"/>
-                            <note>The heading of each Evangile is placed in the first line of the two columns. Finding aids by a similar hand, but
-                                with a different pen and ink is placed at the end of each text part below the text as well as verse numbers and finding aids
-                                on top of the text throughout.</note>
-                            <msItem xml:id="ms_i4.1">
-                                <locus from="23ra" to="84rb"/>
-                                <title ref="LIT1558Matthew"/>
-                                    <msItem xml:id="ms_i4.1.1">
+                    <physDesc>
+                        <objectDesc form="Codex">
+                        <supportDesc> 
+                            <support>
+                                <material key="parchment"/>
+                            </support>
+                            <extent>
+                                <measure unit="leaf" quantity="239">239</measure>
+                                <note>Number of leaves contrary to <bibl><ptr target="bm:Hammerschmidt1973Tanasee"/><citedRange
+                                    unit="page">84</citedRange></bibl>, who counted 240 leaves.</note>
+                                <note>Dimensions indicated below may concern outer dimensions of bookcover or dimensions of folia (not clearly 
+                                    specified in catalogue).</note>
+                                <dimensions type="outer" unit="mm">                                        
+                                    <height cert="medium" unit="mm">380</height>
+                                    <width cert="medium" unit="mm">260</width>
+                                    <depth cert="medium" unit="mm">100</depth>
+                                </dimensions>
+                            </extent>
+                            <foliation>Foliation marks on small pieces of paper, which were applied to the inner margin of every 5th recto when photographed. 
+                                The folio mark for <locus target="#200"/> is missing. The folio mark '205r' is misplaced and actually indicates 
+                                <locus target="#204r"/>. Following this mistake the mark '210r' is in fact placed on <locus target="#209r"/>and so on until to 
+                                the end.</foliation>
+                            <collation>
+                                <note>The quire structure is not discernible in the microfilmed images, but based on the contents and palaeographic analyses of the 
+                                    hands involved, the last quire, which may extend from <locus target="#233"/> to <locus target="#239"/> and which contains a 
+                                    number of additions and extras, may have been added to the codex later in a rebinding.</note>
+                            </collation>
+                            <condition key="good">Microfilm images in some places hardly legible, particularly on <locus from="1r" to="5v"/>, 
+                                where several parts have been erased and are not legible in the images. Damaged by moisture on <locus target="#29v #30r #46v"/>.</condition>
+                        </supportDesc>
+                        </objectDesc>
+                        <additions>
+                            <list>
+                                <item xml:id="a1">
+                                    <locus target="#2r"/>
+                                    <desc type="OwnershipNote">By a modern Ethiopian hand on top of the folio with previously erased text.</desc>
+                                    <q xml:lang="gez">ዘደሴት፡ ቅዱስ፡ ገብርኤል፡ መጽሐ።</q>
+                                </item>
+                                <item xml:id="a41">
+                                    <locus from="233vb"  to="234r"/>
+                                    <desc type="Inventory">Note with tall size characters, on the books of <placeName ref="LOC4042Kebran "/> 
+                                        since the time of <persName ref="PRS8595SayfaAr"/> and <persName ref="PRS8387SalamaI"/>. However the note is 
+                                        likely to be copied later, because also <persName ref="PRS3429DawitII"/> is mentioned, what indicates a date for this 
+                                        addition not before <date notBefore="1380">1380</date>. It was written on two folia <locus target="#233vb #234r"/>, 
+                                        that are supposed to be part of two distinct quires from distinct codices, that have been joined later. It contains an ancient 
+                                        form of <foreign xml:lang="gez">ኍ</foreign> with the mark of the order on top. The list was continued in 
+                                        <ref target="#a42"/>.</desc>
+                                    <q xml:lang="gez">በአኰቴተ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ። ኍልቈ፡ መጻሕፍት፡ ለገብርኤል፡ 
+                                        ዘደብረ፡ <placeName ref="LOC4042Kebran">ክብራን፡</placeName> ነዋ፡ ዝንቱ፡ ውእቱ፡ ወንጌል፡ ፪፡
+                                        <gap reason="ellipsis" unit="lines" quantity="49"/>ተጽሕፈት፡ ዛቲ፡ ግዘት፡ እንዘ፡ ንጉሥነ፡ 
+                                        <persName ref="PRS8595SayfaAr">ሰይፈ፡ አርዐደ፡</persName> 
+                                        ወጳጳስነ፡ አባ፡ <persName ref="PRS8387SalamaI">ሰላማ፡</persName> 
+                                        ወአበመካንነ፡ አባ፡ <persName ref="PRS14209Daneel">ዳንኤል፡</persName> ይጽሐፍ፡ ስሞሙ፡ እግዚአብሔር፡ 
+                                        ውስተ፡ መጽሕይወት፡ በሰማያት፡ አሜን። ወለንጉሥነሂ፡ <persName ref="PRS3429DawitII">ቈስጠንጢኖስ፡</persName> ዘሐነጸ፡ ዘንተ፡ መካነ፡ 
+                                        ቅዱሰ፡ ሀቦ፡ እግዚአብሔር፡ ማኅደረ፡ ሰማያዌ፡ አሜን። <persName ref="PRS3429DawitII">ቈስጠንጢኖስ፡</persName> ንጉሥነ፡
+                                        <gap reason="ellipsis" unit="lines" quantity="7"/> ብዝኀ፡ ምሕረትከ፡ ተሣሀሎ፡ በሕቱ፡ አሜን።</q>
+                                </item>
+                                <item xml:id="a42">
+                                    <locus from="234r" to="234v"/>
+                                    <desc type="Inventory">Continuation of the aforementioned inventory list in <ref target="#a38"/> by a later hand.</desc>
+                                    <q xml:lang="gez">ወእምድኅረ፡ ተጽፋ። እላንቱ፡ ተወሰከ፡ ወጽሐፍነ፡ እስክንድር፩፡ <gap reason="ellipsis" unit="lines" quantity="17"/>
+                                    ለይወስከ፡ ላዕሌሃ፡ መከዕቢት፡ መከዕቢት፡ እግዚእነ፡ ኢያሱስ፡ ክርስቶስ፡ አሜን። አሜን። አሜን። ። ።</q>
+                                </item>
+                                <item xml:id="e4">
+                                    <locus target="#234v"/>
+                                    <desc type="findingAid"/>
+                                    <q xml:lang="gez">ዘንተ፡ ሥርዐተ፡ ሠራ</q>
+                                </item>
+                            </list>
+                        </additions>
+                        <bindingDesc>
+                            <binding>
+                                <decoNote xml:id="b1" type="Boards">Two wooden boards covered with leather.</decoNote>    
+                                <decoNote xml:id="b2" type="SewingStations">4</decoNote>
+                                <decoNote xml:id="b3" type="bindingMaterial"><material key="wood"></material></decoNote>
+                                <decoNote xml:id="b4" type="Cover"><material key="leather"></material></decoNote>
+                            </binding>
+                        </bindingDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1350" notAfter="1412" evidence="internal-date">Palaeographic analysis indicates that the manuscript 
+                                dates from the late 14th or early 15th century. This dating is supported by an addition <ref target="#a2"/>, which has 
+                                <date when="1412"/> as date for this addition. However this early dating of the manuscript is contradicted by a scribal 
+                                supplication in <ref target="#a46"/>, which dates the manuscript to the mid-16th century, but which is at odds with another scribal 
+                                supplication in <ref target="#a4"/> and is most likely a supplication referring to another codex on a folio, which was
+                                added later to the codex in a rebinding. This view is supported by <ref target="#a51"/> in the same quire, that contains 
+                                a reference to the <ref target="LIT1955Mashaf"/>, that is not included in this volume.</origDate>
+                        </origin>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source><listBibl type="catalogue">
+                                        <bibl><ptr target="bm:Hammerschmidt1973Tanasee"/><citedRange
+                                                unit="page">84–91</citedRange></bibl>
+                                    </listBibl></source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                    <msPart xml:id="p1"><msIdentifier/>
+                        <msContents><summary>Gospels</summary>
+                            <msItem xml:id="p1_i1">
+                                <locus from="6r" to="7r"/>
+                                <title ref="LIT1349EpistlEusebius"/>
+                                <incipit xml:lang="gez">አውሴብስ፡ ለቃርጲያኖስ፡ ለዘ፡ ኣፈቅር፡ እኁየ፡ ፍሥሓ፡ ወዳኅና፡ ለከ፡ እምኀበ፡ እግዚአብሔር፡ እምንስ፡ አንከ፡ አሌክስንድርያዊ፡ በብዙኅ፡ 
+                                    አስተሐምሞ፡ </incipit>
+                                <explicit xml:lang="gez">ኢያሱስ፡ ክርስቶስ፡ ወኀበሂ፡ አዘዘ፡ ወኀበሂ፡ ገሠጸ፡ ወኀበሂ፡ መሀረ፡ ወኀበሂ፡ ነበረ፡ ወትአምርት፡ ኀበ፡ ማዕተበ፡ መስቀል። </explicit> 
+                                <note>Decorated with finely <ref target="#d1 #d2 #d3">illuminated frames</ref>.</note>
+                            </msItem>
+                            <msItem xml:id="p1_i2">
+                                <locus from="7v" to="10v"/>
+                                <title ref="LIT1224Canons"/>
+                                <note>Decorated with finely <ref target="#d4 #d5 #d6 #d7 #d8 #d9 #d10">illuminated frames</ref> bearing the 
+                                    headline <q xml:lang="gez">ሥርዐት። ። ዘኀብሩ፡ አርባዕቱ። ።</q>.</note>
+                            </msItem>
+                            <msItem xml:id="p1_i3">
+                                <locus from="22va" to="22vb"/>
+                                <title>Treatise on the four Evangelists and their symbols</title> 
+                                <incipit xml:lang="gez">እስመ፡ ኵሎሙ፡ ጸሐፉ፡ ዘከመ፡ ርእዩ፡ ወስምዑ፡ ዜና፡ ስብከቱ፡ ለኢያሱስ፡ ክርስቶስ፡ ወንጌል፡ ቅዱስ።</incipit>
+                                <explicit xml:lang="gez">ወንሕነኒ፡ ተማሕፀነ፡ በወንጌለ፡ መላኮትከ፡ ከመ፡ ትምሐረነ፡ ለዓለመ፡ ዓለም፡ አሜን። ።</explicit>
+                            </msItem>
+                            <msItem xml:id="p1_i4">
+                                <locus from="23ra" to="230vb"/>
+                                <title ref="LIT1560Gospel"/>
+                                <note>The heading of each Gospel is placed in the first line of the two columns. Finding aids by a similar hand, but
+                                    with a different pen and ink are placed at the end of each text part below the text as well as verse numbers and finding aids
+                                    on top of the text throughout.</note>
+                                <msItem xml:id="p1_i4.1">
+                                    <locus from="23ra" to="84rb"/>
+                                    <title ref="LIT1558Matthew"/>
+                                    <msItem xml:id="p1_i4.1.1">
                                         <locus from="23ra" to="23vb"/>
                                         <title ref="LIT1558Matthew#TitlesMatthew"/>
                                         <incipit xml:lang="gez">፩በእንተ፡ ሰብአ፡ ሰገል። ። ፪በእንተ፡ እለ፡ ተቀትሉ፡ ሕፃናት። ። </incipit>
                                         <explicit xml:lang="gez">፷፰በእንተ፡ ዘከመ፡ ስእለ፡ ዮሴፍ፡ ሥጋሁ፡ ለእግዚእነ። ። አርእስተ፡ ነገር፡ እምወንጌለ፡ ማቴዎስ፡ ቅዱስ፡ ፷ወ፰። ። </explicit>
                                     </msItem>
-                                    <msItem xml:id="ms_i4.1.2">
+                                    <msItem xml:id="p1_i4.1.2">
                                         <locus from="25ra" to="84rb"/>
                                         <title ref="LIT2709Matthew"/>
                                         <incipit xml:lang="gez">መጽሐፈ፡ ልደቱ፡ ለኢየሱስ፡ ክርስቶስ፡ ወልደ፡ ዳዊት፡ ወልደ፡ አብርሃም።</incipit>
@@ -84,17 +184,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             has been erased and replaced by a shorter text by a later hand as indicated by 
                                             <bibl><ptr target="bm:NestleAlandNTGrL1969"/></bibl> in his apparatus to Mt. 27,49.</note>
                                     </msItem>
-                            </msItem>
-                            <msItem xml:id="ms_i4.2">
-                                <locus from="84va" to="121va"/>
-                                <title ref="LIT1882MarkGo"/>
-                                    <msItem xml:id="ms_i4.2.1">
+                                </msItem>
+                                <msItem xml:id="p1_i4.2">
+                                    <locus from="84va" to="121va"/>
+                                    <title ref="LIT1882MarkGo"/>
+                                    <msItem xml:id="p1_i4.2.1">
                                         <locus from="84va" to="85rb"/>
                                         <title ref="LIT1882MarkGo#TituliMark"/>
                                         <incipit xml:lang="gez">፩በእንተ፡ ዘጋኔን።</incipit>
                                         <explicit xml:lang="gez">፵፰በእንተ፡ ስእለተ፡ ሥጋሁ፡ ለእግዚእነ።</explicit>
                                     </msItem>
-                                    <msItem xml:id="ms_i4.2.2">
+                                    <msItem xml:id="p1_i4.2.2">
                                         <locus from="87ra" to="121va"/>
                                         <title ref="LIT2711Mark"/>
                                         <incipit xml:lang="gez">ቀዳሚሁ፡ ለወንጌል፡ ኢየሱስ፡ ክርስቶስ፡ ወልደ፡ እግዚኣብሔር፡ በከመ፡ ጽሑፍ፡ ውስተ፡ ነቢያት፡ ናሁ፡ አነ፡ እፌኑ፡ መልአክየ፡ ቅድመ፡ ግጽከ፡
@@ -102,83 +202,54 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <explicit xml:lang="gez">ወነበረ፡ በየማነ፡ እግዚአብሔር፡ አቡሁ። ። ወወፂኦሙ፡ እምህየ፡ እሙንቱ፡ በኵልሄ፡ ሰበኩ፡ እንዘ፡ እግዚአብሔር፡ ይረድእ፡ ወቃሎ፡ ያጽንዕ፡ 
                                             በትእምርት፡ ዘይተሉ፡ አሜን። ።</explicit>
                                     </msItem>
-                            </msItem>
-                            <msItem xml:id="ms_i4.3">
-                                <locus from="121vb" to="183ra"/>
-                                <title ref="LIT1812GospelLuke"/>
-                                    <msItem xml:id="ms_i4.3.1">
+                                </msItem>
+                                <msItem xml:id="p1_i4.3">
+                                    <locus from="121vb" to="183ra"/>
+                                    <title ref="LIT1812GospelLuke"/>
+                                    <msItem xml:id="p1_i4.3.1">
                                         <locus from="121vb" to="123ra"/>
                                         <title ref="LIT1812GospelLuke#TituliLuke"/>
                                         <incipit xml:lang="gez">፩በእንተ፡ ጻሕፍ።</incipit>
                                         <explicit xml:lang="gez">፹፫በእንተ፡ ዘሰአለ፡ ሥጋሁ፡ ለእግዚእነ። ።</explicit>
                                     </msItem>
-                                    <msItem xml:id="ms_i4.3.2">
+                                    <msItem xml:id="p1_i4.3.2">
                                         <locus from="124ra" to="183ra"/>
                                         <title ref="LIT2713Luke"/>
                                         <incipit xml:lang="gez">እስመ፡ ብዙኃን፡ እለ፡ አኃዙ፡ ወጠኑ፡ ይንግሩ፡ ወይግበሩ፡ ወይሜህሩ፡ በእንተ፡ ግብር፡ ዘአምኑ፡ በላዕሌነ፡ በከመ፡ መሀሩነ፡ 
                                             እለ፡ ቀደሙነ፡ ርእዮቶ፡ ወተልእክዎ፡ በቃሉ።</incipit>
                                         <explicit xml:lang="gez">ወነበሩ፡ ቤተ፡ መቅደስ፡ ዘልፈ፡ እንዘ፡ ይሴብሕዎ፡ ወይባርክዎ፡ ለእግዚኣብሔር፡ ለዓለመ፡ ዓለም፡ አሜን። ። ።</explicit>
                                     </msItem>
-                            </msItem>
-                            <msItem xml:id="ms_i4.4">
-                                <locus from="183rb" to="231vb"/>
-                                <title ref="LIT1693John"/>
-                                    <msItem xml:id="ms_i4.4.1">
+                                </msItem>
+                                <msItem xml:id="p1_i4.4">
+                                    <locus from="183rb" to="231vb"/>
+                                    <title ref="LIT1693John"/>
+                                    <msItem xml:id="p1_i4.4.1">
                                         <locus from="183rb" to="183va"/>
                                         <title ref="LIT1693John#TituliJohn"/>
                                         <incipit xml:lang="gez">፩በእንተ፡ ከብካብ፡ ዘበቃና።</incipit>
                                         <explicit xml:lang="gez">፲፱በእንተ፡ ስእለተ፡ ሥጋሁ፡ ለእግዚእነ። ። አርእስት፡ ነገር፡ እምንጌለ፡ ዮሐንስ፡ ቅዱስ፡ ፲፱። ።</explicit>
                                     </msItem>
-                                    <msItem xml:id="ms_i4.4.2">
+                                    <msItem xml:id="p1_i4.4.2">
                                         <locus from="185ra" to="230vb"/>
                                         <title ref="LIT2715John"></title>
                                         <incipit xml:lang="gez">፩ቀዳሚሁ፡ ቃል፡ ውእቱ፡ ወውእቱ፡ ቃል፡ ኀበ፡ እግዚኣብሔር፡ ውእቱ።</incipit>
                                         <explicit xml:lang="gez">ወቦ፡ ባዕደኒ፡ ብዙኅ፡ ዘገብረ፡ ኢየሱስ፡ ወሶበ፡ ተጽሕፈ፡ ኵሉ፡ በበ፡ አሐዱ፡ እመ፡ ኢያግመሮ፡ ዓለም፡ ጥቀ፡ መጻሕፍቲሁ፡
                                             ዘተጽሕፈ። አሜን፡ አሜን። ።</explicit>
                                     </msItem>
-                                <explicit xml:lang="gez">ወኮነ፡ ኵሉ፡ ድሙሩ፡ ቃሎሙ፡ ለአርባዕቱ፡ ወንጌላት። ፺፻፡ ፯፻። ወከመ፡ ታእምሩ፡ ኍልቈ፡ ቃላቲሆሙ፡ ለአርባዕቱ፡ ወንጌል። 
-                                    ጸሐፍነ፡ ለክሙ። ። ። በጸጋሁ፡ ለእግዚኣብሔር፡ ተፈጸመ፡ በሕየ፡ አርባዕቱ፡ ወንጌላት፡ ማቴዎስ፡ ወማርቆስ፡ ሉቃስ፡ ወዮሐንስ። ። ኵሉ፡ ቃላቱ፡ ለወንጌል፡ 
-                                    ጽድቅ። ወእምርእሱ፡ እስከ፡ ተፍጻሜቱ፡ ለሊሁ፡ ወልድ፡ ትናገረ። ። ።</explicit>
+                                    <explicit xml:lang="gez">ወኮነ፡ ኵሉ፡ ድሙሩ፡ ቃሎሙ፡ ለአርባዕቱ፡ ወንጌላት። ፺፻፡ ፯፻። ወከመ፡ ታእምሩ፡ ኍልቈ፡ ቃላቲሆሙ፡ ለአርባዕቱ፡ ወንጌል። 
+                                        ጸሐፍነ፡ ለክሙ። ። ። በጸጋሁ፡ ለእግዚኣብሔር፡ ተፈጸመ፡ በሕየ፡ አርባዕቱ፡ ወንጌላት፡ ማቴዎስ፡ ወማርቆስ፡ ሉቃስ፡ ወዮሐንስ። ። ኵሉ፡ ቃላቱ፡ ለወንጌል፡ 
+                                        ጽድቅ። ወእምርእሱ፡ እስከ፡ ተፍጻሜቱ፡ ለሊሁ፡ ወልድ፡ ትናገረ። ። ።</explicit>
+                                </msItem>
                             </msItem>
-                        </msItem>
-                        <msItem xml:id="ms_i5">
-                            <locus from="231ra" to="232ra"/>
-                            <title ref="LIT1548Gessaw"/>
-                            <incipit xml:lang="gez"><add place="above">ገጻዌ፡ ሥርዓት፡</add>በእንተ፡ ኅብረተ፡ ቃላት፡ ዘአርባዕቱ፡ ወንጌላት፡</incipit>
-                            <explicit xml:lang="gez">አብኡ፡ መጥዎ፡ በእንተ፡ ኅብረተ፡ ቃላት፡ ዘቅዱሳን፡ አርባዕቱ፡ ወንጌላት፡ ተፈጸመ። ። </explicit>
-                        </msItem>
-                    </msContents>
-                    <physDesc>
+                            <msItem xml:id="p1_i5">
+                                <locus from="231ra" to="232ra"/>
+                                <title ref="LIT1548Gessaw"/>
+                                <incipit xml:lang="gez"><add place="above">ገጻዌ፡ ሥርዓት፡</add>በእንተ፡ ኅብረተ፡ ቃላት፡ ዘአርባዕቱ፡ ወንጌላት፡</incipit>
+                                <explicit xml:lang="gez">አብኡ፡ መጥዎ፡ በእንተ፡ ኅብረተ፡ ቃላት፡ ዘቅዱሳን፡ አርባዕቱ፡ ወንጌላት፡ ተፈጸመ። ። </explicit>
+                            </msItem>
+                        </msContents>
+                        <physDesc>
                         <objectDesc form="Codex">
-                            <supportDesc>
-                                <support>
-                                    <material key="parchment"/>
-                                </support>
-                                <extent>
-                                    <measure unit="leaf" quantity="239">239</measure>
-                                    <note>Number of leaves contrary to <bibl><ptr target="bm:Hammerschmidt1973Tanasee"/><citedRange
-                                        unit="page">84</citedRange></bibl>, who counted 240 leaves.</note>
-                                    <note>Dimensions indicated below may concern outer dimensions of bookcover or dimensions of folia (not clearly 
-                                        specified in cataloque).</note>
-                                    <dimensions type="outer" unit="mm">                                        
-                                        <height cert="medium" unit="mm">380</height>
-                                        <width cert="medium" unit="mm">260</width>
-                                        <depth cert="medium" unit="mm">100</depth>
-                                    </dimensions>
-                                </extent>
-                                <foliation>Foliation marks on small pieces of paper, which were applied to the inner margin of every 5th recto when photographed. 
-                                    The folio mark for <locus target="#200"/> is missing. The folio mark '205r' is misplaced and actually indicates 
-                                    <locus target="#204r"/>. Following this mistake the mark '210r' is in fact placed on <locus target="#209r"/>and so on until to 
-                                    the end.</foliation>
-                                <collation>
-                                    <note>The quire structure is not discernible in the microfilmed images, but based on the contents and palaeographic analyses of the 
-                                        hands involved, the last quire, which may extend from <locus target="#233"/> to <locus target="#239"/> and which contains a 
-                                        number of additions and extras, may have been added to the codex later in a rebinding.</note>
-                                </collation>
-                                <condition key="good">Microfilm images in some places hardly legible, particularly on <locus from="1r" to="5v"/>, 
-                                    where several parts have been erased and are not legible in the images. Single words or several phrases erased and 
-                                    in some cases overwritten throughout the manuscript. Damaged by moisture on <locus target="#29v #30r #46v"/>.</condition>
-                            </supportDesc>
                             <layoutDesc>
                                 <layout columns="1" writtenLines="26">
                                     <locus from="6r" to="7r"/>
@@ -194,13 +265,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <locus from="22r" to="238v"/>
                                     <ab type="pricking">Pricking is partly visible.</ab>
                                     <ab type="ruling">Ruling is partly visible.</ab>
+                                    <ab type="CruxAnsata">Many pages are decorated with several crux ansata.</ab>
                                 </layout>
-                            </layoutDesc>
+                            </layoutDesc>  
                         </objectDesc>
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <seg type="ink">Black.</seg>
-                                <seg type="script">Script of the fourteenth to fifteenth century, angular and with triangular, rounded loops.</seg>
+                                <seg type="script">Angular script with triangular, rounded loops.</seg>
+                                <date notBefore="1301" notAfter="1500">Script of the fourteenth to fifteenth century.</date>
                             </handNote>     
                         </handDesc>
                         <decoDesc>
@@ -213,7 +286,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <decoNote xml:id="d2" type="miniature">
                                 <locus target="#6v"/>
                                 <desc>Finely illuminated frame, that was described and reproduced in 
-                                    <bibl><ptr target="bm:LeroyÄth1968"/><citedRange>Abb. 430a</citedRange></bibl> and
+                                    <bibl><ptr target="bm:LeroyAeth1968"/><citedRange>Abb. 430a</citedRange></bibl> and
                                     <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 86</citedRange></bibl> 
                                     surrounding the text of the <ref target="LIT1349EpistlEusebius"/> in <ref target="#ms_i1"/>.</desc>
                             </decoNote>
@@ -256,10 +329,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </decoNote>
                             <decoNote xml:id="d11" type="miniature">
                                 <locus target="#11r"/>
-                                <desc>Finely executed full-page miniature depicting a pavillon with a number of birds including two peacocks accompanied 
-                                    by two gazelles representing the Fountain of Life with some words added: <foreign xml:lang="gez">ባቡላ</foreign>, 
-                                    <foreign xml:lang="gez">ኑባሬ፡ ሥርዓት።</foreign> and <foreign xml:lang="gez">ባዙላ</foreign>. 
-                                    This miniature was described and reproduced 
+                                <desc>Finely executed full-page <ref target="AT1034Tempietto"/> depicting a pavillon with a number of birds including two 
+                                    peacocks accompanied by two gazelles representing the Fountain of Life with some words added: 
+                                    <foreign xml:lang="gez">ባቡላ</foreign>, <foreign xml:lang="gez">ኑባሬ፡ ሥርዓት።</foreign> and 
+                                    <foreign xml:lang="gez">ባዙላ</foreign>. This miniature was described and reproduced 
                                     in <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>Plate VII</citedRange></bibl>, 
                                     <bibl><ptr target="bm:LeroyPittura1964"/><citedRange>Tavola II</citedRange></bibl>
                                     and <bibl><ptr target="bm:Hammerschmidt1966KultsymbolikTafelband"/><citedRange unit="page">117</citedRange></bibl>. 
@@ -278,7 +351,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <desc>Finely executed full-page miniature depicting the <ref type="authFile" corresp="AT1025NativityJesus"/>, described and 
                                     reproduced in <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 88</citedRange></bibl>,
                                     <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>Plate x</citedRange></bibl>, and in
-                                    <bibl><ptr target="bm:LeroyÄth1968LerÄth"/><citedRange>Tafel LII</citedRange></bibl>.</desc>
+                                    <bibl><ptr target="bm:LeroyAeth1968"/><citedRange>Tafel LII</citedRange></bibl>.</desc>
                             </decoNote>
                             <decoNote xml:id="d14" type="miniature">
                                 <locus target="#13r"/>
@@ -371,361 +444,769 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </decoNote>
                             <decoNote xml:id="d30" type="miniature">
                                 <locus target="#24v"/>
-                                <desc>Finely executed full-page miniature depicting <persName ref="PRS6902Matthew"/>.</desc>
+                                <desc>Finely executed full-page miniature depicting <persName ref="PRS6902Matthew"/> in <ref type="authFile" corresp="AT1013EvaPortrait"/>.
+                                    </desc>
                             </decoNote>
                             <decoNote xml:id="d31" type="miniature">
                                 <locus target="#86v"/>
-                                <desc>Finely executed full-page miniature depicting <persName ref="PRS6751Mark"/>, described and reproduced in 
-                                    <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>Plate VIII</citedRange></bibl> and in 
+                                <desc>Finely executed full-page miniature depicting <persName ref="PRS6751Mark"/> in <ref type="authFile" corresp="AT1013EvaPortrait"/>, 
+                                    described and reproduced in <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>Plate VIII</citedRange></bibl> and in 
                                     <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 101</citedRange></bibl>.</desc>
                             </decoNote>
                             <decoNote xml:id="d32" type="miniature">
                                 <locus target="#123v"/>
-                                <desc>Finely executed full-page miniature depicting <persName ref="PRS6387Luke"/>, described and reproduced in 
-                                    <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>Plate IX</citedRange></bibl> and in 
+                                <desc>Finely executed full-page miniature depicting <persName ref="PRS6387Luke"/> in <ref type="authFile" corresp="AT1013EvaPortrait"/>, 
+                                    described and reproduced in <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>Plate IX</citedRange></bibl> and in 
                                     <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 102</citedRange></bibl>.</desc>
                             </decoNote>
                             <decoNote xml:id="d33" type="miniature">
                                 <locus target="#184v"/>
-                                <desc>Finely executed full-page miniature depicting <persName ref="PRS5695John"/>, described and reproduced in
-                                    <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 103</citedRange></bibl>.</desc>
+                                <desc>Finely executed full-page miniature depicting <persName ref="PRS5695John"/> in in <ref type="authFile" corresp="AT1013EvaPortrait"/>, 
+                                    described and reproduced in <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 103</citedRange></bibl>.</desc>
                             </decoNote>
                         </decoDesc>
                         <additions>
                             <list>
-                                <item xml:id="a1">
+                                <item xml:id="a2">
                                     <locus target="#3ra"/>
-                                    <desc type="Record">Stipulations for the comemoration of <persName ref="PRS8595SayfaAr"/> 
+                                    <desc type="Record">Stipulations for the commemoration of <persName ref="PRS8595SayfaAr"/> 
                                         (Tazkāra Sayfa ʾArʿād) dated to <date when="1412">29th july 1412</date> corresponding to 
                                         <date when-custom="64" calendar="grace">5th Naḥase 64</date> that is during the reign of 
                                         <persName ref="PRS3429DawitII"/> and <persName ref="PRS2469Bartalom"/>.</desc>
-                                </item>
-                                <item xml:id="a2">
-                                    <locus target="#3ra"/>
-                                    <desc type="ScribalSupplication">Scribal supplication with a similar hand as <ref target="#a3"/></desc>
+                                    <q xml:lang="gez">በአኰቴተ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ተጽሕፈት፡ ዛቲ፡ መጽሐፍ፡ በ<date when="1412" when-custom="64" calendar="grace">
+                                            ፷፬፡ ዓመተ፡ ምሕረት፡ በወርኃ፡ ነሐሴ፡ አመ፡ ፭፡</date> በሠርቀ፡ መዓልት፡ ወአመ፡ ፳፭፡ በሠርቀ፡ ሌሊት፡ ወእንዘ፡ ንጉሥነ፡ 
+                                            <persName ref="PRS3429DawitII">ዳዊት፡</persName> ዘተሰምየ፡ ቈስጢንጢኖስ፡ ወእንዘ፡ ጳጳስ<add place="above">ነ</add>፡ 
+                                            አባ፡ <persName ref="PRS2469Bartalom">በርተሎሜዎስ፡</persName> ወእንዘ፡ 
+                                            <placeName ref="LOC3549Gojjam">ጐዛም፡</placeName>
+                                            ነጋሢ፡ <persName ref="PRS14167MaataGwane">መዓተ፡ ጐኔ፡</persName> 
+                                            ወእንዘ፡ <placeName ref="LOC1713Bagemd">በጌምድር፡</placeName>
+                                            <persName ref="PRS14168Delmangasa">ድልመንገሣ፡</persName> 
+                                            ወእንዘ፡ ንቡረ፡ እድ፡ <persName ref="PRS14169KrestosMadhen">ክርስቶስ፡ መድኅን።</persName> 
+                                            ተሠርዓት፡ ተዝካር፡ በደብረ፡ ክብራን፡ ዘንጉሥ፡ <persName ref="PRS8595SayfaAr">ሰይፈ፡ ዐርአደ፡</persName> 
+                                            አመ፡ ፲፭፡ እም<gap reason="omitted"/></q>
                                 </item>
                                 <item xml:id="a3">
-                                    <locus target="#3rb"/>
-                                    <desc type="ScribalSupplication">Scribal supplication naming <persName ref="PRS14048Petros"/> as a scribe with
-                                        a similar hand as <ref target="#a2"/>.</desc>
+                                    <locus target="#3ra"/>
+                                    <desc type="ScribalSupplication">Scribal supplication with a similar hand as <ref target="#a4"/></desc>
+                                    <q xml:lang="gez">ሰሰዮሙሂ፡ ሠራዕኩ፡ እምቍቢጸ፡ ዘነበረ፡ ቀዳሚ፡ ለግብር። ወለግብርሂ፡ ሠራዕኩ፡ ክነመስዳ፡ ወ<add place="above">ለ</add>እገና። ወዘንተ፡ ሥርዓተ፡ 
+                                            ዘአብጠለ፡ ዘሄደ፡ ወዘተዓገለ፡ ውጉዘ፡ ለይኩን፡ በአፈ፡ ነቢያት፡ ወሐዋርያት፡ በአፈ፡ ጻድቃን፡ ወሰማዕት፡ በአፈ፡ ሚካኤል፡ ወገብርኤል፡ በአፈ፡ ፫፻፲፰፡ ርቱዓነ፡ ሃይማኖት፡ በአፈ፡ 
+                                            አቡነ፡ <persName ref="PRS10688Zayohan">ዘዮሐንስ፡ </persName>በአፈ፡ አግአዝእትነ፡ ማርያም፡ በአፈ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ውጉዘ፡ 
+                                            ለይኩን፡ ለዓለም፡ አሜን።</q>
                                 </item>
                                 <item xml:id="a4">
+                                    <locus target="#3rb"/>
+                                    <desc type="ScribalSupplication">Scribal supplication naming <persName role="donor" ref="PRS14048Petros"/> for 
+                                        commissioning the manuscript. Executed by a similar hand as <ref target="#a3"/>.</desc>
+                                    <q xml:lang="gez">በስመ፡ ሥሉስ፡ ቅዱስ፡ አጽሐፍኩ፡ አነ፡ <persName ref="PRS14048Petros">ጴጥሮስ፡</persName> ለደብረ፡ ክብራ፡ ቅዱስ፡ ዝይከውነኒ፡ ለመድኅኒተ፡ 
+                                            ነፍስ፡ ዘሐኒታ፡ ወይነ፡ ዘወሀብዋ፡ አበዊነ፡ ቀደምት፡ ወደኅረሂ፡ ዘነሥአዋ፡ በትእግልት። <gap reason="ellipsis"/> በአፈ፡ ነቢያት፡ ወሐዋርያት፡ በአፈ፡ ጻድቅን፡ ወሰማዕት፡ 
+                                            በአፈ፡ ሚካኤል፡ ወገብርኤል። በአፈ፡ ፫፻፲፰፡ ርቱዓነ፡ ሃይማኖት፡በአፈ፡ አግዝእትነ፡ ማርያም። በአፈ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ቅውመ፡ ወጉዘ፡ ወውቦአ፡ እመንግሥተ፡ 
+                                            እግዚአብሔር፡ ለይኩን፡ አሜን። ወሊተኒ፡ ዝክሩኒ፡ በጸሎትክሙ፡ ለትውልደ፡ ትውልድክሙ፡ አሜን። ።</q>
+                                </item>
+                                <item xml:id="a5">
                                     <locus target="#3va"/>
                                     <desc type="Unclear">Almost completely erased and not legible text.</desc>
                                 </item>
-                                <item xml:id="a5">
+                                <item xml:id="a6">
                                     <locus target="#3vb"/>
                                     <desc type="LandGrant">Account of donations from <persName ref="PRS1854Amdase"/> to 
                                         <persName ref="PRS10688Zayohan"/>, written in three different hands.</desc>
-                                </item>
-                                <item xml:id="a6">
-                                    <locus from="4ra" to="4rb"/>
-                                    <desc type="Inventory">List of the church utensils of Kəbrān with spaces left for the numbers 
-                                        of the individual furnishings: <foreign xml:lang="gez">ተጽሕፈት፡ ኆልቈ፡ ንዋየ፡ ቤተ፡ ክርስቲያን፡ ዘተረከበ፡ በሢመቱ፡ አቡነ፡ 
-                                        <persName ref="PRS14049GabraMasqal">ገብረ፡ መስቀል፡</persName><gap reason="omitted" unit="chars" quantity="1"/> 
-                                         ዘነቦ፡ ወርቅ፡ <gap reason="ellipsis"/>የሲሕ፡ ለዓጠኒ፡ ልብሰ፡ ዘበዐላት፡ </foreign>.</desc>
+                                    <q xml:lang="gez">ንጉሥኒ፡ <persName ref="PRS1854Amdase">አምደ፡ ጽዮን፡ </persName>መጽአ፡ ኀቤሁ፡ በፍሥሐ፡ ዐቢይ፡ ከመ፡ ይትባረክ፡ እምኀበ፡ አቡነ፡ 
+                                            <persName ref="PRS10688Zayohan">ዘዮሐንስ፡</persName><gap reason="ellipsis"/> ወወሀቦ፡ ብዙኃተ፡ እምድረ፡
+                                            አዳማ፡ እስከ፡ ባሕር፡ እስከ፡ ወሰና፡ ለግዮን፡ እስከ፡ ቱምሐ፡ ወእ<add place="above">ስ</add>ከ፡ <add place="above">አገው፡ </add>
+                                            <gap reason="ellipsis"/>እመጽሐፈ፡ ሕይወት፡ ለዓለመ፡ አለም፡ አሜን።</q>
                                 </item>
                                 <item xml:id="a7">
-                                    <locus target="#4rb"/>
-                                    <desc type="RecordTransaction">Transaction note in Amharic.</desc>
+                                    <locus from="4ra" to="4rb"/>
+                                    <desc type="Inventory">List of the church utensils of <placeName ref="INS0357Kebran"/> with spaces left for the numbers of the 
+                                        individual furnishings.</desc>
+                                    <q xml:lang="gez">ተጽሕፈት፡ ኆልቈ፡ ንዋየ፡ ቤተ፡ ክርስቲያን፡ ዘተረከበ፡ በሢመቱ፡ አቡነ፡ <persName ref="PRS14049GabraMasqal">ገብረ፡ መስቀል፡</persName>
+                                        ዘነቦ፡ ወርቅ፡ <gap reason="ellipsis" unit="lines" quantity="61"/>የሲሕ፡ ለዓጠኒ፡ ልብሰ፡ ዘበዐላት፡</q>
                                 </item>
                                 <item xml:id="a8">
+                                    <locus target="#4rb"/>
+                                    <desc type="RecordTransaction">Transaction note in Amharic.</desc>
+                                    <q xml:lang="am">ወይዘሮ፡ <persName ref="PRS14058Qasaro">ቀጸሮ፡</persName> የገዙት፡ ምድር፡ 
+                                        ከ<persName ref="PRS14059MariGeta">መሪ፡ ጌታ፡ ገብረ፡ ሚካኤል፡</persName> በ፵ጨው፡ ነው፡ አሳቦች፡ ቂሰ፡ ገበዝ፡ ወሰን፡ አይሞት፡ ዠኖ፡ ኑሮ፡ ወሰን፡ ነጮ፡ ናቸው፡ 
+                                        መድኒቱ፡ <persName ref="PRS14060WalattaIyasus">ወለተ፡ ኢየሱስ፡</persName> ናት፡ ግብሩ፡ ፪፳፲፡ ቅብዓ፡ ኑግ፡ ፱ድርጎ፡ አከል፡ ነው፡ አንዘ፡ 
+                                        መምሕርነ፡ ዘፈረ፡ ሥላሴ። ገበዝነ፡ ወሰን፡ ወጭቀው፡ ወሰጥ፡ ነጨ፡ በዘመነ፡ ማቴዎስ፡ ንው። </q>
+                                </item>
+                                <item xml:id="a9">
+                                    <locus target="#4va"/>
+                                    <desc type="Inventory">List of Biblical books.</desc>
+                                    <q xml:lang="gez">ኦሪት፡ ዮዲት፡ ሕዝቅኢል፡ ዮዲት፡ አስቴር፡ በ፡ ኩፋሌ፡ ዳዊት፡ ጥበበ፡ ሰሎሞን፡</q>
+                                </item>
+                                <item xml:id="a10">
                                     <locus target="#4va"/>
                                     <desc type="Record">Note stating, that <persName ref="PRS7481NaodA"/> visited <placeName ref="LOC1602Atrons"/>
                                         <date calendar="qamar" when-custom="159" when="1507" ref="ethiocal:Maggabit"> in the month of Maggābit in 
                                             the year 159 ʿAmata məḥrat</date>.</desc>
-                                </item>
-                                <item xml:id="a9">
-                                    <locus target="#4va"/>
-                                     <desc type="Inventory">Note on church utensils by a rather early hand written on a previously effaced part of the folio: 
-                                         <foreign xml:lang="gez">ይቤሉ፡ ቅዱሳን፡ ዘደብረ፡ ክብራ፡ በእንተ፡ ሠርፀ፡ ማርያም፡ ቀሲስ፡ ዘጻመወ፡ ላቲ፡ ለቤተ፡ ክርስቲያን፡ ፴ወ፪፡ ወቂት፡ ወርቅ። 
-                                             አልህምት፡ ፴ወ፫። መስቀል፡ ፫፡ ታቦታት፡ ፯። <gap reason="ellipsis" unit="lines" quantity="7"/> ምጽሕርት፡ ዘኀፂን። </foreign></desc>
-                                </item>
-                                <item xml:id="a10">
-                                    <locus target="#4vb"/>
-                                    <desc type="Unclear"><foreign xml:lang="gez">ዘኀፂ<gap reason="illegible" unit="chars" quantity="2"/>ላ። አርጋኖን። 
-                                        ፪ሥዕል። </foreign>Possibly the last line of an inventory, that was written on the first column of this folio, effaced
-                                        and rewritten with another inventory in <ref target="#a9"/>.</desc>
+                                    <q xml:lang="gez">በመዋዕለ፡ ሉቃስ፡ ወንጌላዊ፡ በ<date calendar="qamar" when-custom="159" when="1507">፻፶ወ፱፡ አመተ፡ ምሕረት፡</date> እንዘ፡ 
+                                            ሀለዉ፡ ንጉሥነ፡ <persName ref="PRS7481NaodA">ናኦድ፡</persName> በ<placeName ref="LOC1602Atrons">አትሮንስ፡ እግዝእትነ፡ 
+                                            ማርያም፡</placeName> በወርኃ፡ መጋቢት፡ እንዘ፡ ስማዕት፡ ይእቴ፡ <persName ref="PRS3706eleni">እሌኒ፡</persName> ያጼ፡ እናቶ፡ ግራ፡ በአልታ፡ 
+                                            <del rend="effaced" unit="chars" quantity="1"/> <persName ref="PRS7482NaodMo">ናኦድ፡ ሞገሣ፡</persName> 
+                                            ዐቃቤ፡ <del rend="effaced">አካቅ፡</del> ስዐት፡ <persName ref="PRS14065Tewogolos">ቴዎጎሎስ፡</persName> 
+                                            ሊቀ፡ ሊቃውንት፡ <persName ref="PRS14066NagadaEgzio">ነገደ፡ እግዚኦ፡</persName><add place="above">ኢያሱስ፡ </add> 
+                                            ሊቀ፡ ማእምራን፡ <persName ref="PRS14067HabtuSarad">ኀብቱ፡ ጸራድ፡</persName> ማስሬ፡ አቀበስን፡ 
+                                            ቀይስ፡ ሐፄ፡ <persName ref="PRS14068TaklaMaryam">ተክለ፡ ማርያም፡</persName> 
+                                            ሊቀ፡ ደብተራ፡ <persName ref="PRS14069TaklaNabiyat">ተከለ፡ ነቢያት፡</persName> 
+                                            ቀኚዕ፡ ብቶደደ፡ <persName ref="PRS14071HabtaMG">ሐብተ፡ ማርያም፡</persName> 
+                                            ግራ፡ ብቶደደ፡ <persName ref="PRS14072Naze">ናዜ፡</persName> 
+                                            አዛዘ፡ እንዳዘዜ፡ ርእሰ፡ ርኡሳን፡ <persName ref="PRS14073TaklaMaryam">ተከለ፡ ማርያም፡</persName> 
+                                            እንዘ፡ ንቡረ፡ ዕድ፡ <persName ref="PRS14074Gersam">ጌርሣም፡</persName> 
+                                            ወምስለ፡ ንብርዕድ፡ <persName ref="PRS14075Tiwogolos">ቲዎጎሎስ፡</persName> 
+                                            ወቂስ፡ ገበዝ፡ <persName ref="PRS14076GabraNazrawi">ገብረ፡ ናዝራዊ፡</persName> 
+                                            ወሊቀ፡ ዲየቆን፡ ይፅናዩ፡ ወራቍ፡ ማስራ፡ <persName ref="PRS14077FereKrestos">ፍሬ፡ ክርስቶስ፡</persName> ዘተመይጠ፡ ንዋይ፡ ለታቦተ፡ 
+                                            ገብርኤል፡ ዘደብረ፡ ክብራ፡ ፳ወ፫፡ ንዋየ፡ ቤተ፡ ክርስቲያን፡</q>
                                 </item>
                                 <item xml:id="a11">
+                                    <locus target="#4va"/>
+                                     <desc type="Inventory">Note on church utensils by a rather early hand written on a previously effaced part of the folio.</desc>
+                                    <q xml:lang="gez">ይቤሉ፡ ቅዱሳን፡ ዘደብረ፡ ክብራ፡ በእንተ፡ ሠርፀ፡ ማርያም፡ ቀሲስ፡ ዘጻመወ፡ ላቲ፡ ለቤተ፡ ክርስቲያን፡ ፴ወ፪፡ ወቂት፡ ወርቅ። አልህምት፡ ፴ወ፫። መስቀል፡ ፫፡ ታቦታት፡ ፯። 
+                                        <gap reason="ellipsis" unit="lines" quantity="7"/> ምጽሕርት፡ ዘኀፂን። </q>
+                                </item>
+                                <item xml:id="a12">
+                                    <locus target="#4vb"/>
+                                    <desc type="Inventory">Possibly the last line of an inventory, that was written on the first column of this folio, effaced and rewritten 
+                                        with another text in <ref target="#a13"/>.</desc>
+                                    <q xml:lang="gez">ዘኀፂ<gap reason="illegible" unit="chars" quantity="2"/>ላ። አርጋኖን። ፪ሥዕል። </q>
+                                </item>
+                                <item xml:id="a13">
                                     <locus target="#4vb"/>
                                     <desc type="MixedNote">Commemorative note (Tazkār) on a person named 
                                         <persName ref="PRS14080SardaMaryam">ሠርፀ፡ ማርያም፡</persName>, who donated to the church of Māryām by
-                                            a similar hand as <ref target="#a12 #a13"></ref>.</desc>
-                                </item>
-                                <item xml:id="a12">
-                                    <locus target="#5ra"/>
-                                    <desc type="Inventory">Note on church utensils, that Nəbuəraʾəd <persName ref="PRS14081TanseaKrestos"/> 
-                                        donated to Kəbrān by a similar hand as <ref target="#a11 #a13"/>: 
-                                        <foreign xml:lang="gez">ወዘንተ፡ ንዋየ፡ ቤተ፡ ክርስቲያን፡ ዘወሀበ፡ ንቡረ፡ እድ፡ 
-                                            <persName ref="PRS14081TanseaKrestos">ተንሥአ፡ ክርስቶስ፡</persName> ለመካነ፡ ገብርኤል፡ ወለማርያም፡ 
-                                            ፪አጽሕልት፡ ዘወርቅ፡ ወ፪፡ ጽዋዕ፡ ዘወርቅ። <gap reason="ellipsis" unit="lines" quantity="16"/></foreign></desc>
-                                </item>
-                                <item xml:id="a13">
-                                    <locus from="5va" to="5vb"/>
-                                    <desc>Order of <persName ref="PRS6229LebnaDe"/> for the distribution of land when he celebrated Easter in 
-                                        <placeName ref="LOC5733Sima"/> by a similar hand as <ref target="#a11 #a12"/>.</desc>
+                                        a similar hand as <ref target="#a14 #a15"/>.</desc>
+                                    <q xml:lang="gez">ለዘ፡ እምዘ፡ ብእሲ፡ አዕብይዎ፡ ወአክብርዎ፡ በሕይወቱ። ወእምድኅረ፡ ሞቱሂ፡ ግበሩ፡ ሎቱ፡ ተዝካሮ፡ ከመ፡ አባ፡ 
+                                        <persName ref="PRS14078GabraKrestos">ገብረ፡ ክርስቶስ፡</persName> 
+                                        ወ<persName ref="PRS14079GabraAmlak">ገብረ፡ አምላክ</persName>። ወዘንተ፡ ኵሎ፡ ዘወሀበ፡ 
+                                        <persName ref="PRS14080SardaMaryam">ሠርፀ፡ ማርያም፡</persName> ለመካነ፡ ማርያም፡ ዘአውፅአሂ፡ ወዘሤጠ፡ ወዘተሣየጠ፡ ውጉዘ፡ ለይኩን፡ 
+                                        በአፈ፡ ፫አስማት፡ ወበአፉሆሙ፡ ለጴጥሮስ፡ ወጳውሎስ፡ ወዘደምሰሰሂ፡ ለዝመጽሐፍ፡ ወይደስስ፡ ስሙ፡ እመጽሐፈ፡ ሕይወት፡ ለዓለመ፡ ዓለም፡ አሜን፡ ወአሜን።</q>
                                 </item>
                                 <item xml:id="a14">
-                                    <locus target="#11v"/>
-                                    <desc>Order of  <persName ref="PRS8550sardaDe"/> and ʾƎtege <persName ref="PRS1429AdmasMo"/> 
-                                        on the leadership of Kebran.</desc>
+                                    <locus target="#4vb"/>
+                                    <desc>Effaced and not legible text.</desc>
                                 </item>
                                 <item xml:id="a15">
-                                    <locus from="22ra" to="22rb"/>
-                                    <desc>Note on the construction of the church, that is infact supposed to be its restoration, that is stated to have begun 
-                                        in <date when="1598"/> in the time of <persName ref="PRS10198Yaeqob"/> and that was completed on 15th Maggābit
-                                        in the 8th year of <persName ref="PRS9038Susenyos"/> e.g. <date when="1615"/>: <foreign xml:lang="gez">ተፈጸመ፡ 
-                                        ሕንፃ፡ ቤተ፡ ክርስቲያን፡ አመ፡ <date when="1615">፲ወ፭፡ ለመጋቢት፡ በ፲ወ፯፡ አመት</date>፡ እምዘ፡ ተወጥነ፡ ወዘመኑሂ፡ ዘመነ፡ ንጉሥ፡ 
-                                        <persName ref="PRS10198Yaeqob">ያዕቆብ፡</persName> ወፍጻሜሁሰ፡ ኮነ፡ በዘመነ፡ ንጉሥ፡ 
-                                        <persName ref="PRS9038Susenyos">ስልጣን፡ ሰገድ፡</persName> እምዘ፡ ነግሡ፡ በ፰፡ አመት፡ <gap reason="ellipsis"/></foreign></desc>
-                                </item> 
+                                    <locus target="#5ra"/>
+                                    <desc>Effaced and not legible text.</desc>
+                                </item>
+                                <item xml:id="a16">
+                                    <locus target="#5ra"/>
+                                    <desc type="Inventory">Note on church utensils, that Nəbuəraʾəd <persName ref="PRS14081TanseaKrestos"/> 
+                                        donated to <placeName ref="LOC4042Kebran "/> by a similar hand as <ref target="#a13 #a18"/>.</desc>
+                                    <q xml:lang="gez">ወዘንተ፡ ንዋየ፡ ቤተ፡ ክርስቲያን፡ ዘወሀበ፡ ንቡረ፡ እድ፡ <persName ref="PRS14081TanseaKrestos">ተንሥአ፡ ክርስቶስ፡</persName> 
+                                        ለመካነ፡ ገብርኤል፡ ወለማርያም፡ ፪አጽሕልት፡ ዘወርቅ፡ ወ፪፡ ጽዋዕ፡ ዘወርቅ። <gap reason="ellipsis" unit="lines" quantity="16"/></q>
+                                </item>
                                 <item xml:id="a17">
+                                    <locus target="#5rb"/>
+                                    <desc>Effaced and not legible text.</desc>
+                                </item>
+                                <item xml:id="a18">
+                                    <locus from="5va" to="5vb"/>
+                                    <desc>Order of <persName ref="PRS6229LebnaDe"/> for the distribution of land when he celebrated Easter in 
+                                        <placeName ref="LOC5733Sima"/> by a similar hand as <ref target="#a13 #a14"/>.</desc>
+                                    <q xml:lang="gez">በአኰቴተ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ እጕለትኩ፡ አ<add resp="CH">ፄ፡ </add>
+                                        <persName ref="PRS6229LebnaDe">ወናግ፡ ሰገድ፡</persName> 
+                                        ንጉሥ፡ እንዘ፡ ሀላውኩ፡ በ<placeName ref="LOC3549Gojjam">ጐዣም፡</placeName> አመ፡ ወዐልኩ፡ 
+                                        በ<placeName ref="LOC5733Sima">ጺማ፡</placeName> በዐለ፡ ፋሲካ። ምድረ፡ <placeName ref="LOC7378Ababir">ዐቢባር፡</placeName>
+                                        ወምድረ፡ <placeName ref="LOC7379Enawga">እናውጋ</placeName>። ወምድረ፡ <placeName ref="LOC7380Enarij">እናርጀ</placeName>። 
+                                        እሎንተ፡ ፫ምድረ፡ ለዓመተ፡ ጊዮርጊስ፡ ወለወ<gap reason="illegible" unit="chars" quantity="2"/>፡ ቅዱሳን፡ መንፈቀ፡ እሉ፡ 
+                                        <gap reason="illegible" unit="chars" quantity="3"/> ወመንፈቁ፡ ለ<persName ref="PRS14080SardaMaryam">ሠርፀ፡ ማርያም፡</persName> 
+                                        እስመ፡ ርስተ፡ ዚአሁ፡ ውእቱ፡ <gap reason="ellipsis" unit="lines" quantity="35"/></q>
+                                </item>
+                                <item xml:id="a19">
+                                    <locus target="#11v"/>
+                                    <desc>Order of <persName ref="PRS8550sardaDe"/> and ʾƎtege <persName ref="PRS1429AdmasMo"/> on several military 
+                                        and administrative positions. The characters are taller than the other addition containing the character ዠ in a special archaic 
+                                        form with hashes at the lower ends of the legs.</desc>
+                                    <q xml:lang="gez">ተጽሕፈ፡ በትእዛዝ፡ ንጉሥ፡ <persName ref="PRS8550sardaDe">ሠርፀ፡ ድንግል፡</persName> ወበትእዛዘ፡ ይቴጌ፡ 
+                                        <persName ref="PRS1429AdmasMo">አድማስ፡ ሞገሳ፡</persName> ንሕነ፡ በዘመንነ፡ ከመ፡ ይኩን፡ ንቡረ፡ እድነት፡ ወመምሕርነት፡ 
+                                        ዘ<placeName ref="LOC4042Kebran">ክብራን፡</placeName> ለ፩ብእሲ፡ ወአይሳየም፡ ካልእ፡ ዘእንበለ፡ ዘመንኰሰ፡ በደብር፡ ወበግሸኒ፡
+                                        ከመዝ፡ ነበረ፡ ይቤሉነ፡ አእሩግ፡ ወንሕነኒ፡ አዘዝነ፡ ከመዝ፡ እንዘ፡ ጽራጅ፡ ማስሬ፡ አባ፡ <persName ref="PRS14174TaklaWald">ተክለ፡ ወልድ፡</persName> 
+                                        ወቄስ፡ አፄ፡ አባ፡ <persName ref="PRS14175Giyorgis">ጊዮርጊስ፡</persName> 
+                                        ወበግራ፡ አዛዥ፡ <persName ref="PRS14176BahayleSellus">በኃይለ፡ ሥሉስ፡</persName>
+                                        ወበቀኝ፡ አዛዥ፡ <persName ref="PRS14177Manadelewos">መናድሌዎስ፡</persName> 
+                                        ወግራ፡ ጌታ፡ ዘ<placeName ref="LOC4042Kebran">ክብራን፡</placeName> አባ፡ <persName ref="PRS14178Zadengel">ዘድንግል፡</persName>
+                                        ወቀኝ፡ ጌታ፡ <persName ref="PRS14179BatraMikael">በትረ፡ ሚካኤል፡</persName>
+                                        ወቤት፡ ጠባቂ፡ ጌታ፡ <persName ref="PRS14183TaklaNabiyat">ተክለ፡ ነቢያት፡</persName> ወዕንቆ፡ ዘግራ፡
+                                        ወ<placeName ref="LOC3549Gojjam">ጐጃም፡</placeName> ነጋሽ፡ አቤተ፡ ኹን፡ <persName ref="PRS14180Qozmas">ቆዝማስ፡</persName>
+                                        ወበድ፡ ሹም፡ <persName ref="PRS14181Yohannes">ዮሐንስ፡</persName> 
+                                        ወሊቀ፡ መፃኒ፡ <persName ref="PRS14182Kefle">ክፍሌ፡</persName> ወቃቂታቾ፡ በረከት፡ ወአዘዝነ፡ ከመ፡
+                                        <gap reason="ellipsis" unit="lines" quantity="13"/>እመሂ፡ በቃለ፡ ጳጳስ፡ ወእመሂ፡ በቃለ፡ ሊቀ፡ ጳጳሳት፡ ዘእለ፡ 
+                                        <placeName ref="LOC1338Alexan">እስክንድርያ፡</placeName> ለዓለመ፡ ዓለም፡</q>
+                                </item>
+                                <item xml:id="a20">
+                                    <locus target="#22ra"/>
+                                    <desc>Note on the construction of the church, which was probably actually its restoration, which is said to have begun
+                                        in <date when="1598"/> in the time of <persName ref="PRS10198Yaeqob"/> and which was completed on 15th Maggābit
+                                        in the 8th year of <persName ref="PRS9038Susenyos"/> e.g. <date when="1615"/>.</desc>
+                                    <q xml:lang="gez">ተፈጸመ፡ ሕንፃ፡ ቤተ፡ ክርስቲያን፡ አመ፡ <date when="1615">፲ወ፭፡ ለመጋቢት፡ በ፲ወ፯፡ አመት</date>፡ እምዘ፡ ተወጥነ፡ ወዘመኑሂ፡ 
+                                        ዘመነ፡ ንጉሥ፡ <persName ref="PRS10198Yaeqob">ያዕቆብ፡</persName> ወፍጻሜሁሰ፡ ኮነ፡ በዘመነ፡ ንጉሥ፡ 
+                                        <persName ref="PRS9038Susenyos">ስልጣን፡ ሰገድ፡</persName> እምዘ፡ ነግሡ፡ በ፰፡ አመት፡ 
+                                        <gap reason="ellipsis" unit="lines" quantity="13"/>ወለትውልደ፡ ትውልድ፡ ዘደምሰሰ፡ ዘንተ፡ መጽሐፈ፡ ግዘት፡ ውጉዘ፡ ይኩን፡ በስልጣነ፡ ጴጥሮስ፡ 
+                                        ወጳውሎስ፡</q>
+                                </item> 
+                                <item xml:id="a21">
+                                    <locus from="22ra" to="22rb"/>
+                                    <desc type="LandGrant">Note by the same hand as <ref target="#a20"/> directly above on a land grant in the time of 
+                                        <persName ref="PRS9038Susenyos"/>.</desc>
+                                    <q xml:lang="gez">ወለቤተ፡ ክርስቲያንሂ፡ አጕልቱ፡ ላቲ፡ እምብዙኅ፡ ጕልታቲሃ፡ ዘቀዳሚ፡ ክልኤተ፡ ሀገረ፡ 
+                                        <placeName ref="LOC6977Wagalesa">ወገልሳ</placeName>ሃ፡ 
+                                        ወ<placeName ref="LOC6979Waramit">ዌራሚት፡</placeName> 
+                                        እስመ፡ ተፈጸመ፡ በዘመኖሙ፡ በሥምረተ፡ ደጅ፡ አዝማቸ፡ እኅወ፡ ክርስቶስ፡ ወወዐሊሁ፡ ጸጋ፡ ክርስቶስ፡ ወበዘመነ፡ ንጉሥ፡ 
+                                        <persName ref="PRS9038Susenyos">ስልጣን፡ ሰገድ፡</persName> ወዘፈትሐ፡ ዘንተ፡ ጕልተ፡ ውጉዘ፡ ይኩን፡ በስልጣነ፡ ጴጥሮስ፡ ወጳውሎስ።</q>
+                                </item>
+                                <item xml:id="a22">
                                     <locus target="#23v"/>
                                     <desc type="RecordTransaction">Note on the bottom margin in smaller script and unclear readings in some places 
                                         because of the low quality of images.</desc>
-                                </item>
-                                <item xml:id="a18">
-                                    <locus from="85va" to="85vb"/>
-                                    <desc type="ReceiptNote">Note possibly on the transaction or emancipation of slaves.</desc>
-                                </item>
-                                <item xml:id="a19">
-                                    <locus target="#85vb"/>
-                                    <desc>Note by another hand of the eighteenth or nineteenth century in much smaller height containing the character
-                                        ዠ in a special archaic form with hashes at the lower ends of the legs.</desc>
-                                </item>
-                                <item xml:id="a20">
-                                    <locus from="234va" to="234vb"/>
-                                    <desc type="MixedNote">Commemorative note (Tazkār) on nəburaʾed 
-                                        <persName ref="PRS14086Qalementos">ቀሌምንጦስ፡</persName>: <foreign xml:lang="gez">ተዝካረ፡ ዘአዘዝኩ፡ ሎሙ፡ 
-                                         አነ፡ <persName ref="PRS14086Qalementos">ቀሌምንጦስ፡</persName> ንቡረ፡ እድ፡ በመዋዕለ፡ ዳዊት፡ ንጉሥ፡ ለአበዊየ፡ ካህናት፡ 
-                                         ዘደብረ፡ ክብራን። እሉ፡ እሙንቱ፡ ፯፡ በዐላት፡ ዐበይት። <gap reason="ellipsis"/></foreign>.</desc>
-                                </item>
-                                <item xml:id="a21">
-                                    <locus from="234vb" to="235ra"/>
-                                    <desc type="Record">Record of a letter to <persName ref="PRS14087BasaTegest">ባሳ፡ ትዕግሥት፡</persName>
-                                        by a the community of Kəbrān during the reign of <persName ref="PRS10626ZaraY"/>.</desc>
-                                </item>
-                                <item xml:id="a22">
-                                    <locus target="#235rb"/>
-                                    <desc type="RecordTransaction">Note confirming the inheritance of two houses to <persName ref="PRS14102Estifanos"/>,
-                                        possibly the same person recorded in <ref target="#e16"/>: <foreign xml:lang="gez">ወንሕነኒ፡ በኅብረተ፡ ቃል፡ ወሀብኖ፡ ቤተ፡ 
-                                        <persName ref="PRS14105Damatewos">ደማቴዎስ፡</persName> 
-                                        ወቤተ፡ <persName ref="PRS14104Abreham">አብርሃም፡</persName> 
-                                        ይኩኖ፡ ርስተ፡ በሞቱ፡ ወበሕይወቱ፡ ለአቡነ፡ <persName ref="PRS14102Estifanos">እስጢፋኖስ፡</persName> ወእምድኅሬሁ፡ ይኩን፡ 
-                                        ለወልዱ፡ <persName ref="PRS14103Ishaq">ይስሐቅ፡ </persName><gap reason="ellipsis"/></foreign></desc>
+                                    <q xml:lang="am">በዘመነ፡ ማቴዎስ፡ ዓሳ። ች፡ <persName ref="PRS14082WaldaAmanuel">ወልደ፡ አማኑኤል፡</persName> አደሩ፡ ባይሌ፡ ሠርጉ፡ ነገዱ፡ 
+                                        <unclear reason="illegible">በያድጊ፡</unclear>ሠዳ፡ የምህር፡ አርከ፡ ስሉሥ፡ ምድር፡ ፻ታሰበ፡ ሻጭቱ፡ ወለቱ፡ ልጃዋ፡ መድን፡ ገዢው፡ አዛጅ፡ ከብቴ፡ 
+                                        ምድሩ፡ ግን፡ ጠራሜት።</q>
                                 </item>
                                 <item xml:id="a23">
-                                    <locus from="235va" to="235vb"/>
-                                    <desc type="MixedNote">Instruction of King <persName ref="PRS3429DawitII"/> to commemorate the death (Tazkār) 
-                                        of his father and predecessor <persName ref="PRS8595SayfaAr"/> on 15 Gənbot and of his mother 
-                                        <persName ref="PRS14166LazabWarqa"/> on 12 Sane in the region of <placeName ref="LOC5888Tana"/>.
-                                        The text mentions the 34th year of the reign of <persName ref="PRS3429DawitII"/> as the date of this addition. 
-                                        According to <bibl><ptr target="bm:Tadesse1974Succession"/></bibl>, this indicates a lasting power struggle with 
-                                        his brother <persName ref="PRS7559NewayaM"/> whom he succeeded after his death in <date when="1380"/>, 
-                                        but according to this note started to count his regnal years earlier than that.</desc>
+                                    <locus target="#24ra"/>
+                                    <desc type="MixedNote">Tazkār of a person with the name 
+                                        <persName ref="PRS14184TaklaHaymanot">ተክለ፡ ሃይማኖት</persName>.</desc>
+                                    <q xml:lang="gez">በአኰቴተ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ዘንተ፡ መጽሐፈ፡ ዘአጽሐፈ፡ 
+                                        <persName ref="PRS14185TatamqaMadhen">ተጠምቀ፡ መድኅን፡</persName> ዘከመ፡ ተካየደ፡ በነፍስ፡ ወሥጋ፡ መስለ፡ ዐቢይ፡ 
+                                        ወንኡስ፡ ዘምስለ፡ ገብርኤል፡ ቅዱስ፡ በሢመቱ፡ ለአቡነ፡ <persName ref="PRS14186Pawlos">ጳውሎስ፡</persName> 
+                                        ወቄሰ፡ ገበዝ፡ <persName ref="PRS14187Yaecob">ያዕቆብ፡</persName> 
+                                        ሊቀ፡ ዲያቆን፡ <persName ref="PRS14188HezbaKrestos">ሕዝበ፡ ክርስቶስ፡</persName>
+                                        እራቅ፡ ማሰራ፡ <persName ref="PRS14189KrestosMahari">ክርስቶስ፡ መሐሪ፡</persName> 
+                                        አውጋሬ፡ ተዝካርሂ፡ <persName ref="PRS14184TaklaHaymanot">ተክለ፡ ሃይማኖት</persName>። ይኩን፡ ይቤ፡ ከመዝ፡ ተዝካርየ፡ 
+                                        በዕለተ፡ ሐዋርያት፡ እም፭፡ ለሐምሌ፡ <gap reason="ellipsis" unit="lines" quantity="13"/>ወዘደምሰሰ፡ ዘንተ፡ መጽሐፈ፡ ይደምስስ፡ ስሞ፡ 
+                                        ክርስቶስ፡</q>
                                 </item>
                                 <item xml:id="a24">
-                                    <locus from="236ra" to="236va"/>
-                                    <desc type="LandGrant">Landgrant of King <persName ref="PRS10342Yeshaq">Yəsḥaq</persName> with a very similar incipit,
-                                        to the aforementioned <ref target="#a23"/>, by a similar hand.</desc>
+                                    <locus from="24ra" to="24rb"/>
+                                    <desc type="MixedNote">Tazkār for a person named <persName ref="PRS14190AsrataMaryam"/>.</desc>
+                                    <q xml:lang="gez">ይቤ፡ <persName ref="PRS14190AsrataMaryam">አስራተ፡ ማርያም፡</persName> 
+                                        ወልዱ፡ ለ<persName ref="PRS14191AmdaMikael">አምደ፡ ሚካኤል፡</persName> 
+                                        ወ<persName ref="PRS14192BetaMaryam">ቤተ፡ ማርያም፡</persName> ኢጓነሬ፡ ኢጉሜት፡ ይኩነኒ፡ ለተዝካርየ፡ ወቤተ፡ ጊዮርጊስሂ፡ 
+                                        ዘሀለወ፡ በደብረ፡ <placeName ref="LOC4042Kebran">ክብራ፡</placeName> 
+                                        ወምድረ፡ <placeName ref="LOC6980Desat">ድሸት</placeName>ሂ፡ ያጐሹ፡ ገባሪ፡ ወመንፈቀ፡ ምድሮ፡ በ፭፡ ወቂት፡ ዘተሣየጥኩ፡ 
+                                        ወመን<cb n="24rb"/>ፈቀ፡ ምድረ፡ ለግብር፡ ወሀብኩ፡ 
+                                        ዘአጽሐፋ፡ ለዛቲ፡ ንቡረ፡ እድ፡ <persName ref="PRS14193TasfaMaryam">ተስፋ፡ ማርያም፡</persName> ዘምስለ፡ ቅዱሳን፡ 
+                                        ወሀብኖ፡ ለ<persName ref="PRS14190AsrataMaryam">አስራተ፡ ማርያም፡</persName> ዘሄደ፡ ወዘተአገለ፡ 
+                                        <gap reason="ellipsis" unit="lines" quantity="2"/>ውጉዘ፡ ለይኩን፡ ለዓለመ፡ ዓለም።</q>
                                 </item>
                                 <item xml:id="a25">
-                                    <locus target="#236vb"/>
-                                    <desc type="LandGrant">Notice of <persName ref="PRS14148Nob"/> granting land to the community of Kəbrān.</desc>
+                                    <locus target="#24rb"/>
+                                    <desc type="DonationNote">Note in very small characters and barely legible in the microfilm images. Three glosses are 
+                                        added in the outer margin and below, which are illegible in the microfilm images.</desc>
+                                    <q xml:lang="gez">ወሀብኩ፡ አነ፡ <persName ref="PRS14194Atnatewos">አትናቴዎስ፡</persName> ለአጸ፡ ሰላም፡ ትካትሰ፡ ነበረ፡ ስማ፡ 
+                                        ሹም፡ አቦ፡ ወታቦታሂ፡ ዘትካት፡ ቅድስት፡ ሐና፡ ወዘዮምሰ፡ ታቦተ፡ እግዝእትነ፡ ማርያም፡ <gap reason="ellipsis" unit="lines" quantity="18"/>
+                                        ወዘንተሰ፡ ኵሉ፡ ዘወሀብኩ፡ አነ፡ <persName ref="PRS14194Atnatewos">አትናቴዎስ፡</persName> ኢይወልጠ፡ ብየ፡ ወኢይሢጡ፡ እመሂ፡ 
+                                        መምህር፡ ዘክብራን፡ ወኢመነኮሳተ፡ ደብር፡ ወኢካህናቲሃ፡ ለአጸደ፡ ሰላም፡ ኢንብርእድ፡ ወኢ፡ አፈ፡ ንብርእድ፡ ወኵሎሙ፡ 
+                                        <gap reason="illegible" unit="chars" quantity="2"/>ማን፡ ዛቲ፡ ገለም፡ እድ፡ ወአንስት። 
+                                        ናሁ፡ ይብሉ፡ አባ፡ <persName ref="PRS14195TaklaMaryam">ተክለ፡ ማርያም፡</persName> መምህር፡ 
+                                        ዘ<placeName ref="LOC4042Kebran">ክብራን</placeName>። ወመነኮሰ፡ ደብርሂ፡ ፲ወ፭፡ 
+                                        ወአባ፡ <persName ref="PRS14196Diyosqoros">ዲዮስቆሮስ፡</persName> 
+                                        ወአባ፡ <persName ref="PRS14197Zamalakot">ዘመለኮት፡ </persName>
+                                        ወአባ፡ <persName ref="PRS14198Tewodros">ቴዎድሮስ፡</persName> 
+                                        ወአባ፡ <persName ref="PRS14199Abadir">አበዲር</persName>።
+                                        ናሁ፡ አውገዝነ፡ በስልጣነ፡ ጴጥሮስ፡ ወጳውሎስ፡ <gap reason="ellipsis" unit="lines" quantity="1"/> እለ፡ ነበሩ፡ በመንበረ፡ ማርቆስ፡ ሊቀ፡ ጳጳሳት።
+                                        <gap reason="ellipsis" unit="lines" quantity="3"></gap>እሉ፡ ኵሎሙ፡ ስዩማን፡ እለ፡ ጸሐፍነ፡ አስማቲሆሙ፡ ለዓለም፡ አሜን።</q>
                                 </item>
                                 <item xml:id="a26">
-                                    <locus target="#236vb"/>
-                                    <desc type="LandGrant">Notice by a similar hand as <ref target="#a25"/> directly above.</desc>
-                                </item>
-                                <item xml:id="a27">
-                                    <locus target="#237ra"/>
-                                    <desc type="LandGrant">Note written by a hand similar to that of the previous <ref target="#a25 #a26"/>, but taller 
-                                        and written with an irregular margin to the right on a land grant in the time of <persName ref="PRS6229LebnaDe"/>.</desc>
-                                </item>
-                                <item xml:id="a28">
-                                    <locus target="#237ra"/>
-                                    <desc type="LandGrant"/>
-                                </item>
-                                <item xml:id="a29">
-                                    <locus target="#237va"/>
-                                    <desc type="LandGrant">Land grant written in very small characters and partly not legible in the microfilm images: 
-                                        <foreign xml:lang="gez">ኍልቈ፡ ምድር፡ ዘወራሚት፡ ቢኖራ፡ ፪ምድር፡ ዘ፩ምድር፡ 
-                                            <gap reason="ellipsis" unit="lines" quantity="19"/></foreign></desc>
-                                </item>
-                                <item xml:id="a30">
-                                    <locus target="#237vb"/>
-                                    <desc type="LandGrant">Land grants issued by a king named <foreign xml:lang="gez">አድያም፡ ሰገድ፡</foreign>, who can be 
-                                        identified as either <persName ref="PRS5616IyasuI"/>, <persName ref="PRS5617IyasuII"/> or 
-                                        <persName ref="PRS5636IyoasI"/>.</desc>
-                                </item>
-                                <item xml:id="a31">
-                                    <locus target="#237vb"/>
-                                    <desc type="RecordDistribution">Possibly a record of taxes to be distributed to a number of local chiefs.</desc>
-                                </item>
-                                <item xml:id="e1">
-                                    <locus target="#2r"/>
-                                    <desc type="OwnershipNote"><foreign xml:lang="gez">ዘደሴት፡ ቅዱስ፡ ገብርኤል፡ መጽሐ።</foreign> by a modern Ethiopian 
-                                        hand on top of the folio with previously erased text.</desc>
-                                </item>
-                                <item xml:id="e2">
-                                    <locus target="#4va"/>
-                                    <desc type="findingAid">List of Biblical books: <foreign xml:lang="gez">ኦሪት፡ ዮዲት፡ ሕዝቅኢል፡ ዮዲት፡ አስቴር፡ በ፡ ኩፋሌ፡ ዳዊት፡ 
-                                        ጥበበ፡ ሰሎሞን፡ </foreign></desc>
-                                </item>
-                                <item xml:id="e3">
                                     <locus target="#85va"/>
                                     <desc type="DonationNote">Donation note covering 11 lines of the first column with a reference to 
                                         <persName ref="PRS5616IyasuI"/> or <persName ref="PRS5617IyasuII"/> placed above by another hand. </desc>
+                                    <q xml:lang="gez"><add place="above"> በዘመኑ፡ ለንጉሥነ፡ <persName ref="PRS5616IyasuI">ኢያሱ፡ </persName> 
+                                            ዘስ<add resp="CH">መ፡</add> መንግሥቱ፡ <persName ref="PRS5616IyasuI">አድያም፡ ሰገድ</persName>።</add> 
+                                            ወሀብኩ፡ አነ፡ <persName ref="PRS14083Giyorgis">ጊዮርጊስ፡</persName> ለዝንቱ፡ መጽሐፈ፡ ወንጌል፡ ለመካነ፡ 
+                                            ገብረ<subst><del>ዮ</del><add place="overstrike">ኤል፡ ዘዮ</add></subst>ሐንስ፡ ከመ፡ ይምኃረኒ፡ በጸሎቱ። 
+                                            ለዛቲ፡ መጽሐፍ፡ እመቦ፡ ዘተኣገላ፡ ወተኃየላ፡ ዘሴጣ፡ ወዘሰረቃ፡ ውጉዘ፡ ይኩን፡ በአፈ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ለዓለመ፡ አለም፡ ኣሜን። ። ።</q>
                                 </item>
-                                <item xml:id="e4">
-                                    <locus target="#183ra"/>
-                                    <desc type="DonationNote"><foreign xml:lang="gez">ኈልቈ፡ ሀገር፡ ዘመሀብዎ፡ ንጉሥነ፡ 
-                                        <persName ref="PRS5616IyasuI">አድያም፡ ሰገድ፡ </persName>ለመካነ፡ ገብርኤል፡ <gap reason="ellipsis"></gap></foreign></desc>
+                                <item xml:id="a27">
+                                    <locus from="85va" to="85vb"/>
+                                    <desc type="ReceiptNote">Note possibly on the transaction or emancipation of slaves.</desc>
+                                    <q xml:lang="am">ይቤሉ፡ ሰብአ፡ <placeName ref="LOC4042Kebran">ክቡራን፡</placeName> 
+                                            ወ<placeName ref="LOC6979Waramit">ወራሚት፡</placeName> 
+                                            እንዘ፡ መምሕር፡ <persName ref="PRS14128TaklaHaymanot">ተክለ፡ ሃይማኖት፡</persName>
+                                            ወአፈ፡ መምሕር፡ <persName ref="PRS14129Damye">ደምዬ</persName> 
+                                            መምር፡ <persName ref="PRS14130NikodimosFantaWM">ኒቆዲሞስ፡ ፈንታ፡ ወልደ፡ ሚካኤል፡</persName> 
+                                            በሊሕ፡ ዳኛ፡ ያፀዲን፡ ምድር፡ <del unit="chars" quantity="1"/>ያዘችውን፡ የገዛቸውን፡ 
+                                            ላቤቶ፡<persName ref="PRS14131LabetoGasso">ጋሾ፡ </persName>
+                                            ሸጠናል፡ በ፵፡፩፡ጣን፡ ተዶል፡ በከመምር፡ <persName ref="PRS14132Agne">አግኔ፡</persName> 
+                                            የተገዘውን፡ አባ፡ <persName ref="PRS14133Gabriel">ገብርኤል፡</persName> የተገዛውን፡ 
+                                            <persName ref="PRS14134Kaygats">ካይጋፅ፡</persName> 
+                                            የተገዘውን፡ <persName ref="PRS14135Yehenan">ይህነን፡</persName> ደብሩም፡ መምሩም፡ ሀገሩም፡ ያለቅዳሴ፡ ከዳ፡ አንዳይገናጅ፡ 
+                                            ታቦር፡ ኪዳን፡ ገበዝ፡ <persName ref="PRS14136NatnaelM">ናትናኤል፡ ሚካኤል፡</persName> 
+                                            አፈ፡ ገበዝ፡ <persName ref="PRS14137Zerem">ዝሬም፡</persName> እኒህ፡ ተዳኑ፡ ለሚመጻውም፡ ቦተሾሙ፡ መድን፡ ናቸው፡ ደብር፡ የሰጡች፡ 
+                                            አስጻፊ፡ ደብተራ፤ <persName ref="PRS14138Iyyob" resp="scribe">ኢዮብ፡</persName> ንው፡ 
+                                            ይህ፡ እንዳይፈርስ፡ በቡነ፡ <persName ref="PRS14139Zayohannes">ዘዮሐንስ፡</persName> ቃል፡ በ፯፻፡በ፲፰፡ ቃል፡ ግዝት፡ ነው፡ 
+                                            አባ፡ <persName ref="PRS14140Bakwere">በኵሬ፡</persName> 
+                                            አባ፡ <persName ref="PRS14141Hezqeyas">ሕዝቅያስ</persName>። ገዝቶሉ፡</q>
                                 </item>
-                                <item xml:id="e5">
+                                <item xml:id="a28">
+                                    <locus target="#85vb"/>
+                                    <desc>Note by another hand of the eighteenth or nineteenth century in much smaller height containing the character
+                                        ዠ in a special archaic form with hashes at the lower ends of the legs.</desc>
+                                    <q xml:lang="am">በዘመነ፡ ማርቆ፡ በመጋቢት፡ ራስ፡ ቢት፡ ወደድ፡ <persName ref="PRS14107Mangasha">መንገሻ፡</persName> ታቶ፡ 
+                                            <persName ref="PRS14108Was">ዋስ፡</persName> አገኘሁ፡ አርስት፡ ሲገዙ፡ እማኞቹ፡ 
+                                            ሊቀ፡ ረድ፡ <persName ref="PRS14109Mertenehah">ምርጥነህ፡ </persName>
+                                            ሊቀ፡ ረድ፡ <persName ref="PRS14110Gossu">ጐሹ፡</persName> 
+                                            ሊቀ፡ ረድ፡ <persName ref="PRS14112Wonde">ወንዴ፡</persName> 
+                                            ሊቀ፡ ረድ፡ <del rend="expunctuated">ሊ</del><persName ref="PRS14111Berru">ብሩ፡</persName> 
+                                            ምስለኔ፡ <persName ref="PRS14113TasfaGetahun">ተስፋ፡ ጌታሁን፡</persName> ጔሉ፡ 
+                                            <persName ref="PRS14114AyalewGM">አያሌው፡ ገብረ፡ ማርያም፡ </persName>
+                                            <persName ref="PRS14115BarYahunWale">በር፡ ያሁን፡ ዋሌ፡</persName>ናቸው፡ 
+                                            ለውርሱ፡ እማኞች፡ አቶ፡ <persName ref="PRS14116Tawaqa">ታወቀ፡</persName> 
+                                            ብላታ፡ <persName ref="PRS14117Zallaqa">ዘለቀ፡ </persName>
+                                            <persName ref="PRS14114AyalewGM">አያሌው፡ ገብረ፡ ማርያም፡</persName>
+                                            <persName ref="PRS14118DastaLama">ደስታ፡ ለማ፡</persName> 
+                                            አቶ፡ <persName ref="PRS14119GalagayEste">ገላጋይ፡ እሽቴ፡ </persName>ጔሉ፡ 
+                                            <persName ref="PRS14121SendaqiTekku">ስንደቂ፡ ትኩ፡</persName> 
+                                            አቶ፡ <persName ref="PRS14122Tafarra">ተፈራ፡</persName> 
+                                            አቶ፡ <persName ref="PRS14123TafalaGT">ታፈለ፡ ዠመረ፡ ታወቀ፡</persName> 
+                                            ዳኞቹ፡ ሊቀ፡ ረድ፡ <persName ref="PRS14125LamaMaggabi">ለማ፡ መጋቢ፡</persName> 
+                                            <persName ref="PRS14124WebAyyahu">ውብ፡ አየሁ፡</persName>  
+                                            ሱም፡ <persName ref="PRS14126Warqenah">ወርቅነህ፡ </persName>ናቸው። ዳኞች፡ ለሁሉም፡ 
+                                            <add place="above">ናቸው፡</add></q>
+                                    <q type="translation" corresp="#a28" resp="CH">
+                                            In the year of Marqos, in Maggābit, rās bit waddad Mangašā bought lands from ʾato Wās. The witnesses are liqa rad Mərṭənah, 
+                                            liqa rad Gʷaššu, liqa rad Wande, liqa rad Bərru, and also a person whose name is Tasfā Getāhun, ʾAyālew Gabra Māryām, 
+                                            Bar Yāhun Wāle. The witnesses under warranty are ʾato Tāwwaqa, blāttā Zallaqa ʾAyalāw Gabra Maryām, Dastā Lammā, a person 
+                                            whose name is ʾato Galāgāy ʾƎšte, Səndaqi Təkku, ʾato Tafarā, ʾato Tāfala Žammara Tāwwaqa, and the judges are 
+                                            liqa rad Lammā Maggābi, Wəb ʾAyyahu, sum Warqənah, who are the general judges.</q>
+                                </item>
+                                <item xml:id="a29">
+                                    <locus target="#183va"/>
+                                    <desc type="DonationNote"/>
+                                    <q xml:lang="gez">ኈልቈ፡ ሀ<del unit="chars" quantity="1"/>ገር፡ ዘወሀብዎ፡ ንጉሥነ፡ 
+                                        <persName ref="PRS5616IyasuI">አድያም፡ ሰገድ፡ </persName>ለመካነ፡ ገብርኤል፡ 
+                                        <gap reason="ellipsis" unit="lines" quantity="40"/></q>
+                                </item>
+                                <item xml:id="a30">
                                     <locus target="#184ra"/>
-                                    <desc type="LandGrant"><foreign xml:lang="gez"><persName ref="PRS8550sardaDe">አጼ፡ ሰርጸ፡ ድንግል፡</persName> ዘወሀብዎ፡ 
-                                        ለመቅቅደስ፡ ገብርኤል፡ <gap reason="ellipsis"/>ወጉልቶሙሂ፡ ወሀበ፡ ለመቅደሰ፡ ገብርኤል፡ ዘክብራን፡<gap reason="ellipsis"/></foreign></desc>
+                                    <desc type="LandGrant">Short note on a land grant. The word <foreign xml:lang="gez">ዘአጉልቶ</foreign> was
+                                        added later by another hand, that is also attested in <ref target="a31"/> directly below.</desc>
+                                    <q xml:lang="am">አጼ፡ <persName ref="PRS8550sardaDe">ሰርጸ፡ ድ<add place="above">ን</add>ግል፡</persName>
+                                        ዘወሀብዎ፡ ለመቅደስ፡ ገብርኤል፡ ምድረ፡ <placeName ref="LOC7399Dazma">ደዝማ፡</placeName> የዟመረው፡ ሰረው፡ 
+                                        የ<placeName ref="LOC3549Gojjam">ጎጃም፡</placeName> ነጋሽ፡
+                                        <persName ref="PRS12219Hara">ሐራ፡</persName> ነው፡ <add place="above">ዘአጉልቶ፡</add> ወለቍልቢጥ፡ አባሂ፡ 
+                                        መሪው፡ ሰሪው፡ <persName ref="PRS14200MarawSarawWG">ወልደ፡ ጊዮርጊስ፡</persName> ነው፡ </q>
                                 </item>
-                                <item xml:id="e6">
+                                <item xml:id="a31">
                                     <locus target="#184ra"/>
-                                    <desc type="DonationNote">On the bottom of the page: <foreign xml:lang="gez">በዝየ፡ ከነ፡ ጉባኤ፡ 
-                                        <placeName ref="LOC1071Acafar">አቸፈር፡</placeName> በዘነግሠ፡ 
+                                    <desc type="LandGrant">Note by another hand as <ref target="a30"/>, but apparently refers to regular taxes that
+                                        had to be paid by the inhabitants of the aforementioned fiefdom of <placeName ref="LOC7399Dazma"/> to
+                                        <placeName ref="LOC4042Kebran"/>.</desc>
+                                    <q xml:lang="gez">ወጉልቶሙሂ፡ ወሀበ፡ ለመቅደሰ፡ ገብርኤል፡ ዘ<placeName ref="LOC4042Kebran">ክብራን፡</placeName>
+                                        ወግብሮሙሰ፡ ፲፭፡ ማድጋ፡ ስርናይ፡ ወሰገም፡ በበ፩፩፡ ይሁብዎ፡ ለመምህረ፡ ይእቲ፡ ደሴት፡ ለለዓመት፡ ዘንተሂ፡ ዘተእገለ፡ እመሂ፡ ነጋሤ፡ 
+                                        <placeName ref="LOC3549Gojjam">ጐጃም፡</placeName> ወእመሂ፡ ስዩመ፡ ሀገር፡ በስጣነ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ውጉዘ፡ 
+                                        ለይኩን።</q>
+                                </item>      
+                                <item xml:id="a32">
+                                    <locus from="184ra" to="184rb"/>
+                                    <desc type="LandGrant">Note on the bottom of the column.</desc>
+                                    <q xml:lang="gez">በዝየ፡ ኮነ፡ ጉባኤ፡ <placeName ref="LOC1071Acafar">አቸፈር፡</placeName> በዘነግሠ፡ 
                                         <date notBefore="1633" notAfter="1634">በደግማይ፡ ዓመተ፡ መንግሥቱ፡ </date> 
-                                        ለንጉሥ፡ <persName ref="PRS4015Fasilada">ፋሲል፡</persName><gap reason="ellipsis"/></foreign></desc>
+                                        ለንጉሥ፡ <persName ref="PRS4015Fasilada">ፋሲል፡</persName> 
+                                        ወአጉለታ፡ ለ<placeName ref="LOC7085Ambasa">አምበሳ</placeName>። ማርያም፡ በፈቃዱ፡ ለመቅደስ፡ ገብርኤል፡
+                                        ዘደሴተ፡ <placeName ref="LOC4042Kebran">ክብራን፡</placeName>፡ ወግብሮሙሰ፡ 
+                                        <gap reason="illegible" unit="chars" quantity="1"/>ጨው፡ ለለዓመት፡ 
+                                        ዘይ<add place="above">ሁ</add>ብዎ፡ ለመምህር፡ ይእቲ፡ ደሴት፡ እመሂ፡ ነጋሤ፡ 
+                                        <placeName ref="LOC3549Gojjam">ጐጃም፡</placeName> ወእመሂ፡ ስዩመ፡ 
+                                        <placeName ref="LOC1071Acafar">አቸፈር፡</placeName> 
+                                        ኢ<gap reason="illegible" unit="chars" quantity="1"/>ዕ፡ 
+                                        መኦ<gap reason="illegible" unit="chars" quantity="1"/>፡ ውስቴታ፡ <cb n="184rb"/> ተሀቢሎ፡ 
+                                        <add place="above">በኃይለ</add>፡ በ፲፪ሐዋርያት፡ በ፫፻፲ወ፰ርቱዓነ፡ ሃይማኖት፡ ወጉዘ፡ ለይኩን።</q>
                                 </item>
-                                <item xml:id="e7">
+                                <item xml:id="a33">
                                     <locus target="#184rb"/>
-                                    <desc type="DonationNote"><foreign xml:lang="gez">ጸሐፍነ፡ ዘገብረ፡ በዘመኑ፡ ንጉሠ፡ ሰላም፡ 
-                                        <persName ref="PRS4015Fasilada">ፋሲለደስ፡ </persName> ዘተሰምየ፡ በ<add>በ</add>ፈቃደ፡ እግዚአብሔር፡ ዘወሀበ፡ ጉልታተ፡ 
-                                        ሀገር፡ ለመቅደሰ፡ ክብራን፡ ገብርኤል፡ <gap reason="ellipsis"/></foreign></desc>
+                                    <desc type="LandGrant"/>
+                                    <q xml:lang="gez">ጸሐፍነ፡ ዘገብረ፡ በዘመኑ፡ ንጉሠ፡ ሰላም፡ <persName ref="PRS4015Fasilada">ፋሲለደስ፡ </persName> 
+                                        ዘተሰምየ፡ በበፈቃደ፡ እግዚአብሔር፡ ዘወሀበ፡ ጉልታተ፡ ሀገር፡ ለመቅደሰ፡ <placeName ref="LOC4042Kebran">ክብራን፡</placeName>
+                                        ገብርኤል፡ <placeName ref="LOC7401Dagusmaha">ዳጉስማሃ፡ </placeName>
+                                        ወ<placeName ref="LOC7384Hanita">ሐኒታ፡</placeName> 
+                                        ወ<placeName ref="LOC7402WabarataMaryam">ወበረተ፡ ማርያም፡</placeName> 
+                                        ወ<placeName ref="LOC7403MataqerDaramani">መጣቅር፡ ደረመኒሃ፡</placeName>
+                                        ወ<placeName ref="LOC7404GulgulmaMA">ጉልጉልማ፡ መድኃኔ፡ ዓለም፡</placeName> ከመ፡ ይኩኑ፡ ረዳኢሁ፡ ለገብርኤል፡ በንዋይ፡ 
+                                        ወበኩሉ፡ ግብር፡ ለ<placeName ref="LOC7405Gunagulama">ጉናጉለመ፡</placeName></q>
                                 </item>
-                                <item xml:id="e8">
+                                <item xml:id="a34">
+                                    <locus target="#184rb"/>
+                                    <desc type="LandGrant">Addition to the land grant noted directly above in <ref target="#a33"/>.</desc>
+                                    <q xml:lang="am">ሰሪው፡ መሪው፡ <persName ref="PRS14201TaklaSellase">ተክለ፡ ሥላሴ፡</persName> ነው፡ ወለደበርት፡ 
+                                        ማርያም፡ ሰሪው፡ መሪው፡ የ<placeName ref="LOC3549Gojjam">ጐጃም፡</placeName><add place="above">ነጋሽ፡</add> 
+                                        ነው፡ ወለ<placeName ref="LOC7399Dazma">ደዝማ</placeName>ሂ፡ መሪው፡ ሠሪው፡  
+                                        የ<placeName ref="LOC3549Gojjam">ጐጃም፡</placeName> ነጋሽ፡ ነው፡ ወለኵሎሙ፡ ዘወሀቦ፡ ለመቅድስ፡ ገብርኤል፡ ንጉሠ፡ ሰላም፡ 
+                                        <persName ref="PRS4015Fasilada">ፋሲለደስ፡ </persName> ወዘተርፈሂ፡ ወሀቦ፡ 
+                                        <persName ref="PRS5616IyasuI">ኢያሱ፡</persName> ዘለመንግሥቱ፡ 
+                                        <persName ref="PRS5616IyasuI">አድያም፡ ሰገድ፡</persName> ዘተአገለ፡ ዘንተ፡ ጉልታተ፡ እመሂ፡ ንጉሥ፡ ወእመሂ፡ ስዩመ፡ ሀገር፡ ውጉዘ፡
+                                        ለይኩን፡ በስልጣነ፡ አብ፡ ወወልድ፡ ወመንፈሰ፡ ቅዱስ፡ በ፲፪ሐዋርያት፡ በ፫፻፲ወ፰ርቱዓነ፡ ሃይማኖት።</q>
+                                </item>
+                                <item xml:id="a35">
+                                    <locus target="#232ra"/>
+                                    <desc type="ReceiptNote">Note in very small height, barely legible in some places.</desc>
+                                    <q xml:lang="gez">ስምዑ፡ ኦሰብእ፡ ደብር፡ ዓቢይ፡ ወንኡስ፡ ናሁ፡ ተሣየጥኩ፡ አነ፡ 
+                                        <persName ref="PRS14194Atnatewos">አትናቴዎስ፡ </persName>
+                                        እምነ፡ <persName ref="PRS14202Zadengel">ዘድንግል፡</persName> ወልደ፡ አባ፡ 
+                                        <persName ref="PRS14129Damye">ዳምዬ፡</persName> ቤቱ፡ ወምድሩ፡ 
+                                        <gap reason="ellipsis" unit="lines" quantity="7"/>
+                                        ወአባ፡ <persName ref="PRS14153TaklaGabreel">ተክለ፡ ገብርኤል፡</persName> ቄስ፡ ገበዝ።</q>
+                                </item>
+                                <item xml:id="a36">
                                     <locus target="#232rb"/>
-                                    <desc type="DonationNote"><foreign xml:lang="gez">ወሀብኩ፡ አነ፡ 
-                                        <persName ref="PRS14084NagadaKrestos">ነገደ፡ ክርስቶስ፡</persName> ዘንተ፡ መጽሐፈ፡ ወንጌል፡ ለማርያም፡ ቅድስት፡ ዘክብራን፡<gap reason="ellipsis"/></foreign></desc>
+                                    <desc type="DonationNote"/>
+                                    <q xml:lang="gez">ወሀብኩ፡ አነ፡ <persName ref="PRS14084NagadaKrestos">ነገደ፡ ክርስቶስ፡</persName> ዘንተ፡ መጽሐፈ፡ ወንጌል፡ 
+                                        ለማርያም፡ ቅድስት፡ ዘ<placeName ref="LOC4042Kebran">ክብራን፡</placeName>
+                                        <gap reason="ellipsis" unit="lines" quantity="17"/>በአፈ፡ መላእክት፡ ለዓለመ፡ ዓለም፡ አሜን፡ ወአሜን።</q>
                                 </item>
-                                <item xml:id="e9"> 
+                                <item xml:id="a37"> 
                                     <locus from="232va" to="233ra"/>
-                                    <desc type="DonationNote">Note on the Donation of manuscripts and church utensils to Kəbrān of a similar hand as the
-                                        main text: <foreign xml:lang="gez">በስመ፡ ሥሉስ፡ ቅዱስ፡ ኍልቈ፡ መጻሕፍት፡ ዘደብረ፡ ክብራ፡ ከመዝ፡ ውእቱ፡ ፰ዘአስተጋባእነ፡ ክልኤቱ፡ አኀው፡ 
-                                        ምስኪናን፡ ከመ፡ ይኵነነ፡ ለመድኅኒተ፡ ኃጢአትን። <gap reason="ellipsis"/></foreign></desc>
+                                    <desc type="DonationNote">Note on the Donation of manuscripts and church utensils to 
+                                        <placeName ref="LOC4042Kebran"/> of a similar hand as the main text.</desc>
+                                    <q xml:lang="gez">በስመ፡ ሥሉስ፡ ቅዱስ፡ ኍልቈ፡ መጻሕፍት፡ ዘደብረ፡ <placeName ref="LOC4042Kebran">ክብራ፡</placeName> 
+                                        ከመዝ፡ ውእቱ፡ ፰ዘአስተጋባእነ፡ ክልኤቱ፡ አኀው፡ ምስኪናን፡ ከመ፡ ይኵነነ፡ ለመድኅኒተ፡ ነፍስነ፡ ወለስርየተ፡ ኃጢአትን። ወኀብኩ፡ አነ፡
+                                        <persName ref="PRS14203Tomas">ቶማስ፡</persName> 
+                                        ምስለ፡ እኁየ፡ <persName ref="PRS14204Zayohannes">ዘዮሐንስ</persName>። 
+                                        ለማርያም፡ ወላዲተ፡ አምላክ፡ ቅድስት።<gap reason="ellipsis" unit="lines" quantity="4"/>
+                                        ወቦ፡ እምኔሆሙ፡ <persName ref="PRS14205Marqoryos">መርቆርዮስ፡</persName> ፈላሲ። ለመድኀኒተ፡ ነፍሶሙ፡ አግዚአብሔር፡ 
+                                        የሀቦሙ፡ ዓስቦሙ፡ ፍጹመ፡ አሜን። ወዘንተ፡ ኵሎሙ፡ መጻሕፍተ። <gap reason="ellipsis" unit="lines" quantity="26"/>
+                                        ወይደምሰስ፡ ስሙ፡ እመጽሐፈ፡ ሕይወት፡ ወይጥፋእ፡ ዝክሩ፡ በምድር፡ ወበሰማያት። ለዓለመ፡ ዓለም፡ አሜን፡ ለይኩን፡ ለይኩን። ።</q>
                                 </item>
-                                <item xml:id="e10">
-                                    <locus target="#79ra #79va #82va #83rb #84rb"/>
+                                <item xml:id="a38">
+                                    <locus target="233ra"/>
+                                    <desc type="DonationNote">Addition to the <ref target="#a37">Donation note</ref> directly above.</desc>
+                                    <q xml:lang="gez">፪ቀሚስ፡ ወ፪ሞጠሀተ፡ ወሀብነ፡ ኅቡረ፡ ለመካነ፡ አዝማ፡ ለተዝካረ፡ ንጉሥ፡ ሥዕል፡ ፬በመባሕተ፡ </q>
+                                </item>
+                                <item xml:id="a39">
+                                    <locus target="#233rb"/>
+                                    <desc type="DonationNote">Note on a donation in the time of <persName ref="PRS10473Yostos"/> 
+                                        to <placeName ref="LOC4042Kebran "/>.</desc>
+                                    <q xml:lang="gez">ናሁ፡ ወኀብኩ፡ አነ፡ <persName ref="PRS14206Zadengel">ዘድንግል፡</persName> 
+                                        ምድረ፡ <placeName ref="LOC7406Kubezt">ኩብዝት፡</placeName> 
+                                        ለመቅደስ፡ <placeName ref="LOC4042Kebran">ገብርኤል፡ ክብራን፡</placeName> 
+                                        በትእዛዘ፡ ንጉሥ፡ <persName ref="PRS10473Yostos">ፀሐይ፡ ሰገድ፡ </persName>ወበጸጋ፡ እግዚአብሔር፡ 
+                                        ዘተሠምየ፡ <persName ref="PRS14207Iyasu">ኢያሱ፡</persName> 
+                                        ወእንዘ፡ <persName ref="PRS14208WaldaLeul">ወልደ፡ ልዑል፡</persName> ቢት፡ ወደድ፡ ከመ፡ ይኩነኒ፡ ለምድኃኒተ፡ ሥጋ፡ ወነፍስ።</q>
+                                </item>
+                                <item xml:id="a40">
+                                    <locus target="#233va"/>
+                                    <desc type="DonationNote">Note on the donation from <persName ref="PRS14085Baseleyos"/> 
+                                        to <placeName ref="LOC4042Kebran "/>.</desc>
+                                    <q xml:lang="gez">በስመ፡ ስሉሥ፡ ቅዱስ፡ ወሀብኩ፡ አነ፡ <persName ref="PRS14085Baseleyos">ባስሌዮስ፡</persName> 
+                                        ለዮሐንስ፡ ወለገብርኤል፡ ወለማርያም፡ ዘደብረ፡ <placeName ref="LOC4042Kebran">ክብራን</placeName>። መጻሕፍት፡ ወንጌል፡ ፩፡ 
+                                        ጳውሎስ፡ ፩፡ <gap reason="ellipsis" unit="lines" quantity="20"/>ምአት፡ ኣው፡ ነቡረ፡ እድ፡ አው፡ ሥዩመ፡ ደርሰ፡ አው፡ ነጋሢ፡ 
+                                        <placeName ref="LOC3549Gojjam">ጐዛም፡</placeName> ኣው፡ መነኮስ፡ አው፡ 
+                                        <gap reason="ellipsis" unit="lines" quantity="16"/></q>
+                                </item>
+                                <item xml:id="e1">
+                                    <desc type="Correction">Single words or several phrases erased and overwritten throughout the manuscript.</desc>
+                                </item>
+                                <item xml:id="e2">
                                     <desc type="findingAid">Finding aids above the text and at the end of each Evangile book, and verse numbers by later hand 
                                         throughout.</desc>
                                 </item>
-                                <item xml:id="e11">
-                                    <locus target="#232ra"/>
-                                    <desc type="Unclear">Note in very small height: <foreign xml:lang="gez">ስምዑ፡ ኦሰብእ፡ ደብር፡
-                                        ዓቢይ፡ ወንኡስ፡ ናሁ፡ ተሣየጥኩ፡ አነ፡ አትናቴዎስ፡ እምነ፡ ዘድንግል፡ ወልደ፡ አባ፡ ዳምጻ፡ ቤቱ፡ ወምድሩ፡ <gap reason="ellipsis"/></foreign></desc>
-                                </item>
-                                <item xml:id="e12">
-                                    <locus target="#233rb"/>
-                                    <desc type="DonationNote">Note on a donation from <persName ref="PRS10473Yostos"/> to Kəbrān: 
-                                        <foreign xml:lang="gez">ናሁ፡ ወኀብኩ፡ አነ፡ ዘድንግል፡ ምድረ፡ ኩብዝት፡ ለመቅደስ፡ ገብርኤል፡ ክብራን፡ በትእዛዘ፡ ንጉሥ፡ 
-                                        <persName ref="PRS10473Yostos">ፀሐይ፡ ሰገድ፡ </persName>ወበጸጋ፡ እግዚአብሔር፡ ዘተሠምየ፡ ኢያሱ፡ ወእንዘ፡ ወልደ፡ ልዑል፡ 
-                                         ቤት፡ ወደድ፡ ከመ፡ ይኩነኒ፡ ለምድኃኒተ፡ ሥጋ፡ ወነፍስ።</foreign></desc>
-                                </item>
-                                <item xml:id="e13">
+                                <item xml:id="e3">
                                     <locus target="#233va"/>
-                                    <desc type="DonationNote">Note on the donation from <persName ref="PRS14085Baseleyos"/> to Kəbrān: 
-                                        <foreign xml:lang="gez">በስመ፡ ስሉሥ፡ ቅዱስ፡ ወሀብኩ፡ አነ፡ <persName ref="PRS14085Baseleyos">ባስሌዮስ፡</persName> 
-                                        ለዮሐንስ፡ ወለገብርኤል፡ ወለማርያም፡ ዘደብረ፡ ክብራን። መጻሕፍት፡ ወንጌል፡ ፩፡ ጳውሎስ፡ ፩፡ <gap reason="ellipsis"/></foreign></desc>
+                                    <desc type="Unclear"/>
+                                    <q xml:lang="am">የቀባኑግ፡ ገባር፡ የንከነበር፡ መጽሐፈ፡ ጥምቀት፡ ፬፡ ልጅ፡ ክማበል፡ ምድረ፡ <placeName ref="LOC7407Desht">ድሽት</placeName>።</q>
                                 </item>
-                                <item xml:id="e14">
-                                    <locus from="233vb"  to="234r"/>
-                                    <desc type="Inventory">Note in a tall size, on the books of Kəbrān since the time of <persName ref="PRS8595SayfaAr"/>
-                                        and <persName ref="PRS8387SalamaI"/>. However the note is likely to be copied later, because also 
-                                        <persName ref="PRS3429DawitII"/> is mentioned, what indicates a date for this addition not before 
-                                        <date notBefore="1380">1380</date>. The list was continued in <ref target="#e15"/>.</desc>
-                                </item>
-                                <item xml:id="e15">
-                                    <locus from="234r" to="234v"/>
-                                    <desc type="Inventory">Continuation of the aforementioned inventory list in <ref target="#e14"/> by a later hand.</desc>
-                                </item>
-                                <item xml:id="e16">
-                                    <locus from="235ra"/>
-                                    <desc type="OwnershipNote">Short note below <ref target="#a21"/>: <foreign xml:lang="gez">ዝንቱ፡ ክታብ፡ 
-                                        ዘ<persName ref="PRS14094Estifanos">እስጢፋኖስ፡</persName></foreign></desc>
-                                </item>
-                                <item xml:id="e17">
-                                    <locus from="235ra" to="235rb"/>
-                                    <desc type="DonationNote">Note on the donation of church utensils to Kəbrān by person with the name 
-                                        <persName ref="PRS14095Estifanos">እስጢፋኖስ</persName>, possibly the same, who claimed ownership to this codex 
-                                        in <ref target="#e16"/> by a similar hand: <foreign xml:lang="gez">ወሀብኩ፡ አነ፡ 
-                                        <persName ref="PRS14095Estifanos">እስጢፋኖስ፡</persName> ዘንተ፡ ንዋየ፡ ለመካነ፡ ገብርኤል፡ ወማርያም፡ ለተዝካርየ፡ ወለመድኃኒተ፡ ነፍስየ፡ 
-                                        ፫አዕማሰ፡ የሲኅ፡ ፪። የስንዳሌ፡ ክዳን፡ ፩። <gap reason="ellipsis"/></foreign>.</desc>
-                                </item>
-                                <item xml:id="e18">
-                                    <locus target="#235rb"/>
-                                    <desc type="ReceiptNote">Receipt for the sale of land for the price of four young cows by with several clergymen 
-                                        recorded as witnesses, that are mostly the same as in <ref target="#e18"/>.</desc>
-                                </item>
-                                <item xml:id="e19">
-                                    <locus target="#235rb"/>
-                                    <desc type="ReceiptNote">Receipt for the sale of land by a similar hand, with a similar content and mostly the same persons 
-                                        as witnesses as in <ref target="#e17"/>.</desc>
-                                </item>
-                                <item xml:id="e20">
-                                    <locus target="#236va"/>
-                                    <desc type="OwnershipNote">Note, written by a hand similar to the previous <ref target="#a24"/>, but with a smaller 
-                                        pen and similar to <ref target="e20"/>: <foreign xml:lang="gez">በስመ፡ ሥሉስ፡ ቅዱስ፡ ትጽሕፈት፡ ዛቲ፡ መጽሐፍ፡ ወሀብዎ፡ ቅዱሳን፡ 
-                                        ለ<persName ref="PRS14142GabraBerhan">ገብረ፡ ብርሃን፡</persName> ቤተ፡ ዘነበረ፡ ቅድመ፡ 
-                                        ለ<persName ref="PRS14143TasfaMasqal">ተስፋ፡ መስቀል፡</persName> ከመ፡ ይኩኖ፡ ርስት፡ ለወልዱ፡ ኢኮነ፡ በእንተ፡ ነጋሢነት፡ 
-                                        ዘወሀብዎ፡ በእንተ፡ ፍትረ፡ ገብርኤል፡ ወሀብዎ፡ ለተዘካር፡ በሕይወቶ፡ ወበሞቱ፡ ኵሉ፡ ጊዜ፡ ለዓለመ፡ ዓለም። ። </foreign></desc>
-                                </item>
-                                <item xml:id="e21">
-                                    <locus target="#236va"/>
-                                    <desc type="ScribalNoteCommissioning">Scribal note, that mentions <persName ref="PRS6229LebnaDe"/> and also
-                                        <persName ref="PRS14077FereKrestos"/> and <persName ref="PRS14088TaklaSyon"/>, two dignitaries, who are
-                                        also mentioned in <ref target="#a21"/>. Written by a hand similar to the one of the previous <ref target="#a24"/> 
-                                        and <ref target="#e19"/>.</desc>
-                                </item>
-                                <item xml:id="e22">
-                                    <locus target="#237va"/>
-                                    <desc type="Inventory">Note with very low character height and irregular lines and margins, mentioning a number of church utensils
-                                        of the church of Kəbrān which was originally included into another codex containing a <ref target="LIT1955Mashaf"/>, as indicated at the
-                                        end of the brief note.</desc>
-                                </item>
-                                <item xml:id="e23">
-                                    <locus target="#237va"/>
-                                    <desc type="ReceiptNote">Note of goods given to the church of Kəbrān: <foreign xml:lang="gez">ወሀብኩ፡ ንዋየ፡ 
-                                        ለክብራን፡ ለቅዱስ፡ ገብርኤል፡ <gap reason="ellipsis" unit="lines" quantity="12"/></foreign></desc>    
-                                </item>
-                            </list>
-                        </additions>
-                        <bindingDesc>
-                            <binding>
-                                <decoNote xml:id="b1" type="Boards">Two wooden boards covered with leather.</decoNote>    
-                                <decoNote xml:id="b2" type="SewingStations">4</decoNote>
-                                <decoNote xml:id="b3" type="bindingMaterial"><material key="wood"></material></decoNote>
-                            </binding>
-                        </bindingDesc>
-                    </physDesc>
-                    <history>
-                        <origin>
-                            <origDate notBefore="1350" notAfter="1412" evidence="internal-date">Palaeographic analysis indicates that the manuscript 
-                                dates from the late 14th or early 15th century. This dating is supported by an addition <ref target="#a1"/>, which has 
-                                <date when="1412"/> as date for this addition. However this early dating of the manuscript is contradicted by a scribal 
-                                supplication in <ref target="#e20"/>, which dates the manuscript to the mid-16th century, but which is at odds with another scribal 
-                                supplication in <ref target="#a3"/> and is most likely a supplication referring to another codex on a folio, which was
-                                added later to the codex in a rebinding. This view is supported by <ref target="#e21"/> in the same quire, that contains 
-                                a reference to the <ref target="LIT1955Mashaf"/>, that is not included in this volume.</origDate>
-                        </origin>
-                    </history>
-                    <additional>
-                        <adminInfo>
-                            <recordHist>
-                                <source><listBibl type="catalogue">
-                                        <bibl><ptr target="bm:Hammerschmidt1973Tanasee"/><citedRange
-                                                unit="page">84–91</citedRange></bibl>
-                                    </listBibl></source>
-                            </recordHist>
-                        </adminInfo>
-                    </additional>
+                              </list>
+                            </additions> 
+                        </physDesc>
+                    </msPart>
+                    <msPart xml:id="p2"><msIdentifier/>
+                        <msContents><summary>Various Additions</summary></msContents>
+                        <physDesc>
+                            <additions>
+                                <list>
+                                    <item xml:id="a43">
+                                        <locus from="234va" to="234vb"/>
+                                        <desc type="MixedNote">Commemorative note (Tazkār) on nəburaʾed 
+                                            <persName ref="PRS14086Qalementos">ቀሌምንጦስ፡</persName>.</desc>
+                                        <q xml:lang="gez">ተዝካረ፡ ዘአዘዝኩ፡ ሎሙ፡ አነ፡ <persName ref="PRS14086Qalementos">ቀሌምንጦስ፡</persName> 
+                                            ንቡረ፡ እድ፡ በመዋዕለ፡ <persName ref="PRS3429DawitII">ዳዊት፡</persName> ንጉሥ፡ ለአበዊየ፡ ካህናት፡ ዘደብረ፡ 
+                                            <placeName ref="LOC4042Kebran">ክብራን</placeName>። እሉ፡ እሙንቱ፡ ፯፡ በዐላት፡ ዐበይት። 
+                                            <gap reason="ellipsis" unit="lines" quantity="20"/> ዘንተ፡ ዘሠራዕኩ፡ ሎሙ፡ በመዋዕለየ፡ አነ፡ 
+                                            <persName ref="PRS14086Qalementos">ቀሌምንጦስ</persName>። 
+                                            ወእንዘ፡ ቄስ፡ ገበዝ፡ <persName ref="PRS14210Tomas">ቶማስ</persName>።
+                                            ወራቍ፡ ማሰራ፡ <persName ref="PRS14211Yaeqob">ያዕቆብ፤</persName>
+                                            ወአፈ፡ ንቡረ፡ እድ፡ ተከሰተ። <gap reason="ellipsis" unit="lines" quantity="10"/>በአፈ፡ ፫፻ወ፰ርቱዓነ፡ ሃይማኖት፡ አሜን።</q>
+                                    </item>
+                                    <item xml:id="a44">
+                                        <locus from="234vb" to="235ra"/>
+                                        <desc type="Record">Record of a letter to <persName ref="PRS14087BasaTegest"/> by the community 
+                                            of <placeName ref="LOC4042Kebran"/>during the reign of <persName ref="PRS10626ZaraY"/>.</desc>
+                                        <q xml:lang="gez">በስመ፡ ሥሉስ፡ ቅዱስ፡ ጸሐፍነ፡ ዘንተ፡ ነገረ፡ በቍዔት፡ ደቂቀ፡ 
+                                            <placeName ref="LOC4042Kebran">ክብራ፡</placeName> 
+                                            ኵልን፡ ምስለ፡ አቡነ፡ <persName ref="PRS14089Pawlos">ጳውሎስ፡</persName> ንቡረ፡ ዕድ፡ ኖላዊ፡ መርዔት፡ 
+                                            ለ<persName ref="PRS14087BasaTegest">ባሴ፡ ትዕግሥት፡</persName> በእንተ፡ 
+                                            <persName ref="PRS3706eleni">እሌኒ፡</persName> ንግሥት፡ 
+                                            ወ<persName ref="PRS10626ZaraY">ቈስጠንጢኖስ፡</persName> 
+                                            ንጉሥነ፡ ርቱዓ፡ ሃይማኖት፡ ወ<persName ref="PRS14088TaklaSyon">ተክለ፡ ጽዮን</persName>ሂ፡
+                                            ነጋሢ፡ <placeName ref="LOC3549Gojjam">ጐዛም፡</placeName> 
+                                            <persName ref="PRS14090MeazaHirut">ምዓዘ፡ ኂሩት፡</persName>
+                                            ምስለ፡ ብእሲቱ፡ <persName ref="PRS14091BarbaraLaKres">በርባራ፡ ለክርስቶስ፡</persName> ዓመት፡ ለእሉ፡ ይዕቀቦሙ፡ እግዚእ፡ 
+                                            እስከ፡ ይበልዩ፡ ምድር፡ ወሰማያት፡ ኢይልክፎሙ፡ ሞት፡ ወይረሲ፡ ሕይወቶሙ፡ በፍሥሖ፡ ወበሖሤት፡ ዘአግብኡ፡ ለነ፡ ሢመትነ፡ ዘነሥኡነ፡ በትዕጣን፡ 
+                                            ወመሥዋዕት፡ በረከተ፡ ሠለስቱ፡ አስግት፡ በረከተ፡ ማርያም፡ ንጽሕት፡ በረከተ፡ ነቢያት፡ ወሐዋርያት፡ በረከተ፡ ጻድቃን፡ ወሳማዕት፡ ይከልኦሙ፡ ከመ፡ ሕይመት፡ 
+                                            በኵሉ፡ ጊዜ፡ ወበኵሉ፡ ሰዐት፡ አሜን። <pb n="235ra"/> ስምዑ፡ ዘንተሂ፡ ሥርዐተ፡ መካን፡ ዘጸሐፉ፡ ለነ፡ 
+                                            አቡነ፡ <persName ref="PRS14089Pawlos">ጳውሎስ፡</persName> ንቡረ፡ እድ፡ ምስለ፡ ኵሎሙ፡ መነኮሳት፡ እምይእዜ፡ ይኩን፡ ሢመት፡ 
+                                            መካን፡ በኅርየተ፡ መንፈስ፡ ቅዱስ፡ ኢይኩን፡ በኣድልዎ፡ ወኢበተዛውጎ፡ እመሂ፡ ንቡረ፡ ዕድ፡ እመሂ፡ ቄስ፡ ገበዝ፡ እመሂ፡ እራቅ፡ ማሰራ፡ እመሂ፡ ሊቀ፡ ዲያቆን፡ 
+                                            ከመዝ፡ ይኩን፡ ሢመቶሙ፡ ወሶበሂ፡ ተስዕሩ፡ ይንባሩ፡ በበየቶሙ፡ በህድዓት፡ ወአታደንግፅዎሙ፡ ርእሶሙ፡ ቤተ፡ ቅዱሳን፡ ውእቱ፡ እመቦ፡ ዘተገፍዓ፡ ነዳይ፡ 
+                                            እንበለ፡ ፍትሕ፡ በሢመቶሙ፡ ወይትዋቅሥ፡ በኀበ፡ ቅዱሳን፡ ስምዑ፡ ዘንተኒ፡ ነገረ፡ ዘእነግረክሙ፡ 
+                                            አነ፡ <persName ref="PRS14089Pawlos">ጳውሎስ፡</persName> ወምህርክሙ፡ እመሂ፡ ዐቢይ፡ ወእመሂ፡ ንዑስ፡ እምኔነ፡ ዘየሖር፡ ኀበ፡ 
+                                            መኰንን፡ ወይትናገር፡ በእንተ፡ ጥፋዓታ፡ ለዛቲ፡ መካን፡ ወያጥፍዕ፡ ክርስቶስ፡ እምድር፡ ዝክሮ፡ አሜን፡ ወሶበሂ፡ ፈቀደ፡ ይሖር፡ በአተ፡ ትካዙ፡ እንበለ፡ ጽልሁት፡
+                                            ይሖር። ወዘአስተተ፡ ወዘተአገለ፡ ዘንተ፡ ትእዛዛተ፡ ይኩን፡ ውጉዘ፡ በፈ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ በአፈ፡ አቡነ፡ 
+                                            <persName ref="PRS14093Zayohannes">ዘዮሐንስ፡</persName> 
+                                            በአፈ፡ አቡነ፡ <persName ref="PRS14089Pawlos">ጳውሎስ፡</persName>
+                                            በአፈ፡ ኵሎሙ፡ ለባስያነ፡ መንፈስ፡ ይኩን፡ ውጉዘ፡ ውፁአ፡ ወግሁሰ፡ እምርስተ፡ ቅዱሳን፡ አሜን።</q>
+                                    </item>
+                                    <item xml:id="a45">
+                                        <locus from="235ra"/>
+                                        <desc type="OwnershipNote">Short note below <ref target="#a44"/>.</desc>
+                                        <q xml:lang="gez">ዝንቱ፡ ክታብ፡ ዘ<persName ref="PRS14094Estifanos">እስጢፋኖስ፡</persName></q>
+                                    </item>
+                                    <item xml:id="a46">
+                                        <locus target="#235ra"/>
+                                        <desc type="DonationNote">Note on the donation of church utensils and goods to 
+                                            <placeName ref="LOC4042Kebran "/> by a person with the name 
+                                            <persName ref="PRS14095Estifanos">እስጢፋኖስ</persName>, possibly the same, who claimed ownership to this 
+                                            codex in <ref target="#a45"/> by a similar hand.</desc>
+                                        <q xml:lang="gez">ወሀብኩ፡ አነ፡ <persName ref="PRS14095Estifanos">እስጢፋኖስ፡</persName> ዘንተ፡ ንዋየ፡ ለመካነ፡ 
+                                            <placeName ref="LOC4042Kebran">ገብርኤል፡ ወማርያም፡</placeName> ለተዝካርየ፡ ወለመድኃኒተ፡ ነፍስየ፡ 
+                                            <gap reason="ellipsis" unit="lines" quantity="4"/>ግንዘት፡ ፪። መሰወድ፡ ፩። ምስር፡ ፩።</q>
+                                    </item>
+                                    <item xml:id="a47">
+                                        <locus from="235ra" to="235rb"/>
+                                        <desc type="DonationNote">Continuation of the donation note <ref target="#a46"/> by a similar hand, but with
+                                            different pen.</desc>
+                                        <q xml:lang="gez">ግልባብ፡ ዘውስጥ፡ <del rend="effaced" unit="chars" quantity="1"/>ወዘአፍአ፡ ግልባብ፡ 
+                                            <del rend="effaced" unit="chars" quantity="1"/>ልብሰ፡ የውጽ፡ 
+                                            <del rend="effaced" unit="chars" quantity="1"/>ብዝት፡ 
+                                            <gap reason="ellipsis" unit="lines" quantity="2"/><cb n="235rb"/>ቀሚስ፡ ዘታቦት፡ ፪፡</q>
+                                    </item>
+                                    <item xml:id="a48">
+                                        <locus target="#235rb"/>
+                                        <desc type="ReceiptNote">Receipt for the sale of land by a similar hand, with a similar content and mostly the same 
+                                            persons as witnesses as in <ref target="#a50"/>.</desc>
+                                        <q xml:lang="gez">ዘተሳየጥኩ፡ አነ፡ <persName ref="PRS14096TaklaMaryam">ተክለ፡ ማርያም፡</persName> ምድረ፡ እሊ፡ 
+                                            በ፬፡ ብዕራይ፡ እምነ፡ ኩሎሙ፡ መነኮሳተ፡ ደብር፡ ወእንዘ፡ መምህር፡ አባ፡ <persName ref="PRS14097Hirut">ኂሩት፡</persName> 
+                                            ወቂስገበዝ፡ አባ፡ <persName ref="PRS14098DabraSyon">ደብረ፡ ጽዮን፡</persName> 
+                                            ወመድኀን፡ አባ፡ <persName ref="PRS14099Malkasedeq">መልከጼዴቅ፡</persName> 
+                                            ወራቀ፡ መስራ፡ አባ፡ <persName ref="PRS14100ZaraKrestos">ዘርአ፡ ክርስቶስ፡</persName>
+                                            ወሊቀ፡ ዲያቆን፡ <persName ref="PRS14101Baselyos">ባስልዮስ፡</persName> ዘንተ፡ ምድረ፡ ዘተሳየጥኩ፡ እንበለ፡ ግብር፡ ዘንተ፡ ምድረ፡ ወዘንተ፡ 
+                                            መጽሐፈ፡ ፱ደምሰሰ፡ ወዘፈሀቀ፡ ዘሄደ፡ ወዘተአገለ፡ በሥልጣዎሙ፡ ለጴጥሮስ፡ ወጳውሎስ፡ ውጉዘ፡ በይኩን</q>
+                                    </item>
+                                    <item xml:id="a49">
+                                        <locus target="#235rb"/>
+                                        <desc type="RecordTransaction">Note confirming the inheritance of two houses to 
+                                            <persName ref="PRS14102Estifanos"/>, possibly the same person recorded in <ref target="#a35"/>.</desc>
+                                        <q xml:lang="gez">ወንሕነኒ፡ በኅብረተ፡ ቃል፡ ወሀብኖ፡ ቤተ፡ <persName ref="PRS14105Damatewos">ደማቴዎስ፡</persName> ወቤተ፡ 
+                                            <persName ref="PRS14104Abreham">አብርሃም፡</persName>  ይኩኖ፡ ርስተ፡ በሞቱ፡ ወበሕይወቱ፡ ለአቡነ፡ 
+                                            <persName ref="PRS14102Estifanos">እስጢፋኖስ፡</persName> ወእምድኅሬሁ፡ ይኩን፡ ለወልዱ፡ 
+                                            <persName ref="PRS14103Ishaq">ይስሐቅ፡ </persName><gap reason="ellipsis" unit="lines" quantity="14"/>
+                                            ወቅዉመ፡ ው<del rend="effaced" unit="chars" quantity="1"/>አ፡ እምስብሐተ፡ እግዚአብሔር፡ አሜን። </q>
+                                    </item>
+                                    <item xml:id="a50">
+                                        <locus target="#235rb"/>
+                                        <desc type="LandGrant">Notice by a similar hand with a similar content and mostly the same 
+                                            persons as witnesses as in <ref target="#a50"/> as <ref target="#a48"/> on the same folio above.</desc>
+                                        <q xml:lang="gez">ዘተሳየጥኩ፡ አነ፡ <persName ref="PRS14106ZaraAbreham">ዘርአ፡ አብርሃም፡</persName> ምድረ፡ ዜዲት፡ በ፬ላህም፡ ወ፯ጼው፡ 
+                                            እምነ፡ ኵሎሙ፡ መነኮሳተ፡ ደብረ፡ ወእንዘ፡ መምህር፡ አባ፡ <persName ref="PRS14097Hirut">ኂሩት፡</persName> ወቂስ፡ ገበዝ፡ ወመድኀንሂ፡ አባ፡ 
+                                            <persName ref="PRS14098DabraSyon">ደብረ፡ ጽዮን፡</persName> 
+                                            ወረቍ፡ መስራ፡ <persName ref="PRS14100ZaraKrestos">ዘርአ፡ ክርስቶስ፡</persName>
+                                            ወሊቀ፡ ዲያቆን፡ <persName ref="PRS14101Baselyos">ባስልዮስ፡</persName>
+                                            ዘንተ፡ ምድረ፡ ዘተሳየጥኩ፡ በሐራ፡ እንበለ፡ ግብር፡ ዘንተ፡ ምድረ፡ ወዘንተ፡ መጽሐፈ፡ በደምሰሰ፡<gap reason="illegible" unit="chars" quantity="2"/>ፈቀቀ፡ 
+                                            ዘሄደ፡ ወዘተአገለ፡ <gap reason="illegible" unit="chars" quantity="5"/>ሙ፡ ለጴጥሮስ፡ ወጳውሎስ፡ ውጉዘ፡ በይኩን። ። </q>
+                                    </item>
+                                    <item xml:id="a51">
+                                        <locus from="235va" to="235vb"/>
+                                        <desc type="MixedNote">Instruction of King <persName ref="PRS3429DawitII"/> to commemorate the death (Tazkār) 
+                                            of his father and predecessor <persName ref="PRS8595SayfaAr"/> on 15 Gənbot and of his mother 
+                                            <persName ref="PRS14166LazabWarqa"/> on 12 Sane in the region of <placeName ref="LOC5888Tana"/>.
+                                            The text mentions the 34th year of the reign of <persName ref="PRS3429DawitII"/> as the date of this addition. 
+                                            According to <bibl><ptr target="bm:Tadesse1974Succession"/></bibl>, this indicates a lasting power struggle with 
+                                            his brother <persName ref="PRS7559NewayaM"/> whom he succeeded after his death in <date when="1380"/>, 
+                                            but according to this note started to count his regnal years earlier than that.</desc>
+                                        <q xml:lang="gez">በስመ፡ እግዚአብሔር፡ አብ፡ አበ፡ ኢየሱስ፡ ክርስቶስ፡ አበ፡ ሣህል፡ <gap reason="ellipsis" unit="lines" quantity="7"/>
+                                            ምስለ፡ አብ፡ ወወልድ፡ አጽሐፍኩ፡ ዘንተ፡ መጽሐፈ፡ አነ፡ <persName ref="PRS3429DawitII">ዳዊት፡</persName> ወስመ፡ መንግሥትየ፡
+                                            <persName ref="PRS3429DawitII">ቈስጠንጢኖስ፡ ሠርፀ፡ እስራኤል፡</persName> እምቤተ፡ አብርሃም፡ ይስሐቅ፡ ወያዕቆብ፡ 
+                                            ወይሁዳ፡ ወልደ፡ ዳዊት፡ ወሰሎሞን፡ እዕሎኩ፡ ዘንተ፡ ነገረ፡ ውስተ፡ ዛቲ፡ ወንጌለ፡ ጸጋሁ፡ ለእግዚእነ፡ በ<date>፷ወ፭፡ ዓመተ፡ ምሕረት፡</date> 
+                                            ወበ<date when="1411">፴ወ፩፡ ዓመተ፡ መንግሥትየ፡</date> እዘዝኩ፡ ከመ፡ ይግበሩ፡ ተዝካረ፡ አቡየ፡ 
+                                            <persName ref="PRS8595SayfaAr">ሰይፈ፡ አርዓደ፡</persName> እም፲ወ፭፡ ለግንቦት፡ 
+                                            ወተዝካረ፡ እምየ፡ <persName ref="PRS14166LazabWarqa">ለዘብ፡ ወርቃ፡</persName> እም፲ወ፪ለሰኔ፡ ዘንተ፡ ይገበሩ፡ ለለዓመት፡ 
+                                            በመካነ፡ <placeName ref="LOC5888Tana">ጻና፡</placeName> ቤተ፡ ቂርቆስ፡ ወበምኔተ፡ 
+                                            <placeName ref="LOC4042Kebran">ክብራ፡</placeName> ቤተ፡ ገብርኤል፡ 
+                                            ወበ<placeName ref="LOC5888Tana">ጻና፡</placeName> እለ፡ ይገብሩ፡ እሉ፡ እሙንቱ፡ 
+                                            <gap reason="ellipsis" unit="lines" quantity="43"/> እምነ፡ በወርኅ፡ ኢሎል፡ ይገበሩ፡ 
+                                            <gap reason="illegible" unit="chars" quantity="4"/>እም፲ወ፩፡ እስከ፲ወ፰ይግ
+                                            <gap reason="illegible" unit="chars" quantity="4"/>በዓለ፡ መስቀል።</q>
+                                    </item>
+                                    <item xml:id="a52">
+                                        <locus from="236ra" to="236va"/>
+                                        <desc type="LandGrant">Landgrant of King <persName ref="PRS10342Yeshaq">Yəsḥaq</persName> with a 
+                                            very similar incipit and by a similar hand as <ref target="#a51"/> directly above.</desc>
+                                        <q xml:lang="gez">በስመ፡ እግዚአብሔር፡ አበ፡ ኢየሱስ፡ ክርስቶስ፡ አበ፡ ሣህል፡ <gap reason="ellipsis" unit="lines" quantity="5"/> አጽሐፍኩ፡ 
+                                            ዘንተ፡ መጽሐፈ፡ አነ፡ <persName ref="PRS10342Yeshaq">ይስሐቅ፡</persName> ወስመ፡ መንግሥትየ፡ 
+                                            <persName ref="PRS10342Yeshaq">ገብረ፡ መስቀል፡ ሠርፀ፡ እስራኤል፡</persName> እምቤተ፡ አብርሃም፡
+                                            <gap reason="ellipsis" unit="lines" quantity="1"/> እዕሎኩ፡ ዘንተ፡ መጽሐፈ፡ ውስተ፡ ዛቲ፡ ወንጌለ፡ ጸጋሁ፡ ለእግዚእነ፡ 
+                                            በ<date>፷ወ፯፡ ዓመተ፡ ምሕረት፡</date> 
+                                            ወበ<date notBefore="1414" notAfter="1415">፯፡ አውራኅ፡ እመ፡ ዋዕለ፡ መንግሥትየ፡</date> ወሀብኩ፡ ምድረ፡ እንተ፡ ስማ፡ 
+                                            <placeName ref="LOC7316Andabet">ሀንዳቤት፡</placeName> እምጽንፋ፡ እስከ፡ ጽንፋ፡ ከመ፡ ትኩን፡ ለተዝካረ፡ ዚአየ፡ ወዐቃቤ፡
+                                            ተዝካርሰ፡ አባ፡<persName ref="PRS14216NobWaldaYasey">ኖብ፡ ወልደ፡ ያስይ፡</persName> ዘገሊላ።
+                                            <gap reason="ellipsis" unit="lines" quantity="10"/>
+                                            እንዘ፡ ሊቀ፡ ጳጳሳት፡ አባ፡ <persName ref="PRS4379Gabriel">ገብርኤል፡</persName>
+                                            ወእንዘ፡ ጳጳሳነ፡ አባ፡ <persName ref="PRS2469Bartalom">በርተሎሜዎስ፡ </persName>
+                                            ወእንዘ፡ ቀስ፡ ሐፄ፡ <persName ref="PRS14212BatsagaQirqos">በፀጋ፡ ቂርቆስ</persName>።
+                                            ወእንዘ፡ ሊቀ፡ ዲያቆናት፡ <persName ref="PRS14213Yosef">ዮሴፍ፡</persName>
+                                            ወእንዘ፡ ኢቃቂታት፡ <persName ref="PRS14214GabraKrestos">ገብረ፡ ክርስቶስ</persName>።
+                                            ወእንዘ፡ ቀላበስ፡ ዛን፡ <persName ref="PRS14215Hash">ሐሽ፡</persName> 
+                                            ወእንዘ፡ ይትመጻኔ፡ መዋዔ።
+                                            ወእንዘ፡ መጌምድር፡ <persName ref="PRS14168Delmangasa">ድልመንገሣ፡</persName> ወአፈ፡ መጌምድር፡ ይትአኰት፡ ስሙ፡ 
+                                            ወእንዘ፡ <persName ref="PRS14217ShebherZanane">ሽብሕር፡ ዘናኔ፡</persName> ወእንዘ፡ ስዩመ፡ 
+                                            <placeName ref="LOC7316Andabet">ሀንዳቤት፡</placeName> ብላንቱ።</q>
+                                    </item>
+                                    <item xml:id="a53">
+                                        <locus target="#236va"/>
+                                        <desc type="OwnershipNote">Note, written by a hand similar to the previous <ref target="#a51"/>, but with a 
+                                            smaller pen and similar to <ref target="a47"/>.</desc>
+                                        <q xml:lang="gez">በስመ፡ ሥሉስ፡ ቅዱስ፡ ትጽሕፈት፡ ዛቲ፡ መጽሐፍ፡ ወሀብዎ፡ ቅዱሳን፡ 
+                                            ለ<persName ref="PRS14142GabraBerhan">ገብረ፡ ብርሃን፡</persName> 
+                                            ቤተ፡ ዘነበረ፡ ቅድመ፡ ለ<persName ref="PRS14143TasfaMasqal">ተስፋ፡ መስቀል፡</persName> ከመ፡ ይኩኖ፡ ርስት፡ ለወልዱ፡ ኢኮነ፡ 
+                                            በእንተ፡ ነጋሢነት፡ ዘወሀብዎ፡ በእንተ፡ ፍትረ፡ ገብርኤል፡ ወሀብዎ፡ ለተዘካር፡ በሕይወቶ፡ ወበሞቱ፡ ኵሉ፡ ጊዜ፡ ለዓለመ፡ ዓለም። ። </q>
+                                    </item>
+                                    <item xml:id="a54">
+                                        <locus target="#236va"/>
+                                        <desc type="ScribalNoteCommissioning">Scribal note, that mentions <persName ref="PRS6229LebnaDe"/> and 
+                                            also <persName ref="PRS14077FereKrestos"/> and <persName ref="PRS14088TaklaSyon"/>, two dignitaries, 
+                                            who are also mentioned in <ref target="#a44"/> that can be dated to the early 16th century. 
+                                            Written by a hand similar to <ref target="#a52 #a53"/>.</desc>
+                                        <q xml:lang="gez">ዛቲ፡ መጽሐፍ፡ ዘአጽሐፈ፡ 
+                                            <persName ref="PRS14144GabraKrestosRWN" role="donor">ገብረ፡ ክርስቶስ፡ ራሴ፡ ወልደ፡ ኖብ፡</persName> 
+                                            በ፭አልሕምት፡ ዘተሣየጠ፡ ለ<persName ref="PRS14145TabotSeyon" role="donor">ታቦት፡ ጽዮን፡</persName>
+                                            ወለ<persName ref="PRS14146Giyorgis" role="donor">ጊዮርግስ፡</persName>
+                                            እምነ፡ <persName ref="PRS14147TaklaHawaryat" role="scribe">ተክለ፡ ሃዋርያት፡</persName>
+                                            መነኮስ፡ ንቡረ፡ እድ፡ አባ፡ <persName ref="PRS14148Nob">ኖብ፡</persName>
+                                            ራቅ፡ መስራ፡ <persName ref="PRS14077FereKrestos">ፍሬ፡ ክርስቶስ፡ </persName>ፍሬ፡ ክርስቶስ፡ 
+                                            ወኵሎሙ፡ <gap reason="illegible" unit="chars" quantity="5"/>ራ። ወሊቆሙ። 
+                                            በድ፡ ዮሐን<supplied reason="undefined">ስ፡</supplied><gap reason="illegible" unit="chars" quantity="4"/> 
+                                            ነጋሢ፡ <persName ref="PRS14088TaklaSyon">ተክለ፡ ጽዮን፡</persName> ዘመፍ<gap reason="illegible" unit="chars" quantity="2"/>
+                                            ንጉሥ፡ <persName ref="PRS6229LebnaDe">ልብነ፡ ድንግል፡</persName> 
+                                            ዘተተከለ፡ <gap reason="illegible" unit="chars" quantity="6"/> ለዓለመ፡ ዓለም፡ አሜን።</q>
+                                    </item>
+                                    <item xml:id="a55">
+                                        <locus target="#236vb"/>
+                                        <desc type="LandGrant">Notice of <persName ref="PRS14148Nob"/> granting land to the community of 
+                                            <placeName ref="LOC4042Kebran"/>.</desc>
+                                        <q xml:lang="gez">በአኰቴተ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ። በምዋዕል፡ 
+                                            <persName ref="PRS3429DawitII">ዳዊት፡</persName> ንጉሥ። ወሀብኩ፡ አነ፡ ንቡረ፡ እድ፡ 
+                                            አባ፡ <persName ref="PRS14148Nob">ኖብ</persName>። ምድረ፡ ወራሚት፡ ለመካነ፡ ቅዱሳን፡ ዘደብረ፡ ክብራን። ወእመሂ፡ ንቡረ፡ እድ፡ 
+                                            ወእመሂ፡ ተዐጋሊ። ከመ፡ ኢይግፍዖሙ፡ ወኢይትጉሎሙ፡ አማኅፀንኩ። <gap reason="ellipsis" unit="lines" quantity="5"/>ወበአፈ፡ 
+                                            ቅዱስ፡ ጳጳስነ፡ አባ፡ <persName ref="PRS2469Bartalom">በርተ፡ ሎሜዎስ፡</persName> ይኩን፡ ውጉዘ፡ ወቅውሞ፡ ይኩን፡ እስከ፡ 
+                                            ለዓለመ፡ ዓለም። <gap reason="ellipsis" unit="lines" quantity="7"/>በመንግሥተ፡ ሰማያት፡ አሜን።</q>
+                                    </item>
+                                    <item xml:id="a56">
+                                        <locus target="#236vb"/>
+                                        <desc type="LandGrant">Land grant by an unknown king with the last parts missing.</desc>
+                                        <q xml:lang="gez">ዳረጐትነ፡ ወሀብኩ፡ እምድረ፡ <placeName ref="LOC7381Egana">ኤገና፡</placeName> 
+                                            ለማኅቶተ፡ ገብርኤል፡ ፲ወ፪፡ ለፈትል፡ ለዕጣን<gap reason="illegible" unit="chars" quantity="1"/>፡ ወሀብኩ፡ ምድረ፡ 
+                                            <placeName ref="LOC7382Daf">ዳፍ፡</placeName> ፳፡ ለጥር፡ ወለሀሎየሂ፡ ፀራቢ፡ ገዳፍከዎ፡ ለገብርኤል፡ ዘምስለ፡ ፱ዳስ፡ ዘወይን፡ 
+                                            አሪር፡ የሀብክሙ፡ ዝንቱ፡ ኵሉ፡ መብልዕ፡ ዘነበረ፡ ለንቡረ፡ ዕድ። ዝንተ፡ ሥርዓተ፡ ዘወለጠ፡ ውጉዘ፡ ለይኩን፡ በአፈ፡ አብ፡ ወወልድ፡ ወማንፈስ፡ ቅዱስ፡</q>
+                                    </item>
+                                    <item xml:id="a57">
+                                        <locus target="#237ra"/>
+                                        <desc type="LandGrant">Note on a land grant in the time of <persName ref="PRS6229LebnaDe"/>, written in 
+                                            taller characters and with an irregular margin to the right.</desc>
+                                        <q xml:lang="gez">በአኰቴተ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ። ወበመዋዕሊሁ፡ ለንጉሥነ፡ 
+                                            <persName ref="PRS6229LebnaDe">ልብነ፡ ድንግል</persName>። 
+                                            ወሀብኩ፡ አነ፡ ንቡረ፡ እድ፡ <persName ref="PRS14149TsegeSellus">ጽጌ፡ ሥሉስ፡</persName>
+                                            <gap reason="lost" unit="chars" quantity="1"/>
+                                            መባሕተ፡ አበውየ፡ ቅዱሳ<gap reason="lost" unit="chars" quantity="1"/>፡
+                                            ምድረ፡ <placeName ref="LOC7383Qwebitsa">ቍቢጻ፡</placeName> ከመ፡ ይኩኖ፡ ርስተ፡ 
+                                            ለ<persName ref="PRS14151Zaiyasus">ዘኢየሱስ፡ </persName>ዐቃቢ። እመሂ፡ ንቡረ፡ እድ፡ ወእመሂ፡ ቂስ፡ ገበዝ፡ እመሂ፡ 
+                                            ሊቀ፡ ዲያቆን፡ ወራቅማሰራሂ፡ ዘቦአ፡ በተአድዎ፡ ይኩን፡ ውጉዘ፡ በአፈ፡ ሥሉስ፡ ቅዱስ፡ ወበአፈ፡ እግዝእትነ፡ ማርያም፡
+                                            <gap reason="ellipsis" unit="lines" quantity="4"/>ሰባክያነ፡ ወንጌል፡ ሐዲስ፡ እሱረ፡ ይኩኑ፡ ለዓለመ፡ ዓለም፡ አሜን። ። ።</q>
+                                    </item>
+                                    <item xml:id="a58">
+                                        <locus target="#237ra"/>
+                                        <desc type="LandGrant">Land grant by an unknown king.</desc>
+                                        <q xml:lang="gez">ሰምዑ፡ ዘኮነ፡ እምድሕረ፡ ስደት፡ ፈለሰት፡ ስልጣነ፡ ደብር፡ ናሁ፡ አግብአ፡ ለነ፡ ተመኪሮ፡ በዲዴ፡ ንጉሥ፡ ወንህነኒ፡ ወሀብኖ፡ ረስተ፡ 
+                                            ምድረ፡ <placeName ref="LOC7384Hanita">ሐኒታ፡</placeName> 
+                                            ወ<placeName ref="LOC7385Isala">ኢሳላ፡</placeName> በአዱ፡ ቃል፡ ሀቢረነ፡ በወልድነ፡ ሐቢበ፡ ወንጌል፡ እመቦ፡ ዘደምሰሰ፡ ውጉዘ፡ 
+                                            ለይኩን። ።</q>
+                                    </item>
+                                    <item xml:id="a59">
+                                        <locus target="#237va"/>
+                                        <desc type="Inventory">Note with very low character height and irregular lines and margins, mentioning a number 
+                                            of church utensils of <placeName ref="LOC4042Kebran"/> which was originally included into another codex 
+                                            containing a <ref type="work" corresp="LIT1955Mashaf"/>, as indicated at the end of the brief note.</desc>
+                                        <q xml:lang="gez">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡ በአኰቴተ፡ እግዚአብሔር፡ ንጽሐፍ፡ ነዋየ፡ ቤተ፡ ክርስቲያን፡ 
+                                            ዘገብብርኤል። ለመካነ፡ <placeName ref="LOC4042Kebran">ክብራ፡</placeName> ዘረከብነ፡ 
+                                            በዘመነ፡ መምህር፡ <persName ref="PRS14128TaklaHaymanot">ተክለ፡ ሃይማኖት።</persName>
+                                            ወቄስ፡ ገበዝሂ፡ <persName ref="PRS14152AhabHawaryat">አሃብ፡ ሐዋርያት፡</persName>
+                                            ወራቅመስራ፡ <persName ref="PRS14153TaklaGabreel">ተክለ፡ ገብርኤል፡</persName> 
+                                            <gap reason="illegible" unit="chars" quantity="1"/>፭ብዝቅ፡ <gap reason="ellipsis" unit="lines" quantity="12"/>
+                                            ወኵላ፡ ኵስተሰ፡ አጸሐፍነ። ወመጽሐፍሰ፡ ጽሑፍ፡ ሀሎ፡ በ<ref target="LIT1955Mashaf">መጽሐፈ፡ ሚላድ</ref>። ዘንተ፡ ኵሎ፡ አጽሐፍኩ፡ አነ፡ 
+                                            <persName ref="PRS14153TaklaGabreel">ተክለ፡ ገብርኤል፡</persName> በሢመትየ።</q>
+                                    </item>
+                                    <item xml:id="a60">
+                                        <locus target="#237va"/>
+                                        <desc type="ReceiptNote">Note of goods given to the church of <placeName ref="LOC4042Kebran"/>.</desc>
+                                        <q xml:lang="gez">ወሀብኩ፡ ንዋየ፡ ለክብራን፡ ለቅዱስ፡ ገብርኤል፡ <gap reason="ellipsis" unit="lines" quantity="10"/>በሥልጣነ፡ 
+                                            ጴጥሮስ፡ ወጳውሎስ፡ በሰይፈ፡ ቃሎሙ፡ ለሐዋርያት፡ ውጉዘ፡ ለይኩን።</q>
+                                    </item>
+                                    <item xml:id="a61">
+                                        <locus target="#237va"/>
+                                        <desc type="LandGrant">Land grant written in very small characters and partly not legible in the microfilm images.</desc>
+                                        <q xml:lang="gez">ኍልቈ፡ ምድር፡ ዘ<placeName ref="LOC6979Waramit">ወራሚት፡</placeName> ቢኖራ፡ ፪ምድር፡ 
+                                            ዘ፩ምድር፡ <gap reason="ellipsis" unit="lines" quantity="19"/></q>
+                                    </item>
+                                    <item xml:id="a62">
+                                        <locus target="#237vb"/>
+                                        <desc type="LandGrant">Land grants issued by a king named <q xml:lang="gez">አድያም፡ ሰገድ፡</q>, who can be 
+                                            identified as either <persName ref="PRS5616IyasuI"/>, <persName ref="PRS5617IyasuII"/> or 
+                                            <persName ref="PRS5636IyoasI"/>.</desc>
+                                        <q xml:lang="gez">ኍልቈ፡ ምድር፡ ዘወሀብዎ፡ ንጉሥነ፡ <persName ref="PRS5616IyasuI">አድያም፡ ሰገድ፡</persName> 
+                                            ለ<persName ref="PRS14154GoraDefwu">ጎራ፡ ድፍዉ፡</persName> ይኵኖ፡ ርስተ፡ ለትውልዶ፡ ትውልድ፡ 
+                                            <placeName ref="LOC6893Guaguata">ጓጓታ፡</placeName> ዘታሕታይ፡ 
+                                            ወ<placeName ref="LOC7386Abaraj">አባራጅ፡ </placeName>
+                                            <placeName ref="LOC7387Tsangwya">ጸንጕያ፡</placeName>
+                                            ወ<placeName ref="LOC7388Maqwal">ማቋል፡</placeName> 
+                                            <placeName ref="LOC7389Sakala">ሳከላ፡</placeName> 
+                                            <placeName ref="LOC7390Asya">ዓስያ፡</placeName> 
+                                            <placeName ref="LOC7391Abats">አባጽ፡</placeName>
+                                            <placeName ref="LOC7392Berbets">ብርብጽ፡</placeName>
+                                            <placeName ref="LOC7393Amyatsma">አፙጽማ፡</placeName>
+                                            <placeName ref="LOC7394Mebash">ሜበሽ፡</placeName>
+                                            ወእሉሂ፡ ጕልታት፡ ዘጸንአ፡ በእዴሁ፡ እምአመ፡ ነግሡ፡ ንጉሥነ፡ <persName ref="PRS5616IyasuI">አድያም፡ ሰገድ፡</persName> 
+                                            በ፳ወ፱አመት፡ ወዕለትሂ፡ ዕለተ፡ አርብ፡ በ፲ወ፰ዕለት፡ ለ<placeName ref="LOC6893Guaguata">ጓጓታ፡</placeName> 
+                                            ወለ<placeName ref="LOC7386Abaraj">አባራጅ፡ </placeName> ዘከለልዎ፡ በ፫መስቀል፡ ወበ፫ወንጌል፡ ወበ፫ድባብ፡ ወእሉሂ፡ መነኮሳተ፡ ደብር፡
+                                            ወጺዖሙ፡ ምስለ፡ መምህሮሙ፡ <persName ref="PRS14155Agnateyos">አግናጥዮስ፡</persName> 
+                                            ቄስ፡ ገበዝ፡ <persName ref="PRS14156Temhertu">ትምህርቱ፡</persName> 
+                                            ወአፈ፡ መምህር፡ <persName ref="PRS14157Mammo">ማሞ፡</persName> 
+                                            ራቅ፡ መሰራ፡ <persName ref="PRS14158Bahaylamaryam">በኃይለማርያም፡</persName> 
+                                            ወሊቀ፡ አባው፡ <persName ref="PRS14159TanseaKrestos">ተንሥአ፡ ክርስቶስ፡</persName> አኀያ፡ ጠቦቱ፡
+                                            ወአታ፡ ወንጸ፡ <persName ref="PRS14160TaklaMaryam">ተክለ፡ ማርያም፡</persName> ወዘአጽሐፍዎሰ። ለዝንቱ፡ 
+                                            መጽሐፍ፡ ተጋቢኦሙ፡ በ፩ምክር፡ ኀበ፡ አቡሆሙ፡ አረጋዊ፡ መምህር፡ <persName ref="PRS14161MalkeaKrestos">መልከአ፡ ክርስቶስ፡</persName> 
+                                            ዘንተ፡ ሰሚዖ፡ ዘሔዶ፡ ዘአፍለሰ፡ እምካልእ፡ ኀበ፡ ካልእ፡ ዘእንበለ፡ ውሉዱ፡ ለ<persName ref="PRS14154GoraDefwu">ጎራ፡ ድፍዊ፡</persName>
+                                            እመሂ፡ ንጉሥ፡ ወእመሂ፡ ሠራዊተ፡ ንጉሥ፡ ውጉዘ፡ ይኩን፡ በአፈ፡ ፲ወ፪ሓዋርያት፡ ወ፸ወ፪አርድእት፡ ውጉዘ፡ ለይኩን፡</q>
+                                    </item>
+                                    <item xml:id="a63">
+                                        <locus target="#237vb"/>
+                                        <desc type="RecordDistribution">Possibly a record of taxes to be distributed to a number of local chiefs.</desc>
+                                        <q xml:lang="am">የቅባ፡ ኑግ፡ ግብር፡ ዘሀሎ፡ በወራሚት፡ ፴ስድስት፡ ጽዋ፡ 
+                                            በ<placeName ref="LOC7395LomiBet">ሎሚ፡ ቤት፡</placeName> 
+                                            አለቃው፡ <persName ref="PRS14162WaldaGirgis">ወልደ፡ ጊርጊስ፡</persName> ስንስጣ። 
+                                            ፴ስድስት፡ በ<placeName ref="LOC7396AtsfoBet">አጽፎ፡ ቤት፡</placeName> 
+                                            አለቃው፡ <persName ref="PRS14163AbetoSalabaster">አቤቶ፡ ሰለባስትርዮስ፡</persName> 
+                                            ያለቃ፡ ምድር፡ በገዙ፡ ፴ስድስት፡ በ<placeName ref="LOC7397Shanga">ሻንጋ፡</placeName> አለቃው፡ 
+                                            <persName ref="PRS14164KeramtiZamikael">ክረምቲ፡ ዘሚካኤል፡</persName> 
+                                            ያለቃ፡ ምድር፡ <placeName ref="LOC7398Arash">አራሽ፡</placeName> ቂስ፡ ገበዝ፡ 
+                                            <persName ref="PRS14165WaldaKesos">ወልደ፡ ክሶስ፤</persName> ከድሸት፡ ፯ጽዋ፡ የንከነበር፡</q>
+                                    </item>
+                                    <item xml:id="a64">
+                                        <locus from="238r" to="239v"/>
+                                        <desc type="GuestText">Erased and illegible text in two columns, upside down and partially cut off.</desc>
+                                    </item>
+                                </list>
+                            </additions>
+                        </physDesc>
+                    </msPart>
                 </msDesc>
             </sourceDesc>
         </fileDesc>
@@ -749,291 +1230,5 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <change when="2023-07-20" who="CH">Added contents and physical description.</change>
         </revisionDesc>
     </teiHeader>
-    <text xml:base="https://betamasaheft.eu/">
-        <body>
-            <div type="edition" xml:lang="gez" corresp="#a1">
-                <ab>በአኰቴተ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ተጽሕፈት፡ ዛቲ፡ መጽሐፍ፡ በ<date when="1412" when-custom="64" calendar="grace">
-                    ፷፬፡ ዓመተ፡ ምሕረት፡ በወርኃ፡ ነሐሴ፡ አመ፡ ፭፡</date> በሠርቀ፡ መዓልት፡ ወአመ፡ ፳፭፡ በሠርቀ፡ ሌሊት፡ ወእንዘ፡ ንጉሥነ፡ 
-                    <persName ref="PRS3429DawitII">ዳዊት፡</persName> ዘተሰምየ፡ ቈስጢንጢኖስ፡ ወእንዘ፡ ጳጳስ<add place="above">ነ</add>፡ 
-                    አባ፡ <persName ref="PRS2469Bartalom">በርተሎሜዎስ፡</persName> ወእንዘ፡ <placeName ref="LOC3549Gojjam">ጐዛም፡</placeName>
-                    ነጋሢ፡ <persName ref="PRS14167MaataGwane">መዓተ፡ ጐኔ፡</persName> 
-                    ወእንዘ፡ <placeName ref="LOC1713Bagemd">በጌምድር፡</placeName><persName ref="PRS14168Delmangasa">ድልመንገሣ፡</persName> 
-                    ወእንዘ፡ ንቡረ፡ እድ፡ <persName ref="PRS14169KrestosMadhen">ክርስቶስ፡ መድኅን።</persName> ተሠርዓት፡ ተዝካር፡ በደብረ፡ ክብራን፡ ዘንጉሥ፡ 
-                    <persName ref="PRS8595SayfaAr">ሰይፈ፡ ዐርአደ፡</persName> አመ፡ ፲፭፡ እም<gap reason="omitted"/></ab>
-            </div>
-            <div type="edition" xml:lang="gez" corresp="#a2">
-                <ab>ሰሰዮሙሂ፡ ሠራዕኩ፡ እምቍቢጸ፡ ዘነበረ፡ ቀዳሚ፡ ለግብር። ወለግብርሂ፡ ሠራዕኩ፡ ክነመስዳ፡ ወ<add place="above">ለ</add>እገና። ወዘንተ፡ ሥርዓተ፡ 
-                    ዘአብጠለ፡ ዘሄደ፡ ወዘተዓገለ፡ ውጉዘ፡ ለይኩን፡ በአፈ፡ ነቢያት፡ ወሐዋርያት፡ በአፈ፡ ጻድቃን፡ ወሰማዕት፡ በአፈ፡ ሚካኤል፡ ወገብርኤል፡ በአፈ፡ ፫፻፲፰፡ ርቱዓነ፡ ሃይማኖት፡ በአፈ፡ 
-                    አቡነ፡ <persName ref="PRS10688Zayohan">ዘዮሐንስ፡ </persName>በአፈ፡ አግአዝእትነ፡ ማርያም፡ በአፈ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ውጉዘ፡ 
-                    ለይኩን፡ ለዓለም፡ አሜን። </ab>
-            </div>
-            <div type="edition" xml:lang="gez" corresp="#a3">
-                <ab>በስመ፡ ሥሉስ፡ ቅዱስ፡ ቅዱስ፡ አጽሐፍኩ፡ አነ፡ <persName ref="PRS14048Petros">ጴጥሮስ፡</persName> ለደብረ፡ ክብራ፡ ቅዱስ፡ ዝይከውነኒ፡ ለመድኅኒተ፡ 
-                    ነፍስ፡ ዘሐኒታ፡ ወይነ፡ ዘወሀብዋ፡ አበዊነ፡ ቀደምት፡ ወደኅረሂ፡ ዘነሥአዋ፡ በትእግልት። <gap reason="ellipsis"/> በአፈ፡ ነቢያት፡ ወሐዋርያት፡ በአፈ፡ ጻድቅን፡ ወሰማዕት፡ 
-                    በአፈ፡ ሚካኤል፡ ወገብርኤል። በአፈ፡ ፫፻፲፰፡ ርቱዓነ፡ ሃይማኖት፡በአፈ፡ አግዝእትነ፡ ማርያም። በአፈ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ቅውመ፡ ወጉዘ፡ ወውቦአ፡ እመንግሥተ፡ 
-                    እግዚአብሔር፡ ለይኩን፡ አሜን። ወሊተኒ፡ ዝክሩኒ፡ በጸሎትክሙ፡ ለትውልደ፡ ትውልድክሙ፡ አሜን። ።</ab>
-            </div>
-            <div type="edition" xml:lang="gez" corresp="#a5">
-                <ab>ንጉሥኒ፡ <persName ref="PRS1854Amdase">አምደ፡ ጽዮን፡ </persName>መጽአ፡ ኀቤሁ፡ በፍሥሐ፡ ዐቢይ፡ ከመ፡ ይትባረክ፡ እምኀበ፡ አቡነ፡ 
-                    <persName ref="PRS10688Zayohan">ዘዮሐንስ፡</persName><gap reason="ellipsis"/> ወወሀቦ፡ ብዙኃተ፡ እምድረ፡
-                    አዳማ፡ እስከ፡ ባሕር፡ እስከ፡ ወሰና፡ ለግዮን፡ እስከ፡ ቱምሐ፡ ወእ<add place="above">ስ</add>ከ፡ <add place="above">አገው፡ </add>
-                    <gap reason="ellipsis"/>እመጽሐፈ፡ ሕይወት፡ ለዓለመ፡ አለም፡ አሜን።</ab>
-            </div>
-            <div type="edition" xml:lang="am" corresp="#a7">
-                <ab>ወይዘሮ፡ <persName ref="PRS14058Qasaro">ቀጸሮ፡</persName> የገዙት፡ ምድር፡ 
-                    ከ<persName ref="PRS14059MariGeta">መሪ፡ ጌታ፡ ገብረ፡ ሚካኤል፡</persName> 
-                    በ፵ጨው፡ ነው፡ አሳቦች፡ ቂሰ፡ ገበዝ፡ ወሰን፡ አይሞት፡ ዠኖ፡ ኑሮ፡ ወሰን፡ ነጮ፡ ናቸው፡ መድኒቱ፡ 
-                    <persName ref="PRS14060WalattaIyasus">ወለተ፡ ኢየሱስ፡</persName> ናት፡ ግብሩ፡ ፪፳፲፡ ቅብዓ፡ ኑግ፡ ፱ድርጎ፡ አከል፡ ነው፡ አንዘ፡ መምሕርነ፡ 
-                    ዘፈረ፡ ሥላሴ። ገበዝነ፡ ወሰን፡ ወጭቀው፡ ወሰጥ፡ ነጨ፡ በዘመነ፡ ማቴዎስ፡ ንው። </ab>
-            </div>
-            <div type="edition" corresp="#a8" xml:lang="gez">
-                <ab>በመዋዕለ፡ ሉቃስ፡ ወንጌላዊ፡ በ<date calendar="qamar" when-custom="159" when="1507">፻፶ወ፱፡ አመተ፡ ምሕረት፡</date> እንዘ፡ 
-                    ሀለዉ፡ ንጉሥነ፡ <persName ref="PRS7481NaodA">ናኦድ፡</persName> በ<placeName ref="LOC1602Atrons">አትሮንስ፡ እግዝእትነ፡ 
-                    ማርያም፡</placeName> በወርኃ፡ መጋቢት፡ እንዘ፡ ስማዕት፡ 
-                    ይእቴ፡ <persName ref="PRS3706eleni">እሌኒ፡</persName> ያጼ፡ እናቶ፡ ግራ፡ በአልታ፡ 
-                    <del rend="effaced" unit="chars" quantity="1"/> <persName ref="PRS7482NaodMo">ናኦድ፡ ሞገሣ፡</persName> 
-                    ዐቃቤ፡ <del rend="effaced">አካቅ፡</del> ስዐት፡ <persName ref="PRS14065Tewogolos">ቴዎጎሎስ፡</persName> 
-                    ሊቀ፡ ሊቃውንት፡ <persName ref="PRS14066NagadaEgzio">ነገደ፡ እግዚኦ፡</persName><add place="above">ኢያሱስ፡ </add> 
-                    ሊቀ፡ ማእምራን፡ <persName ref="PRS14067HabtuSarad">ኀብቱ፡ ጸራድ፡</persName> ማስሬ፡ አቀበስን፡ 
-                    ቀይስ፡ ሐፄ፡ <persName ref="PRS14068TaklaMaryam">ተክለ፡ ማርያም፡</persName> 
-                    ሊቀ፡ ደብተራ፡ <persName ref="PRS14069TaklaNabiyat">ተከለ፡ ነቢያት፡</persName> 
-                    ቀኚዕ፡ ብቶደደ፡ <persName ref="PRS14071HabtaMG">ሐብተ፡ ማርያም፡ ግራ፡</persName> 
-                    ብቶደደ፡ <persName ref="PRS14072Naze">ናዜ፡</persName> 
-                    አዛዘ፡ እንዳዘዜ፡ ርእሰ፡ ርኡሳን፡ <persName ref="PRS14073TaklaMaryam">ተከለ፡ ማርያም፡</persName> 
-                    እንዘ፡ ንቡረ፡ ዕድ፡ <persName ref="PRS14074Gersam">ጌርሣም፡</persName> 
-                    ወምስለ፡ ንብርዕድ፡ <persName ref="PRS14075Tiwogolos">ቲዎጎሎስ፡</persName> 
-                    ወቂስ፡ ገበዝ፡ <persName ref="PRS14076GabraNazrawi">ገብረ፡ ናዝራዊ፡</persName> 
-                    ወሊቀ፡ ዲየቆን፡ ይፅናዩ፡ ወራቍ፡ ማስራ፡ <persName ref="PRS14077FereKrestos">ፍሬ፡ ክርስቶስ፡</persName> ዘተመይጠ፡ ንዋይ፡ ለታቦተ፡ 
-                    ገብርኤል፡ ዘደብረ፡ ክብራ፡ ፳ወ፫፡ ንዋየ፡ ቤተ፡ ክርስቲያን፡ </ab>
-            </div>
-            <div type="edition" corresp="#a11" xml:lang="gez">
-                <ab>ለዘ፡ እምዘ፡ ብእሲ፡ አዕብይዎ፡ ወአክብርዎ፡ በሕይወቱ። ወእምድኅረ፡ ሞቱሂ፡ ግበሩ፡ ሎቱ፡ ተዝካሮ፡ ከመ፡ አባ፡ <persName ref="PRS14078GabraKrestos">ገብረ፡ ክርስቶስ፡</persName> 
-                    ወ<persName ref="PRS14079GabraAmlak">ገብረ፡ አምላክ</persName>። ወዘንተ፡ ኵሎ፡ ዘወሀበ፡ <persName ref="PRS14080SardaMaryam">ሠርፀ፡ ማርያም፡</persName> 
-                    ለመካነ፡ ማርያም፡ ዘአውፅአሂ፡ ወዘሤጠ፡ ወዘተሣየጠ፡ ውጉዘ፡ ለይኩን፡ በአፈ፡ ፫አስማት፡ ወበአፉሆሙ፡ ለጴጥሮስ፡ ወጳውሎስ፡ ወዘደምሰሰሂ፡ ለዝመጽሐፍ፡ ወይደስስ፡ ስሙ፡ 
-                    እመጽሐፈ፡ ሕይወት፡ ለዓለመ፡ ዓለም፡ አሜን፡ ወአሜን። </ab>
-            </div>
-            <div type="edition" corresp="#a13" xml:lang="gez">
-                <ab>በአኰቴተ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ እጕለትኩ፡ አ<add resp="CH">ፄ፡ </add>
-                    <persName ref="PRS6229LebnaDe">ወናግ፡ ሰገድ፡</persName> ንጉሥ፡ እንዘ፡ ሀላውኩ፡ በ<placeName ref="LOC3549Gojjam">ጐዣም፡</placeName> 
-                    አመ፡ ወዐልኩ፡ በ<placeName ref="LOC5733Sima">ጺማ፡</placeName> በዐለ፡ ፋሲካ። ምድረ፡ <placeName ref="LOC7378Ababir">ዐቢባር፡</placeName>
-                    ወምድረ፡ <placeName ref="LOC7379Enawga">እናውጋ</placeName>። ወምድረ፡ <placeName ref="LOC7380Enarij">እናርጀ</placeName>። 
-                    እሎንተ፡ ፫ምድረ፡ ለዓመተ፡ ጊዮርጊስ፡ ወለወ<gap reason="illegible" unit="chars" quantity="2"/>፡ ቅዱሳን፡ መንፈቀ፡ እሉ፡ 
-                    <gap reason="illegible" unit="chars" quantity="3"/> ወመንፈቁ፡ ለ<persName ref="PRS14080SardaMaryam">ሠርፀ፡ ማርያም፡</persName> እስመ፡ 
-                    ርስተ፡ ዚአሁ፡ ውእቱ፡ <gap reason="ellipsis" unit="lines" quantity="35"/></ab>
-            </div>
-            <div type="edition" corresp="#a16" xml:lang="am">
-                <ab>በዘመነ፡ ማቴዎስ፡ ዓሳ። ች፡ <persName ref="PRS14082WaldaAmanuel">ወልደ፡ አማኑኤል፡</persName> አደሩ፡ ባይሌ፡ ሠርጉ፡ ነገዱ፡ <unclear reason="illegible">በያድጊ፡</unclear>
-                    ሠዳ፡ የምህር፡ አርከ፡ ስሉሥ፡ ምድር፡ ፻ታሰበ፡ ሻጭቱ፡ ወለቱ፡ ልጃዋ፡ መድን፡ ገዢው፡ አዛጅ፡ ከብቴ፡ ምድሩ፡ ግን፡ ጠራሜት። </ab>
-            </div>
-            <div type="edition" corresp="#a18" xml:lang="am">
-                <ab>ይቤሉ፡ ሰብአ፡ ክቡራን፡ ወወራሚት፡ እንዘ፡ መምሕር፡ <persName ref="PRS14128TaklaHaymanot">ተክለ፡ ሃይማኖት፡</persName>
-                    ወአፈ፡ መምሕር፡ <persName ref="PRS14129Damye">ደምዬ</persName> 
-                    መምር፡ <persName ref="PRS14130NikodimosFantaWM">ኒቆዲሞስ፡ ፈንታ፡ ወልደ፡ ሚካኤል፡</persName> 
-                    በሊሕ፡ ዳኛ፡ ያፀዲን፡ ምድር፡ <del unit="chars" quantity="1"/>ያዘችውን፡ የገዛቸውን፡ 
-                    <persName ref="PRS14131LabetoGasso">ላቤቶ፡ ጋሾ፡ </persName>
-                    ሸጠናል፡ በ፵፡፩፡ጣን፡ ተዶል፡ በከመምር፡ <persName ref="PRS14132Agne">አግኔ፡</persName> 
-                    የተገዘውን፡ አባ፡ <persName ref="PRS14133Gabriel">ገብርኤል፡</persName> የተገዛውን፡ 
-                    <persName ref="PRS14134Kaygats">ካይጋፅ፡</persName> 
-                    የተገዘውን፡ <persName ref="PRS14135Yehenan">ይህነን፡</persName> ደብሩም፡ መምሩም፡ ሀገሩም፡ ያለቅዳሴ፡ ከዳ፡ አንዳይገናጅ፡ 
-                    ታቦር፡ ኪዳን፡ ገበዝ፡ <persName ref="PRS14136NatnaelM">ናትናኤል፡ ሚካኤል፡</persName> 
-                    አፈ፡ ገበዝ፡ <persName ref="PRS14137Zerem">ዝሬም፡</persName> እኒህ፡ ተዳኑ፡ ለሚመጻውም፡ ቦተሾሙ፡ መድን፡ ናቸው፡ ደብር፡ የሰጡች፡ 
-                    አስጻፊ፡ ደብተራ፤ <persName ref="PRS14138Iyyob" resp="scribe">ኢዮብ፡</persName> ንው፡ 
-                    ይህ፡ እንዳይፈርስ፡ በቡነ፡ <persName ref="PRS14139Zayohannes">ዘዮሐንስ፡</persName> ቃል፡ በ፯፻፡በ፲፰፡ ቃል፡ ግዝት፡ ነው፡ 
-                    አባ፡ <persName ref="PRS14140Bakwere">በኵሬ፡</persName> 
-                    አባ፡ <persName ref="PRS14141Hezqeyas">ሕዝቅያስ</persName>። ገዝቶሉ፡</ab>
-            </div>
-            <div type="edition" corresp="a19" xml:lang="am">
-                <ab>በዘመነ፡ ማርቆ፡ በመጋቢት፡ ራስ፡ ቢት፡ ወደድ፡ <persName ref="PRS14107Mangasha">መንገሻ፡</persName> ታቶ፡ 
-                    <persName ref="PRS14108Was">ዋስ፡</persName> አገኘሁ፡ አርስት፡ ሲገዙ፡ እማኞቹ፡ 
-                    ሊቀ፡ ረድ፡ <persName ref="PRS14109Mertenehah">ምርንኀህ፡ </persName>
-                    ሊቀ፡ ረድ፡ <persName ref="PRS14110Gossu">ጐሹ፡</persName> 
-                    ሊቀ፡ ረድ፡ <persName ref="PRS14112Wonde">ወንዴ፡</persName> 
-                    ሊቀ፡ ረድ፡ <del rend="expunctuated">ሊ</del><persName ref="PRS14111Berru">ብሩ፡</persName> 
-                    ምስለኔ፡ <persName ref="PRS14113TasfaGetahun">ተስፋ፡ ጌታሁን፡</persName> ጔሉ፡ 
-                    <persName ref="PRS14114AyalewGM">አያሌው፡ ገብረ፡ ማርያም፡ </persName>
-                    <persName ref="PRS14115BarYahunWale">በር፡ ያሁን፡ ዋሌ፡</persName>ናቸው፡ 
-                    ለውርሱ፡ እማኞች፡ አቶ፡ <persName ref="PRS14116Tawaqa">ታወቀ፡</persName> 
-                    ብላታ፡ <persName ref="PRS14117Zallaqa">ዘለቀ፡ </persName>
-                    <persName ref="PRS14114AyalewGM">አያሌው፡ ገብረ፡ ማርያም፡</persName>
-                    <persName ref="PRS14118DastaLama">ደስታ፡ ለማ፡</persName> 
-                    አቶ፡ <persName ref="PRS14119GalagayEste">ገላጋይ፡ እሽቴ፡ </persName>ጔሉ፡ 
-                    <persName ref="PRS14121SendaqiTekku">ስንደቂ፡ ትኩ፡</persName> 
-                    አቶ፡ <persName ref="PRS14122Tafarra">ተፈራ፡</persName> 
-                    አቶ፡ <persName ref="PRS14123TafalaGT">ታፈለ፡ ዠመረ፡ ታወቀ፡</persName> 
-                    ዳኞቹ፡ ሊቀ፡ ረድ፡ <persName ref="PRS14125LamaMaggabi">ለማ፡ መጋቢ፡</persName> 
-                    <persName ref="PRS14124WebAyyahu">ውብ፡ አየሁ፡</persName>  
-                    ሱም፡ <persName ref="PRS14126Warqenah">ወርቅነህ፡ </persName>ናቸው። ዳኞች፡ ለሁሉም፡ ናቸው፡</ab>
-            </div>
-            <div type="translation" corresp="a19" resp="CH">
-                <ab>In the year of Marqos, in Maggābit, rās bit wadad Mangašā bought lands from ʾato Wās. The witnesses are liqa rad Mərṭənah, 
-                    liqa rad Gʷašu, liqa rad Wande, liqa rad Bərru, and also a person whose name is Tasfā Getāhun, ʾAyālew Gabra Māryām, 
-                    Bar Yāhun Wāle. The witnesses under warranty are ʾato Tāwqa, blāttā Zallaqa ʾAyalāw Gabra Maryām, Dastā Lammā, a person 
-                    whose name is ʾato Galāgāy ʾƎšte, Səndaqi Təkku, ʾato Tafarā, ʾato Tāfala Žammara Tāwqa, and the judges are 
-                    liqa rad Lammā Maggābi, Wəb ʾAyyahu, sum Warqənah, who are the general judges.</ab>
-            </div>
-            <div type="edition" corresp="a21" xml:lang="gez">
-                <ab>በስመ፡ ሥሉስ፡ ቅዱስ፡ ጸሐፍነ፡ ዘንተ፡ ነገረ፡ በቍዔት፡ ደቂቀ፡ ክብራ፡ ኵልን፡ ምስለ፡ አቡነ፡ <persName ref="PRS14089Pawlos">ጳውሎስ፡</persName> 
-                    ንቡረ፡ ዕድ፡ ኖላዊ፡ መርዔት፡ ለ<persName ref="PRS14087BasaTegest">ባሴ፡ ትዕግሥት፡</persName> በእንተ፡ 
-                    <persName ref="PRS3706eleni">እሌኒ፡</persName> ንግሥት፡ ወ<persName ref="PRS10626ZaraY">ቈስጠንጢኖስ፡</persName> 
-                    ንጉሥነ፡ ርቱዓ፡ ሃይማኖት፡ ወ<persName ref="PRS14088TaklaSyon">ተክለ፡ ጽዮን</persName>ሂ፡
-                    ነጋሢ፡ <placeName ref="LOC3549Gojjam">ጐዛም፡</placeName> <persName ref="PRS14090MeazaHirut">ምዓዘ፡ ኂሩት፡</persName>
-                    ምስለ፡ ብእሲቱ፡ <persName ref="PRS14091BarbaraLaKres">በርባራ፡ ለክርስቶስ፡</persName> ዓመት፡ ለእሉ፡ ይዕቀቦሙ፡ እግዚእ፡ እስከ፡ ይበልዩ፡ 
-                    ምድር፡ ወሰማያት፡ ኢይልክፎሙ፡ ሞት፡ ወይረሲ፡ ሕይወቶሙ፡ በፍሥሖ፡ ወበሖሤት፡ ዘአግብኡ፡ ለነ፡ ሢመትነ፡ ዘነሥኡነ፡ በትዕጣን፡ ወመሥዋዕት፡ በረከተ፡ ሠለስቱ፡ አስግት፡ 
-                    በረከተ፡ ማርያም፡ ንጽሕት፡ በረከተ፡ ነቢያት፡ ወሐዋርያት፡ በረከተ፡ ጻድቃን፡ ወሳማዕት፡ ይከልኦሙ፡ ከመ፡ ሕይመት፡ በኵሉ፡ ጊዜ፡ ወበኵሉ፡ ሰዐት፡ አሜን። 
-                    ስምዑ፡ ዘንተሂ፡ ሥርዐተ፡ መካን፡ ዘጸሐፉ፡ ለነ፡ አቡነ፡ <persName ref="PRS14089Pawlos">ጳውሎስ፡</persName> ንቡረ፡ እድ፡ ምስለ፡ ኵሎሙ፡ መነኮሳት፡ 
-                    እምይእዜ፡ ይኩን፡ ሢመት፡ መካን፡ በኅርየተ፡ መንፈስ፡ ቅዱስ፡ ኢይኩን፡ በኣድልዎ፡ ወኢበተዛውጎ፡ እመሂ፡ ንቡረ፡ ዕድ፡ እመሂ፡ ቂስ፡ ገበዝ፡ እመሂ፡ 
-                    <persName ref="PRS14092EraqMasera">እራቅ፡ ማሰራ፡</persName> እመሂ፡ ሊቀ፡ ዲያቆን፡ ከመዝ፡ ይኩን፡ ሢመቶሙ፡ ወሶበሂ፡ ተስዕሩ፡ ይንባሩ፡ 
-                    በበየቶሙ፡ በህድዓት፡ ወአታደንግፅዎሙ፡ ርእሶሙ፡ ቤተ፡ ቅዱሳን፡ ውእቱ፡ እመቦ፡ ዘተገፍዓ፡ ነዳይ፡ እንበለ፡ ፍትሕ፡ በሢመቶሙ፡ ወይትዋቅሥ፡ በኀበ፡ ቅዱሳን፡
-                    ስምዑ፡ ዘንተኒ፡ ነገረ፡ ዘእነግረክሙ፡ አነ፡ <persName ref="PRS14089Pawlos">ጳውሎስ፡</persName> ወምህርክሙ፡ እመሂ፡ ዐቢይ፡ ወእመሂ፡ ንዑስ፡ 
-                    እምኔነ፡ ዘየሖር፡ ኀበ፡ መኰንን፡ ወይትናገር፡ በእንተ፡ ጥፋዓታ፡ ለዛቲ፡ መካን፡ ወያጥፍዕ፡ ክርስቶስ፡ እምድር፡ ዝክሮ፡ አሜን፡ ወሶበሂ፡ ፈቀደ፡ ይሖር፡ በአተ፡ ትካዙ፡ እንበለ፡ ጽልሁት፡
-                    ይሖር። ወዘአስተተ፡ ወዘተአገለ፡ ዘንተ፡ ትእዛዛተ፡ ይኩን፡ ውጉዘ፡ በፈ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ በአፈ፡ አቡነ፡ 
-                    <persName ref="PRS14093Zayohannes">ዘዮሐንስ፡</persName> በአፈ፡ አቡነ፡ <persName ref="PRS14089Pawlos">ጳውሎስ፡</persName>
-                    በአፈ፡ ኵሎሙ፡ ለባስያነ፡ መንፈስ፡ ይኩን፡ ውጉዘ፡ ውፁአ፡ ወግሁሰ፡ እምርስተ፡ ቅዱሳን፡ አሜን።</ab>
-            </div>
-            <div type="edition" corresp="a23" xml:lang="gez">
-                <ab>በስመ፡ እግዚአብሔር፡ አብ፡ አበ፡ ኢየሱስ፡ ክርስቶስ፡ አበ፡ ሣህል፡ <gap reason="ellipsis"/>ምስለ፡ አብ፡ ወወልድ፡ አጽሐፍኩ፡ ዘንተ፡ 
-                    መጽሐፈ፡ አነ፡ <persName ref="PRS3429DawitII">ዳዊት፡</persName> ወስመ፡ መንግሥትየ፡ 
-                    <persName ref="PRS3429DawitII">ቈስጠንጢኖስ፡ ሠርፀ፡ እስራኤል፡</persName> እምቤተ፡ አብርሃም፡ ይስሐቅ፡ ወያዕቆብ፡ 
-                    ወይሁዳ፡ ወልደ፡ ዳዊት፡ ወሰሎሞን፡ እዕሎኩ፡ ዘንተ፡ ነገረ፡ ውስተ፡ ዛቲ፡ ወንጌለ፡ ጸጋሁ፡ ለእግዚእነ፡ በ<date>፷ወ፭፡ ዓመተ፡ ምሕረት፡</date> 
-                    ወበ<date when="1411">፴ወ፩፡ ዓመተ፡ መንግሥትየ፡</date> እዘዝኩ፡ ከመ፡ ይግበሩ፡ ተዝካረ፡ አቡየ፡ 
-                    <persName ref="PRS8595SayfaAr">ሰይፈ፡ አርዓደ፡</persName> እም፲ወ፭፡ ለግንቦት፡ 
-                    ወተዝካረ፡ እምየ፡ <persName ref="PRS14166LazabWarqa">ለዘብ፡ ወርቃ፡</persName> እም፲ወ፪ለሰኔ፡ ዘንተ፡ ይገበሩ፡ ለለዓመት፡ 
-                    በመካነ፡ <placeName ref="LOC5888Tana">ጻና፡</placeName> ቤተ፡ ቂርቆስ፡ ወበምኔተ፡ ክብራ፡ ቤተ፡ ገብርኤል፡ 
-                    ወበ<placeName ref="LOC5888Tana">ጻና፡</placeName> እለ፡ ይገብሩ፡ እሉ፡ እሙንቱ፡ <gap reason="ellipsis"/>
-                    እምነ፡ በወርኅ፡ ኢሎል፡ ይገበሩ፡ <gap reason="illegible" unit="chars" quantity="4"/>እም፲ወ፩፡ እስከ፲ወ፰ይግ
-                    <gap reason="illegible" unit="chars" quantity="4"/>በዓለ፡ መስቀል። </ab>
-            </div>
-            <div type="edition" corresp="a24" xml:lang="gez">
-                <ab>በስመ፡ እግዚአብሔር፡ አብ፡ አበ፡ ኢየሱስ፡ ክርስቶስ፡ አበ፡ ሣህል፡ <gap reason="ellipsis"/> አጽሐፍኩ፡ ዘንተ፡ መጽሐፈ፡ አነ፡ 
-                    <persName ref="PRS10342Yeshaq">ይስሐቅ፡</persName> ወስመ፡ መንግሥትየ፡ 
-                    <persName ref="PRS10342Yeshaq">ገብረ፡ መስቀል፡ ሠርፀ፡ አስራኤል፡</persName> እምቤተ፡ አብርሃም፡<gap reason="ellipsis"/>
-                    እዕሎኩ፡ ዘንተ፡ መጽሐፈ፡ ውስተ፡ ዛቲ፡ ወንጌለ፡ ጸጋሁ፡ ለእግዚእነ፡ በ<date>፷ወ፯፡ ዓመተ፡ ምሕረት፡</date> 
-                    ወበ<date notBefore="1414" notAfter="1415">፯፡ አውራኅ፡ እመ፡ ዋዕለ፡ መንግሥትየ፡</date> ወሀብኩ፡ ምድረ፡ እንተ፡ ስማ፡ 
-                    <placeName ref="LOC7316Andabet">ሀንዳቤት፡</placeName> እምጽንፈ፡ እስከ፡ ጽንፈ፡ <gap reason="ellipsis"/></ab>
-            </div>
-            <div type="edition" corresp="a25" xml:lang="gez">
-                <ab>በአኰቴተ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ። በምዋዕል፡ 
-                    <persName ref="PRS3429DawitII">ዳዊት፡</persName> ንጉሥ። ወሀብኩ፡ አነ፡ ንቡረ፡ እድ፡ አባ፡ 
-                    <persName ref="PRS14148Nob">ኖብ</persName>። ምድረ፡ ወራሚት፡ ለመካነ፡ ቅዱሳን፡ ዘደብረ፡ ክብራን። ወእመሂ፡ ንቡረ፡ እድ፡ 
-                    ወእመሂ፡ ተዐጋሊ። ከመ፡ ኢይግፍዖሙ፡ ወኢይትጉሎሙ፡ አማኅፀንኩ። <gap reason="ellipsis" unit="lines" quantity="5"/>ወበአፈ፡ 
-                    ቅዱስ፡ ጳጳስነ፡ አባ፡ <persName ref="PRS2469Bartalom">በርተ፡ ሎሜዎስ፡</persName> ይኩን፡ ውጉዘ፡ ወቅውሞ፡ ይኩን፡ እስከ፡ ለዓለመ፡ 
-                    ዓለም። <gap reason="ellipsis" unit="lines" quantity="8"/></ab>
-            </div>
-            <div type="edition" corresp="a26" xml:lang="gez">
-                <ab>ዳረጐትነ፡ ወሀብኩ፡ እምድረ፡ <placeName ref="LOC7381Egana">ኤገና፡</placeName> 
-                    ለማኅቶተ፡ ገብርኤል፡ ፲ወ፪፡ ለፈትል፡ ለዕጣን<gap reason="illegible" unit="chars" quantity="1"/>፡ ወሀብኩ፡ ምድረ፡ 
-                    <placeName ref="LOC7382Daf">ዳፍ፡</placeName> ፳፡ ለጥር፡ ወለሀሎየሂ፡ ፀራቢ፡ ገዳፍከዎ፡ ለገብርኤል፡ ዘምስለ፡ ፱ዳስ፡ ዘወይን፡ 
-                    አሪር፡ የሀብክሙ፡ ዝንቱ፡ ኵሉ፡ መብልዕ፡ ዘነበረ፡ ለንቡረ፡ ዕድ። <gap reason="ellipsis" unit="lines" quantity="3"/></ab>
-            </div>
-            <div type="edition" corresp="a27" xml:lang="gez">
-                <ab>በአኰቴተ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ። ወበመዋዕሊሁ፡ ለንጉሥነ፡ <persName ref="PRS6229LebnaDe">ልብነ፡ ድንግል</persName>። 
-                    ወሀብኩ፡ አነ፡ ንቡረ፡ እድ፡ <persName ref="PRS14149TsegeSellus">ጽጌ፡ ሥሉስ፡</persName><gap reason="lost" unit="chars" quantity="1"/>
-                    መባሕተ፡ አበውየ፡ ቅዱሳ<gap reason="lost" unit="chars" quantity="1"/>፡
-                    ምድረ፡ <placeName ref="LOC7383Qwebitsa">ቍቢጻ፡</placeName> ከመ፡ ይኩኖ፡ ርስተ፡ 
-                    ለ<persName ref="PRS14151Zaiyasus">ዘኢየሱስ፡ </persName>ዐቃቢ። እመሂ፡ ንቡረ፡ እድ፡ ወእመሂ፡ ቂስ፡ ገበዝ፡ እመሂ፡ ሊቀ፡ ዲያቆን፡ 
-                    ወራቅማሰራሂ፡ ዘቦአ፡ በተአድዎ፡ ይኩን፡ ውጉዘ፡ በአፈ፡ ሥሉስ፡ ቅዱስ፡ ወበአፈ፡ እግዝእትነ፡ ማርያም፡
-                    <gap reason="ellipsis" unit="lines" quantity="5"/></ab>
-            </div>
-            <div type="edition" corresp="a28" xml:lang="gez">
-                <ab>ሰምዑ፡ ዘኮነ፡ እምድሕረ፡ ስደት፡ ፈለሰት፡ ስልጣነ፡ ደብር፡ ናሁ፡ አግብአ፡ ለነ፡ ተመኪሮ፡ በዲዴ፡ ንጉሥ፡ ወንህነኒ፡ ወሀብኖ፡ ረስተ፡ ምድረ፡ 
-                    <placeName ref="LOC7384Hanita">ሐኒታ፡</placeName> ወ<placeName ref="LOC7385Isala">ኢሳላ፡</placeName> 
-                    በአዱ፡ ቃል፡ ሀቢረነ፡ በወልድነ፡ ሐቢበ፡ ወንጌል፡ እመቦ፡ ዘደምሰሰ፡ ውጉዘ፡ ለይኩን። ።</ab>
-            </div>
-            <div type="edition" corresp="a30" xml:lang="gez">
-                <ab>ኍልቈ፡ ምድር፡ ዘወሀብዎ፡ ንጉሥነ፡ <persName ref="PRS5616IyasuI">አድያም፡ ሰገድ፡</persName> 
-                    ለ<persName ref="PRS14154GoraDefwu">ጎራ፡ ድፍዉ፡</persName> ይኵኖ፡ ርስተ፡ ለትውልዶ፡ ትውልድ፡ 
-                    <placeName ref="LOC6893Guaguata">ጓጓታ፡</placeName> ዘታሕታይ፡ 
-                    ወ<placeName ref="LOC7386Abaraj">አባራጅ፡ </placeName>
-                    <placeName ref="LOC7387Tsangwya">ጸንጕያ፡</placeName>
-                    ወ<placeName ref="LOC7388Maqwal">ማቋል፡</placeName> 
-                    <placeName ref="LOC7389Sakala">ሳከላ፡</placeName> 
-                    <placeName ref="LOC7390Asya">ዓስያ፡</placeName> 
-                    <placeName ref="LOC7391Abats">አባጽ፡</placeName>
-                    <placeName ref="LOC7392Berbets">ብርብጽ፡</placeName>
-                    <placeName ref="LOC7393Amyatsma">አፙጽማ፡</placeName>
-                    <placeName ref="LOC7394Mebash">ሜበሽ፡</placeName>
-                    ወእሉሂ፡ ጕልታት፡ ዘጸንአ፡ በእዴሁ፡ እምአመ፡ ነግሡ፡ ንጉሥነ፡ <persName ref="PRS5616IyasuI">አድያም፡ ሰገድ፡</persName> 
-                    በ፳ወ፱አመት፡ ወዕለትሂ፡ ዕለተ፡ አርብ፡ በ፲ወ፰ዕለት፡ ለ<placeName ref="LOC6893Guaguata">ጓጓታ፡</placeName> 
-                    ወለ<placeName ref="LOC7386Abaraj">አባራጅ፡ </placeName> ዘከለልዎ፡ በ፫መስቀል፡ ወበ፫ወንጌል፡ ወበ፫ድባብ፡ ወእሉሂ፡ መነኮሳተ፡ ደብር፡
-                    ወጺዖሙ፡ ምስለ፡ መምህሮሙ፡ <persName ref="PRS14155Agnateyos">አግናጥዮስ፡</persName> 
-                    ቂስ፡ ገባዝ፡ <persName ref="PRS14156Temhertu">ትምህርቱ፡</persName> 
-                    ወአፈ፡ መምህር፡ <persName ref="PRS14157Mammo">ማሞ፡</persName> 
-                    ራቅ፡ መሰራ፡ <persName ref="PRS14158Bahaylamaryam">በኃይለማርያም፡</persName> 
-                    ወሊቀ፡ አባው፡ <persName ref="PRS14159TanseaKrestos">ተንሥአ፡ ክርስቶስ፡</persName>
-                    አኅያ፡ ጠቦቱ፡ ወአታ፡ ወንጸ፡ <persName ref="PRS14160TaklaMaryam">ተክለ፡ ማርያም፡</persName> ወዘአጽሐፍዎሰ። ለዝንቱ፡ 
-                    መጽሐፍ፡ ተጋቢኦሙ፡ በ፩ምክር፡ ኀበ፡ አቡሆሙ፡ አረጋዊ፡ መምህር፡ <persName ref="PRS14161MalkeaKrestos">መልከአ፡ ክርስቶስ፡</persName> 
-                    ዘንተ፡ ሰሚዖ፡ ዘሔዶ፡ ዘአፍለሰ፡ እምካልእ፡ ኀበ፡ ካልእ፡ ዘእንበለ፡ ውሉዱ፡ ለ<persName ref="PRS14154GoraDefwu">ጎራ፡ ድፍዊ፡</persName>
-                    እመሂ፡ ንጉሥ፡ ወእመሂ፡ ሠራዊተ፡ ንጉሥ፡ ውጉዘ፡ ይኩን፡ በአፈ፡ ፲ወ፪ሓዋርያት፡ ወ፸ወ፪አርድእት፡ ውጉዘ፡ ለይኩን፡</ab>
-            </div>
-            <div type="edition" corresp="a31" xml:lang="am">
-                <ab>የቅባ፡ ኑግ፡ ግብር፡ ዘሀሎ፡ በወራሚት፡ ፴ስድስት፡ ጽዋ፡ በ<placeName ref="LOC7395LomiBet">ሎሚ፡ ቤት፡ </placeName> አለቃው፡
-                        <persName ref="PRS14162WaldaGirgis">ወልደ፡ ጊርጊስ፡</persName> ስንስጣ። 
-                    ፴ስድስት፡ በ<placeName ref="LOC7396AtsfoBet">አጽፎ፡ ቤት፡</placeName> አለቃው፡ 
-                        <persName ref="PRS14163AbetoSalabaster">አቤቶ፡ ሰለባስትርዮስ፡</persName> 
-                    ያለቃ፡ ምድር፡ በገዙ፡ ፴ስድስት፡ በ<placeName ref="LOC7397Shanga">ሻንጋ፡</placeName> አለቃው፡ 
-                        <persName ref="PRS14164KeramtiZamikael">ክረምቲ፡ ዘሚካኤል፡</persName> 
-                    ያለቃ፡ ምድር፡ <placeName ref="LOC7398Arash">አራሽ፡</placeName> ቂስ፡ ገበዝ፡ 
-                        <persName ref="PRS14165WaldaKesos">ወልደ፡ ክሶስ፤</persName> ከድሸት፡ ፯ጽዋ፡ የንከነበር፡
-                    </ab>
-            </div>
-            <div type="edition" corresp="#e3" xml:lang="gez">
-                <ab><add place="above"> በዘመኑ፡ ለንጉሥነ፡ <persName ref="PRS5616IyasuI">ኢያሱ፡ </persName> 
-                    ዘስ<add resp="CH">መ፡</add> መንግሥቱ፡ <persName ref="PRS5616IyasuI">አድያም፡ ሰገድ፡ </persName></add> 
-                    ወሀብኩ፡ አነ፡ <persName ref="PRS14083Giyorgis">ጊዮርጊስ፡</persName> ለዝንቱ፡ መጽሐፈ፡ ወንጌል፡ ለመካነ፡ 
-                    ገብረ<subst><del>ዮ</del><add place="overstrike">ኤል፡ ዘዮ</add></subst>ሐንስ፡ ከመ፡ ይምኃረኒ፡ በጸሎቱ። 
-                    ለዛቲ፡ መጽሐፍ፡ እመቦ፡ ዘተኣገላ፡ ወተኃየላ፡ ዘሴጣ፡ ወዘሰረቃ፡ ውጉዘ፡ ይኩን፡ በአፈ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ለዓለመ፡ አለም፡ ኣሜን። ። ።</ab>
-            </div>
-            <div type="edition" corresp="#e14" xml:lang="gez">
-                <ab>በአኰቴተ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ። ኍልቈ፡ መጻሕፍት፡ ለገብርኤል፡ ዘደብረ፡ ክብራን፡ ነዋ፡ ዝንቱ፡ ውእቱ፡ ወንጌል፡ ፪፡
-                    <gap reason="ellipsis" unit="lines" quantity="49"/>
-                    ተጽሕፈት፡ ዛቲ፡ ግዘት፡ እንዘ፡ ንጉሥነ፡ <persName ref="PRS8595SayfaAr">ሰይፈ፡ አርዐደ፡</persName> 
-                    ወጳጳስነ፡ አባ፡ <persName ref="PRS8387SalamaI">ሰላማ፡</persName> ወአበመካንነ፡ አባ፡ ዳንኤል፡ ይጽሐፍ፡ ስሞሙ፡ እግዚአብሔር፡ 
-                    ውስተ፡ መጽሕይወት፡ በሰማያት፡ አሜን። ወለንጉሥነሂ፡ ቈስጠንጢኖስ፡ ዘሐነጸ፡ ዘንተ፡ መካነ፡ ቅዱሰ፡ ሀቦ፡ እግዚአብሔር፡ ማኅደረ፡ ሰማያዌ፡ አሜን።
-                    <gap reason="ellipsis" unit="lines" quantity="8"/></ab>
-            </div>
-            <div type="edition" corresp="#e15" xml:lang="gez">
-                <ab>ወእምድኅረ፡ ተጽፋ። እላንቱ፡ ተወሰከ፡ ወጽሐፍነ፡ እስክንድር፩፡ <gap reason="ellipsis" unit="lines" quantity="18"/></ab>
-            </div>
-            <div type="edition" corresp="#e18" xml:lang="gez">
-                <ab>ዘተሳየጥኩ፡ አነ፡ <persName ref="PRS14096TaklaMaryam">ተክለ፡ ማርያም፡</persName> ምድረ፡ እሊ፡ በ፬፡ ብዕራይ፡
-                    እምነ፡ ኩሎሙ፡ መነኮሳተ፡ ደብር፡ ወእንዘ፡ መምህር፡ አባ፡ <persName ref="PRS14097Hirut">ኂሩት፡</persName> 
-                    ወቂስገበዝ፡ አባ፡ <persName ref="PRS14098DabraSyon">ደብረ፡ ጽዮን፡</persName> 
-                    ወመድኀን፡ አባ፡ <persName ref="PRS14099Malkasedeq">መልከጼዴቅ፡</persName> 
-                    ወራቀ፡ መስራ፡ አባ፡ <persName ref="PRS14100ZaraKrestos">ዘርአ፡ ክርስቶስ፡</persName>
-                    ወሊቀ፡ ዲያቆን፡ <persName ref="PRS14101Baselyos">ባስልዮስ፡</persName> ዘንተ፡ ምድረ፡ ዘተሳየጥኩ፡ እንበለ፡ ግብር፡ ዘንተ፡ ምድረ፡ ወዘንተ፡ 
-                    መጽሐፈ፡ ፱ደምሰሰ፡ ወዘፈሀቀ፡ ዘሄደ፡ ወዘተአገለ፡ በሥልጣዎሙ፡ ለጴጥሮስ፡ ወጳውሎስ፡ ውጉዘ፡ በይኩን</ab>
-            </div>
-            <div type="edition" corresp="#e19" xml:lang="gez">
-                <ab>ዘተሳየጥኩ፡ አነ፡ <persName ref="PRS14106ZaraAbreham">ዘርአ፡ አብርሃም፡</persName> ምድረ፡ ዜዲት፡ በ፬ላህም፡ ወ፯ጼው፡ እምነ፡ ኵሎሙ፡ 
-                    መነኮሳተ፡ ደብረ፡ ወእንዘ፡ መምህር፡ አባ፡ <persName ref="PRS14097Hirut">ኂሩት፡</persName> 
-                    ወቂስ፡ ገበዝ፡ ወመድኀንሂ፡ አባ፡ <persName ref="PRS14098DabraSyon">ደብረ፡ ጽዮን፡</persName> 
-                    ወረቍ፡ መስራ፡ <persName ref="PRS14100ZaraKrestos">ዘርአ፡ ክርስቶስ፡</persName>
-                    ወሊቀ፡ ዲያቆን፡ <persName ref="PRS14101Baselyos">ባስልዮስ፡</persName>
-                    ዘንተ፡ ምድረ፡ ዘተሳየጥኩ፡ በሐራ፡ እንበለ፡ ግብር፡ ዘንተ፡ ምድረ፡ ወዘንተ፡ መጽሐፈ፡ በደምሰሰ፡<gap reason="illegible" unit="chars" quantity="2"/>ፈቀቀ፡ 
-                    ዘሄደ፡ ወዘተአገለ፡ <gap reason="illegible" unit="chars" quantity="5"/>ሙ፡ ለጴጥሮስ፡ ወጳውሎስ፡ ውጉዘ፡ በይኩን። ። </ab>
-            </div>
-            <div type="edition" corresp="#e21" xml:lang="gez">
-                <ab>ዛቲ፡ መጽሐፍ፡ ዘአጽሐፈ፡ <persName ref="PRS14144GabraKrestosRWN" role="donor">ገብረ፡ ክርስቶስ፡ ራሴ፡ ወልደ፡ ኖብ፡</persName> 
-                    በ፭አልሕምት፡ ዘተሣየጠ፡ ለ<persName ref="PRS14145TabotSeyon" role="donor">ታቦት፡ ጽዮን፡</persName>
-                    ወለ<persName ref="PRS14146Giyorgis" role="donor">ጊዮርግስ፡</persName>
-                    እምነ፡ <persName ref="PRS14147TaklaHawaryat" role="scribe">ተክለ፡ ሃዋርያት፡</persName>
-                    መነኮስ፡ ንቡረ፡ እድ፡ አባ፡ <persName ref="PRS14148Nob">ኖብ፡</persName>
-                    ራቅ፡ መስራ፡ <persName ref="PRS14077FereKrestos">ፍሬ፡ ክርስቶስ፡ </persName>ፍሬ፡ ክርስቶስ፡ 
-                    ወኵሎሙ፡ <gap reason="illegible" unit="chars" quantity="5"/>ራ። ወሊቆሙ። 
-                    በድ፡ ዮሐን<supplied reason="undefined">ስ፡</supplied><gap reason="illegible" unit="chars" quantity="4"/> 
-                    ነጋሢ፡ <persName ref="PRS14088TaklaSyon">ተክለ፡ ጽዮን፡</persName> ዘመፍ<gap reason="illegible" unit="chars" quantity="2"/>
-                    ንጉሥ፡ <persName ref="PRS6229LebnaDe">ልብነ፡ ድንግል፡</persName> 
-                    ዘተተከለ፡ <gap reason="illegible" unit="chars" quantity="6"/> ለዓለመ፡ ዓለም፡ </ab>
-            </div>
-            <div type="edition" corresp="#e22" xml:lang="gez">
-                <ab>በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡ በአኰቴተ፡ እግዚአብሔር፡ ንጽሐፍ፡ ነዋየ፡ ቤተ፡ ክርስቲያን፡ ዘገብብርኤል። ለመካነ፡ ክብራ፡ ዘረከብነ፡ 
-                    በዘመነ፡ መምህር፡ <persName ref="PRS14128TaklaHaymanot">ተክለ፡ ሃይማኖት።</persName>
-                    ወቂስ፡ ገበዝሂ፡ <persName ref="PRS14152AhabHawaryat">አሃብ፡ ሐዋርያት፡</persName>
-                    ወራቅመስራ፡ <persName ref="PRS14153TaklaGabreel">ተክለ፡ ገብርኤል፡</persName> 
-                    <gap reason="illegible" unit="chars" quantity="1"/>፭ብዝቅ፡ <gap reason="ellipsis" unit="lines" quantity="12"/>
-                    ወኵላ፡ ኵስተሰ፡ አጸሐፍነ። ወመጽሐፍሰ፡ ጽሑፍ፡ ሀሎ፡ በ<ref target="LIT1955Mashaf">መጽሐፈ፡ ሚላድ</ref>። ዘንተ፡ ኵሎ፡ አጽሐፍኩ፡ አነ፡ 
-                    <persName ref="PRS14153TaklaGabreel">ተክለ፡ ገብርኤል፡</persName> በሢመትየ።</ab>
-            </div>
-        </body>
-    </text>
+    <text xml:base="https://betamasaheft.eu/"><body><ab></ab></body></text>
 </TEI>

--- a/Tanasee/Tanasee1.xml
+++ b/Tanasee/Tanasee1.xml
@@ -117,11 +117,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <history>
                         <origin>
                             <origDate notBefore="1350" notAfter="1412" evidence="internal-date">Palaeographic analysis indicates that the manuscript 
-                                dates from the late 14th or early 15th century. This dating is supported by an addition <ref target="#a2"/>, which has 
-                                <date when="1412"/> as date for this addition. However this early dating of the manuscript is contradicted by a scribal 
-                                supplication in <ref target="#a46"/>, which dates the manuscript to the mid-16th century, but which is at odds with another scribal 
+                                dates from the late 14th or early 15th century. This dating is supported by an addition <ref target="#a2"/>, which 
+                                has <date when="1412"/> as date for this addition. However this early dating of the manuscript is contradicted by a scribal 
+                                supplication in <ref target="#a54"/>, which dates the manuscript to the mid-16th century, but which is at odds with another scribal 
                                 supplication in <ref target="#a4"/> and is most likely a supplication referring to another codex on a folio, which was
-                                added later to the codex in a rebinding. This view is supported by <ref target="#a51"/> in the same quire, that contains 
+                                added later to the codex in a rebinding. This view is supported by <ref target="#a59"/> in the same quire, that contains 
                                 a reference to the <ref type="work" target="LIT1955Mashaf"/>, that is not included in this volume.</origDate>
                         </origin>
                     </history>
@@ -143,13 +143,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <incipit xml:lang="gez">አውሴብስ፡ ለቃርጲያኖስ፡ ለዘ፡ ኣፈቅር፡ እኁየ፡ ፍሥሓ፡ ወዳኅና፡ ለከ፡ እምኀበ፡ እግዚአብሔር፡ እምንስ፡ አንከ፡ አሌክስንድርያዊ፡ በብዙኅ፡ 
                                     አስተሐምሞ፡ </incipit>
                                 <explicit xml:lang="gez">ኢያሱስ፡ ክርስቶስ፡ ወኀበሂ፡ አዘዘ፡ ወኀበሂ፡ ገሠጸ፡ ወኀበሂ፡ መሀረ፡ ወኀበሂ፡ ነበረ፡ ወትአምርት፡ ኀበ፡ ማዕተበ፡ መስቀል። </explicit> 
-                                <note>Decorated with finely <ref target="#d1 #d2 #d3">illuminated frames</ref>.</note>
+                                <note>Decorated with finely <ref type="deco" target="#d1 #d2 #d3">illuminated frames</ref>.</note>
                             </msItem>
                             <msItem xml:id="p1_i2">
                                 <locus from="7v" to="10v"/>
                                 <title ref="LIT1224Canons"/>
-                                <note>Decorated with finely <ref target="#d4 #d5 #d6 #d7 #d8 #d9 #d10">illuminated frames</ref> bearing the 
-                                    headline <q xml:lang="gez">ሥርዐት። ። ዘኀብሩ፡ አርባዕቱ። ።</q>.</note>
+                                <note>Decorated with finely <ref type="deco" target="#d4 #d5 #d6 #d7 #d8 #d9 #d10">illuminated frames</ref> 
+                                    bearing the headline <q xml:lang="gez">ሥርዐት። ። ዘኀብሩ፡ አርባዕቱ። ።</q>.</note>
                             </msItem>
                             <msItem xml:id="p1_i3">
                                 <locus from="22va" to="22vb"/>
@@ -280,61 +280,63 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <locus target="#6r"/>
                                 <desc>Finely illuminated frame as described and reproduced in <bibl><ptr target="bm:Heldman1972miniatures"/>
                                     <citedRange>Figure 85</citedRange></bibl> surrounding the text of the 
-                                    <ref type="work" target="LIT1349EpistlEusebius"/> as described in <ref target="#ms_i1"/></desc>
+                                    <ref type="work" target="LIT1349EpistlEusebius"/> as described in <ref type="item" target="#ms_i1"/></desc>
                             </decoNote>
                             <decoNote xml:id="d2" type="miniature">
                                 <locus target="#6v"/>
                                 <desc>Finely illuminated frame, that was described and reproduced in 
                                     <bibl><ptr target="bm:LeroyAeth1968"/><citedRange>Abb. 430a</citedRange></bibl> and
                                     <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 86</citedRange></bibl> 
-                                    surrounding the text of the <ref type="work" target="LIT1349EpistlEusebius"/> in <ref target="#ms_i1"/>.</desc>
+                                    surrounding the text of the <ref type="work" target="LIT1349EpistlEusebius"/> in 
+                                    <ref type="item" target="#ms_i1"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d3" type="miniature">
                                 <locus target="#7r"/>
                                 <desc>Finely illuminated frame, that was described and reproduced in 
                                     <bibl><ptr target="bm:Leroy1962Recherches"/><citedRange>Figure 7</citedRange></bibl>, surrounding 
-                                    the text of <ref type="work" target="LIT1349EpistlEusebius"/> as described in <ref target="#ms_i1"/>.</desc>
+                                    the text of <ref type="work" target="LIT1349EpistlEusebius"/> as described in 
+                                    <ref type="item" target="#ms_i1"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d4" type="frame">
                                 <locus target="#7v"/>
                                 <desc>Finely illuminated frame surrounding <ref type="work" target="LIT1224Canons"/> as described in 
-                                    <ref target="#ms_i2"/>.</desc>
+                                    <ref type="item" target="#ms_i2"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d5" type="frame">
                                 <locus target="#8r"/>
                                 <desc>Finely illuminated frame surrounding <ref type="work" target="LIT1224Canons"/> as described in 
-                                    <ref target="#ms_i2"/>.</desc>
+                                    <ref type="item" target="#ms_i2"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d6" type="frame">
                                 <locus target="#8v"/>
                                 <desc>Finely illuminated frame surrounding <ref type="work" target="LIT1224Canons"/> as described in 
-                                    <ref target="#ms_i2"/>.</desc>
+                                    <ref type="item" target="#ms_i2"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d7" type="frame">
                                 <locus target="#9r"/>
                                 <desc>Finely illuminated frame surrounding <ref type="work" target="LIT1224Canons"/> as described in 
-                                    <ref target="#ms_i2"/>.</desc>
+                                    <ref type="item" target="#ms_i2"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d8" type="frame">
                                 <locus target="#9v"/>
                                 <desc>Finely illuminated frame surrounding <ref type="work" target="LIT1224Canons"/> as described in 
-                                    <ref target="#ms_i2"/>.</desc>
+                                    <ref type="item" target="#ms_i2"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d9" type="frame">
                                 <locus target="#10r"/>
                                 <desc>Finely illuminated frame, that was described and reproduced in 
                                     <bibl><ptr target="bm:Leroy1962Recherches"/><citedRange>Figure 8</citedRange></bibl>, surrounding
-                                    <ref type="work" target="LIT1224Canons"/> as described in <ref target="#ms_i2"/>.</desc>
+                                    <ref type="work" target="LIT1224Canons"/> as described in <ref type="item" target="#ms_i2"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d10" type="frame">
                                 <locus target="#10v"/>
                                 <desc>Finely illuminated frame, that was described and reproduced in <bibl><ptr target="bm:LeroyEthMss1961"/>
                                     <citedRange>10</citedRange></bibl>, surrounding <ref type="work" target="LIT1224Canons"/> in 
-                                    <ref target="#ms_i2"/>.</desc>
+                                    <ref type="item" target="#ms_i2"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d11" type="miniature">
                                 <locus target="#11r"/>
-                                <desc>Finely executed full-page <ref target="AT1034Tempietto"/> depicting a pavillon with a number of birds including two 
+                                <desc>Finely executed full-page <ref type="authFile" target="AT1034Tempietto"/> depicting a pavillon with a number of birds including two 
                                     peacocks accompanied by two gazelles representing the Fountain of Life with some words added: 
                                     <foreign xml:lang="gez">ባቡላ</foreign>, <foreign xml:lang="gez">ኑባሬ፡ ሥርዓት።</foreign> and 
                                     <foreign xml:lang="gez">ባዙላ</foreign>. This miniature was described and reproduced 
@@ -348,8 +350,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </decoNote>
                             <decoNote xml:id="d12" type="miniature">
                                 <locus target="#12r"/>
-                                <desc>Finely executed full-page miniature depicting the <ref type="authFile" corresp="AT1002Annunciation"/> described and 
-                                    reproduced in <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 87</citedRange></bibl>.</desc>
+                                <desc>Finely executed full-page miniature depicting the <ref type="authFile" corresp="AT1002Annunciation"/> 
+                                    described and reproduced in 
+                                    <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 87</citedRange></bibl>.</desc>
                             </decoNote>
                             <decoNote xml:id="d13" type="miniature">
                                 <locus target="#12v"/>
@@ -652,8 +655,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </item> 
                                 <item xml:id="a21">
                                     <locus from="22ra" to="22rb"/>
-                                    <desc type="LandGrant">Note by the same hand as <ref target="#a20"/> directly above on a land grant in the time of 
-                                        <persName ref="PRS9038Susenyos"/>.</desc>
+                                    <desc type="LandGrant">Note by the same hand as <ref target="#a20"/> directly above on a land grant 
+                                        in the time of <persName ref="PRS9038Susenyos"/>.</desc>
                                     <q xml:lang="gez">ወለቤተ፡ ክርስቲያንሂ፡ አጕልቱ፡ ላቲ፡ እምብዙኅ፡ ጕልታቲሃ፡ ዘቀዳሚ፡ ክልኤተ፡ ሀገረ፡ 
                                         <placeName ref="LOC6977Wagalesa">ወገልሳ</placeName>ሃ፡ 
                                         ወ<placeName ref="LOC6979Waramit">ዌራሚት፡</placeName> 
@@ -875,7 +878,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </item>
                                 <item xml:id="a38">
                                     <locus target="233ra"/>
-                                    <desc type="DonationNote">Addition to the <ref target="#a37">Donation note</ref> directly above.</desc>
+                                    <desc type="DonationNote">Addition to <ref target="#a37"/> directly above.</desc>
                                     <q xml:lang="gez">፪ቀሚስ፡ ወ፪ሞጠሀተ፡ ወሀብነ፡ ኅቡረ፡ ለመካነ፡ አዝማ፡ ለተዝካረ፡ ንጉሥ፡ ሥዕል፡ ፬በመባሕተ፡ </q>
                                 </item>
                                 <item xml:id="a39">

--- a/Tanasee/Tanasee1.xml
+++ b/Tanasee/Tanasee1.xml
@@ -44,7 +44,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <extent>
                                 <measure unit="leaf" quantity="239">239</measure>
                                 <note>Number of leaves contrary to <bibl><ptr target="bm:Hammerschmidt1973Tanasee"/><citedRange
-                                    unit="page">84</citedRange></bibl>, who counted 240 leaves.</note>
+                                    unit="page">84</citedRange></bibl>, who counted 240 leaves, because he skipped folio 204 from the count.</note>
                                 <note>Dimensions indicated below may concern outer dimensions of bookcover or dimensions of folia (not clearly 
                                     specified in catalogue).</note>
                                 <dimensions type="outer" unit="mm">                                        
@@ -122,7 +122,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 supplication in <ref target="#a54"/>, which dates the manuscript to the mid-16th century, but which is at odds with another scribal 
                                 supplication in <ref target="#a4"/> and is most likely a supplication referring to another codex on a folio, which was
                                 added later to the codex in a rebinding. This view is supported by <ref target="#a59"/> in the same quire, that contains 
-                                a reference to the <ref type="work" target="LIT1955Mashaf"/>, that is not included in this volume.</origDate>
+                                a reference to the <ref type="work" corresp="LIT1955Mashaf"/>, that is not included in this volume.</origDate>
                         </origin>
                     </history>
                     <additional>
@@ -280,58 +280,58 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <locus target="#6r"/>
                                 <desc>Finely illuminated frame as described and reproduced in <bibl><ptr target="bm:Heldman1972miniatures"/>
                                     <citedRange>Figure 85</citedRange></bibl> surrounding the text of the 
-                                    <ref type="work" target="LIT1349EpistlEusebius"/> as described in <ref type="item" target="#ms_i1"/></desc>
+                                    <ref type="work" corresp="LIT1349EpistlEusebius"/> as described in <ref type="item" target="#ms_i1"/></desc>
                             </decoNote>
                             <decoNote xml:id="d2" type="miniature">
                                 <locus target="#6v"/>
                                 <desc>Finely illuminated frame, that was described and reproduced in 
                                     <bibl><ptr target="bm:LeroyAeth1968"/><citedRange>Abb. 430a</citedRange></bibl> and
                                     <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 86</citedRange></bibl> 
-                                    surrounding the text of the <ref type="work" target="LIT1349EpistlEusebius"/> in 
+                                    surrounding the text of the <ref type="work" corresp="LIT1349EpistlEusebius"/> in 
                                     <ref type="item" target="#ms_i1"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d3" type="miniature">
                                 <locus target="#7r"/>
                                 <desc>Finely illuminated frame, that was described and reproduced in 
                                     <bibl><ptr target="bm:Leroy1962Recherches"/><citedRange>Figure 7</citedRange></bibl>, surrounding 
-                                    the text of <ref type="work" target="LIT1349EpistlEusebius"/> as described in 
+                                    the text of <ref type="work" corresp="LIT1349EpistlEusebius"/> as described in 
                                     <ref type="item" target="#ms_i1"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d4" type="frame">
                                 <locus target="#7v"/>
-                                <desc>Finely illuminated frame surrounding <ref type="work" target="LIT1224Canons"/> as described in 
+                                <desc>Finely illuminated frame surrounding <ref type="work" corresp="LIT1224Canons"/> as described in 
                                     <ref type="item" target="#ms_i2"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d5" type="frame">
                                 <locus target="#8r"/>
-                                <desc>Finely illuminated frame surrounding <ref type="work" target="LIT1224Canons"/> as described in 
+                                <desc>Finely illuminated frame surrounding <ref type="work" corresp="LIT1224Canons"/> as described in 
                                     <ref type="item" target="#ms_i2"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d6" type="frame">
                                 <locus target="#8v"/>
-                                <desc>Finely illuminated frame surrounding <ref type="work" target="LIT1224Canons"/> as described in 
+                                <desc>Finely illuminated frame surrounding <ref type="work" corresp="LIT1224Canons"/> as described in 
                                     <ref type="item" target="#ms_i2"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d7" type="frame">
                                 <locus target="#9r"/>
-                                <desc>Finely illuminated frame surrounding <ref type="work" target="LIT1224Canons"/> as described in 
+                                <desc>Finely illuminated frame surrounding <ref type="work" corresp="LIT1224Canons"/> as described in 
                                     <ref type="item" target="#ms_i2"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d8" type="frame">
                                 <locus target="#9v"/>
-                                <desc>Finely illuminated frame surrounding <ref type="work" target="LIT1224Canons"/> as described in 
+                                <desc>Finely illuminated frame surrounding <ref type="work" corresp="LIT1224Canons"/> as described in 
                                     <ref type="item" target="#ms_i2"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d9" type="frame">
                                 <locus target="#10r"/>
                                 <desc>Finely illuminated frame, that was described and reproduced in 
                                     <bibl><ptr target="bm:Leroy1962Recherches"/><citedRange>Figure 8</citedRange></bibl>, surrounding
-                                    <ref type="work" target="LIT1224Canons"/> as described in <ref type="item" target="#ms_i2"/>.</desc>
+                                    <ref type="work" corresp="LIT1224Canons"/> as described in <ref type="item" target="#ms_i2"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d10" type="frame">
                                 <locus target="#10v"/>
                                 <desc>Finely illuminated frame, that was described and reproduced in <bibl><ptr target="bm:LeroyEthMss1961"/>
-                                    <citedRange>10</citedRange></bibl>, surrounding <ref type="work" target="LIT1224Canons"/> in 
+                                    <citedRange>10</citedRange></bibl>, surrounding <ref type="work" corresp="LIT1224Canons"/> in 
                                     <ref type="item" target="#ms_i2"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d11" type="miniature">
@@ -1150,7 +1150,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             ወቄስ፡ ገበዝሂ፡ <persName ref="PRS14152AhabHawaryat">አሃብ፡ ሐዋርያት፡</persName>
                                             ወራቅመስራ፡ <persName ref="PRS14153TaklaGabreel">ተክለ፡ ገብርኤል፡</persName> 
                                             <gap reason="illegible" unit="chars" quantity="1"/>፭ብዝቅ፡ <gap reason="ellipsis" unit="lines" quantity="12"/>
-                                            ወኵላ፡ ኵስተሰ፡ አጸሐፍነ። ወመጽሐፍሰ፡ ጽሑፍ፡ ሀሎ፡ በ<ref type="work" target="LIT1955Mashaf">መጽሐፈ፡ ሚላድ</ref>። ዘንተ፡ ኵሎ፡ አጽሐፍኩ፡ አነ፡ 
+                                            ወኵላ፡ ኵስተሰ፡ አጸሐፍነ። ወመጽሐፍሰ፡ ጽሑፍ፡ ሀሎ፡ በ<ref type="work" corresp="LIT1955Mashaf">መጽሐፈ፡ ሚላድ</ref>። ዘንተ፡ ኵሎ፡ አጽሐፍኩ፡ አነ፡ 
                                             <persName ref="PRS14153TaklaGabreel">ተክለ፡ ገብርኤል፡</persName> በሢመትየ።</q>
                                     </item>
                                     <item xml:id="a60">

--- a/Tanasee/Tanasee1.xml
+++ b/Tanasee/Tanasee1.xml
@@ -526,7 +526,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <locus target="#4rb"/>
                                     <desc type="RecordTransaction">Transaction note in Amharic.</desc>
                                     <q xml:lang="am">ወይዘሮ፡ <persName ref="PRS14058Qasaro">ቀጸሮ፡</persName> የገዙት፡ ምድር፡ 
-                                        ከ<persName ref="PRS14059MariGeta">መሪ፡ ጌታ፡ ገብረ፡ ሚካኤል፡</persName> በ፵ጨው፡ ነው፡ አሳቦች፡ ቂሰ፡ ገበዝ፡ ወሰን፡ አይሞት፡ ዠኖ፡ ኑሮ፡ ወሰን፡ ነጮ፡ ናቸው፡ 
+                                        ከመሪ፡ ጌታ፡<persName ref="PRS14059MariGeta">ገብረ፡ ሚካኤል፡</persName> በ፵ጨው፡ ነው፡ አሳቦች፡ ቂሰ፡ ገበዝ፡ ወሰን፡ አይሞት፡ ዠኖ፡ ኑሮ፡ ወሰን፡ ነጮ፡ ናቸው፡ 
                                         መድኒቱ፡ <persName ref="PRS14060WalattaIyasus">ወለተ፡ ኢየሱስ፡</persName> ናት፡ ግብሩ፡ ፪፳፲፡ ቅብዓ፡ ኑግ፡ ፱ድርጎ፡ አከል፡ ነው፡ አንዘ፡ 
                                         መምሕርነ፡ ዘፈረ፡ ሥላሴ። ገበዝነ፡ ወሰን፡ ወጭቀው፡ ወሰጥ፡ ነጨ፡ በዘመነ፡ ማቴዎስ፡ ንው። </q>
                                 </item>
@@ -1193,10 +1193,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             በ<placeName ref="LOC7395LomiBet">ሎሚ፡ ቤት፡</placeName> 
                                             አለቃው፡ <persName ref="PRS14162WaldaGirgis">ወልደ፡ ጊርጊስ፡</persName> ስንስጣ። 
                                             ፴ስድስት፡ በ<placeName ref="LOC7396AtsfoBet">አጽፎ፡ ቤት፡</placeName> 
-                                            አለቃው፡ <persName ref="PRS14163AbetoSalabaster">አቤቶ፡ ሰለባስትርዮስ፡</persName> 
+                                            አለቃው፡ አቤቶ፡ <persName ref="PRS14163AbetoSalabaster">ሰለባስትርዮስ፡</persName> 
                                             ያለቃ፡ ምድር፡ በገዙ፡ ፴ስድስት፡ በ<placeName ref="LOC7397Shanga">ሻንጋ፡</placeName> አለቃው፡ 
                                             <persName ref="PRS14164KeramtiZamikael">ክረምቲ፡ ዘሚካኤል፡</persName> 
-                                            ያለቃ፡ ምድር፡ <placeName ref="LOC7398Arash">አራሽ፡</placeName> ቂስ፡ ገበዝ፡ 
+                                            ያለቃ፡ ምድር፡ <placeName ref="LOC7398Arash">አራሽ፡</placeName> ቄስ፡ ገበዝ፡ 
                                             <persName ref="PRS14165WaldaKesos">ወልደ፡ ክሶስ፤</persName> ከድሸት፡ ፯ጽዋ፡ የንከነበር፡</q>
                                     </item>
                                     <item xml:id="a64">

--- a/Tanasee/Tanasee1.xml
+++ b/Tanasee/Tanasee1.xml
@@ -547,7 +547,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <locus target="#4va"/>
                                     <desc type="Record">Note stating, that <persName ref="PRS7481NaodA"/> visited <placeName ref="LOC1602Atrons"/>
                                         <date calendar="qamar" when-custom="159" when="1507" ref="ethiocal:Maggabit"> in the month of Maggābit in 
-                                            the year 159 ʿAmata məḥrat</date>.</desc>
+                                            the year 159 ʿAmata mǝḥrat</date>.</desc>
                                     <q xml:lang="gez">በመዋዕለ፡ ሉቃስ፡ ወንጌላዊ፡ በ<date calendar="qamar" when-custom="159" when="1507">፻፶ወ፱፡ አመተ፡ ምሕረት፡</date> እንዘ፡ 
                                             ሀለዉ፡ ንጉሥነ፡ <persName ref="PRS7481NaodA">ናኦድ፡</persName> በ<placeName ref="LOC1602Atrons">አትሮንስ፡ እግዝእትነ፡ 
                                             ማርያም፡</placeName> በወርኃ፡ መጋቢት፡ እንዘ፡ ስማዕት፡ ይእቴ፡ <persName ref="PRS3706eleni">እሌኒ፡</persName> ያጼ፡ እናቶ፡ ግራ፡ በአልታ፡ 
@@ -599,7 +599,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </item>
                                 <item xml:id="a16">
                                     <locus target="#5ra"/>
-                                    <desc type="Inventory">Note on church utensils, that Nəbuəraʾəd <persName ref="PRS14081TanseaKrestos"/> 
+                                    <desc type="Inventory">Note on church utensils, that nǝburaʾǝd <persName ref="PRS14081TanseaKrestos"/> 
                                         donated to <placeName ref="LOC4042Kebran "/> by a similar hand as <ref target="#a13 #a18"/>.</desc>
                                     <q xml:lang="gez">ወዘንተ፡ ንዋየ፡ ቤተ፡ ክርስቲያን፡ ዘወሀበ፡ ንቡረ፡ እድ፡ <persName ref="PRS14081TanseaKrestos">ተንሥአ፡ ክርስቶስ፡</persName> 
                                         ለመካነ፡ ገብርኤል፡ ወለማርያም፡ ፪አጽሕልት፡ ዘወርቅ፡ ወ፪፡ ጽዋዕ፡ ዘወርቅ። <gap reason="ellipsis" unit="lines" quantity="16"/></q>
@@ -773,11 +773,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             ሱም፡ <persName ref="PRS14126Warqenah">ወርቅነህ፡ </persName>ናቸው። ዳኞች፡ ለሁሉም፡ 
                                             <add place="above">ናቸው፡</add></q>
                                     <q type="translation" corresp="#a28" resp="CH">
-                                            In the year of Marqos, in Maggābit, rās bit waddad Mangašā bought lands from ʾato Wās. The witnesses are liqa rad Mərṭənah, 
-                                            liqa rad Gʷaššu, liqa rad Wande, liqa rad Bərru, and also a person whose name is Tasfā Getāhun, ʾAyālew Gabra Māryām, 
+                                        In the year of Marqos, in Maggābit, rās bit waddad Mangašā bought lands from ʾato Wās. The witnesses are liqa rad Mǝrṭǝnah, 
+                                        liqa rad Gʷaššu, liqa rad Wande, liqa rad Bǝrru, and also a person whose name is Tasfā Getāhun, ʾAyālew Gabra Māryām, 
                                             Bar Yāhun Wāle. The witnesses under warranty are ʾato Tāwwaqa, blāttā Zallaqa ʾAyalāw Gabra Maryām, Dastā Lammā, a person 
-                                            whose name is ʾato Galāgāy ʾƎšte, Səndaqi Təkku, ʾato Tafarā, ʾato Tāfala Žammara Tāwwaqa, and the judges are 
-                                            liqa rad Lammā Maggābi, Wəb ʾAyyahu, sum Warqənah, who are the general judges.</q>
+                                            whose name is ʾato Galāgāy ʾƎšte, Sǝndaqi Tǝkku, ʾato Tafarā, ʾato Tāfala Žammara Tāwwaqa, and the judges are 
+                                            liqa rad Lammā Maggābi, Wǝb ʾAyyahu, sum Warqǝnah, who are the general judges.</q>
                                 </item>
                                 <item xml:id="a29">
                                     <locus target="#183va"/>
@@ -925,7 +925,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <list>
                                     <item xml:id="a43">
                                         <locus from="234va" to="234vb"/>
-                                        <desc type="MixedNote">Commemorative note (Tazkār) on nəburaʾed 
+                                        <desc type="MixedNote">Commemorative note (Tazkār) on nǝburaʾǝd 
                                             <persName ref="PRS14086Qalementos">ቀሌምንጦስ፡</persName>.</desc>
                                         <q xml:lang="gez">ተዝካረ፡ ዘአዘዝኩ፡ ሎሙ፡ አነ፡ <persName ref="PRS14086Qalementos">ቀሌምንጦስ፡</persName> 
                                             ንቡረ፡ እድ፡ በመዋዕለ፡ <persName ref="PRS3429DawitII">ዳዊት፡</persName> ንጉሥ፡ ለአበዊየ፡ ካህናት፡ ዘደብረ፡ 
@@ -1025,7 +1025,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <item xml:id="a51">
                                         <locus from="235va" to="235vb"/>
                                         <desc type="MixedNote">Instruction of King <persName ref="PRS3429DawitII"/> to commemorate the death (Tazkār) 
-                                            of his father and predecessor <persName ref="PRS8595SayfaAr"/> on 15 Gənbot and of his mother 
+                                            of his father and predecessor <persName ref="PRS8595SayfaAr"/> on 15 Gǝnbot and of his mother 
                                             <persName ref="PRS14166LazabWarqa"/> on 12 Sane in the region of <placeName ref="LOC5888Tana"/>.
                                             The text mentions the 34th year of the reign of <persName ref="PRS3429DawitII"/> as the date of this addition. 
                                             According to <bibl><ptr target="bm:Tadesse1974Succession"/></bibl>, this indicates a lasting power struggle with 
@@ -1047,7 +1047,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </item>
                                     <item xml:id="a52">
                                         <locus from="236ra" to="236va"/>
-                                        <desc type="LandGrant">Landgrant of King <persName ref="PRS10342Yeshaq">Yəsḥaq</persName> with a 
+                                        <desc type="LandGrant">Landgrant of King <persName ref="PRS10342Yeshaq"/> with a 
                                             very similar incipit and by a similar hand as <ref target="#a51"/> directly above.</desc>
                                         <q xml:lang="gez">በስመ፡ እግዚአብሔር፡ አበ፡ ኢ<supplied reason="omitted">የ</supplied>ሱስ፡ ክርስቶስ፡ አበ፡ ሣህል፡ 
                                             <gap reason="ellipsis" unit="lines" quantity="5"/> አጽሐፍኩ፡ 
@@ -1231,7 +1231,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <langUsage>
                 <language ident="en">English</language>
                 <language ident="am">Amharic</language>
-                <language ident="gez">Gəʿəz</language>
+                <language ident="gez">Gǝʿǝz</language>
             </langUsage>
         </profileDesc>
         <revisionDesc>

--- a/Tanasee/Tanasee1.xml
+++ b/Tanasee/Tanasee1.xml
@@ -32,9 +32,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <msIdentifier>
                         <repository ref="INS0357Kebran"/>
                         <idno  facs="EMIP/Codices/3496/" n="263">Ṭānāsee 1</idno>
-                        <altIdentifier>
-                            <idno>Kǝbrān 1</idno>
-                        </altIdentifier>
+                        <altIdentifier><idno>Kǝbrān 1</idno></altIdentifier>
+                        <altIdentifier><idno>EMIP 3496</idno></altIdentifier>
                     </msIdentifier>
                     <physDesc>
                         <objectDesc form="Codex">
@@ -123,7 +122,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 supplication in <ref target="#a46"/>, which dates the manuscript to the mid-16th century, but which is at odds with another scribal 
                                 supplication in <ref target="#a4"/> and is most likely a supplication referring to another codex on a folio, which was
                                 added later to the codex in a rebinding. This view is supported by <ref target="#a51"/> in the same quire, that contains 
-                                a reference to the <ref target="LIT1955Mashaf"/>, that is not included in this volume.</origDate>
+                                a reference to the <ref type="work" target="LIT1955Mashaf"/>, that is not included in this volume.</origDate>
                         </origin>
                     </history>
                     <additional>
@@ -280,52 +279,58 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <decoNote xml:id="d1" type="frame">
                                 <locus target="#6r"/>
                                 <desc>Finely illuminated frame as described and reproduced in <bibl><ptr target="bm:Heldman1972miniatures"/>
-                                    <citedRange>Figure 85</citedRange></bibl> surrounding the text of the <ref target="LIT1349EpistlEusebius"/> 
-                                    as described in <ref target="#ms_i1"/></desc>
+                                    <citedRange>Figure 85</citedRange></bibl> surrounding the text of the 
+                                    <ref type="work" target="LIT1349EpistlEusebius"/> as described in <ref target="#ms_i1"/></desc>
                             </decoNote>
                             <decoNote xml:id="d2" type="miniature">
                                 <locus target="#6v"/>
                                 <desc>Finely illuminated frame, that was described and reproduced in 
                                     <bibl><ptr target="bm:LeroyAeth1968"/><citedRange>Abb. 430a</citedRange></bibl> and
                                     <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 86</citedRange></bibl> 
-                                    surrounding the text of the <ref target="LIT1349EpistlEusebius"/> in <ref target="#ms_i1"/>.</desc>
+                                    surrounding the text of the <ref type="work" target="LIT1349EpistlEusebius"/> in <ref target="#ms_i1"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d3" type="miniature">
                                 <locus target="#7r"/>
                                 <desc>Finely illuminated frame, that was described and reproduced in 
                                     <bibl><ptr target="bm:Leroy1962Recherches"/><citedRange>Figure 7</citedRange></bibl>, surrounding 
-                                    the text of <ref target="LIT1349EpistlEusebius"/> as described in <ref target="#ms_i1"/>.</desc>
+                                    the text of <ref type="work" target="LIT1349EpistlEusebius"/> as described in <ref target="#ms_i1"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d4" type="frame">
                                 <locus target="#7v"/>
-                                <desc>Finely illuminated frame surrounding <ref target="LIT1224Canons"/> as described in <ref target="#ms_i2"/>.</desc>
+                                <desc>Finely illuminated frame surrounding <ref type="work" target="LIT1224Canons"/> as described in 
+                                    <ref target="#ms_i2"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d5" type="frame">
                                 <locus target="#8r"/>
-                                <desc>Finely illuminated frame surrounding <ref target="LIT1224Canons"/> as described in <ref target="#ms_i2"/>.</desc>
+                                <desc>Finely illuminated frame surrounding <ref type="work" target="LIT1224Canons"/> as described in 
+                                    <ref target="#ms_i2"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d6" type="frame">
                                 <locus target="#8v"/>
-                                <desc>Finely illuminated frame surrounding <ref target="LIT1224Canons"/> as described in <ref target="#ms_i2"/>.</desc>
+                                <desc>Finely illuminated frame surrounding <ref type="work" target="LIT1224Canons"/> as described in 
+                                    <ref target="#ms_i2"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d7" type="frame">
                                 <locus target="#9r"/>
-                                <desc>Finely illuminated frame surrounding <ref target="LIT1224Canons"/> as described in <ref target="#ms_i2"/>.</desc>
+                                <desc>Finely illuminated frame surrounding <ref type="work" target="LIT1224Canons"/> as described in 
+                                    <ref target="#ms_i2"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d8" type="frame">
                                 <locus target="#9v"/>
-                                <desc>Finely illuminated frame surrounding <ref target="LIT1224Canons"/> as described in <ref target="#ms_i2"/>.</desc>
+                                <desc>Finely illuminated frame surrounding <ref type="work" target="LIT1224Canons"/> as described in 
+                                    <ref target="#ms_i2"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d9" type="frame">
                                 <locus target="#10r"/>
                                 <desc>Finely illuminated frame, that was described and reproduced in 
                                     <bibl><ptr target="bm:Leroy1962Recherches"/><citedRange>Figure 8</citedRange></bibl>, surrounding
-                                    <ref target="LIT1224Canons"/> as described in <ref target="#ms_i2"/>.</desc>
+                                    <ref type="work" target="LIT1224Canons"/> as described in <ref target="#ms_i2"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d10" type="frame">
                                 <locus target="#10v"/>
-                                <desc>Finely illuminated frame, that was described and reproduced in <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>10</citedRange></bibl>, 
-                                    surrounding <ref target="LIT1224Canons"/> in <ref target="#ms_i2"/>.</desc>
+                                <desc>Finely illuminated frame, that was described and reproduced in <bibl><ptr target="bm:LeroyEthMss1961"/>
+                                    <citedRange>10</citedRange></bibl>, surrounding <ref type="work" target="LIT1224Canons"/> in 
+                                    <ref target="#ms_i2"/>.</desc>
                             </decoNote>
                             <decoNote xml:id="d11" type="miniature">
                                 <locus target="#11r"/>
@@ -1142,7 +1147,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             ወቄስ፡ ገበዝሂ፡ <persName ref="PRS14152AhabHawaryat">አሃብ፡ ሐዋርያት፡</persName>
                                             ወራቅመስራ፡ <persName ref="PRS14153TaklaGabreel">ተክለ፡ ገብርኤል፡</persName> 
                                             <gap reason="illegible" unit="chars" quantity="1"/>፭ብዝቅ፡ <gap reason="ellipsis" unit="lines" quantity="12"/>
-                                            ወኵላ፡ ኵስተሰ፡ አጸሐፍነ። ወመጽሐፍሰ፡ ጽሑፍ፡ ሀሎ፡ በ<ref target="LIT1955Mashaf">መጽሐፈ፡ ሚላድ</ref>። ዘንተ፡ ኵሎ፡ አጽሐፍኩ፡ አነ፡ 
+                                            ወኵላ፡ ኵስተሰ፡ አጸሐፍነ። ወመጽሐፍሰ፡ ጽሑፍ፡ ሀሎ፡ በ<ref type="work" target="LIT1955Mashaf">መጽሐፈ፡ ሚላድ</ref>። ዘንተ፡ ኵሎ፡ አጽሐፍኩ፡ አነ፡ 
                                             <persName ref="PRS14153TaklaGabreel">ተክለ፡ ገብርኤል፡</persName> በሢመትየ።</q>
                                     </item>
                                     <item xml:id="a60">

--- a/Tanasee/Tanasee1.xml
+++ b/Tanasee/Tanasee1.xml
@@ -6,6 +6,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:id="t1">Gospels</title>
+                <editor key="AB" role="generalEditor"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
             <editionStmt>
                 <p>The manuscript was originally microfilmed in situ in 1968 
@@ -35,14 +38,684 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     </msIdentifier>
                     <msContents>
                         <summary>Gospels</summary>
+                        <msItem xml:id="ms_i1">
+                            <locus from="6r" to="7r"/>
+                            <title ref="LIT1349EpistlEusebius"/>
+                            <incipit xml:lang="gez">አውሴብስ፡ ለቃርጲያኖስ፡ ለዘ፡ ኣፈቅር፡ እኁየ፡ ፍሥሓ፡ ወዳኅና፡ ለከ፡ እምኀበ፡ እግዚአብሔር፡ እምንስ፡ አንከ፡ አሌክስንድርያዊ፡ በብዙኅ፡ 
+                                አስተሐምሞ፡ </incipit>
+                           <explicit xml:lang="gez">ኢያሱስ፡ ክርስቶስ፡ ወኀበሂ፡ አዘዘ፡ ወኀበሂ፡ ገሠጸ፡ ወኀበሂ፡ መሀረ፡ ወኀበሂ፡ ነበረ፡ ወትአምርት፡ ኀበ፡ ማዕተበ፡ መስቀል። </explicit> 
+                            <note>Decorated with in finely <ref target="#d1 #d2 #d3">illuminated frames</ref>.</note>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <locus from="7v" to="10v"/>
+                            <title ref="LIT1224Canons"/>
+                            <note>Decorated with finely <ref target="#d4 #d5 #d6 #d7 #d8 #d9 #d10">illuminated frames</ref> bearing the 
+                                headline <foreign xml:lang="gez">ሥርዐት። ። ዘኀብሩ፡ አርባዕቱ። ።</foreign>.</note>
+                        </msItem>
+                        <msItem xml:id="ms_i3">
+                            <locus from="22va" to="22vb"/>
+                            <title>Treatise on the four Evangelists and their symbols</title> 
+                            <incipit xml:lang="gez">እስመ፡ ኵሎሙ፡ ጸሐፉ፡ ዘከመ፡ ርእዩ፡ ወስምዑ፡ ዜና፡ ስብከቱ፡ ለኢያሱስ፡ ክርስቶስ፡ ወንጌል፡ ቅዱስ።</incipit>
+                            <explicit xml:lang="gez">ወንሕነኒ፡ ተማሕፀነ፡ በወንጌለ፡ መላኮትከ፡ ከመ፡ ትምሐረነ፡ ለዓለመ፡ ዓለም፡ አሜን። ።</explicit>
+                        </msItem>
+                        <msItem xml:id="ms_i4">
+                            <locus from="23ra" to="230vb"/>
+                            <title ref="LIT1560Gospel"/>
+                            <note>The heading of each Evangile is placed in the first line of the two columns. Finding aids by a similar hand, but
+                                with a different pen and ink is placed at the end of each text part below the text as well as verse numbers and finding aids
+                                on top of the text throughout.</note>
+                            <msItem xml:id="ms_i4.1">
+                                <locus from="23ra" to="84rb"/>
+                                <title ref="LIT1558Matthew"/>
+                                    <msItem xml:id="ms_i4.1.1">
+                                        <locus from="23ra" to="23vb"/>
+                                        <title ref="LIT1558Matthew#TitlesMatthew"/>
+                                        <incipit xml:lang="gez">፩በእንተ፡ ሰብአ፡ ሰገል። ። ፪በእንተ፡ እለ፡ ተቀትሉ፡ ሕፃናት። ። </incipit>
+                                        <explicit xml:lang="gez">፷፰በእንተ፡ ዘከመ፡ ስእለ፡ ዮሴፍ፡ ሥጋሁ፡ ለእግዚእነ። ። አርእስተ፡ ነገር፡ እምወንጌለ፡ ማቴዎስ፡ ቅዱስ፡ ፷ወ፰። ። </explicit>
+                                    </msItem>
+                                    <msItem xml:id="ms_i4.1.2">
+                                        <locus from="25ra" to="84rb"/>
+                                        <title ref="LIT2709Matthew"/>
+                                        <incipit xml:lang="gez">መጽሐፈ፡ ልደቱ፡ ለኢየሱስ፡ ክርስቶስ፡ ወልደ፡ ዳዊት፡ ወልደ፡ አብርሃም።</incipit>
+                                        <explicit xml:lang="gez">ወመሀርዎሙ፡ ይዕቀቡ፡ ኵሎ፡ ዘአዘዝኩክሙ፡ ወናሁ፡ አነ፡ ሀለውኩ፡ ምስሌክሙ፡ በኵሉ፡ መዋዕል፡ እስከ፡ ኅልቀተ፡ ዓለም፡ 
+                                            አሜን። ።</explicit>
+                                        <note>The text of <title ref="LIT2709Matthew">Mt. 27,49b-50</title> on <locus target="#82rb"/>, that was 
+                                            according to Hammerschmidt possibly containing some phrases from <title ref="LIT1693John">Jo. 19,34</title>, 
+                                            has been erased and replaced by a shorter text by a later hand as indicated by 
+                                            <bibl><ptr target="bm:NestleAlandNTGrL1969"/></bibl> in his apparatus to Mt. 27,49.</note>
+                                    </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i4.2">
+                                <locus from="84va" to="121va"/>
+                                <title ref="LIT1882MarkGo"/>
+                                    <msItem xml:id="ms_i4.2.1">
+                                        <locus from="84va" to="85rb"/>
+                                        <title ref="LIT1882MarkGo#TituliMark"/>
+                                        <incipit xml:lang="gez">፩በእንተ፡ ዘጋኔን።</incipit>
+                                        <explicit xml:lang="gez">፵፰በእንተ፡ ስእለተ፡ ሥጋሁ፡ ለእግዚእነ።</explicit>
+                                    </msItem>
+                                    <msItem xml:id="ms_i4.2.2">
+                                        <locus from="87ra" to="121va"/>
+                                        <title ref="LIT2711Mark"/>
+                                        <incipit xml:lang="gez">ቀዳሚሁ፡ ለወንጌል፡ ኢየሱስ፡ ክርስቶስ፡ ወልደ፡ እግዚኣብሔር፡ በከመ፡ ጽሑፍ፡ ውስተ፡ ነቢያት፡ ናሁ፡ አነ፡ እፌኑ፡ መልአክየ፡ ቅድመ፡ ግጽከ፡
+                                            ዘይጸይሕ፡ ፍኖተከ። ።</incipit>
+                                        <explicit xml:lang="gez">ወነበረ፡ በየማነ፡ እግዚአብሔር፡ አቡሁ። ። ወወፂኦሙ፡ እምህየ፡ እሙንቱ፡ በኵልሄ፡ ሰበኩ፡ እንዘ፡ እግዚአብሔር፡ ይረድእ፡ ወቃሎ፡ ያጽንዕ፡ 
+                                            በትእምርት፡ ዘይተሉ፡ አሜን። ።</explicit>
+                                    </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i4.3">
+                                <locus from="121vb" to="183ra"/>
+                                <title ref="LIT1812GospelLuke"/>
+                                    <msItem xml:id="ms_i4.3.1">
+                                        <locus from="121vb" to="123ra"/>
+                                        <title ref="LIT1812GospelLuke#TituliLuke"/>
+                                        <incipit xml:lang="gez">፩በእንተ፡ ጻሕፍ።</incipit>
+                                        <explicit xml:lang="gez">፹፫በእንተ፡ ዘሰአለ፡ ሥጋሁ፡ ለእግዚእነ። ።</explicit>
+                                    </msItem>
+                                    <msItem xml:id="ms_i4.3.2">
+                                        <locus from="124ra" to="183ra"/>
+                                        <title ref="LIT2713Luke"/>
+                                        <incipit xml:lang="gez">እስመ፡ ብዙኃን፡ እለ፡ አኃዙ፡ ወጠኑ፡ ይንግሩ፡ ወይግበሩ፡ ወይሜህሩ፡ በእንተ፡ ግብር፡ ዘአምኑ፡ በላዕሌነ፡ በከመ፡ መሀሩነ፡ 
+                                            እለ፡ ቀደሙነ፡ ርእዮቶ፡ ወተልእክዎ፡ በቃሉ።</incipit>
+                                        <explicit xml:lang="gez">ወነበሩ፡ ቤተ፡ መቅደስ፡ ዘልፈ፡ እንዘ፡ ይሴብሕዎ፡ ወይባርክዎ፡ ለእግዚኣብሔር፡ ለዓለመ፡ ዓለም፡ አሜን። ። ።</explicit>
+                                    </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i4.4">
+                                <locus from="183rb" to="231vb"/>
+                                <title ref="LIT1693John"/>
+                                    <msItem xml:id="ms_i4.4.1">
+                                        <locus from="183rb" to="183va"/>
+                                        <title ref="LIT1693John#TituliJohn"/>
+                                        <incipit xml:lang="gez">፩በእንተ፡ ከብካብ፡ ዘበቃና።</incipit>
+                                        <explicit xml:lang="gez">፲፱በእንተ፡ ስእለተ፡ ሥጋሁ፡ ለእግዚእነ። ። አርእስት፡ ነገር፡ እምንጌለ፡ ዮሐንስ፡ ቅዱስ፡ ፲፱። ።</explicit>
+                                    </msItem>
+                                    <msItem xml:id="ms_i4.4.2">
+                                        <locus from="185ra" to="230vb"/>
+                                        <title ref="LIT2715John"></title>
+                                        <incipit xml:lang="gez">፩ቀዳሚሁ፡ ቃል፡ ውእቱ፡ ወውእቱ፡ ቃል፡ ኀበ፡ እግዚኣብሔር፡ ውእቱ።</incipit>
+                                        <explicit xml:lang="gez">ወቦ፡ ባዕደኒ፡ ብዙኅ፡ ዘገብረ፡ ኢየሱስ፡ ወሶበ፡ ተጽሕፈ፡ ኵሉ፡ በበ፡ አሐዱ፡ እመ፡ ኢያግመሮ፡ ዓለም፡ ጥቀ፡ መጻሕፍቲሁ፡
+                                            ዘተጽሕፈ። አሜን፡ አሜን። ።</explicit>
+                                    </msItem>
+                                <explicit xml:lang="gez">ወኮነ፡ ኵሉ፡ ድሙሩ፡ ቃሎሙ፡ ለአርባዕቱ፡ ወንጌላት። ፺፻፡ ፯፻። ወከመ፡ ታእምሩ፡ ኍልቈ፡ ቃላቲሆሙ፡ ለአርባዕቱ፡ ወንጌል። 
+                                    ጸሐፍነ፡ ለክሙ። ። ። በጸጋሁ፡ ለእግዚኣብሔር፡ ተፈጸመ፡ በሕየ፡ አርባዕቱ፡ ወንጌላት፡ ማቴዎስ፡ ወማርቆስ፡ ሉቃስ፡ ወዮሐንስ። ። ኵሉ፡ ቃላቱ፡ ለወንጌል፡ 
+                                    ጽድቅ። ወእምርእሱ፡ እስከ፡ ተፍጻሜቱ፡ ለሊሁ፡ ወልድ፡ ትናገረ። ። ።</explicit>
+                            </msItem>
+                        </msItem>
+                        <msItem xml:id="ms_i5">
+                            <locus from="231ra" to="232ra"/>
+                            <title ref="LIT1548Gessaw"/>
+                            <incipit xml:lang="gez"><add place="above">ገጻዌ፡ ሥርዓት፡</add>በእንተ፡ ኅብረተ፡ ቃላት፡ ዘአርባዕቱ፡ ወንጌላት፡</incipit>
+                            <explicit xml:lang="gez">አብኡ፡ መጥዎ፡ በእንተ፡ ኅብረተ፡ ቃላት፡ ዘቅዱሳን፡ አርባዕቱ፡ ወንጌላት፡ ተፈጸመ። ። </explicit>
+                        </msItem>
                     </msContents>
                     <physDesc>
                         <objectDesc form="Codex">
                             <supportDesc>
-                                <support><p/></support>
+                                <support>
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf" quantity="239">239</measure>
+                                    <note>Number of leaves contrary to <bibl><ptr target="bm:Hammerschmidt1973Tanasee"/><citedRange
+                                        unit="page">84</citedRange></bibl>, who counted 240 leaves.</note>
+                                    <note>Dimensions indicated below may concern outer dimensions of bookcover or dimensions of folia (not clearly 
+                                        specified in cataloque).</note>
+                                    <dimensions type="outer" unit="mm">                                        
+                                        <height cert="medium" unit="mm">380</height>
+                                        <width cert="medium" unit="mm">260</width>
+                                        <depth cert="medium" unit="mm">100</depth>
+                                    </dimensions>
+                                </extent>
+                                <foliation>Foliation marks on small pieces of paper, which were applied to the inner margin of every 5th recto when photographed. 
+                                    The folio mark for <locus target="#200"/> is missing. The folio mark '205r' is misplaced and actually indicates 
+                                    <locus target="#204r"/>. Following this mistake the mark '210r' is in fact placed on <locus target="#209r"/>and so on until to 
+                                    the end.</foliation>
+                                <collation>
+                                    <note>The quire structure is not discernible in the microfilmed images, but based on the contents and palaeographic analyses of the 
+                                        hands involved, the last quire, which may extend from <locus target="#233"/> to <locus target="#239"/> and which contains a 
+                                        number of additions and extras, may have been added to the codex later in a rebinding.</note>
+                                </collation>
+                                <condition key="good">Microfilm images in some places hardly legible, particularly on <locus from="1r" to="5v"/>, 
+                                    where several parts have been erased and are not legible in the images. Single words or several phrases erased and 
+                                    in some cases overwritten throughout the manuscript. Damaged by moisture on <locus target="#29v #30r #46v"/>.</condition>
                             </supportDesc>
+                            <layoutDesc>
+                                <layout columns="1" writtenLines="26">
+                                    <locus from="6r" to="7r"/>
+                                    <ab type="pricking">Pricking is not visible in the microfilm image.</ab>
+                                    <ab type="ruling">Ruling is not visible in the microfilm image.</ab>
+                                </layout>
+                                <layout columns="1" writtenLines="30">
+                                    <locus target="11v"/>
+                                    <ab type="pricking">Pricking is not visible in the microfilm image.</ab>
+                                    <ab type="ruling">Ruling is not visible in the microfilm image.</ab>
+                                </layout>
+                                <layout columns="2" writtenLines="26">
+                                    <locus from="22r" to="238v"/>
+                                    <ab type="pricking">Pricking is partly visible.</ab>
+                                    <ab type="ruling">Ruling is partly visible.</ab>
+                                </layout>
+                            </layoutDesc>
                         </objectDesc>
+                        <handDesc>
+                            <handNote xml:id="h1" script="Ethiopic">
+                                <seg type="ink">Black.</seg>
+                                <seg type="script">Script of the fourteenth to fifteenth century, angular and with triangular, rounded loops.</seg>
+                            </handNote>     
+                        </handDesc>
+                        <decoDesc>
+                            <decoNote xml:id="d1" type="frame">
+                                <locus target="#6r"/>
+                                <desc>Finely illuminated frame as described and reproduced in <bibl><ptr target="bm:Heldman1972miniatures"/>
+                                    <citedRange>Figure 85</citedRange></bibl> surrounding the text of the <ref target="LIT1349EpistlEusebius"/> 
+                                    as described in <ref target="#ms_i1"/></desc>
+                            </decoNote>
+                            <decoNote xml:id="d2" type="miniature">
+                                <locus target="#6v"/>
+                                <desc>Finely illuminated frame, that was described and reproduced in 
+                                    <bibl><ptr target="bm:LeroyÄth1968"/><citedRange>Abb. 430a</citedRange></bibl> and
+                                    <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 86</citedRange></bibl> 
+                                    surrounding the text of the <ref target="LIT1349EpistlEusebius"/> in <ref target="#ms_i1"/>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d3" type="miniature">
+                                <locus target="#7r"/>
+                                <desc>Finely illuminated frame, that was described and reproduced in 
+                                    <bibl><ptr target="bm:Leroy1962Recherches"/><citedRange>Figure 7</citedRange></bibl>, surrounding 
+                                    the text of <ref target="LIT1349EpistlEusebius"/> as described in <ref target="#ms_i1"/>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d4" type="frame">
+                                <locus target="#7v"/>
+                                <desc>Finely illuminated frame surrounding <ref target="LIT1224Canons"/> as described in <ref target="#ms_i2"/>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d5" type="frame">
+                                <locus target="#8r"/>
+                                <desc>Finely illuminated frame surrounding <ref target="LIT1224Canons"/> as described in <ref target="#ms_i2"/>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d6" type="frame">
+                                <locus target="#8v"/>
+                                <desc>Finely illuminated frame surrounding <ref target="LIT1224Canons"/> as described in <ref target="#ms_i2"/>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d7" type="frame">
+                                <locus target="#9r"/>
+                                <desc>Finely illuminated frame surrounding <ref target="LIT1224Canons"/> as described in <ref target="#ms_i2"/>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d8" type="frame">
+                                <locus target="#9v"/>
+                                <desc>Finely illuminated frame surrounding <ref target="LIT1224Canons"/> as described in <ref target="#ms_i2"/>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d9" type="frame">
+                                <locus target="#10r"/>
+                                <desc>Finely illuminated frame, that was described and reproduced in 
+                                    <bibl><ptr target="bm:Leroy1962Recherches"/><citedRange>Figure 8</citedRange></bibl>, surrounding
+                                    <ref target="LIT1224Canons"/> as described in <ref target="#ms_i2"/>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d10" type="frame">
+                                <locus target="#10v"/>
+                                <desc>Finely illuminated frame, that was described and reproduced in <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>10</citedRange></bibl>, 
+                                    surrounding <ref target="LIT1224Canons"/> in <ref target="#ms_i2"/>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d11" type="miniature">
+                                <locus target="#11r"/>
+                                <desc>Finely executed full-page miniature depicting a pavillon with a number of birds including two peacocks accompanied 
+                                    by two gazelles representing the Fountain of Life with some words added: <foreign xml:lang="gez">ባቡላ</foreign>, 
+                                    <foreign xml:lang="gez">ኑባሬ፡ ሥርዓት።</foreign> and <foreign xml:lang="gez">ባዙላ</foreign>. 
+                                    This miniature was described and reproduced 
+                                    in <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>Plate VII</citedRange></bibl>, 
+                                    <bibl><ptr target="bm:LeroyPittura1964"/><citedRange>Tavola II</citedRange></bibl>
+                                    and <bibl><ptr target="bm:Hammerschmidt1966KultsymbolikTafelband"/><citedRange unit="page">117</citedRange></bibl>. 
+                                    It has been depicted on a postal stamp by 1970. 
+                                    See <bibl><ptr target="bm:Leroy1962Recherches"/><citedRange unit="page">186</citedRange></bibl>, 
+                                    <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange unit="page">104-109</citedRange></bibl>,
+                                    <bibl><ptr target="bm:UnderwoodFountain1950"/><citedRange unit="page">43-138</citedRange></bibl>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d12" type="miniature">
+                                <locus target="#12r"/>
+                                <desc>Finely executed full-page miniature depicting the <ref type="authFile" corresp="AT1002Annunciation"/> described and 
+                                    reproduced in <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 87</citedRange></bibl>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d13" type="miniature">
+                                <locus target="#12v"/>
+                                <desc>Finely executed full-page miniature depicting the <ref type="authFile" corresp="AT1025NativityJesus"/>, described and 
+                                    reproduced in <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 88</citedRange></bibl>,
+                                    <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>Plate x</citedRange></bibl>, and in
+                                    <bibl><ptr target="bm:LeroyÄth1968LerÄth"/><citedRange>Tafel LII</citedRange></bibl>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d14" type="miniature">
+                                <locus target="#13r"/>
+                                <desc>Finely executed full-page miniature depicting <persName ref="PRS5684JesusCh"/> in the temple, described and 
+                                    reproduced in <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 89</citedRange></bibl> and 
+                                    in <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>Plate XII</citedRange></bibl>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d15" type="miniature">
+                                <locus target="#13v"/>
+                                <desc>Finely executed full-page miniature depicting the <persName ref="PRS6462MagiWi"></persName>, described 
+                                    and reproduced in <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 90</citedRange></bibl> 
+                                    and in <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>Plate XI</citedRange></bibl>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d16" type="miniature">
+                                <locus target="#14r"/>
+                                <desc>Finely executed full-page miniature depicting the <ref type="authFile" corresp="AT1020Massacre"/> described and 
+                                    reproduced in <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 91</citedRange></bibl>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d17" type="miniature">
+                                <locus target="#14v"/>
+                                <desc>Finely executed full-page miniature depicting the <ref type="authFile" corresp="AT1038Baptism"/> described and 
+                                    reproduced in <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 92</citedRange></bibl> 
+                                    and in <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>Plate XIII</citedRange></bibl>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d18" type="miniature">
+                                <locus target="#15r"/>
+                                <desc>Finely executed full-page miniature depicting <persName ref="PRS5684JesusCh"/> on Mount Tabor, described 
+                                    and reproduced in <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 93</citedRange></bibl>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d19" type="miniature">
+                                <locus from="15v" to="16r"/>
+                                <desc>Finely executed full-page miniature depicting the <ref type="authFile" corresp="AT1011Entry"/>, described and 
+                                    reproduced in <bibl><ptr target="bm:LeroyPittura1964"/><citedRange>Tavola I</citedRange></bibl> and in 
+                                    <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>Plate XIV</citedRange></bibl>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d20" type="miniature">
+                                <locus target="#16v"/>
+                                <desc>Finely executed full-page miniature depicting <ref type="authFile" corresp="AT1032Washing"/>, described and 
+                                    reproduced in <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>Plate XV</citedRange></bibl> and in
+                                    <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 94</citedRange></bibl>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d21" type="miniature">
+                                <locus target="#17r"/>
+                                <desc>Finely executed full-page miniature depicting the <ref type="authFile" corresp="AT1006Denial"/>, described and
+                                    reproduced and in <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 95</citedRange></bibl>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d22" type="miniature">
+                                <locus target="#17v"/>
+                                <desc>Finely executed full-page miniature depicting the <ref type="authFile" corresp="AT1003Arrest"/>, described and 
+                                    reproduced and in <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>Plate XVI</citedRange></bibl>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d23" type="miniature">
+                                <locus target="#18r"/>
+                                <desc>Finely executed full-page miniature depicting the <ref type="authFile" corresp="AT1005Crucifixion"/>, described 
+                                    and reproduced in <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>Plate XVII</citedRange></bibl> and 
+                                    in <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 96</citedRange></bibl>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d24" type="miniature">
+                                <locus target="#18v"/>
+                                <desc>Finely executed full-page miniature depicting the <ref type="authFile" corresp="AT1007Deposition"/>, described and 
+                                    reproduced in <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 97</citedRange></bibl>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d25" type="miniature">
+                                <locus target="#19r"/>
+                                <desc>Finely executed full-page miniature depicting the <ref type="authFile" corresp="AT1010Entombment"/>, described  
+                                    and reproduced in <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>Plate XVIII</citedRange></bibl>
+                                    and in <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 98</citedRange></bibl>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d26" type="miniature">
+                                <locus target="#19v"/>
+                                <desc>Finely executed full-page miniature depicting the Angel announcing the Resurrection of <persName ref="PRS5684JesusCh"/>
+                                    to the women, described and reproduced in <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>Plate XX</citedRange></bibl>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d27" type="miniature">
+                                <locus target="#20r"/>
+                                <desc>Finely executed full-page miniature depicting <ref type="authFile" corresp="AT1008Descent"/> , described and 
+                                    reproduced in <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>Plate XIX</citedRange></bibl>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d28" type="miniature">
+                                <locus target="#20v"/>
+                                <desc>Finely executed full-page miniature depicting <persName ref="PRS5695John"/> and <persName ref="PRS7805Peter"/>
+                                    at the tomb and the appearance of <persName ref="PRS5684JesusCh"/> to <persName ref="PRS6820MaryMag"/>, 
+                                    described and reproduced in <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 99</citedRange></bibl>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d29" type="miniature">
+                                <locus target="#21r"/>
+                                <desc>Finely executed full-page miniature depicting the <ref type="authFile" corresp="AT1033Ascension"/>, described and 
+                                    reproduced in <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 100</citedRange></bibl> and in
+                                    <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>Plate XXI</citedRange></bibl>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d30" type="miniature">
+                                <locus target="#24v"/>
+                                <desc>Finely executed full-page miniature depicting <persName ref="PRS6902Matthew"/>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d31" type="miniature">
+                                <locus target="#86v"/>
+                                <desc>Finely executed full-page miniature depicting <persName ref="PRS6751Mark"/>, described and reproduced in 
+                                    <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>Plate VIII</citedRange></bibl> and in 
+                                    <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 101</citedRange></bibl>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d32" type="miniature">
+                                <locus target="#123v"/>
+                                <desc>Finely executed full-page miniature depicting <persName ref="PRS6387Luke"/>, described and reproduced in 
+                                    <bibl><ptr target="bm:LeroyEthMss1961"/><citedRange>Plate IX</citedRange></bibl> and in 
+                                    <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 102</citedRange></bibl>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d33" type="miniature">
+                                <locus target="#184v"/>
+                                <desc>Finely executed full-page miniature depicting <persName ref="PRS5695John"/>, described and reproduced in
+                                    <bibl><ptr target="bm:Heldman1972miniatures"/><citedRange>Figure 103</citedRange></bibl>.</desc>
+                            </decoNote>
+                        </decoDesc>
+                        <additions>
+                            <list>
+                                <item xml:id="a1">
+                                    <locus target="#3ra"/>
+                                    <desc type="Record">Stipulations for the comemoration of <persName ref="PRS8595SayfaAr"/> 
+                                        (Tazkāra Sayfa ʾArʿād) dated to <date when="1412">29th july 1412</date> corresponding to 
+                                        <date when-custom="64" calendar="grace">5th Naḥase 64</date> that is during the reign of 
+                                        <persName ref="PRS3429DawitII"/> and <persName ref="PRS2469Bartalom"/>.</desc>
+                                </item>
+                                <item xml:id="a2">
+                                    <locus target="#3ra"/>
+                                    <desc type="ScribalSupplication">Scribal supplication with a similar hand as <ref target="#a3"/></desc>
+                                </item>
+                                <item xml:id="a3">
+                                    <locus target="#3rb"/>
+                                    <desc type="ScribalSupplication">Scribal supplication naming <persName ref="PRS14048Petros"/> as a scribe with
+                                        a similar hand as <ref target="#a2"/>.</desc>
+                                </item>
+                                <item xml:id="a4">
+                                    <locus target="#3va"/>
+                                    <desc type="Unclear">Almost completely erased and not legible text.</desc>
+                                </item>
+                                <item xml:id="a5">
+                                    <locus target="#3vb"/>
+                                    <desc type="LandGrant">Account of donations from <persName ref="PRS1854Amdase"/> to 
+                                        <persName ref="PRS10688Zayohan"/>, written in three different hands.</desc>
+                                </item>
+                                <item xml:id="a6">
+                                    <locus from="4ra" to="4rb"/>
+                                    <desc type="Inventory">List of the church utensils of Kəbrān with spaces left for the numbers 
+                                        of the individual furnishings: <foreign xml:lang="gez">ተጽሕፈት፡ ኆልቈ፡ ንዋየ፡ ቤተ፡ ክርስቲያን፡ ዘተረከበ፡ በሢመቱ፡ አቡነ፡ 
+                                        <persName ref="PRS14049GabraMasqal">ገብረ፡ መስቀል፡</persName><gap reason="omitted" unit="chars" quantity="1"/> 
+                                         ዘነቦ፡ ወርቅ፡ <gap reason="ellipsis"/>የሲሕ፡ ለዓጠኒ፡ ልብሰ፡ ዘበዐላት፡ </foreign>.</desc>
+                                </item>
+                                <item xml:id="a7">
+                                    <locus target="#4rb"/>
+                                    <desc type="RecordTransaction">Transaction note in Amharic.</desc>
+                                </item>
+                                <item xml:id="a8">
+                                    <locus target="#4va"/>
+                                    <desc type="Record">Note stating, that <persName ref="PRS7481NaodA"/> visited <placeName ref="LOC1602Atrons"/>
+                                        <date calendar="qamar" when-custom="159" when="1507" ref="ethiocal:Maggabit"> in the month of Maggābit in 
+                                            the year 159 ʿAmata məḥrat</date>.</desc>
+                                </item>
+                                <item xml:id="a9">
+                                    <locus target="#4va"/>
+                                     <desc type="Inventory">Note on church utensils by a rather early hand written on a previously effaced part of the folio: 
+                                         <foreign xml:lang="gez">ይቤሉ፡ ቅዱሳን፡ ዘደብረ፡ ክብራ፡ በእንተ፡ ሠርፀ፡ ማርያም፡ ቀሲስ፡ ዘጻመወ፡ ላቲ፡ ለቤተ፡ ክርስቲያን፡ ፴ወ፪፡ ወቂት፡ ወርቅ። 
+                                             አልህምት፡ ፴ወ፫። መስቀል፡ ፫፡ ታቦታት፡ ፯። <gap reason="ellipsis" unit="lines" quantity="7"/> ምጽሕርት፡ ዘኀፂን። </foreign></desc>
+                                </item>
+                                <item xml:id="a10">
+                                    <locus target="#4vb"/>
+                                    <desc type="Unclear"><foreign xml:lang="gez">ዘኀፂ<gap reason="illegible" unit="chars" quantity="2"/>ላ። አርጋኖን። 
+                                        ፪ሥዕል። </foreign>Possibly the last line of an inventory, that was written on the first column of this folio, effaced
+                                        and rewritten with another inventory in <ref target="#a9"/>.</desc>
+                                </item>
+                                <item xml:id="a11">
+                                    <locus target="#4vb"/>
+                                    <desc type="MixedNote">Commemorative note (Tazkār) on a person named 
+                                        <persName ref="PRS14080SardaMaryam">ሠርፀ፡ ማርያም፡</persName>, who donated to the church of Māryām by
+                                            a similar hand as <ref target="#a12 #a13"></ref>.</desc>
+                                </item>
+                                <item xml:id="a12">
+                                    <locus target="#5ra"/>
+                                    <desc type="Inventory">Note on church utensils, that Nəbuəraʾəd <persName ref="PRS14081TanseaKrestos"/> 
+                                        donated to Kəbrān by a similar hand as <ref target="#a11 #a13"/>: 
+                                        <foreign xml:lang="gez">ወዘንተ፡ ንዋየ፡ ቤተ፡ ክርስቲያን፡ ዘወሀበ፡ ንቡረ፡ እድ፡ 
+                                            <persName ref="PRS14081TanseaKrestos">ተንሥአ፡ ክርስቶስ፡</persName> ለመካነ፡ ገብርኤል፡ ወለማርያም፡ 
+                                            ፪አጽሕልት፡ ዘወርቅ፡ ወ፪፡ ጽዋዕ፡ ዘወርቅ። <gap reason="ellipsis" unit="lines" quantity="16"/></foreign></desc>
+                                </item>
+                                <item xml:id="a13">
+                                    <locus from="5va" to="5vb"/>
+                                    <desc>Order of <persName ref="PRS6229LebnaDe"/> for the distribution of land when he celebrated Easter in 
+                                        <placeName ref="LOC5733Sima"/> by a similar hand as <ref target="#a11 #a12"/>.</desc>
+                                </item>
+                                <item xml:id="a14">
+                                    <locus target="#11v"/>
+                                    <desc>Order of  <persName ref="PRS8550sardaDe"/> and ʾƎtege <persName ref="PRS1429AdmasMo"/> 
+                                        on the leadership of Kebran.</desc>
+                                </item>
+                                <item xml:id="a15">
+                                    <locus from="22ra" to="22rb"/>
+                                    <desc>Note on the construction of the church, that is infact supposed to be its restoration, that is stated to have begun 
+                                        in <date when="1598"/> in the time of <persName ref="PRS10198Yaeqob"/> and that was completed on 15th Maggābit
+                                        in the 8th year of <persName ref="PRS9038Susenyos"/> e.g. <date when="1615"/>: <foreign xml:lang="gez">ተፈጸመ፡ 
+                                        ሕንፃ፡ ቤተ፡ ክርስቲያን፡ አመ፡ <date when="1615">፲ወ፭፡ ለመጋቢት፡ በ፲ወ፯፡ አመት</date>፡ እምዘ፡ ተወጥነ፡ ወዘመኑሂ፡ ዘመነ፡ ንጉሥ፡ 
+                                        <persName ref="PRS10198Yaeqob">ያዕቆብ፡</persName> ወፍጻሜሁሰ፡ ኮነ፡ በዘመነ፡ ንጉሥ፡ 
+                                        <persName ref="PRS9038Susenyos">ስልጣን፡ ሰገድ፡</persName> እምዘ፡ ነግሡ፡ በ፰፡ አመት፡ <gap reason="ellipsis"/></foreign></desc>
+                                </item> 
+                                <item xml:id="a17">
+                                    <locus target="#23v"/>
+                                    <desc type="RecordTransaction">Note on the bottom margin in smaller script and unclear readings in some places 
+                                        because of the low quality of images.</desc>
+                                </item>
+                                <item xml:id="a18">
+                                    <locus from="85va" to="85vb"/>
+                                    <desc type="ReceiptNote">Note possibly on the transaction or emancipation of slaves.</desc>
+                                </item>
+                                <item xml:id="a19">
+                                    <locus target="#85vb"/>
+                                    <desc>Note by another hand of the eighteenth or nineteenth century in much smaller height containing the character
+                                        ዠ in a special archaic form with hashes at the lower ends of the legs.</desc>
+                                </item>
+                                <item xml:id="a20">
+                                    <locus from="234va" to="234vb"/>
+                                    <desc type="MixedNote">Commemorative note (Tazkār) on nəburaʾed 
+                                        <persName ref="PRS14086Qalementos">ቀሌምንጦስ፡</persName>: <foreign xml:lang="gez">ተዝካረ፡ ዘአዘዝኩ፡ ሎሙ፡ 
+                                         አነ፡ <persName ref="PRS14086Qalementos">ቀሌምንጦስ፡</persName> ንቡረ፡ እድ፡ በመዋዕለ፡ ዳዊት፡ ንጉሥ፡ ለአበዊየ፡ ካህናት፡ 
+                                         ዘደብረ፡ ክብራን። እሉ፡ እሙንቱ፡ ፯፡ በዐላት፡ ዐበይት። <gap reason="ellipsis"/></foreign>.</desc>
+                                </item>
+                                <item xml:id="a21">
+                                    <locus from="234vb" to="235ra"/>
+                                    <desc type="Record">Record of a letter to <persName ref="PRS14087BasaTegest">ባሳ፡ ትዕግሥት፡</persName>
+                                        by a the community of Kəbrān during the reign of <persName ref="PRS10626ZaraY"/>.</desc>
+                                </item>
+                                <item xml:id="a22">
+                                    <locus target="#235rb"/>
+                                    <desc type="RecordTransaction">Note confirming the inheritance of two houses to <persName ref="PRS14102Estifanos"/>,
+                                        possibly the same person recorded in <ref target="#e16"/>: <foreign xml:lang="gez">ወንሕነኒ፡ በኅብረተ፡ ቃል፡ ወሀብኖ፡ ቤተ፡ 
+                                        <persName ref="PRS14105Damatewos">ደማቴዎስ፡</persName> 
+                                        ወቤተ፡ <persName ref="PRS14104Abreham">አብርሃም፡</persName> 
+                                        ይኩኖ፡ ርስተ፡ በሞቱ፡ ወበሕይወቱ፡ ለአቡነ፡ <persName ref="PRS14102Estifanos">እስጢፋኖስ፡</persName> ወእምድኅሬሁ፡ ይኩን፡ 
+                                        ለወልዱ፡ <persName ref="PRS14103Ishaq">ይስሐቅ፡ </persName><gap reason="ellipsis"/></foreign></desc>
+                                </item>
+                                <item xml:id="a23">
+                                    <locus from="235va" to="235vb"/>
+                                    <desc type="MixedNote">Instruction of King <persName ref="PRS3429DawitII"/> to commemorate the death (Tazkār) 
+                                        of his father and predecessor <persName ref="PRS8595SayfaAr"/> on 15 Gənbot and of his mother 
+                                        <persName ref="PRS14166LazabWarqa"/> on 12 Sane in the region of <placeName ref="LOC5888Tana"/>.
+                                        The text mentions the 34th year of the reign of <persName ref="PRS3429DawitII"/> as the date of this addition. 
+                                        According to <bibl><ptr target="bm:Tadesse1974Succession"/></bibl>, this indicates a lasting power struggle with 
+                                        his brother <persName ref="PRS7559NewayaM"/> whom he succeeded after his death in <date when="1380"/>, 
+                                        but according to this note started to count his regnal years earlier than that.</desc>
+                                </item>
+                                <item xml:id="a24">
+                                    <locus from="236ra" to="236va"/>
+                                    <desc type="LandGrant">Landgrant of King <persName ref="PRS10342Yeshaq">Yəsḥaq</persName> with a very similar incipit,
+                                        to the aforementioned <ref target="#a23"/>, by a similar hand.</desc>
+                                </item>
+                                <item xml:id="a25">
+                                    <locus target="#236vb"/>
+                                    <desc type="LandGrant">Notice of <persName ref="PRS14148Nob"/> granting land to the community of Kəbrān.</desc>
+                                </item>
+                                <item xml:id="a26">
+                                    <locus target="#236vb"/>
+                                    <desc type="LandGrant">Notice by a similar hand as <ref target="#a25"/> directly above.</desc>
+                                </item>
+                                <item xml:id="a27">
+                                    <locus target="#237ra"/>
+                                    <desc type="LandGrant">Note written by a hand similar to that of the previous <ref target="#a25 #a26"/>, but taller 
+                                        and written with an irregular margin to the right on a land grant in the time of <persName ref="PRS6229LebnaDe"/>.</desc>
+                                </item>
+                                <item xml:id="a28">
+                                    <locus target="#237ra"/>
+                                    <desc type="LandGrant"/>
+                                </item>
+                                <item xml:id="a29">
+                                    <locus target="#237va"/>
+                                    <desc type="LandGrant">Land grant written in very small characters and partly not legible in the microfilm images: 
+                                        <foreign xml:lang="gez">ኍልቈ፡ ምድር፡ ዘወራሚት፡ ቢኖራ፡ ፪ምድር፡ ዘ፩ምድር፡ 
+                                            <gap reason="ellipsis" unit="lines" quantity="19"/></foreign></desc>
+                                </item>
+                                <item xml:id="a30">
+                                    <locus target="#237vb"/>
+                                    <desc type="LandGrant">Land grants issued by a king named <foreign xml:lang="gez">አድያም፡ ሰገድ፡</foreign>, who can be 
+                                        identified as either <persName ref="PRS5616IyasuI"/>, <persName ref="PRS5617IyasuII"/> or 
+                                        <persName ref="PRS5636IyoasI"/>.</desc>
+                                </item>
+                                <item xml:id="a31">
+                                    <locus target="#237vb"/>
+                                    <desc type="RecordDistribution">Possibly a record of taxes to be distributed to a number of local chiefs.</desc>
+                                </item>
+                                <item xml:id="e1">
+                                    <locus target="#2r"/>
+                                    <desc type="OwnershipNote"><foreign xml:lang="gez">ዘደሴት፡ ቅዱስ፡ ገብርኤል፡ መጽሐ።</foreign> by a modern Ethiopian 
+                                        hand on top of the folio with previously erased text.</desc>
+                                </item>
+                                <item xml:id="e2">
+                                    <locus target="#4va"/>
+                                    <desc type="findingAid">List of Biblical books: <foreign xml:lang="gez">ኦሪት፡ ዮዲት፡ ሕዝቅኢል፡ ዮዲት፡ አስቴር፡ በ፡ ኩፋሌ፡ ዳዊት፡ 
+                                        ጥበበ፡ ሰሎሞን፡ </foreign></desc>
+                                </item>
+                                <item xml:id="e3">
+                                    <locus target="#85va"/>
+                                    <desc type="DonationNote">Donation note covering 11 lines of the first column with a reference to 
+                                        <persName ref="PRS5616IyasuI"/> or <persName ref="PRS5617IyasuII"/> placed above by another hand. </desc>
+                                </item>
+                                <item xml:id="e4">
+                                    <locus target="#183ra"/>
+                                    <desc type="DonationNote"><foreign xml:lang="gez">ኈልቈ፡ ሀገር፡ ዘመሀብዎ፡ ንጉሥነ፡ 
+                                        <persName ref="PRS5616IyasuI">አድያም፡ ሰገድ፡ </persName>ለመካነ፡ ገብርኤል፡ <gap reason="ellipsis"></gap></foreign></desc>
+                                </item>
+                                <item xml:id="e5">
+                                    <locus target="#184ra"/>
+                                    <desc type="LandGrant"><foreign xml:lang="gez"><persName ref="PRS8550sardaDe">አጼ፡ ሰርጸ፡ ድንግል፡</persName> ዘወሀብዎ፡ 
+                                        ለመቅቅደስ፡ ገብርኤል፡ <gap reason="ellipsis"/>ወጉልቶሙሂ፡ ወሀበ፡ ለመቅደሰ፡ ገብርኤል፡ ዘክብራን፡<gap reason="ellipsis"/></foreign></desc>
+                                </item>
+                                <item xml:id="e6">
+                                    <locus target="#184ra"/>
+                                    <desc type="DonationNote">On the bottom of the page: <foreign xml:lang="gez">በዝየ፡ ከነ፡ ጉባኤ፡ 
+                                        <placeName ref="LOC1071Acafar">አቸፈር፡</placeName> በዘነግሠ፡ 
+                                        <date notBefore="1633" notAfter="1634">በደግማይ፡ ዓመተ፡ መንግሥቱ፡ </date> 
+                                        ለንጉሥ፡ <persName ref="PRS4015Fasilada">ፋሲል፡</persName><gap reason="ellipsis"/></foreign></desc>
+                                </item>
+                                <item xml:id="e7">
+                                    <locus target="#184rb"/>
+                                    <desc type="DonationNote"><foreign xml:lang="gez">ጸሐፍነ፡ ዘገብረ፡ በዘመኑ፡ ንጉሠ፡ ሰላም፡ 
+                                        <persName ref="PRS4015Fasilada">ፋሲለደስ፡ </persName> ዘተሰምየ፡ በ<add>በ</add>ፈቃደ፡ እግዚአብሔር፡ ዘወሀበ፡ ጉልታተ፡ 
+                                        ሀገር፡ ለመቅደሰ፡ ክብራን፡ ገብርኤል፡ <gap reason="ellipsis"/></foreign></desc>
+                                </item>
+                                <item xml:id="e8">
+                                    <locus target="#232rb"/>
+                                    <desc type="DonationNote"><foreign xml:lang="gez">ወሀብኩ፡ አነ፡ 
+                                        <persName ref="PRS14084NagadaKrestos">ነገደ፡ ክርስቶስ፡</persName> ዘንተ፡ መጽሐፈ፡ ወንጌል፡ ለማርያም፡ ቅድስት፡ ዘክብራን፡<gap reason="ellipsis"/></foreign></desc>
+                                </item>
+                                <item xml:id="e9"> 
+                                    <locus from="232va" to="233ra"/>
+                                    <desc type="DonationNote">Note on the Donation of manuscripts and church utensils to Kəbrān of a similar hand as the
+                                        main text: <foreign xml:lang="gez">በስመ፡ ሥሉስ፡ ቅዱስ፡ ኍልቈ፡ መጻሕፍት፡ ዘደብረ፡ ክብራ፡ ከመዝ፡ ውእቱ፡ ፰ዘአስተጋባእነ፡ ክልኤቱ፡ አኀው፡ 
+                                        ምስኪናን፡ ከመ፡ ይኵነነ፡ ለመድኅኒተ፡ ኃጢአትን። <gap reason="ellipsis"/></foreign></desc>
+                                </item>
+                                <item xml:id="e10">
+                                    <locus target="#79ra #79va #82va #83rb #84rb"/>
+                                    <desc type="findingAid">Finding aids above the text and at the end of each Evangile book, and verse numbers by later hand 
+                                        throughout.</desc>
+                                </item>
+                                <item xml:id="e11">
+                                    <locus target="#232ra"/>
+                                    <desc type="Unclear">Note in very small height: <foreign xml:lang="gez">ስምዑ፡ ኦሰብእ፡ ደብር፡
+                                        ዓቢይ፡ ወንኡስ፡ ናሁ፡ ተሣየጥኩ፡ አነ፡ አትናቴዎስ፡ እምነ፡ ዘድንግል፡ ወልደ፡ አባ፡ ዳምጻ፡ ቤቱ፡ ወምድሩ፡ <gap reason="ellipsis"/></foreign></desc>
+                                </item>
+                                <item xml:id="e12">
+                                    <locus target="#233rb"/>
+                                    <desc type="DonationNote">Note on a donation from <persName ref="PRS10473Yostos"/> to Kəbrān: 
+                                        <foreign xml:lang="gez">ናሁ፡ ወኀብኩ፡ አነ፡ ዘድንግል፡ ምድረ፡ ኩብዝት፡ ለመቅደስ፡ ገብርኤል፡ ክብራን፡ በትእዛዘ፡ ንጉሥ፡ 
+                                        <persName ref="PRS10473Yostos">ፀሐይ፡ ሰገድ፡ </persName>ወበጸጋ፡ እግዚአብሔር፡ ዘተሠምየ፡ ኢያሱ፡ ወእንዘ፡ ወልደ፡ ልዑል፡ 
+                                         ቤት፡ ወደድ፡ ከመ፡ ይኩነኒ፡ ለምድኃኒተ፡ ሥጋ፡ ወነፍስ።</foreign></desc>
+                                </item>
+                                <item xml:id="e13">
+                                    <locus target="#233va"/>
+                                    <desc type="DonationNote">Note on the donation from <persName ref="PRS14085Baseleyos"/> to Kəbrān: 
+                                        <foreign xml:lang="gez">በስመ፡ ስሉሥ፡ ቅዱስ፡ ወሀብኩ፡ አነ፡ <persName ref="PRS14085Baseleyos">ባስሌዮስ፡</persName> 
+                                        ለዮሐንስ፡ ወለገብርኤል፡ ወለማርያም፡ ዘደብረ፡ ክብራን። መጻሕፍት፡ ወንጌል፡ ፩፡ ጳውሎስ፡ ፩፡ <gap reason="ellipsis"/></foreign></desc>
+                                </item>
+                                <item xml:id="e14">
+                                    <locus from="233vb"  to="234r"/>
+                                    <desc type="Inventory">Note in a tall size, on the books of Kəbrān since the time of <persName ref="PRS8595SayfaAr"/>
+                                        and <persName ref="PRS8387SalamaI"/>. However the note is likely to be copied later, because also 
+                                        <persName ref="PRS3429DawitII"/> is mentioned, what indicates a date for this addition not before 
+                                        <date notBefore="1380">1380</date>. The list was continued in <ref target="#e15"/>.</desc>
+                                </item>
+                                <item xml:id="e15">
+                                    <locus from="234r" to="234v"/>
+                                    <desc type="Inventory">Continuation of the aforementioned inventory list in <ref target="#e14"/> by a later hand.</desc>
+                                </item>
+                                <item xml:id="e16">
+                                    <locus from="235ra"/>
+                                    <desc type="OwnershipNote">Short note below <ref target="#a21"/>: <foreign xml:lang="gez">ዝንቱ፡ ክታብ፡ 
+                                        ዘ<persName ref="PRS14094Estifanos">እስጢፋኖስ፡</persName></foreign></desc>
+                                </item>
+                                <item xml:id="e17">
+                                    <locus from="235ra" to="235rb"/>
+                                    <desc type="DonationNote">Note on the donation of church utensils to Kəbrān by person with the name 
+                                        <persName ref="PRS14095Estifanos">እስጢፋኖስ</persName>, possibly the same, who claimed ownership to this codex 
+                                        in <ref target="#e16"/> by a similar hand: <foreign xml:lang="gez">ወሀብኩ፡ አነ፡ 
+                                        <persName ref="PRS14095Estifanos">እስጢፋኖስ፡</persName> ዘንተ፡ ንዋየ፡ ለመካነ፡ ገብርኤል፡ ወማርያም፡ ለተዝካርየ፡ ወለመድኃኒተ፡ ነፍስየ፡ 
+                                        ፫አዕማሰ፡ የሲኅ፡ ፪። የስንዳሌ፡ ክዳን፡ ፩። <gap reason="ellipsis"/></foreign>.</desc>
+                                </item>
+                                <item xml:id="e18">
+                                    <locus target="#235rb"/>
+                                    <desc type="ReceiptNote">Receipt for the sale of land for the price of four young cows by with several clergymen 
+                                        recorded as witnesses, that are mostly the same as in <ref target="#e18"/>.</desc>
+                                </item>
+                                <item xml:id="e19">
+                                    <locus target="#235rb"/>
+                                    <desc type="ReceiptNote">Receipt for the sale of land by a similar hand, with a similar content and mostly the same persons 
+                                        as witnesses as in <ref target="#e17"/>.</desc>
+                                </item>
+                                <item xml:id="e20">
+                                    <locus target="#236va"/>
+                                    <desc type="OwnershipNote">Note, written by a hand similar to the previous <ref target="#a24"/>, but with a smaller 
+                                        pen and similar to <ref target="e20"/>: <foreign xml:lang="gez">በስመ፡ ሥሉስ፡ ቅዱስ፡ ትጽሕፈት፡ ዛቲ፡ መጽሐፍ፡ ወሀብዎ፡ ቅዱሳን፡ 
+                                        ለ<persName ref="PRS14142GabraBerhan">ገብረ፡ ብርሃን፡</persName> ቤተ፡ ዘነበረ፡ ቅድመ፡ 
+                                        ለ<persName ref="PRS14143TasfaMasqal">ተስፋ፡ መስቀል፡</persName> ከመ፡ ይኩኖ፡ ርስት፡ ለወልዱ፡ ኢኮነ፡ በእንተ፡ ነጋሢነት፡ 
+                                        ዘወሀብዎ፡ በእንተ፡ ፍትረ፡ ገብርኤል፡ ወሀብዎ፡ ለተዘካር፡ በሕይወቶ፡ ወበሞቱ፡ ኵሉ፡ ጊዜ፡ ለዓለመ፡ ዓለም። ። </foreign></desc>
+                                </item>
+                                <item xml:id="e21">
+                                    <locus target="#236va"/>
+                                    <desc type="ScribalNoteCommissioning">Scribal note, that mentions <persName ref="PRS6229LebnaDe"/> and also
+                                        <persName ref="PRS14077FereKrestos"/> and <persName ref="PRS14088TaklaSyon"/>, two dignitaries, who are
+                                        also mentioned in <ref target="#a21"/>. Written by a hand similar to the one of the previous <ref target="#a24"/> 
+                                        and <ref target="#e19"/>.</desc>
+                                </item>
+                                <item xml:id="e22">
+                                    <locus target="#237va"/>
+                                    <desc type="Inventory">Note with very low character height and irregular lines and margins, mentioning a number of church utensils
+                                        of the church of Kəbrān which was originally included into another codex containing a <ref target="LIT1955Mashaf"/>, as indicated at the
+                                        end of the brief note.</desc>
+                                </item>
+                                <item xml:id="e23">
+                                    <locus target="#237va"/>
+                                    <desc type="ReceiptNote">Note of goods given to the church of Kəbrān: <foreign xml:lang="gez">ወሀብኩ፡ ንዋየ፡ 
+                                        ለክብራን፡ ለቅዱስ፡ ገብርኤል፡ <gap reason="ellipsis" unit="lines" quantity="12"/></foreign></desc>    
+                                </item>
+                            </list>
+                        </additions>
+                        <bindingDesc>
+                            <binding>
+                                <decoNote xml:id="b1" type="Boards">Two wooden boards covered with leather.</decoNote>    
+                                <decoNote xml:id="b2" type="SewingStations">4</decoNote>
+                                <decoNote xml:id="b3" type="bindingMaterial"><material key="wood"></material></decoNote>
+                            </binding>
+                        </bindingDesc>
                     </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1350" notAfter="1412" evidence="internal-date">Palaeographic analysis indicates that the manuscript 
+                                dates from the late 14th or early 15th century. This dating is supported by an addition <ref target="#a1"/>, which has 
+                                <date when="1412"/> as date for this addition. However this early dating of the manuscript is contradicted by a scribal 
+                                supplication in <ref target="#e20"/>, which dates the manuscript to the mid-16th century, but which is at odds with another scribal 
+                                supplication in <ref target="#a3"/> and is most likely a supplication referring to another codex on a folio, which was
+                                added later to the codex in a rebinding. This view is supported by <ref target="#e21"/> in the same quire, that contains 
+                                a reference to the <ref target="LIT1955Mashaf"/>, that is not included in this volume.</origDate>
+                        </origin>
+                    </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
@@ -67,15 +740,300 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <langUsage>
                 <language ident="en">English</language>
+                <language ident="am">Amharic</language>
+                <language ident="gez">Gəʿəz</language>
             </langUsage>
         </profileDesc>
         <revisionDesc>
             <change who="PL" when="2021-02-09">Created XML record from table </change>
+            <change when="2023-07-20" who="CH">Added contents and physical description.</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">
         <body>
-            <ab/>
+            <div type="edition" xml:lang="gez" corresp="#a1">
+                <ab>በአኰቴተ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ተጽሕፈት፡ ዛቲ፡ መጽሐፍ፡ በ<date when="1412" when-custom="64" calendar="grace">
+                    ፷፬፡ ዓመተ፡ ምሕረት፡ በወርኃ፡ ነሐሴ፡ አመ፡ ፭፡</date> በሠርቀ፡ መዓልት፡ ወአመ፡ ፳፭፡ በሠርቀ፡ ሌሊት፡ ወእንዘ፡ ንጉሥነ፡ 
+                    <persName ref="PRS3429DawitII">ዳዊት፡</persName> ዘተሰምየ፡ ቈስጢንጢኖስ፡ ወእንዘ፡ ጳጳስ<add place="above">ነ</add>፡ 
+                    አባ፡ <persName ref="PRS2469Bartalom">በርተሎሜዎስ፡</persName> ወእንዘ፡ <placeName ref="LOC3549Gojjam">ጐዛም፡</placeName>
+                    ነጋሢ፡ <persName ref="PRS14167MaataGwane">መዓተ፡ ጐኔ፡</persName> 
+                    ወእንዘ፡ <placeName ref="LOC1713Bagemd">በጌምድር፡</placeName><persName ref="PRS14168Delmangasa">ድልመንገሣ፡</persName> 
+                    ወእንዘ፡ ንቡረ፡ እድ፡ <persName ref="PRS14169KrestosMadhen">ክርስቶስ፡ መድኅን።</persName> ተሠርዓት፡ ተዝካር፡ በደብረ፡ ክብራን፡ ዘንጉሥ፡ 
+                    <persName ref="PRS8595SayfaAr">ሰይፈ፡ ዐርአደ፡</persName> አመ፡ ፲፭፡ እም<gap reason="omitted"/></ab>
+            </div>
+            <div type="edition" xml:lang="gez" corresp="#a2">
+                <ab>ሰሰዮሙሂ፡ ሠራዕኩ፡ እምቍቢጸ፡ ዘነበረ፡ ቀዳሚ፡ ለግብር። ወለግብርሂ፡ ሠራዕኩ፡ ክነመስዳ፡ ወ<add place="above">ለ</add>እገና። ወዘንተ፡ ሥርዓተ፡ 
+                    ዘአብጠለ፡ ዘሄደ፡ ወዘተዓገለ፡ ውጉዘ፡ ለይኩን፡ በአፈ፡ ነቢያት፡ ወሐዋርያት፡ በአፈ፡ ጻድቃን፡ ወሰማዕት፡ በአፈ፡ ሚካኤል፡ ወገብርኤል፡ በአፈ፡ ፫፻፲፰፡ ርቱዓነ፡ ሃይማኖት፡ በአፈ፡ 
+                    አቡነ፡ <persName ref="PRS10688Zayohan">ዘዮሐንስ፡ </persName>በአፈ፡ አግአዝእትነ፡ ማርያም፡ በአፈ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ውጉዘ፡ 
+                    ለይኩን፡ ለዓለም፡ አሜን። </ab>
+            </div>
+            <div type="edition" xml:lang="gez" corresp="#a3">
+                <ab>በስመ፡ ሥሉስ፡ ቅዱስ፡ ቅዱስ፡ አጽሐፍኩ፡ አነ፡ <persName ref="PRS14048Petros">ጴጥሮስ፡</persName> ለደብረ፡ ክብራ፡ ቅዱስ፡ ዝይከውነኒ፡ ለመድኅኒተ፡ 
+                    ነፍስ፡ ዘሐኒታ፡ ወይነ፡ ዘወሀብዋ፡ አበዊነ፡ ቀደምት፡ ወደኅረሂ፡ ዘነሥአዋ፡ በትእግልት። <gap reason="ellipsis"/> በአፈ፡ ነቢያት፡ ወሐዋርያት፡ በአፈ፡ ጻድቅን፡ ወሰማዕት፡ 
+                    በአፈ፡ ሚካኤል፡ ወገብርኤል። በአፈ፡ ፫፻፲፰፡ ርቱዓነ፡ ሃይማኖት፡በአፈ፡ አግዝእትነ፡ ማርያም። በአፈ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ቅውመ፡ ወጉዘ፡ ወውቦአ፡ እመንግሥተ፡ 
+                    እግዚአብሔር፡ ለይኩን፡ አሜን። ወሊተኒ፡ ዝክሩኒ፡ በጸሎትክሙ፡ ለትውልደ፡ ትውልድክሙ፡ አሜን። ።</ab>
+            </div>
+            <div type="edition" xml:lang="gez" corresp="#a5">
+                <ab>ንጉሥኒ፡ <persName ref="PRS1854Amdase">አምደ፡ ጽዮን፡ </persName>መጽአ፡ ኀቤሁ፡ በፍሥሐ፡ ዐቢይ፡ ከመ፡ ይትባረክ፡ እምኀበ፡ አቡነ፡ 
+                    <persName ref="PRS10688Zayohan">ዘዮሐንስ፡</persName><gap reason="ellipsis"/> ወወሀቦ፡ ብዙኃተ፡ እምድረ፡
+                    አዳማ፡ እስከ፡ ባሕር፡ እስከ፡ ወሰና፡ ለግዮን፡ እስከ፡ ቱምሐ፡ ወእ<add place="above">ስ</add>ከ፡ <add place="above">አገው፡ </add>
+                    <gap reason="ellipsis"/>እመጽሐፈ፡ ሕይወት፡ ለዓለመ፡ አለም፡ አሜን።</ab>
+            </div>
+            <div type="edition" xml:lang="am" corresp="#a7">
+                <ab>ወይዘሮ፡ <persName ref="PRS14058Qasaro">ቀጸሮ፡</persName> የገዙት፡ ምድር፡ 
+                    ከ<persName ref="PRS14059MariGeta">መሪ፡ ጌታ፡ ገብረ፡ ሚካኤል፡</persName> 
+                    በ፵ጨው፡ ነው፡ አሳቦች፡ ቂሰ፡ ገበዝ፡ ወሰን፡ አይሞት፡ ዠኖ፡ ኑሮ፡ ወሰን፡ ነጮ፡ ናቸው፡ መድኒቱ፡ 
+                    <persName ref="PRS14060WalattaIyasus">ወለተ፡ ኢየሱስ፡</persName> ናት፡ ግብሩ፡ ፪፳፲፡ ቅብዓ፡ ኑግ፡ ፱ድርጎ፡ አከል፡ ነው፡ አንዘ፡ መምሕርነ፡ 
+                    ዘፈረ፡ ሥላሴ። ገበዝነ፡ ወሰን፡ ወጭቀው፡ ወሰጥ፡ ነጨ፡ በዘመነ፡ ማቴዎስ፡ ንው። </ab>
+            </div>
+            <div type="edition" corresp="#a8" xml:lang="gez">
+                <ab>በመዋዕለ፡ ሉቃስ፡ ወንጌላዊ፡ በ<date calendar="qamar" when-custom="159" when="1507">፻፶ወ፱፡ አመተ፡ ምሕረት፡</date> እንዘ፡ 
+                    ሀለዉ፡ ንጉሥነ፡ <persName ref="PRS7481NaodA">ናኦድ፡</persName> በ<placeName ref="LOC1602Atrons">አትሮንስ፡ እግዝእትነ፡ 
+                    ማርያም፡</placeName> በወርኃ፡ መጋቢት፡ እንዘ፡ ስማዕት፡ 
+                    ይእቴ፡ <persName ref="PRS3706eleni">እሌኒ፡</persName> ያጼ፡ እናቶ፡ ግራ፡ በአልታ፡ 
+                    <del rend="effaced" unit="chars" quantity="1"/> <persName ref="PRS7482NaodMo">ናኦድ፡ ሞገሣ፡</persName> 
+                    ዐቃቤ፡ <del rend="effaced">አካቅ፡</del> ስዐት፡ <persName ref="PRS14065Tewogolos">ቴዎጎሎስ፡</persName> 
+                    ሊቀ፡ ሊቃውንት፡ <persName ref="PRS14066NagadaEgzio">ነገደ፡ እግዚኦ፡</persName><add place="above">ኢያሱስ፡ </add> 
+                    ሊቀ፡ ማእምራን፡ <persName ref="PRS14067HabtuSarad">ኀብቱ፡ ጸራድ፡</persName> ማስሬ፡ አቀበስን፡ 
+                    ቀይስ፡ ሐፄ፡ <persName ref="PRS14068TaklaMaryam">ተክለ፡ ማርያም፡</persName> 
+                    ሊቀ፡ ደብተራ፡ <persName ref="PRS14069TaklaNabiyat">ተከለ፡ ነቢያት፡</persName> 
+                    ቀኚዕ፡ ብቶደደ፡ <persName ref="PRS14071HabtaMG">ሐብተ፡ ማርያም፡ ግራ፡</persName> 
+                    ብቶደደ፡ <persName ref="PRS14072Naze">ናዜ፡</persName> 
+                    አዛዘ፡ እንዳዘዜ፡ ርእሰ፡ ርኡሳን፡ <persName ref="PRS14073TaklaMaryam">ተከለ፡ ማርያም፡</persName> 
+                    እንዘ፡ ንቡረ፡ ዕድ፡ <persName ref="PRS14074Gersam">ጌርሣም፡</persName> 
+                    ወምስለ፡ ንብርዕድ፡ <persName ref="PRS14075Tiwogolos">ቲዎጎሎስ፡</persName> 
+                    ወቂስ፡ ገበዝ፡ <persName ref="PRS14076GabraNazrawi">ገብረ፡ ናዝራዊ፡</persName> 
+                    ወሊቀ፡ ዲየቆን፡ ይፅናዩ፡ ወራቍ፡ ማስራ፡ <persName ref="PRS14077FereKrestos">ፍሬ፡ ክርስቶስ፡</persName> ዘተመይጠ፡ ንዋይ፡ ለታቦተ፡ 
+                    ገብርኤል፡ ዘደብረ፡ ክብራ፡ ፳ወ፫፡ ንዋየ፡ ቤተ፡ ክርስቲያን፡ </ab>
+            </div>
+            <div type="edition" corresp="#a11" xml:lang="gez">
+                <ab>ለዘ፡ እምዘ፡ ብእሲ፡ አዕብይዎ፡ ወአክብርዎ፡ በሕይወቱ። ወእምድኅረ፡ ሞቱሂ፡ ግበሩ፡ ሎቱ፡ ተዝካሮ፡ ከመ፡ አባ፡ <persName ref="PRS14078GabraKrestos">ገብረ፡ ክርስቶስ፡</persName> 
+                    ወ<persName ref="PRS14079GabraAmlak">ገብረ፡ አምላክ</persName>። ወዘንተ፡ ኵሎ፡ ዘወሀበ፡ <persName ref="PRS14080SardaMaryam">ሠርፀ፡ ማርያም፡</persName> 
+                    ለመካነ፡ ማርያም፡ ዘአውፅአሂ፡ ወዘሤጠ፡ ወዘተሣየጠ፡ ውጉዘ፡ ለይኩን፡ በአፈ፡ ፫አስማት፡ ወበአፉሆሙ፡ ለጴጥሮስ፡ ወጳውሎስ፡ ወዘደምሰሰሂ፡ ለዝመጽሐፍ፡ ወይደስስ፡ ስሙ፡ 
+                    እመጽሐፈ፡ ሕይወት፡ ለዓለመ፡ ዓለም፡ አሜን፡ ወአሜን። </ab>
+            </div>
+            <div type="edition" corresp="#a13" xml:lang="gez">
+                <ab>በአኰቴተ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ እጕለትኩ፡ አ<add resp="CH">ፄ፡ </add>
+                    <persName ref="PRS6229LebnaDe">ወናግ፡ ሰገድ፡</persName> ንጉሥ፡ እንዘ፡ ሀላውኩ፡ በ<placeName ref="LOC3549Gojjam">ጐዣም፡</placeName> 
+                    አመ፡ ወዐልኩ፡ በ<placeName ref="LOC5733Sima">ጺማ፡</placeName> በዐለ፡ ፋሲካ። ምድረ፡ <placeName ref="LOC7378Ababir">ዐቢባር፡</placeName>
+                    ወምድረ፡ <placeName ref="LOC7379Enawga">እናውጋ</placeName>። ወምድረ፡ <placeName ref="LOC7380Enarij">እናርጀ</placeName>። 
+                    እሎንተ፡ ፫ምድረ፡ ለዓመተ፡ ጊዮርጊስ፡ ወለወ<gap reason="illegible" unit="chars" quantity="2"/>፡ ቅዱሳን፡ መንፈቀ፡ እሉ፡ 
+                    <gap reason="illegible" unit="chars" quantity="3"/> ወመንፈቁ፡ ለ<persName ref="PRS14080SardaMaryam">ሠርፀ፡ ማርያም፡</persName> እስመ፡ 
+                    ርስተ፡ ዚአሁ፡ ውእቱ፡ <gap reason="ellipsis" unit="lines" quantity="35"/></ab>
+            </div>
+            <div type="edition" corresp="#a16" xml:lang="am">
+                <ab>በዘመነ፡ ማቴዎስ፡ ዓሳ። ች፡ <persName ref="PRS14082WaldaAmanuel">ወልደ፡ አማኑኤል፡</persName> አደሩ፡ ባይሌ፡ ሠርጉ፡ ነገዱ፡ <unclear reason="illegible">በያድጊ፡</unclear>
+                    ሠዳ፡ የምህር፡ አርከ፡ ስሉሥ፡ ምድር፡ ፻ታሰበ፡ ሻጭቱ፡ ወለቱ፡ ልጃዋ፡ መድን፡ ገዢው፡ አዛጅ፡ ከብቴ፡ ምድሩ፡ ግን፡ ጠራሜት። </ab>
+            </div>
+            <div type="edition" corresp="#a18" xml:lang="am">
+                <ab>ይቤሉ፡ ሰብአ፡ ክቡራን፡ ወወራሚት፡ እንዘ፡ መምሕር፡ <persName ref="PRS14128TaklaHaymanot">ተክለ፡ ሃይማኖት፡</persName>
+                    ወአፈ፡ መምሕር፡ <persName ref="PRS14129Damye">ደምዬ</persName> 
+                    መምር፡ <persName ref="PRS14130NikodimosFantaWM">ኒቆዲሞስ፡ ፈንታ፡ ወልደ፡ ሚካኤል፡</persName> 
+                    በሊሕ፡ ዳኛ፡ ያፀዲን፡ ምድር፡ <del unit="chars" quantity="1"/>ያዘችውን፡ የገዛቸውን፡ 
+                    <persName ref="PRS14131LabetoGasso">ላቤቶ፡ ጋሾ፡ </persName>
+                    ሸጠናል፡ በ፵፡፩፡ጣን፡ ተዶል፡ በከመምር፡ <persName ref="PRS14132Agne">አግኔ፡</persName> 
+                    የተገዘውን፡ አባ፡ <persName ref="PRS14133Gabriel">ገብርኤል፡</persName> የተገዛውን፡ 
+                    <persName ref="PRS14134Kaygats">ካይጋፅ፡</persName> 
+                    የተገዘውን፡ <persName ref="PRS14135Yehenan">ይህነን፡</persName> ደብሩም፡ መምሩም፡ ሀገሩም፡ ያለቅዳሴ፡ ከዳ፡ አንዳይገናጅ፡ 
+                    ታቦር፡ ኪዳን፡ ገበዝ፡ <persName ref="PRS14136NatnaelM">ናትናኤል፡ ሚካኤል፡</persName> 
+                    አፈ፡ ገበዝ፡ <persName ref="PRS14137Zerem">ዝሬም፡</persName> እኒህ፡ ተዳኑ፡ ለሚመጻውም፡ ቦተሾሙ፡ መድን፡ ናቸው፡ ደብር፡ የሰጡች፡ 
+                    አስጻፊ፡ ደብተራ፤ <persName ref="PRS14138Iyyob" resp="scribe">ኢዮብ፡</persName> ንው፡ 
+                    ይህ፡ እንዳይፈርስ፡ በቡነ፡ <persName ref="PRS14139Zayohannes">ዘዮሐንስ፡</persName> ቃል፡ በ፯፻፡በ፲፰፡ ቃል፡ ግዝት፡ ነው፡ 
+                    አባ፡ <persName ref="PRS14140Bakwere">በኵሬ፡</persName> 
+                    አባ፡ <persName ref="PRS14141Hezqeyas">ሕዝቅያስ</persName>። ገዝቶሉ፡</ab>
+            </div>
+            <div type="edition" corresp="a19" xml:lang="am">
+                <ab>በዘመነ፡ ማርቆ፡ በመጋቢት፡ ራስ፡ ቢት፡ ወደድ፡ <persName ref="PRS14107Mangasha">መንገሻ፡</persName> ታቶ፡ 
+                    <persName ref="PRS14108Was">ዋስ፡</persName> አገኘሁ፡ አርስት፡ ሲገዙ፡ እማኞቹ፡ 
+                    ሊቀ፡ ረድ፡ <persName ref="PRS14109Mertenehah">ምርንኀህ፡ </persName>
+                    ሊቀ፡ ረድ፡ <persName ref="PRS14110Gossu">ጐሹ፡</persName> 
+                    ሊቀ፡ ረድ፡ <persName ref="PRS14112Wonde">ወንዴ፡</persName> 
+                    ሊቀ፡ ረድ፡ <del rend="expunctuated">ሊ</del><persName ref="PRS14111Berru">ብሩ፡</persName> 
+                    ምስለኔ፡ <persName ref="PRS14113TasfaGetahun">ተስፋ፡ ጌታሁን፡</persName> ጔሉ፡ 
+                    <persName ref="PRS14114AyalewGM">አያሌው፡ ገብረ፡ ማርያም፡ </persName>
+                    <persName ref="PRS14115BarYahunWale">በር፡ ያሁን፡ ዋሌ፡</persName>ናቸው፡ 
+                    ለውርሱ፡ እማኞች፡ አቶ፡ <persName ref="PRS14116Tawaqa">ታወቀ፡</persName> 
+                    ብላታ፡ <persName ref="PRS14117Zallaqa">ዘለቀ፡ </persName>
+                    <persName ref="PRS14114AyalewGM">አያሌው፡ ገብረ፡ ማርያም፡</persName>
+                    <persName ref="PRS14118DastaLama">ደስታ፡ ለማ፡</persName> 
+                    አቶ፡ <persName ref="PRS14119GalagayEste">ገላጋይ፡ እሽቴ፡ </persName>ጔሉ፡ 
+                    <persName ref="PRS14121SendaqiTekku">ስንደቂ፡ ትኩ፡</persName> 
+                    አቶ፡ <persName ref="PRS14122Tafarra">ተፈራ፡</persName> 
+                    አቶ፡ <persName ref="PRS14123TafalaGT">ታፈለ፡ ዠመረ፡ ታወቀ፡</persName> 
+                    ዳኞቹ፡ ሊቀ፡ ረድ፡ <persName ref="PRS14125LamaMaggabi">ለማ፡ መጋቢ፡</persName> 
+                    <persName ref="PRS14124WebAyyahu">ውብ፡ አየሁ፡</persName>  
+                    ሱም፡ <persName ref="PRS14126Warqenah">ወርቅነህ፡ </persName>ናቸው። ዳኞች፡ ለሁሉም፡ ናቸው፡</ab>
+            </div>
+            <div type="translation" corresp="a19" resp="CH">
+                <ab>In the year of Marqos, in Maggābit, rās bit wadad Mangašā bought lands from ʾato Wās. The witnesses are liqa rad Mərṭənah, 
+                    liqa rad Gʷašu, liqa rad Wande, liqa rad Bərru, and also a person whose name is Tasfā Getāhun, ʾAyālew Gabra Māryām, 
+                    Bar Yāhun Wāle. The witnesses under warranty are ʾato Tāwqa, blāttā Zallaqa ʾAyalāw Gabra Maryām, Dastā Lammā, a person 
+                    whose name is ʾato Galāgāy ʾƎšte, Səndaqi Təkku, ʾato Tafarā, ʾato Tāfala Žammara Tāwqa, and the judges are 
+                    liqa rad Lammā Maggābi, Wəb ʾAyyahu, sum Warqənah, who are the general judges.</ab>
+            </div>
+            <div type="edition" corresp="a21" xml:lang="gez">
+                <ab>በስመ፡ ሥሉስ፡ ቅዱስ፡ ጸሐፍነ፡ ዘንተ፡ ነገረ፡ በቍዔት፡ ደቂቀ፡ ክብራ፡ ኵልን፡ ምስለ፡ አቡነ፡ <persName ref="PRS14089Pawlos">ጳውሎስ፡</persName> 
+                    ንቡረ፡ ዕድ፡ ኖላዊ፡ መርዔት፡ ለ<persName ref="PRS14087BasaTegest">ባሴ፡ ትዕግሥት፡</persName> በእንተ፡ 
+                    <persName ref="PRS3706eleni">እሌኒ፡</persName> ንግሥት፡ ወ<persName ref="PRS10626ZaraY">ቈስጠንጢኖስ፡</persName> 
+                    ንጉሥነ፡ ርቱዓ፡ ሃይማኖት፡ ወ<persName ref="PRS14088TaklaSyon">ተክለ፡ ጽዮን</persName>ሂ፡
+                    ነጋሢ፡ <placeName ref="LOC3549Gojjam">ጐዛም፡</placeName> <persName ref="PRS14090MeazaHirut">ምዓዘ፡ ኂሩት፡</persName>
+                    ምስለ፡ ብእሲቱ፡ <persName ref="PRS14091BarbaraLaKres">በርባራ፡ ለክርስቶስ፡</persName> ዓመት፡ ለእሉ፡ ይዕቀቦሙ፡ እግዚእ፡ እስከ፡ ይበልዩ፡ 
+                    ምድር፡ ወሰማያት፡ ኢይልክፎሙ፡ ሞት፡ ወይረሲ፡ ሕይወቶሙ፡ በፍሥሖ፡ ወበሖሤት፡ ዘአግብኡ፡ ለነ፡ ሢመትነ፡ ዘነሥኡነ፡ በትዕጣን፡ ወመሥዋዕት፡ በረከተ፡ ሠለስቱ፡ አስግት፡ 
+                    በረከተ፡ ማርያም፡ ንጽሕት፡ በረከተ፡ ነቢያት፡ ወሐዋርያት፡ በረከተ፡ ጻድቃን፡ ወሳማዕት፡ ይከልኦሙ፡ ከመ፡ ሕይመት፡ በኵሉ፡ ጊዜ፡ ወበኵሉ፡ ሰዐት፡ አሜን። 
+                    ስምዑ፡ ዘንተሂ፡ ሥርዐተ፡ መካን፡ ዘጸሐፉ፡ ለነ፡ አቡነ፡ <persName ref="PRS14089Pawlos">ጳውሎስ፡</persName> ንቡረ፡ እድ፡ ምስለ፡ ኵሎሙ፡ መነኮሳት፡ 
+                    እምይእዜ፡ ይኩን፡ ሢመት፡ መካን፡ በኅርየተ፡ መንፈስ፡ ቅዱስ፡ ኢይኩን፡ በኣድልዎ፡ ወኢበተዛውጎ፡ እመሂ፡ ንቡረ፡ ዕድ፡ እመሂ፡ ቂስ፡ ገበዝ፡ እመሂ፡ 
+                    <persName ref="PRS14092EraqMasera">እራቅ፡ ማሰራ፡</persName> እመሂ፡ ሊቀ፡ ዲያቆን፡ ከመዝ፡ ይኩን፡ ሢመቶሙ፡ ወሶበሂ፡ ተስዕሩ፡ ይንባሩ፡ 
+                    በበየቶሙ፡ በህድዓት፡ ወአታደንግፅዎሙ፡ ርእሶሙ፡ ቤተ፡ ቅዱሳን፡ ውእቱ፡ እመቦ፡ ዘተገፍዓ፡ ነዳይ፡ እንበለ፡ ፍትሕ፡ በሢመቶሙ፡ ወይትዋቅሥ፡ በኀበ፡ ቅዱሳን፡
+                    ስምዑ፡ ዘንተኒ፡ ነገረ፡ ዘእነግረክሙ፡ አነ፡ <persName ref="PRS14089Pawlos">ጳውሎስ፡</persName> ወምህርክሙ፡ እመሂ፡ ዐቢይ፡ ወእመሂ፡ ንዑስ፡ 
+                    እምኔነ፡ ዘየሖር፡ ኀበ፡ መኰንን፡ ወይትናገር፡ በእንተ፡ ጥፋዓታ፡ ለዛቲ፡ መካን፡ ወያጥፍዕ፡ ክርስቶስ፡ እምድር፡ ዝክሮ፡ አሜን፡ ወሶበሂ፡ ፈቀደ፡ ይሖር፡ በአተ፡ ትካዙ፡ እንበለ፡ ጽልሁት፡
+                    ይሖር። ወዘአስተተ፡ ወዘተአገለ፡ ዘንተ፡ ትእዛዛተ፡ ይኩን፡ ውጉዘ፡ በፈ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ በአፈ፡ አቡነ፡ 
+                    <persName ref="PRS14093Zayohannes">ዘዮሐንስ፡</persName> በአፈ፡ አቡነ፡ <persName ref="PRS14089Pawlos">ጳውሎስ፡</persName>
+                    በአፈ፡ ኵሎሙ፡ ለባስያነ፡ መንፈስ፡ ይኩን፡ ውጉዘ፡ ውፁአ፡ ወግሁሰ፡ እምርስተ፡ ቅዱሳን፡ አሜን።</ab>
+            </div>
+            <div type="edition" corresp="a23" xml:lang="gez">
+                <ab>በስመ፡ እግዚአብሔር፡ አብ፡ አበ፡ ኢየሱስ፡ ክርስቶስ፡ አበ፡ ሣህል፡ <gap reason="ellipsis"/>ምስለ፡ አብ፡ ወወልድ፡ አጽሐፍኩ፡ ዘንተ፡ 
+                    መጽሐፈ፡ አነ፡ <persName ref="PRS3429DawitII">ዳዊት፡</persName> ወስመ፡ መንግሥትየ፡ 
+                    <persName ref="PRS3429DawitII">ቈስጠንጢኖስ፡ ሠርፀ፡ እስራኤል፡</persName> እምቤተ፡ አብርሃም፡ ይስሐቅ፡ ወያዕቆብ፡ 
+                    ወይሁዳ፡ ወልደ፡ ዳዊት፡ ወሰሎሞን፡ እዕሎኩ፡ ዘንተ፡ ነገረ፡ ውስተ፡ ዛቲ፡ ወንጌለ፡ ጸጋሁ፡ ለእግዚእነ፡ በ<date>፷ወ፭፡ ዓመተ፡ ምሕረት፡</date> 
+                    ወበ<date when="1411">፴ወ፩፡ ዓመተ፡ መንግሥትየ፡</date> እዘዝኩ፡ ከመ፡ ይግበሩ፡ ተዝካረ፡ አቡየ፡ 
+                    <persName ref="PRS8595SayfaAr">ሰይፈ፡ አርዓደ፡</persName> እም፲ወ፭፡ ለግንቦት፡ 
+                    ወተዝካረ፡ እምየ፡ <persName ref="PRS14166LazabWarqa">ለዘብ፡ ወርቃ፡</persName> እም፲ወ፪ለሰኔ፡ ዘንተ፡ ይገበሩ፡ ለለዓመት፡ 
+                    በመካነ፡ <placeName ref="LOC5888Tana">ጻና፡</placeName> ቤተ፡ ቂርቆስ፡ ወበምኔተ፡ ክብራ፡ ቤተ፡ ገብርኤል፡ 
+                    ወበ<placeName ref="LOC5888Tana">ጻና፡</placeName> እለ፡ ይገብሩ፡ እሉ፡ እሙንቱ፡ <gap reason="ellipsis"/>
+                    እምነ፡ በወርኅ፡ ኢሎል፡ ይገበሩ፡ <gap reason="illegible" unit="chars" quantity="4"/>እም፲ወ፩፡ እስከ፲ወ፰ይግ
+                    <gap reason="illegible" unit="chars" quantity="4"/>በዓለ፡ መስቀል። </ab>
+            </div>
+            <div type="edition" corresp="a24" xml:lang="gez">
+                <ab>በስመ፡ እግዚአብሔር፡ አብ፡ አበ፡ ኢየሱስ፡ ክርስቶስ፡ አበ፡ ሣህል፡ <gap reason="ellipsis"/> አጽሐፍኩ፡ ዘንተ፡ መጽሐፈ፡ አነ፡ 
+                    <persName ref="PRS10342Yeshaq">ይስሐቅ፡</persName> ወስመ፡ መንግሥትየ፡ 
+                    <persName ref="PRS10342Yeshaq">ገብረ፡ መስቀል፡ ሠርፀ፡ አስራኤል፡</persName> እምቤተ፡ አብርሃም፡<gap reason="ellipsis"/>
+                    እዕሎኩ፡ ዘንተ፡ መጽሐፈ፡ ውስተ፡ ዛቲ፡ ወንጌለ፡ ጸጋሁ፡ ለእግዚእነ፡ በ<date>፷ወ፯፡ ዓመተ፡ ምሕረት፡</date> 
+                    ወበ<date notBefore="1414" notAfter="1415">፯፡ አውራኅ፡ እመ፡ ዋዕለ፡ መንግሥትየ፡</date> ወሀብኩ፡ ምድረ፡ እንተ፡ ስማ፡ 
+                    <placeName ref="LOC7316Andabet">ሀንዳቤት፡</placeName> እምጽንፈ፡ እስከ፡ ጽንፈ፡ <gap reason="ellipsis"/></ab>
+            </div>
+            <div type="edition" corresp="a25" xml:lang="gez">
+                <ab>በአኰቴተ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ። በምዋዕል፡ 
+                    <persName ref="PRS3429DawitII">ዳዊት፡</persName> ንጉሥ። ወሀብኩ፡ አነ፡ ንቡረ፡ እድ፡ አባ፡ 
+                    <persName ref="PRS14148Nob">ኖብ</persName>። ምድረ፡ ወራሚት፡ ለመካነ፡ ቅዱሳን፡ ዘደብረ፡ ክብራን። ወእመሂ፡ ንቡረ፡ እድ፡ 
+                    ወእመሂ፡ ተዐጋሊ። ከመ፡ ኢይግፍዖሙ፡ ወኢይትጉሎሙ፡ አማኅፀንኩ። <gap reason="ellipsis" unit="lines" quantity="5"/>ወበአፈ፡ 
+                    ቅዱስ፡ ጳጳስነ፡ አባ፡ <persName ref="PRS2469Bartalom">በርተ፡ ሎሜዎስ፡</persName> ይኩን፡ ውጉዘ፡ ወቅውሞ፡ ይኩን፡ እስከ፡ ለዓለመ፡ 
+                    ዓለም። <gap reason="ellipsis" unit="lines" quantity="8"/></ab>
+            </div>
+            <div type="edition" corresp="a26" xml:lang="gez">
+                <ab>ዳረጐትነ፡ ወሀብኩ፡ እምድረ፡ <placeName ref="LOC7381Egana">ኤገና፡</placeName> 
+                    ለማኅቶተ፡ ገብርኤል፡ ፲ወ፪፡ ለፈትል፡ ለዕጣን<gap reason="illegible" unit="chars" quantity="1"/>፡ ወሀብኩ፡ ምድረ፡ 
+                    <placeName ref="LOC7382Daf">ዳፍ፡</placeName> ፳፡ ለጥር፡ ወለሀሎየሂ፡ ፀራቢ፡ ገዳፍከዎ፡ ለገብርኤል፡ ዘምስለ፡ ፱ዳስ፡ ዘወይን፡ 
+                    አሪር፡ የሀብክሙ፡ ዝንቱ፡ ኵሉ፡ መብልዕ፡ ዘነበረ፡ ለንቡረ፡ ዕድ። <gap reason="ellipsis" unit="lines" quantity="3"/></ab>
+            </div>
+            <div type="edition" corresp="a27" xml:lang="gez">
+                <ab>በአኰቴተ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ። ወበመዋዕሊሁ፡ ለንጉሥነ፡ <persName ref="PRS6229LebnaDe">ልብነ፡ ድንግል</persName>። 
+                    ወሀብኩ፡ አነ፡ ንቡረ፡ እድ፡ <persName ref="PRS14149TsegeSellus">ጽጌ፡ ሥሉስ፡</persName><gap reason="lost" unit="chars" quantity="1"/>
+                    መባሕተ፡ አበውየ፡ ቅዱሳ<gap reason="lost" unit="chars" quantity="1"/>፡
+                    ምድረ፡ <placeName ref="LOC7383Qwebitsa">ቍቢጻ፡</placeName> ከመ፡ ይኩኖ፡ ርስተ፡ 
+                    ለ<persName ref="PRS14151Zaiyasus">ዘኢየሱስ፡ </persName>ዐቃቢ። እመሂ፡ ንቡረ፡ እድ፡ ወእመሂ፡ ቂስ፡ ገበዝ፡ እመሂ፡ ሊቀ፡ ዲያቆን፡ 
+                    ወራቅማሰራሂ፡ ዘቦአ፡ በተአድዎ፡ ይኩን፡ ውጉዘ፡ በአፈ፡ ሥሉስ፡ ቅዱስ፡ ወበአፈ፡ እግዝእትነ፡ ማርያም፡
+                    <gap reason="ellipsis" unit="lines" quantity="5"/></ab>
+            </div>
+            <div type="edition" corresp="a28" xml:lang="gez">
+                <ab>ሰምዑ፡ ዘኮነ፡ እምድሕረ፡ ስደት፡ ፈለሰት፡ ስልጣነ፡ ደብር፡ ናሁ፡ አግብአ፡ ለነ፡ ተመኪሮ፡ በዲዴ፡ ንጉሥ፡ ወንህነኒ፡ ወሀብኖ፡ ረስተ፡ ምድረ፡ 
+                    <placeName ref="LOC7384Hanita">ሐኒታ፡</placeName> ወ<placeName ref="LOC7385Isala">ኢሳላ፡</placeName> 
+                    በአዱ፡ ቃል፡ ሀቢረነ፡ በወልድነ፡ ሐቢበ፡ ወንጌል፡ እመቦ፡ ዘደምሰሰ፡ ውጉዘ፡ ለይኩን። ።</ab>
+            </div>
+            <div type="edition" corresp="a30" xml:lang="gez">
+                <ab>ኍልቈ፡ ምድር፡ ዘወሀብዎ፡ ንጉሥነ፡ <persName ref="PRS5616IyasuI">አድያም፡ ሰገድ፡</persName> 
+                    ለ<persName ref="PRS14154GoraDefwu">ጎራ፡ ድፍዉ፡</persName> ይኵኖ፡ ርስተ፡ ለትውልዶ፡ ትውልድ፡ 
+                    <placeName ref="LOC6893Guaguata">ጓጓታ፡</placeName> ዘታሕታይ፡ 
+                    ወ<placeName ref="LOC7386Abaraj">አባራጅ፡ </placeName>
+                    <placeName ref="LOC7387Tsangwya">ጸንጕያ፡</placeName>
+                    ወ<placeName ref="LOC7388Maqwal">ማቋል፡</placeName> 
+                    <placeName ref="LOC7389Sakala">ሳከላ፡</placeName> 
+                    <placeName ref="LOC7390Asya">ዓስያ፡</placeName> 
+                    <placeName ref="LOC7391Abats">አባጽ፡</placeName>
+                    <placeName ref="LOC7392Berbets">ብርብጽ፡</placeName>
+                    <placeName ref="LOC7393Amyatsma">አፙጽማ፡</placeName>
+                    <placeName ref="LOC7394Mebash">ሜበሽ፡</placeName>
+                    ወእሉሂ፡ ጕልታት፡ ዘጸንአ፡ በእዴሁ፡ እምአመ፡ ነግሡ፡ ንጉሥነ፡ <persName ref="PRS5616IyasuI">አድያም፡ ሰገድ፡</persName> 
+                    በ፳ወ፱አመት፡ ወዕለትሂ፡ ዕለተ፡ አርብ፡ በ፲ወ፰ዕለት፡ ለ<placeName ref="LOC6893Guaguata">ጓጓታ፡</placeName> 
+                    ወለ<placeName ref="LOC7386Abaraj">አባራጅ፡ </placeName> ዘከለልዎ፡ በ፫መስቀል፡ ወበ፫ወንጌል፡ ወበ፫ድባብ፡ ወእሉሂ፡ መነኮሳተ፡ ደብር፡
+                    ወጺዖሙ፡ ምስለ፡ መምህሮሙ፡ <persName ref="PRS14155Agnateyos">አግናጥዮስ፡</persName> 
+                    ቂስ፡ ገባዝ፡ <persName ref="PRS14156Temhertu">ትምህርቱ፡</persName> 
+                    ወአፈ፡ መምህር፡ <persName ref="PRS14157Mammo">ማሞ፡</persName> 
+                    ራቅ፡ መሰራ፡ <persName ref="PRS14158Bahaylamaryam">በኃይለማርያም፡</persName> 
+                    ወሊቀ፡ አባው፡ <persName ref="PRS14159TanseaKrestos">ተንሥአ፡ ክርስቶስ፡</persName>
+                    አኅያ፡ ጠቦቱ፡ ወአታ፡ ወንጸ፡ <persName ref="PRS14160TaklaMaryam">ተክለ፡ ማርያም፡</persName> ወዘአጽሐፍዎሰ። ለዝንቱ፡ 
+                    መጽሐፍ፡ ተጋቢኦሙ፡ በ፩ምክር፡ ኀበ፡ አቡሆሙ፡ አረጋዊ፡ መምህር፡ <persName ref="PRS14161MalkeaKrestos">መልከአ፡ ክርስቶስ፡</persName> 
+                    ዘንተ፡ ሰሚዖ፡ ዘሔዶ፡ ዘአፍለሰ፡ እምካልእ፡ ኀበ፡ ካልእ፡ ዘእንበለ፡ ውሉዱ፡ ለ<persName ref="PRS14154GoraDefwu">ጎራ፡ ድፍዊ፡</persName>
+                    እመሂ፡ ንጉሥ፡ ወእመሂ፡ ሠራዊተ፡ ንጉሥ፡ ውጉዘ፡ ይኩን፡ በአፈ፡ ፲ወ፪ሓዋርያት፡ ወ፸ወ፪አርድእት፡ ውጉዘ፡ ለይኩን፡</ab>
+            </div>
+            <div type="edition" corresp="a31" xml:lang="am">
+                <ab>የቅባ፡ ኑግ፡ ግብር፡ ዘሀሎ፡ በወራሚት፡ ፴ስድስት፡ ጽዋ፡ በ<placeName ref="LOC7395LomiBet">ሎሚ፡ ቤት፡ </placeName> አለቃው፡
+                        <persName ref="PRS14162WaldaGirgis">ወልደ፡ ጊርጊስ፡</persName> ስንስጣ። 
+                    ፴ስድስት፡ በ<placeName ref="LOC7396AtsfoBet">አጽፎ፡ ቤት፡</placeName> አለቃው፡ 
+                        <persName ref="PRS14163AbetoSalabaster">አቤቶ፡ ሰለባስትርዮስ፡</persName> 
+                    ያለቃ፡ ምድር፡ በገዙ፡ ፴ስድስት፡ በ<placeName ref="LOC7397Shanga">ሻንጋ፡</placeName> አለቃው፡ 
+                        <persName ref="PRS14164KeramtiZamikael">ክረምቲ፡ ዘሚካኤል፡</persName> 
+                    ያለቃ፡ ምድር፡ <placeName ref="LOC7398Arash">አራሽ፡</placeName> ቂስ፡ ገበዝ፡ 
+                        <persName ref="PRS14165WaldaKesos">ወልደ፡ ክሶስ፤</persName> ከድሸት፡ ፯ጽዋ፡ የንከነበር፡
+                    </ab>
+            </div>
+            <div type="edition" corresp="#e3" xml:lang="gez">
+                <ab><add place="above"> በዘመኑ፡ ለንጉሥነ፡ <persName ref="PRS5616IyasuI">ኢያሱ፡ </persName> 
+                    ዘስ<add resp="CH">መ፡</add> መንግሥቱ፡ <persName ref="PRS5616IyasuI">አድያም፡ ሰገድ፡ </persName></add> 
+                    ወሀብኩ፡ አነ፡ <persName ref="PRS14083Giyorgis">ጊዮርጊስ፡</persName> ለዝንቱ፡ መጽሐፈ፡ ወንጌል፡ ለመካነ፡ 
+                    ገብረ<subst><del>ዮ</del><add place="overstrike">ኤል፡ ዘዮ</add></subst>ሐንስ፡ ከመ፡ ይምኃረኒ፡ በጸሎቱ። 
+                    ለዛቲ፡ መጽሐፍ፡ እመቦ፡ ዘተኣገላ፡ ወተኃየላ፡ ዘሴጣ፡ ወዘሰረቃ፡ ውጉዘ፡ ይኩን፡ በአፈ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ለዓለመ፡ አለም፡ ኣሜን። ። ።</ab>
+            </div>
+            <div type="edition" corresp="#e14" xml:lang="gez">
+                <ab>በአኰቴተ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ። ኍልቈ፡ መጻሕፍት፡ ለገብርኤል፡ ዘደብረ፡ ክብራን፡ ነዋ፡ ዝንቱ፡ ውእቱ፡ ወንጌል፡ ፪፡
+                    <gap reason="ellipsis" unit="lines" quantity="49"/>
+                    ተጽሕፈት፡ ዛቲ፡ ግዘት፡ እንዘ፡ ንጉሥነ፡ <persName ref="PRS8595SayfaAr">ሰይፈ፡ አርዐደ፡</persName> 
+                    ወጳጳስነ፡ አባ፡ <persName ref="PRS8387SalamaI">ሰላማ፡</persName> ወአበመካንነ፡ አባ፡ ዳንኤል፡ ይጽሐፍ፡ ስሞሙ፡ እግዚአብሔር፡ 
+                    ውስተ፡ መጽሕይወት፡ በሰማያት፡ አሜን። ወለንጉሥነሂ፡ ቈስጠንጢኖስ፡ ዘሐነጸ፡ ዘንተ፡ መካነ፡ ቅዱሰ፡ ሀቦ፡ እግዚአብሔር፡ ማኅደረ፡ ሰማያዌ፡ አሜን።
+                    <gap reason="ellipsis" unit="lines" quantity="8"/></ab>
+            </div>
+            <div type="edition" corresp="#e15" xml:lang="gez">
+                <ab>ወእምድኅረ፡ ተጽፋ። እላንቱ፡ ተወሰከ፡ ወጽሐፍነ፡ እስክንድር፩፡ <gap reason="ellipsis" unit="lines" quantity="18"/></ab>
+            </div>
+            <div type="edition" corresp="#e18" xml:lang="gez">
+                <ab>ዘተሳየጥኩ፡ አነ፡ <persName ref="PRS14096TaklaMaryam">ተክለ፡ ማርያም፡</persName> ምድረ፡ እሊ፡ በ፬፡ ብዕራይ፡
+                    እምነ፡ ኩሎሙ፡ መነኮሳተ፡ ደብር፡ ወእንዘ፡ መምህር፡ አባ፡ <persName ref="PRS14097Hirut">ኂሩት፡</persName> 
+                    ወቂስገበዝ፡ አባ፡ <persName ref="PRS14098DabraSyon">ደብረ፡ ጽዮን፡</persName> 
+                    ወመድኀን፡ አባ፡ <persName ref="PRS14099Malkasedeq">መልከጼዴቅ፡</persName> 
+                    ወራቀ፡ መስራ፡ አባ፡ <persName ref="PRS14100ZaraKrestos">ዘርአ፡ ክርስቶስ፡</persName>
+                    ወሊቀ፡ ዲያቆን፡ <persName ref="PRS14101Baselyos">ባስልዮስ፡</persName> ዘንተ፡ ምድረ፡ ዘተሳየጥኩ፡ እንበለ፡ ግብር፡ ዘንተ፡ ምድረ፡ ወዘንተ፡ 
+                    መጽሐፈ፡ ፱ደምሰሰ፡ ወዘፈሀቀ፡ ዘሄደ፡ ወዘተአገለ፡ በሥልጣዎሙ፡ ለጴጥሮስ፡ ወጳውሎስ፡ ውጉዘ፡ በይኩን</ab>
+            </div>
+            <div type="edition" corresp="#e19" xml:lang="gez">
+                <ab>ዘተሳየጥኩ፡ አነ፡ <persName ref="PRS14106ZaraAbreham">ዘርአ፡ አብርሃም፡</persName> ምድረ፡ ዜዲት፡ በ፬ላህም፡ ወ፯ጼው፡ እምነ፡ ኵሎሙ፡ 
+                    መነኮሳተ፡ ደብረ፡ ወእንዘ፡ መምህር፡ አባ፡ <persName ref="PRS14097Hirut">ኂሩት፡</persName> 
+                    ወቂስ፡ ገበዝ፡ ወመድኀንሂ፡ አባ፡ <persName ref="PRS14098DabraSyon">ደብረ፡ ጽዮን፡</persName> 
+                    ወረቍ፡ መስራ፡ <persName ref="PRS14100ZaraKrestos">ዘርአ፡ ክርስቶስ፡</persName>
+                    ወሊቀ፡ ዲያቆን፡ <persName ref="PRS14101Baselyos">ባስልዮስ፡</persName>
+                    ዘንተ፡ ምድረ፡ ዘተሳየጥኩ፡ በሐራ፡ እንበለ፡ ግብር፡ ዘንተ፡ ምድረ፡ ወዘንተ፡ መጽሐፈ፡ በደምሰሰ፡<gap reason="illegible" unit="chars" quantity="2"/>ፈቀቀ፡ 
+                    ዘሄደ፡ ወዘተአገለ፡ <gap reason="illegible" unit="chars" quantity="5"/>ሙ፡ ለጴጥሮስ፡ ወጳውሎስ፡ ውጉዘ፡ በይኩን። ። </ab>
+            </div>
+            <div type="edition" corresp="#e21" xml:lang="gez">
+                <ab>ዛቲ፡ መጽሐፍ፡ ዘአጽሐፈ፡ <persName ref="PRS14144GabraKrestosRWN" role="donor">ገብረ፡ ክርስቶስ፡ ራሴ፡ ወልደ፡ ኖብ፡</persName> 
+                    በ፭አልሕምት፡ ዘተሣየጠ፡ ለ<persName ref="PRS14145TabotSeyon" role="donor">ታቦት፡ ጽዮን፡</persName>
+                    ወለ<persName ref="PRS14146Giyorgis" role="donor">ጊዮርግስ፡</persName>
+                    እምነ፡ <persName ref="PRS14147TaklaHawaryat" role="scribe">ተክለ፡ ሃዋርያት፡</persName>
+                    መነኮስ፡ ንቡረ፡ እድ፡ አባ፡ <persName ref="PRS14148Nob">ኖብ፡</persName>
+                    ራቅ፡ መስራ፡ <persName ref="PRS14077FereKrestos">ፍሬ፡ ክርስቶስ፡ </persName>ፍሬ፡ ክርስቶስ፡ 
+                    ወኵሎሙ፡ <gap reason="illegible" unit="chars" quantity="5"/>ራ። ወሊቆሙ። 
+                    በድ፡ ዮሐን<supplied reason="undefined">ስ፡</supplied><gap reason="illegible" unit="chars" quantity="4"/> 
+                    ነጋሢ፡ <persName ref="PRS14088TaklaSyon">ተክለ፡ ጽዮን፡</persName> ዘመፍ<gap reason="illegible" unit="chars" quantity="2"/>
+                    ንጉሥ፡ <persName ref="PRS6229LebnaDe">ልብነ፡ ድንግል፡</persName> 
+                    ዘተተከለ፡ <gap reason="illegible" unit="chars" quantity="6"/> ለዓለመ፡ ዓለም፡ </ab>
+            </div>
+            <div type="edition" corresp="#e22" xml:lang="gez">
+                <ab>በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡ በአኰቴተ፡ እግዚአብሔር፡ ንጽሐፍ፡ ነዋየ፡ ቤተ፡ ክርስቲያን፡ ዘገብብርኤል። ለመካነ፡ ክብራ፡ ዘረከብነ፡ 
+                    በዘመነ፡ መምህር፡ <persName ref="PRS14128TaklaHaymanot">ተክለ፡ ሃይማኖት።</persName>
+                    ወቂስ፡ ገበዝሂ፡ <persName ref="PRS14152AhabHawaryat">አሃብ፡ ሐዋርያት፡</persName>
+                    ወራቅመስራ፡ <persName ref="PRS14153TaklaGabreel">ተክለ፡ ገብርኤል፡</persName> 
+                    <gap reason="illegible" unit="chars" quantity="1"/>፭ብዝቅ፡ <gap reason="ellipsis" unit="lines" quantity="12"/>
+                    ወኵላ፡ ኵስተሰ፡ አጸሐፍነ። ወመጽሐፍሰ፡ ጽሑፍ፡ ሀሎ፡ በ<ref target="LIT1955Mashaf">መጽሐፈ፡ ሚላድ</ref>። ዘንተ፡ ኵሎ፡ አጽሐፍኩ፡ አነ፡ 
+                    <persName ref="PRS14153TaklaGabreel">ተክለ፡ ገብርኤል፡</persName> በሢመትየ።</ab>
+            </div>
         </body>
     </text>
 </TEI>

--- a/Tanasee/Tanasee1.xml
+++ b/Tanasee/Tanasee1.xml
@@ -1084,7 +1084,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <desc type="ScribalNoteCommissioning">Scribal note, that mentions <persName ref="PRS6229LebnaDe"/> and 
                                             also <persName ref="PRS14077FereKrestos"/> and <persName ref="PRS14088TaklaSyon"/>, two dignitaries, 
                                             who are also mentioned in <ref target="#a44"/> that can be dated to the early 16th century. 
-                                            Written by a hand similar as <ref target="#a52"/> and <ref target="#a53"/>.</desc>
+                                            Written by a hand similar to <ref target="#a52"/> and <ref target="#a53"/>.</desc>
                                         <q xml:lang="gez">ዛቲ፡ መጽሐፍ፡ ዘአጽሐፈ፡ 
                                             <persName ref="PRS14144GabraKrestosRWN" role="donor">ገብረ፡ ክርስቶስ፡ ራሴ፡ ወልደ፡ ኖብ፡</persName> 
                                             በ፭አልሕምት፡ ዘተሣየጠ፡ ለ<persName ref="PRS14145TabotSeyon" role="donor">ታቦት፡ ጽዮን፡</persName>


### PR DESCRIPTION
I created a physDesc and a ContentDesc for Tanasee1 according to Hammerschmidt's catalogue.
 
I found that Hammerschmidt is wrong about the number of folios, which is actually 239, and the folio numbers for the folios over 200 are given with one too high as I indicated in my foliation description. I have coded all text parts and additions according to the actual number of folios. It would be helpful if you could manually add the new true folio numbers to the images. I can do this if you send me the images and tell me how to do it. Otherwise users might get confused.

Unfortunately, the manuscript is only available in microfilm images, unless better images must exist, as the decoration is reproduced in colour images, and an article by Roger Schneider has a better image of a folio. It would be nice to acquire better images or get new ones, but this may not be very easy, as discussed in issue #2416. 

With a few exceptions, the text is readable, but the quire structure is not visible and is not given in Hammerschmidt's catalogue. For this reason, we cannot be sure whether the last quire, with its many additions, was added to the codex later in a rebinding, as I hypothesised in my collation description and in the story. 

I have coded a great many personal names and also some place names which occur in large numbers in the additions. I have tried to encode the additions very carefully because they are very old and very valuable. Not all of them were mentioned in Hammerschmidt's description. 

Some of the additions have already been discussed in issues #2410, #2410, #2421, #2429, #2434 and #2434. For some others, I am still not always sure what is a title, what is a personal name, and what is a place name. It would be nice to have a critical eye on this!

I have opened #2428 for the encoding of decorations. I am including Guesh in this pull request, so he can keep an eye on the result.

Unfortunately the manuscript is available only in microfilm images, unless better pictures must exist, because the decorations are reproduced in coloured pictures and one article by Roger Schneider has a better image from a folio. It would be nice to acquire better pictures or get new ones, but that might be not very easy, as discussed in issue #2416. 

With some exceptions, the text is nevertheless well readable, but the quire structure is not discernable and not given in Hammerschmidts catalogue. For this reason, we can not be certain, if the last quire with many additions was added later to the codex in a rebinding, as I hypothesized in my collation description and in history. 

I encoded very many personal names and also some place names, that are found in high number in additions. I tried to encode the additions very carefully, because they are very old and very valuable. Not all of them have been mentioned in Hammerschmidts description. 

Some of the additions have been already discussed in issue #2410, #2410, #2421, #2429, #2434 and #2434. For some others I am still not always certain about what is a title, what is a personal name and what is a place name. It would be nice, if you had a critical eye on it!

For the encoding of decorations, I have opened #2428. I include Guesh in this pull request, so he can also have an eye on the outcome.