### PR TITLE
Update BMLacq384

### DIFF
--- a/FlorenceBML/BMLacq384/BMLacq384.xml
+++ b/FlorenceBML/BMLacq384/BMLacq384.xml
@@ -35,7 +35,212 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                             <idno>Marrassini ms. 17</idno>
                         </altIdentifier>
                     </msIdentifier>
+                    <msContents>
+                        <summary/>
+                        <msItem xml:id="ms_i1">
+                            <locus from="1r" to="29r"/>
+                            <title ref="LIT1758Lefafa"/>
+                                <note>According to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/>
+                                    <citedRange unit="page">97</citedRange></bibl> a version different to the the one published by 
+                                    <bibl><ptr target="bm:Budge1929"/></bibl> and <bibl><ptr target="bm:Euringer1940Rechtfertigung"/></bibl>.</note>
+                                <msItem xml:id="ms_i1.1">
+                                    <locus from="1r" to="21r"/>
+                                    <title>Ləfāfa ṣədq proper</title>
+                                    <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱ</hi>ስ፡ ፩አምላክ። ጸሎተ፡ ድኅነት፡ ወመጽሐፈ፡ ሕይወት፡
+                                        ልፋፈ፡ ጽድቅ፡ ዘ<hi rend="rubric">ጸሐፋ፡ አብ፡ በእ</hi>ዴሁ፡ ቅድስት፡ እም<pb n="1v"/>ቅድመ፡ ይትወለድ፡ ክርስቶስ፡ እምእግዝእትነ፡ 
+                                        <hi rend="rubric">ማርያም፡</hi> እንተ፡ ታበውዕ፡ ውስተ፡ መንግሥት፡ ሰማያት።</incipit>
+                                    <explicit xml:lang="gez">ስሙ፡ ለአብ፡ ሙርያል፡ <pb n="20v"/>ስሙ፡ ለወልድ፡ ምናቴር፡ ስሙ፡ ለመንፈስ፡ ቅዱስ፡ አብያቴር፡ በዝአስማቲከ፡ ዕቀበኒ፡
+                                        መከራ፡ ሥጋ፡ ወነፍስ፡ ለዓመትከ፡ <pb n="21r"/>
+                                        <hi rend="rubric"><persName ref="PRS14219WalattaIyasus">ወለተ፡ ኢያሱስ፡</persName></hi></explicit>
+                                </msItem>
+                                <msItem xml:id="ms_i1.2">
+                                    <locus from="21r" to="29r"/>
+                                    <title>Prayers for the ascension to heaven</title>
+                                    <note>Seven prayers, that are most often preceding the <ref target="LIT1758Lefafa"/> proper, but that are here attached 
+                                        behind, each one having <foreign xml:lang="gez">ጸሎት፡ ዘመንገደ፡ ሰማይ፡ ዕቀበኒ፡ ክርስቶስ፡ ከመ፡ ኢያዕቅፍዋ፡ ለነፍስየ፡ መላእክተ፡ 
+                                            ጽልመት፡</foreign> in its incipit.</note>
+                                    <msItem xml:id="ms_i1.2.1">
+                                        <locus from="21r" to="22r"/>
+                                        <title>Prayer</title>
+                                        <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡</hi><gap reason="ellipsis" unit="lines" quantity="2"/> 
+                                            ጸሎት፡ ዘመንገደ፡ ሰማይ፡ </incipit>
+                                        <explicit xml:lang="gez">በኢልዳን፡ ስምከ፡ ወበምኅሰ፡ ምሥዋሪከ። ወይቤላ፡ ኢያሱስ፡ ለ<hi rend="rubric">ማርያም፡</hi> ወይበል፡ 
+                                            በብርሃናኤል፡ ስምከ፡ ተማኅፀንኩ፡ አነ፡ ዓመትከ፡ <pb n="22r"/>
+                                            <hi rend="rubric"><persName ref="PRS14219WalattaIyasus">ወለተ፡ ኢያሱስ፡</persName></hi></explicit>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.2">
+                                        <locus from="22r" to="23r"/>
+                                        <title>Prayer</title>
+                                        <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡</hi><gap reason="ellipsis" unit="lines" quantity="2"/> 
+                                            ጸሎት፡ ዘመንገደ፡ ሰማይ፡ </incipit>
+                                        <explicit xml:lang="gez">በኢያሱስ፡ ወበአንጥያከስ፡ አስማቲከ፡ ወይቤላ፡ ኢያሱስ፡ ለ<hi rend="rubric">ማርያም፡</hi> ሀለዎ፡ ምሕረቱ፡ 
+                                            ለአቡየ፡ ወምሕረትየ፡ ይከውኖ፡ ለሕይወት፡ ወለመድኃኒ<pb n="23r"/>ት። ወሊትኒ፡ አጽኅነኒ፡ ለዓመትከ።</explicit>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.3">
+                                        <locus from="23r" to="24r"/>
+                                        <title>Prayer</title>
+                                        <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡</hi><gap reason="ellipsis" unit="lines" quantity="2"/>
+                                            ጸሎት፡ ዘመንገደ፡<pb n="23v"/> ሰማይ፡</incipit>
+                                        <explicit xml:lang="gez"><hi rend="rubric">ሚካኤል፡</hi> ወ<hi rend="rubric">ገብርኤል፡</hi> 
+                                            ወ<hi rend="rubric">ጳራቅሊጦስሃ፡</hi> ናዛዚ፡ ኅዙናን፡ ኢታርኅቅ፡ እ<pb n="24r"/>ምኔየ፡ በይእቲ፡ ስዓት፡ ወበይእቲ፡ ዕለት፡ ይትቃመኒ፡ 
+                                            ውስተ፡ ጸናፌ፡ ጽልመት፤ ወሊተነ፡ ለዓመትከ፡ <persName ref="PRS14219WalattaIyasus">ወለተ፤ <hi rend="rubric">ኢያሱስ፡</hi></persName>
+                                                    </explicit>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.4">
+                                        <locus from="24r" to="25v"/>
+                                        <title>Prayer</title>
+                                        <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡</hi><gap reason="ellipsis" unit="lines" quantity="3"/>
+                                            ጸሎት፡ ዘመንገደ፡ ሰማይ፡</incipit>
+                                        <explicit xml:lang="gez"><hi rend="rubric">ሚካኤል፡</hi><pb n="25r"/> ወገብርኤል፡ ሱራፌል፡ ወኪሩቤል፡ ዑራኤል፡ 
+                                            ወሩፋኤል፡ ፋኑኤል፡ ወሳቁኤል፡ አፍኒን፡ ወራጉኤል፡ ሰአሉነ፡ አስተምሕሩ፡ ለነ፡ ቅድመ፡ መንበ<pb n="25v"/><surplus>በ</surplus>ሩ፡ 
+                                            ለእግዚእነ። ወሊተኒ፡ አድኅነኒ፡ ለዓመትከ፡ <persName ref="PRS14219WalattaIyasus">ወለተ፡ <hi rend="rubric">ኢያሱስ፡</hi></persName>
+                                                    </explicit>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.5">
+                                        <locus from="25v" to="26v"/>
+                                        <title>Prayer</title>
+                                        <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡</hi><gap reason="ellipsis" unit="lines" quantity="2"/>
+                                            ጸሎት፡ ዘመንገደ፡ ሰማይ፡</incipit>
+                                        <explicit xml:lang="gez">ሰአሉ፡ ለነ፡ ሰላትያል፡ ወስዳክያል፡ እክናታኤል፡ ሰአሉ፡ ለነ፡ አስተምህሩ፡ ለነ፡ ቅ<pb n="26v"/>ድመ፡ መንበሩ፡ ለእግዚእነ።
+                                            ወሊተኒ፡ አድኅነኒ፤ ለዓመትክ፡ <hi rend="rubric"><persName ref="PRS14219WalattaIyasus">ወለተ፡ ኢያሱስ፡</persName></hi></explicit>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.6">
+                                        <locus from="26v" to="27v"/>
+                                        <title>Prayer</title>
+                                        <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡</hi><gap reason="ellipsis" unit="lines" quantity="2"/>
+                                            ጸሎት፡ ዘመንገደ፡ <pb n="27r"/>ሰማይ፡</incipit>
+                                        <explicit xml:lang="gez">በጣፃዌ፡ ወበልንጰዌ፡ ስሙ፡ ለመድኃኒነ፡ ወበ<hi rend="rubric">ማርያም፡</hi> ወላዲትከ፡ በጥ፡ 
+                                            በ<pb n="27v"/>ርያዶስ፡ ዘንጹሕ፡ ጽርሐ፡ መቅደሱ፡ አልቦ፡ ዘየአምሮሙ፡ ለአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ዕቀበኒ፡ ለዓመትከ፡ 
+                                            <persName ref="PRS14219WalattaIyasus">ወለተ፡ <hi rend="rubric">ኢያሱስ፡</hi></persName></explicit>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.7">
+                                        <locus from="27v" to="29r"/>
+                                        <title>Prayer</title>
+                                        <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ ወአ<pb n="28r"/>ብ፡</hi><gap reason="ellipsis" unit="lines" 
+                                            quantity="2"/> ጸሎት፡ ዘመንገደ፡ ሰማይ፡</incipit>
+                                        <explicit xml:lang="gez"> በኤ<pb n="28v"/>ልዳን፡ ስምከ፡ ወበምኅንሳ፡ ማኅደርከ፡ በ፲ወ፭፡ ነቢያት፡ በ፲ወ፪ሐዋርያት፡ በ፸ወ፪አርድእት፡ በ፭፻ቢጽ፡
+                                            በ፫፻፲ወ፰ርቱዓነ፡ ሃይማኖት፡ <pb n="29r"/>በ፳ወ፬ካህናተ፡ ሰማይ፡ ወበ፬እንስሳ፡ ፀዋርያነ፤ መንበሩ፡ ለእግዚአብሔር፤ ተማኅፀንኩ፡ አነ፡ ዓመትከ፡
+                                            <persName ref="PRS14219WalattaIyasus">ወለተ፡ ኢያሱ<hi rend="rubric">ስ፡</hi></persName></explicit>
+                                    </msItem>
+                                </msItem>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <locus from="29r" to="31v"/>
+                            <title>Narration of the Passion of Christ revealed to Maria Magdalene, Sara and Salome.</title>
+                            <note>One of the works, that are according to Euringer (p. 83) often added to the Ləfāfa ṣədq.</note>
+                            <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡</hi><gap reason="ellipsis" unit="lines" quantity="2"/>ንጽሕፍ፡ ዜና፡ 
+                                ሕማማቲሁ፡ ለእግዚእነ፡ ወቅንዋቲሁ፡ ለመድኀኒነ፡ ኢያሱስ፡ ክርስቶስ፡ ዘከሠተ፡ ሎን፡ ለሠላ<pb n="30r"/>ስ፡ ቅድስት፡ አንስት፡ እለ፡ ይሰመይ፡ 
+                                <persName ref="PRS6820MaryMag">ማርያም፡ መግደላዊት፡</persName> ለ<persName ref="PRS14218Sara">ሳራ፡</persName> 
+                                ወለ<persName ref="PRS8417Salome">ሰሎሜ፡</persName></incipit>
+                            <explicit xml:lang="gez">በእደ፡ ዮሴፍ፡ ወኒቆዲሞስ። ሥመር፡ እግዚኦ፡ በርኅራኄከ፡ ከመ፡ ትሰደኒ፤ ኀበ፤ ት<pb n="31v"/>ንሣኤከ፡ በእንተ፡ ሞትከ፡ 
+                                ወተቀብሮትከ፡ ዘትነግሥ፡ ለዓለመ፡ ዓለም፡ አሜን። ። ።</explicit>
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Codex">
+                            <supportDesc>
+                                <support>
+                                    <watermark/>
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf" quantity="37">IV+32+I</measure>   
+                                    <measure unit="quire" quantity="6">6</measure> 
+                                    <note>Dimensions indicated below are taken from a note, that was inserted during the digitazition. Dimensions 
+                                        indicated in the cataloque of <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/>
+                                        <citedRange unit="page">97</citedRange></bibl> are slightly different and may concern dimensions of folia 
+                                        (not clearly specified in catalogue).</note>
+                                    <dimensions type="outer" unit="mm">                                        
+                                        <height cert="medium">74</height>
+                                        <width cert="medium">52</width>
+                                        <depth cert="medium">19</depth>
+                                    </dimensions>
+                                    <note>Folia <locus from="6v" to="7r"/> missing in the images.</note>
+                                </extent>
+                                <foliation>Quire marks in Ethiopian numbers at top left. Folio numbers only occasionally on the bottom left by 
+                                    an European hand.</foliation>
+                                <collation>
+                                    <list>
+                                        <item xml:id="q1" n="1">
+                                            <dim unit="leaf">4</dim>
+                                            <locus from="i" to="iv"></locus>
+                                        </item>
+                                        <item xml:id="q2" n="2">
+                                            <dim unit="leaf">8</dim>
+                                            <locus from="1" to="8"/>
+                                        </item>
+                                        <item xml:id="q3" n="3">
+                                            <dim unit="leaf">8</dim>
+                                            <locus from="9" to="16"/>
+                                        </item>
+                                        <item xml:id="q4" n="4">
+                                            <dim unit="leaf">8</dim>
+                                            <locus from="17" to="24"/>
+                                        </item>
+                                        <item xml:id="q5" n="5">
+                                            <dim unit="leaf">9</dim>
+                                            <locus from="25" to="i'"/>
+                                            s.l. 9; stub before 1
+                                        </item>
+                                    </list>
+                                </collation>
+                                <condition key="intact">Front board broken in two pieces and repaired with a thread. </condition>
+                            </supportDesc>
+                            <layoutDesc>
+                                <layout columns="1" writtenLines="8">
+                                    <ab type="pricking">pricking mostly visible</ab>
+                                    <ab type="ruling">ruling partly visible</ab>
+                                </layout>
+                                <layout/>
+                            </layoutDesc>
+                        </objectDesc>
+                        <handDesc>
+                            <handNote xml:id="h1" script="Ethiopic">
+                                <date notBefore="1801" notAfter="1987"/>
+                                <seg type="ink">Black, red.</seg>
+                                <seg type="rubrication">Incipit, tables, sacred names, name of the owner.</seg>
+                                <seg type="script">Careful script of the nineteenth or twentieth century.</seg>
+                                <note>Contains <hi rend="ligature">ግዚ</hi> throughout.</note>
+                            </handNote>
+                        </handDesc>
+                        <decoDesc>
+                            <decoNote xml:id="d1" type="band">Band with ornamentic features at the bottom, that marks the end of the text at 
+                                <locus target="#31v"/></decoNote>
+                        </decoDesc>
+                        <additions>
+                            <list>
+                                <item xml:id="e1">
+                                    <locus target="#ir"/>
+                                    <desc type="StampExlibris">"Acq. e doni 384</desc>
+                                </item>
+                                <item xml:id="e2">
+                                    <locus target="i'v"/>
+                                    <desc type="StampExlibris">"VI 2 L 200 Manoscritto copto?" probably by the same hand as <ref target="#e1"/>.</desc>
+                                </item>
+                                <item xml:id="e3">
+                                    <locus target="#ivr #31v"/>
+                                    <desc type="StampExlibris">"17101"</desc>
+                                </item>
+                                <item xml:id="e4">
+                                    <locus target="#ivr #31v"/>
+                                    <desc type="StampExlibris">Big round stamp with the inscription: <foreign xml:lang="it">R. Bibl. Medic. Laurenziana. 
+                                        Firenze</foreign>.</desc>
+                                </item>
+                            </list>
+                        </additions>
+                        <bindingDesc>
+                            <binding contemporary="true">
+                                <decoNote xml:id="b1" type="Boards">Two wooden boards, front board broken in two pieces.</decoNote>    
+                                <decoNote xml:id="b2" type="bindingMaterial"><material key="wood"></material></decoNote>
+                            </binding>
+                        </bindingDesc>
+                    </physDesc>
                     <history>
