### PR TITLE
BMLacq784

### DIFF
--- a/FlorenceBML/BMLacq784/BMLacq784.xml
+++ b/FlorenceBML/BMLacq784/BMLacq784.xml
@@ -5,7 +5,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <title/>
+                <title>Prayers; Ṭabiba ṭabibān</title>
                 <editor key="AB" role="generalEditor"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
@@ -29,7 +29,184 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                             <idno>Marrassini ms. 18</idno>
                         </altIdentifier>
                     </msIdentifier>
+                    <msContents>
+                        <summary/>
+                        <msItem xml:id="ms_i1">
+                            <locus from="1r" to="1v"/>
+                            <title>Magical Prayer</title>
+                            <note>Beginning mostly not legible, but with some magical expressions as the name of a demon: 
+                                <foreign xml:lang="gez">ባርያ፡ ጸሊም፡</foreign>.</note>
+                            <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩፡ አምላክ፡ 
+                                ተ<gap reason="illegible" unit="chars" quantity="1"/></hi>
+                                <gap reason="illegible" unit="chars" quantity="5"/> ባርያ፡ ጸሊም፡ አዝመ
+                                <gap reason="illegible"/></incipit>
+                            <explicit xml:lang="gez">መ<pb n="1v"/>ንፈስ፡ ቅዱስ፡ ተሰደድ፡ ውፃእ፡ በሳሬአዴቀ፡ እሳት፡ ተተኰስ፡ ከመ፡ መሬት፡ በስሕናና፡ 
+                                በአር<hi rend="rubric">አስተ፡ እሳት፡ ተመንሰግ፡ በሰሬይሰ፡ አጸናይ፡ ይስደድከ፡ 
+                                <gap reason="illegible" unit="chars" quantity="1"/>ስቅኤል፡ ዕመ</hi>ቀ፡ ሲኦል፡ ያሥጥምከ፡ ለእመ፡ ኅለፍከ፡ ወተአደውከ፡ ላዕለ፤ 
+                                ገብረ፡ እግዚአብሔር። <gap reason="illegible" unit="chars" quantity="7"/></explicit>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <locus from="2r" to="3r"/>
+                            <title ref="LIT1824Mafteh"/>
+                            <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ <gap reason="ellipsis" unit="lines" quantity="2"/>
+                                እሙና</hi>ዝር፡ ክሙናዝር፤ ኤልናዝር፤ ፍታሕ፤ ወዘርዝር፤ ሰአር፤ ወመንዝር፡ በስምከ፤ 
+                                በ<gap reason="illegible" unit="chars" quantity="1"/>ናዝር፡ ሥራየ፡ ብእሲ፡ ወብእሲት፤ ሥራየ፡ ነህቢ፡ ወነሃቢት፡ 
+                                ሥራየ፡ ቦላ፤ ወ<persName ref="ETH2043sanqel">ሸንቀላ፤</persName> 
+                                ሥራየ፡ ትርኵ፤ ወ<persName ref="ETH1083Agaw">አገው፤</persName> ሥራየ፡ ቅማንት፡ ወአስማት፤ ሥራየ፡ እስላም፡ ወክርስቲያን፤ 
+                                ሥራየ፡ <persName ref="ETH1126Amhara">አምሀራ፡</persName> 
+                                ወ<placeName ref="LOC6569Tegray">ትግራይ፡</placeName></incipit>
+                            <explicit xml:lang="gez">ወነጽር፡ ኀበ፡ ገፀ፡ ገ<gap reason="illegible" unit="chars" quantity="6"/> ። ። ። 
+                                <hi rend="rubric">ወገፁ፡ ዘፍፁም፡ በጽልመት፡ ፈርሃ፡ ወ</hi>ወደንገፀ፡ ዲያብሎስ፡ ርእዮ፡ ብሁተ፡ ልደት፡ በሥጋ፡ አምላክ፡ በሲኦል፡
+                                </explicit>
+                        </msItem>
+                        <msItem xml:id="ms_i3">
+                            <locus from="4r" to="65r"/>
+                            <title ref="LIT2393tabiba"/>
+                            <note>The text is divided for reading on the various days of the week (indications on the upper margins on 
+                                <locus target="#11v #20r #29r #38v #46r #54r"/>).</note>
+                            <incipit xml:lang="gez"><hi rend="rubric">ኦእግዚአብሔር፡ ጥበበ፡ ጠቢባን፡ ከሀሊ። እ</hi>ስከ፡ ለዓለም፡ እምጥንት፤ እንተ፡ ኢትበሊ፤ ድኩመ፡ 
+                                ሐሊና፡ ገብርከ፡ ወፈራሃ፡ ልብ፡ ኢተሐባሲ። </incipit>
+                            <explicit xml:lang="gez">ቀትረ፡ መዓልትነ፡ እንዘ፡ ኢይመሲ<hi rend="rubric">። እግዚአብሔር፡ አብ፡</hi> ተሰላሢ። ጌጋይ<pb n="65r"/>ነ፡
+                                ሣሀልከ፡ ያናሕሲ። <hi rend="rubric">ስብሐት፡ ለከ፡ ፡ ።</hi></explicit>
+                        </msItem>
+                        <msItem xml:id="ms_i4">
+                            <locus from="65r" to="69v"/>
+                            <title ref="LIT2967RepCh248"/>
+                            <incipit xml:lang="gez">በሰማይ፡ ወምድር፡ አልብየ፡ ባዕደ፤ አበ፡ ወእመ፡ እኅተ፡ ወውሉደ፤ <hi rend="rubric">ማርያም</hi>፡ ድንግል፡ እትአመነኪ፡
+                                ገሀዳ። ኪያኪ፡ ተስፋ፡ ኪያኪ፡ መፍቅደ።</incipit>
+                            <explicit xml:lang="gez">ስብሐት፡ ለኪ፡ <hi rend="rubric">ማርያም</hi>፡ በስብሐት፡ መንፈስ፡ ቅዱስ፡ ማኅየዊ። ስብሐት፡ ለኪ፡ 
+                                <hi rend="rubric">ማርያም</hi>፡ ወለይሁዳ፡ ወሌዊ። ለዓለመ፡ ዓለም፡ ዘልፈ፡ ምስሌየ፡ ሀልዊ።</explicit>
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Codex">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf" quantity="134">69</measure> 
+                                    <measure unit="quire" quantity="14">9</measure> 
+                                    <note>Dimensions indicated below may concern outer dimensions of bookcover or 
+                                        dimensions of folia (not clearly specified in cataloque).</note>
+                                    <dimensions type="outer" unit="mm">                                        
+                                        <height cert="medium">80</height>
+                                        <width cert="medium">70</width>    
+                                    </dimensions>
+                                </extent>
+                                <foliation>Foliated in pencil by a recent European hand at the bottom on the right.</foliation>
+                                <collation>
+                                    <list>
+                                        <item xml:id="q1" n="1"> 
+                                            <dim unit="leaf">3</dim>
+                                            <locus from="1" to="3"/>
+                                        </item>
+                                        <item xml:id="q2" n="2">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="4" to="13"/>              
+                                        </item>
+                                        <item xml:id="q3" n="3">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="14" to="23"/>
+                                        </item>
+                                        <item xml:id="q4" n="4">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="24" to="33"/>
+                                        </item> 
+                                        <item xml:id="q5" n="5">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="34" to="43"/>
+                                        </item> 
+                                        <item xml:id="q6" n="6">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="44" to="53"/>
+                                        </item> 
+                                        <item xml:id="q7" n="7">
+                                            <dim unit="leaf">10</dim>
+                                            <locus from="54" to="63"/>
+                                        </item> 
+                                        <item xml:id="q8" n="8">
+                                            <dim unit="leaf">4</dim>
+                                            <locus from="64" to="67"/>
+                                        </item> 
+                                        <item xml:id="q9" n="9">
+                                            <dim unit="leaf">2</dim>
+                                            <locus from="68" to="69"/>
+                                        </item> 
+                                    </list>
+                                </collation>
+                                <condition key="deficient">Some lose folios, water stains throughout, text partly erased on <locus target="#1r"/>,
+                                    some repairs with a thread.</condition>          
+                            </supportDesc>
+                            <layoutDesc>
+                                <layout columns="1" writtenLines="9">
+                                    <note>Number of written lines vary from 9 to 12.</note>
+                                </layout>                             
+                            </layoutDesc>
+                        </objectDesc>
+                        <handDesc>
+                            <handNote xml:id="h1" script="Ethiopic">
+                                <seg type="script">19th to 20th century script</seg>
+                                <seg type="ink">black, red</seg>
+                                <seg type="rubrication">Incipits, sacred names, name of the owner</seg>
+                                <note>Minute and regular script.</note>
+                            </handNote>
+                        </handDesc>
+                        <decoDesc>
+                            <decoNote type="ornamentation" xml:id="d1">
+                                <locus target="#1v"/>
+                                <desc>Two crosses in the lower margin.</desc>
+                            </decoNote>
+                            <decoNote type="ornamentation" xml:id="d2">
+                                <locus target="#3r"/>
+                                <desc>A band of symmetrical figures in the lower margin.</desc>
+                            </decoNote>
+                            <decoNote type="drawing" xml:id="d3">
+                                <locus target="#3v"/>
+                                <desc>A full-page drawing in black and red with human faces arranged in and around a rectangular box at the centre 
+                                    of a cross, with branches ending in two spirals.</desc>
+                            </decoNote>
+                        </decoDesc>
+                        <additions>
+                            <list>
+                                <item xml:id="e1">
+                                    <locus target="#1r"/>
+                                    <desc type="StampExlibris">"Acq e doni 784" with pencil on the bottom right by a recent European hand and
+                                        according to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">99</citedRange>
+                                        </bibl>, in the centre of the outside of the wooden front cover, under the fabric.</desc>
+                                </item>
+                                <item xml:id="e2">
+                                    <locus target="#69v"/>
+                                    <desc type="StampExlibris">Small round stamp: <foreign xml:lang="la">Bibl. Med. Laur. Flor.</foreign></desc>
+                                </item>
+                                <item xml:id="e3">
+                                    <locus target="#69v"/>
+                                    <desc type="StampExlibris">"116885"</desc>
+                                </item>
+                                <item xml:id="e4">
+                                    <locus target="#6r #7r #8v #9r #15r #19r #37r #44r #57r #67v"/>
+                                    <desc type="Unclear">Various pen trials.</desc>
+                                </item>
+                                <item xml:id="e5">
+                                    <locus target="#11v #20r #29r #38v #46r #54r"/>
+                                    <desc type="findingAid">Indications for the reading on the various days of the week on the upper margins by later hand.
+                                        </desc>
+                                </item>
+                            </list>
+                        </additions>
+                        <bindingDesc>
+                            <binding contemporary="false">
+                                <decoNote xml:id="b1" type="Boards">Two wooden boards, covered with black fabric with horizontal white stripes, partially 
+                                    detached.</decoNote>    
+                                <decoNote xml:id="b2" type="SewingStations">2</decoNote>
+                                <decoNote xml:id="b3" type="bindingMaterial"><material key="wood"></material></decoNote>
+                            </binding>
+                        </bindingDesc>
+                    </physDesc>
                     <history>