+                        <origin>
+                            <origDate notBefore="1801" notAfter="1987">19th to 20th century</origDate>
+                        </origin>
+                        <provenance>Owned by <persName ref="PRS14219WalattaIyasus">Walatta Iyasus</persName>, as indicated at the end 
+                            of each text part.</provenance>
                     </history>
                     <additional>
                         <adminInfo>
@@ -58,18 +263,23 @@ schematypens="http://relaxng.org/ns/structure/1.0"
             <projectDesc>
                 <p>Encoded according to TEI P5 Guidelines.</p>
             </projectDesc>
-        <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
-            <xi:fallback>
-               <p>Definitions of prefixes used.</p>
-            </xi:fallback>
-         </xi:include>
-      </encodingDesc>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+                <xi:fallback>
+                    <p>Definitions of prefixes used.</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
-            <langUsage><language ident="en">English</language></langUsage>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="it">Italian</language>
+                <language ident="gez">Gəʿəz</language>
+            </langUsage>
         </profileDesc>
         <revisionDesc>
             <change who="PL" when="2019-02-21">Created catalogue entry</change>
             <change when="2021-09-20" who="PL">added text from transkribus and facsimile with xi:include</change>
+            <change when="2023-11-07" who="CH">added physical description and content description from catalogue</change>
         </revisionDesc>
     </teiHeader>
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" 
@@ -78,11 +288,11 @@ schematypens="http://relaxng.org/ns/structure/1.0"
             <!-- facsimile -->
         </xi:fallback>
     </xi:include>
-
-            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" 
-                href="transkribusText.xml">
-                <xi:fallback>
-                    <!-- transkribus text -->
-                </xi:fallback>
-            </xi:include>
+    
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" 
+        href="transkribusText.xml">
+        <xi:fallback>
+            <!-- transkribus text -->
+        </xi:fallback>
+    </xi:include>
 </TEI>

--- a/FlorenceBML/BMLacq384/BMLacq384.xml
+++ b/FlorenceBML/BMLacq384/BMLacq384.xml
@@ -126,10 +126,10 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         </msItem>
                         <msItem xml:id="ms_i2">
                             <locus from="29r" to="31v"/>
-                            <title>Narration of the Passion of Christ revealed to Maria Magdalene, Sara and Salome.</title>
+                            <title ref="LIT5020Hemamatihu">Narration of the Passion of Christ revealed to Maria Magdalene, Sara and Salome.</title>
                             <note>One of the works, that are according to <bibl><ptr target="bm:Euringer1940Rechtfertigung"/>
-                                <citedRange unit="page">83</citedRange></bibl> often added to the <title ref="LIT1758Lefafa"/>, 
-                                possibly the same as <ref type="work" corresp="LIT5020Hemamatihu"></ref>.</note>
+                                <citedRange unit="page">83</citedRange></bibl> often added to the <title ref="LIT1758Lefafa"/>, different from
+                                the version in <bibl><ptr target="bm:Piovanelli2014Passion"/></bibl>.</note>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡</hi><gap reason="ellipsis" unit="lines" quantity="2"/>ንጽሕፍ፡ ዜና፡ 
                                 ሕማማቲሁ፡ ለእግዚእነ፡ ወቅንዋቲሁ፡ ለመድኀኒነ፡ ኢያሱስ፡ ክርስቶስ፡ ዘከሠተ፡ ሎን፡ ለሠላ<pb n="30r"/>ስ፡ ቅድስት፡ አንስት፡ እለ፡ ይሰመይ፡ 
                                 <persName ref="PRS6820MaryMag">ማርያም፡ መግደላዊት፡</persName> ለ<persName ref="PRS14218Sara">ሳራ፡</persName> 