+                        <origin>
+                            <origDate notBefore="1801" notAfter="1987" evidence="lettering">19th to 20th century</origDate>
+                        </origin>
                     </history>
                     <additional>
                         <adminInfo>
@@ -59,7 +236,10 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          </xi:include>
       </encodingDesc>
         <profileDesc>
-            <langUsage><language ident="en">English</language></langUsage>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="la">Latin</language>
+            </langUsage>
         </profileDesc>
         <revisionDesc>
             <change who="PL" when="2019-02-21">Created catalogue entry</change>

--- a/FlorenceBML/BMLacq784/BMLacq784.xml
+++ b/FlorenceBML/BMLacq784/BMLacq784.xml
@@ -33,7 +33,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <summary/>
                         <msItem xml:id="ms_i1">
                             <locus from="1r" to="1v"/>
-                            <title>Magical Prayer</title>
+                            <title ref="LIT6609ProtectPrayer"/>
                             <note>Beginning mostly not legible, but with some magical expressions as the name of a demon: 
                                 <foreign xml:lang="gez">ባርያ፡ ጸሊም፡</foreign>.</note>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩፡ አምላክ፡ 
@@ -85,8 +85,8 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                     <material key="parchment"/>
                                 </support>
                                 <extent>
-                                    <measure unit="leaf" quantity="134">69</measure> 
-                                    <measure unit="quire" quantity="14">9</measure> 
+                                    <measure unit="leaf" quantity="69">69</measure> 
+                                    <measure unit="quire" quantity="9">9</measure> 
                                     <note>Dimensions indicated below may concern outer dimensions of bookcover or 
                                         dimensions of folia (not clearly specified in cataloque).</note>
                                     <dimensions type="outer" unit="mm">                                        


### PR DESCRIPTION
I updated the record of BMLacq784 according to Marrassini's catalogue. 

In ms_i2 I encoded several ethnic names as ሸንቀላ, አገው, አምሀራ, ትግራይ as ethnic or place names. Even though this is a magical text, I think they are used as ethnic names rather than demon names. I would also like to create new IDs for ትርኵ and ቅማንት and eventually also for ቦላ, which, according to my exploration, do not yet exist.

<img width="430" alt="Screenshot 2023_Turk" src="https://github.com/BetaMasaheft/Manuscripts/assets/40291787/bd576b71-31e2-423e-bccf-d0bebb7ace05">