--- a/FlorenceBML/BMLacq384/BMLacq384.xml
+++ b/FlorenceBML/BMLacq384/BMLacq384.xml
@@ -45,7 +45,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                     <bibl><ptr target="bm:Budge1929"/></bibl> and <bibl><ptr target="bm:Euringer1940Rechtfertigung"/></bibl>.</note>
                                 <msItem xml:id="ms_i1.1">
                                     <locus from="1r" to="21r"/>
-                                    <title>Ləfāfa ṣədq proper</title>
+                                    <title>Lǝfāfa ṣǝdq proper</title>
                                     <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱ</hi>ስ፡ ፩አምላክ። ጸሎተ፡ ድኅነት፡ ወመጽሐፈ፡ ሕይወት፡
                                         ልፋፈ፡ ጽድቅ፡ ዘ<hi rend="rubric">ጸሐፋ፡ አብ፡ በእ</hi>ዴሁ፡ ቅድስት፡ እም<pb n="1v"/>ቅድመ፡ ይትወለድ፡ ክርስቶስ፡ እምእግዝእትነ፡ 
                                         <hi rend="rubric">ማርያም፡</hi> እንተ፡ ታበውዕ፡ ውስተ፡ መንግሥት፡ ሰማያት።</incipit>
@@ -127,7 +127,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <msItem xml:id="ms_i2">
                             <locus from="29r" to="31v"/>
                             <title>Narration of the Passion of Christ revealed to Maria Magdalene, Sara and Salome.</title>
-                            <note>One of the works, that are according to Euringer (p. 83) often added to the Ləfāfa ṣədq.</note>
+                            <note>One of the works, that are according to Euringer (p. 83) often added to the Lǝfāfa ṣǝdq.</note>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡</hi><gap reason="ellipsis" unit="lines" quantity="2"/>ንጽሕፍ፡ ዜና፡ 
                                 ሕማማቲሁ፡ ለእግዚእነ፡ ወቅንዋቲሁ፡ ለመድኀኒነ፡ ኢያሱስ፡ ክርስቶስ፡ ዘከሠተ፡ ሎን፡ ለሠላ<pb n="30r"/>ስ፡ ቅድስት፡ አንስት፡ እለ፡ ይሰመይ፡ 
                                 <persName ref="PRS6820MaryMag">ማርያም፡ መግደላዊት፡</persName> ለ<persName ref="PRS14218Sara">ሳራ፡</persName> 
@@ -273,7 +273,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
             <langUsage>
                 <language ident="en">English</language>
                 <language ident="it">Italian</language>
-                <language ident="gez">Gəʿəz</language>
+                <language ident="gez">Gǝʿǝz</language>
             </langUsage>
         </profileDesc>
         <revisionDesc>

--- a/FlorenceBML/BMLacq384/BMLacq384.xml
+++ b/FlorenceBML/BMLacq384/BMLacq384.xml
@@ -55,32 +55,32 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                 </msItem>
                                 <msItem xml:id="ms_i1.2">
                                     <locus from="21r" to="29r"/>
-                                    <title>Prayers for the ascension to heaven</title>
+                                    <title ref="LIT1873Mangad"/>
                                     <note>Seven prayers, that are most often preceding the <ref target="LIT1758Lefafa"/> proper, but that are here attached 
                                         behind, each one having <foreign xml:lang="gez">ጸሎት፡ ዘመንገደ፡ ሰማይ፡ ዕቀበኒ፡ ክርስቶስ፡ ከመ፡ ኢያዕቅፍዋ፡ ለነፍስየ፡ መላእክተ፡ 
                                             ጽልመት፡</foreign> in its incipit.</note>
                                     <msItem xml:id="ms_i1.2.1">
                                         <locus from="21r" to="22r"/>
-                                        <title>Prayer</title>
+                                        <title>Prayer for the Journey to Heaven (Ba-ʾeldān sǝm-ka wa-ba-mǝḫǝsa mǝśwāri-ka)</title>
                                         <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡</hi><gap reason="ellipsis" unit="lines" quantity="2"/> 
                                             ጸሎት፡ ዘመንገደ፡ ሰማይ፡ </incipit>
-                                        <explicit xml:lang="gez">በኢልዳን፡ ስምከ፡ ወበምኅሰ፡ ምሥዋሪከ። ወይቤላ፡ ኢያሱስ፡ ለ<hi rend="rubric">ማርያም፡</hi> ወይበል፡ 
+                                        <explicit xml:lang="gez">በኤልዳን፡ ስምከ፡ ወበምኅሰ፡ ምሥዋሪከ። ወይቤላ፡ ኢያሱስ፡ ለ<hi rend="rubric">ማርያም፡</hi> ወይበል፡ 
                                             በብርሃናኤል፡ ስምከ፡ ተማኅፀንኩ፡ አነ፡ ዓመትከ፡ <pb n="22r"/>
                                             <hi rend="rubric"><persName ref="PRS14219WalattaIyasus">ወለተ፡ ኢያሱስ፡</persName></hi></explicit>
                                     </msItem>
                                     <msItem xml:id="ms_i1.2.2">
                                         <locus from="22r" to="23r"/>
-                                        <title>Prayer</title>
+                                        <title>Prayer for the Journey to Heaven (Ba-ʾIyāsus wa-ba-ʾAnṭǝyās)</title>
                                         <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡</hi><gap reason="ellipsis" unit="lines" quantity="2"/> 
                                             ጸሎት፡ ዘመንገደ፡ ሰማይ፡ </incipit>
-                                        <explicit xml:lang="gez">በኢያሱስ፡ ወበአንጥያከስ፡ አስማቲከ፡ ወይቤላ፡ ኢያሱስ፡ ለ<hi rend="rubric">ማርያም፡</hi> ሀለዎ፡ ምሕረቱ፡ 
+                                        <explicit xml:lang="gez"> በኢያሱስ፡ ወበአንጥያከስ፡ አስማቲከ፡ ወይቤላ፡ ኢያሱስ፡ ለ<hi rend="rubric">ማርያም፡</hi> ሀለዎ፡ ምሕረቱ፡ 
                                             ለአቡየ፡ ወምሕረትየ፡ ይከውኖ፡ ለሕይወት፡ ወለመድኃኒ<pb n="23r"/>ት። ወሊትኒ፡ አጽኅነኒ፡ ለዓመትከ።</explicit>
                                     </msItem>
                                     <msItem xml:id="ms_i1.2.3">
                                         <locus from="23r" to="24r"/>
-                                        <title>Prayer</title>
+                                        <title>Prayer for the Journey to Heaven (Mikāʾel wa-Gabrǝʾel wa-Ṗarāqliṭos-hā)</title>
                                         <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡</hi><gap reason="ellipsis" unit="lines" quantity="2"/>
-                                            ጸሎት፡ ዘመንገደ፡<pb n="23v"/> ሰማይ፡</incipit>
+                                            ጸሎት፡ ዘመንገደ፡<pb n="23v"/> ሰማይ፡ </incipit>
                                         <explicit xml:lang="gez"><hi rend="rubric">ሚካኤል፡</hi> ወ<hi rend="rubric">ገብርኤል፡</hi> 
                                             ወ<hi rend="rubric">ጳራቅሊጦስሃ፡</hi> ናዛዚ፡ ኅዙናን፡ ኢታርኅቅ፡ እ<pb n="24r"/>ምኔየ፡ በይእቲ፡ ስዓት፡ ወበይእቲ፡ ዕለት፡ ይትቃመኒ፡ 
                                             ውስተ፡ ጸናፌ፡ ጽልመት፤ ወሊተነ፡ ለዓመትከ፡ <persName ref="PRS14219WalattaIyasus">ወለተ፤ <hi rend="rubric">ኢያሱስ፡</hi></persName>
@@ -88,9 +88,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                     </msItem>
                                     <msItem xml:id="ms_i1.2.4">
                                         <locus from="24r" to="25v"/>
-                                        <title>Prayer</title>
+                                        <title>Prayer for the Journey to Heaven (Mikāʾel wa-Gabrǝʾel, Surāfel wa-Kirubel, ʿUrāʾel wa-Rufāʾel, ...)</title>
                                         <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡</hi><gap reason="ellipsis" unit="lines" quantity="3"/>
-                                            ጸሎት፡ ዘመንገደ፡ ሰማይ፡</incipit>
+                                            ጸሎት፡ ዘመንገደ፡ ሰማይ፡ </incipit>
                                         <explicit xml:lang="gez"><hi rend="rubric">ሚካኤል፡</hi><pb n="25r"/> ወገብርኤል፡ ሱራፌል፡ ወኪሩቤል፡ ዑራኤል፡ 
                                             ወሩፋኤል፡ ፋኑኤል፡ ወሳቁኤል፡ አፍኒን፡ ወራጉኤል፡ ሰአሉነ፡ አስተምሕሩ፡ ለነ፡ ቅድመ፡ መንበ<pb n="25v"/><surplus>በ</surplus>ሩ፡ 
                                             ለእግዚእነ። ወሊተኒ፡ አድኅነኒ፡ ለዓመትከ፡ <persName ref="PRS14219WalattaIyasus">ወለተ፡ <hi rend="rubric">ኢያሱስ፡</hi></persName>
@@ -98,26 +98,26 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                     </msItem>
                                     <msItem xml:id="ms_i1.2.5">
                                         <locus from="25v" to="26v"/>
-                                        <title>Prayer</title>
+                                        <title>Prayer for the Journey to Heaven (Saʾalu lana Salātyāl wa-Sadākyāl, ʾƎknātāʾel)</title>
                                         <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡</hi><gap reason="ellipsis" unit="lines" quantity="2"/>
-                                            ጸሎት፡ ዘመንገደ፡ ሰማይ፡</incipit>
+                                            ጸሎት፡ ዘመንገደ፡ ሰማይ፡ </incipit>
                                         <explicit xml:lang="gez">ሰአሉ፡ ለነ፡ ሰላትያል፡ ወስዳክያል፡ እክናታኤል፡ ሰአሉ፡ ለነ፡ አስተምህሩ፡ ለነ፡ ቅ<pb n="26v"/>ድመ፡ መንበሩ፡ ለእግዚእነ።
                                             ወሊተኒ፡ አድኅነኒ፤ ለዓመትክ፡ <hi rend="rubric"><persName ref="PRS14219WalattaIyasus">ወለተ፡ ኢያሱስ፡</persName></hi></explicit>
                                     </msItem>
                                     <msItem xml:id="ms_i1.2.6">
                                         <locus from="26v" to="27v"/>
-                                        <title>Prayer</title>
+                                        <title>Prayer for the Journey to Heaven (Ba-gǝṣṣāwe)</title>
                                         <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡</hi><gap reason="ellipsis" unit="lines" quantity="2"/>
-                                            ጸሎት፡ ዘመንገደ፡ <pb n="27r"/>ሰማይ፡</incipit>
+                                            ጸሎት፡ ዘመንገደ፡ <pb n="27r"/>ሰማይ፡ </incipit>
                                         <explicit xml:lang="gez">በጣፃዌ፡ ወበልንጰዌ፡ ስሙ፡ ለመድኃኒነ፡ ወበ<hi rend="rubric">ማርያም፡</hi> ወላዲትከ፡ በጥ፡ 
                                             በ<pb n="27v"/>ርያዶስ፡ ዘንጹሕ፡ ጽርሐ፡ መቅደሱ፡ አልቦ፡ ዘየአምሮሙ፡ ለአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ዕቀበኒ፡ ለዓመትከ፡ 
                                             <persName ref="PRS14219WalattaIyasus">ወለተ፡ <hi rend="rubric">ኢያሱስ፡</hi></persName></explicit>
                                     </msItem>
                                     <msItem xml:id="ms_i1.2.7">
                                         <locus from="27v" to="29r"/>
-                                        <title>Prayer</title>
+                                        <title>Prayer for the Journey to Heaven (Ba-ʾeldān sǝm-ka wa-ba-mǝḫǝnǝsā māḫdar-ka)</title>
                                         <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ ወአ<pb n="28r"/>ብ፡</hi><gap reason="ellipsis" unit="lines" 
-                                            quantity="2"/> ጸሎት፡ ዘመንገደ፡ ሰማይ፡</incipit>
+                                            quantity="2"/> ጸሎት፡ ዘመንገደ፡ ሰማይ፡ </incipit>
                                         <explicit xml:lang="gez"> በኤ<pb n="28v"/>ልዳን፡ ስምከ፡ ወበምኅንሳ፡ ማኅደርከ፡ በ፲ወ፭፡ ነቢያት፡ በ፲ወ፪ሐዋርያት፡ በ፸ወ፪አርድእት፡ በ፭፻ቢጽ፡
                                             በ፫፻፲ወ፰ርቱዓነ፡ ሃይማኖት፡ <pb n="29r"/>በ፳ወ፬ካህናተ፡ ሰማይ፡ ወበ፬እንስሳ፡ ፀዋርያነ፤ መንበሩ፡ ለእግዚአብሔር፤ ተማኅፀንኩ፡ አነ፡ ዓመትከ፡
                                             <persName ref="PRS14219WalattaIyasus">ወለተ፡ ኢያሱ<hi rend="rubric">ስ፡</hi></persName></explicit>
@@ -127,7 +127,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <msItem xml:id="ms_i2">
                             <locus from="29r" to="31v"/>
                             <title>Narration of the Passion of Christ revealed to Maria Magdalene, Sara and Salome.</title>
-                            <note>One of the works, that are according to Euringer (p. 83) often added to the Lǝfāfa ṣǝdq.</note>
+                            <note>One of the works, that are according to <bibl><ptr target="bm:Euringer1940Rechtfertigung"/>
+                                <citedRange unit="page">83</citedRange></bibl> often added to the <title ref="LIT1758Lefafa"/>, 
+                                possibly the same as <ref type="work" corresp="LIT5020Hemamatihu"></ref>.</note>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡</hi><gap reason="ellipsis" unit="lines" quantity="2"/>ንጽሕፍ፡ ዜና፡ 
                                 ሕማማቲሁ፡ ለእግዚእነ፡ ወቅንዋቲሁ፡ ለመድኀኒነ፡ ኢያሱስ፡ ክርስቶስ፡ ዘከሠተ፡ ሎን፡ ለሠላ<pb n="30r"/>ስ፡ ቅድስት፡ አንስት፡ እለ፡ ይሰመይ፡ 
                                 <persName ref="PRS6820MaryMag">ማርያም፡ መግደላዊት፡</persName> ለ<persName ref="PRS14218Sara">ሳራ፡</persName> 
@@ -140,7 +142,6 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <objectDesc form="Codex">
                             <supportDesc>
                                 <support>
-                                    <watermark/>
                                     <material key="parchment"/>
                                 </support>
                                 <extent>
@@ -158,7 +159,8 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                     <note>Folia <locus from="6v" to="7r"/> missing in the images.</note>
                                 </extent>
                                 <foliation>Quire marks in Ethiopian numbers at top left. Folio numbers only occasionally on the bottom left by 
-                                    an European hand.</foliation>
+                                    an European hand. Two protective leaves in front are marked with Roman numbers (I and II), while the protective leaf 
+                                    behind the text block is marked as well with a Roman capital (I').</foliation>
                                 <collation>
                                     <list>
                                         <item xml:id="q1" n="1">
@@ -200,7 +202,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                 <seg type="ink">Black, red.</seg>
                                 <seg type="rubrication">Incipit, tables, sacred names, name of the owner.</seg>
                                 <seg type="script">Careful script of the nineteenth or twentieth century.</seg>
-                                <note>Contains <hi rend="ligature">ግዚ</hi> throughout.</note>
+                                <note>Contains the ligature <hi rend="ligature">ግዚ</hi> throughout.</note>
                             </handNote>
                         </handDesc>
                         <decoDesc>

--- a/FlorenceBML/BMLacq384/BMLacq384.xml
+++ b/FlorenceBML/BMLacq384/BMLacq384.xml
@@ -30,7 +30,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                     <msIdentifier>
                         <repository ref="INS0339BML"/>
                         <collection>Acquisizioni e doni</collection>
-                        <idno facs="Laurenziana/BML_017/BML_017-" n="55">BML Acq. e doni 384</idno>
+                        <idno facs="Laurenziana/BML_017/BML_017-" n="56">BML Acq. e doni 384</idno>
                         <altIdentifier>
                             <idno>Marrassini ms. 17</idno>
                         </altIdentifier>


### PR DESCRIPTION
I have updated the record for BMLacq384 according to Marrassini's catalogue description. 

Again, there is one image missing in the viewer. It is the opening 6v-7r. It is clear from Marrassini's description of the quire structure, which agrees with my own observation (quadernion with 8 leaves with no visible stubs), but also from the text: 6r ends with ኀበ፤, but the next folio on image (no. 13 in the viewer) starts with ለ፡ ይስሕቱ፡) that do not fit together. 

For this reason, it may be advantageous to enter the folio numbers manually. There are some folio numbers written in pencil in the manuscript, but only on a very few folios.

image no. 12:
<img width="783" alt="Screenshot 2023_haba (1)" src="https://github.com/BetaMasaheft/Manuscripts/assets/40291787/b0bac005-4b58-488a-a8a3-4613f2754a47">

image no. 13:
<img width="795" alt="Screenshot 2023_habe (2)" src="https://github.com/BetaMasaheft/Manuscripts/assets/40291787/d137be87-3058-4154-af95-0fec4923221e">
