### PR TITLE
YOMA inventory

### DIFF
--- a/MaaquddiYohannes/MaaquddiYohan001.xml
+++ b/MaaquddiYohannes/MaaquddiYohan001.xml
@@ -1,0 +1,101 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan001" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Four Gospels</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-001</idno>
+                        <altIdentifier>
+                            <idno>C3-IV-204</idno>
+                        </altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">
+                         <locus from="1r" to="92v"></locus>
+                           <title type="complete" ref="LIT1560Gospel">Four Gospels, with miniatures of the Evangelists</title>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>
+                                           <measure unit="leaf">95</measure>                                            
+                                           <dimensions type="outer">
+                                               <height unit="mm">430</height>
+                                               <width unit="mm">335</width>
+                                               <depth unit="mm">10</depth>
+                                           </dimensions>
+                                       </extent>
+                            <foliation>Foliation by D. Nosnitsin.</foliation>
+                            <condition key="good">Three parchment leaves at the end (with two miniatures) originate from a different, possibly older manuscript. 
+                                These leaves bear traces of modern conservation.</condition>
+                         </supportDesc>
+                     </objectDesc>
+                      </physDesc>
+                      <history>
+                         <origin>
+                           <origDate notBefore="1550" notAfter="1650">Mid-15th/mid-16th century.</origDate>                          
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Hagiography"/>
+                    <term key="NewTestament"/>
+                    <term key="Paks2"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="DN" when="2023-11-15">Photographed the manuscript.</change>
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+              description.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan001.xml
+++ b/MaaquddiYohannes/MaaquddiYohan001.xml
@@ -24,46 +24,94 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-001</idno>
                         <altIdentifier>
                             <idno>C3-IV-204</idno>
                         </altIdentifier>
                     </msIdentifier>
-                    <msContents>
-                       <summary/>
-                       <msItem xml:id="ms_i1">
-                         <locus from="1r" to="92v"></locus>
-                           <title type="complete" ref="LIT1560Gospel">Four Gospels, with miniatures of the Evangelists</title>
-                         <textLang mainLang="gez"/>
-                         </msItem>
+                    
+                    <physDesc>
+                        <objectDesc form="Codex">
+                            <supportDesc>
+                                <support>                          
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf">95</measure>                                            
+                                    <dimensions type="outer">
+                                        <height unit="mm">430</height>
+                                        <width unit="mm">335</width>
+                                        <depth unit="mm">10</depth>
+                                    </dimensions>
+                                </extent>
+                                <foliation>Foliation by D. Nosnitsin.</foliation>
+                                <condition key="good">Three parchment leaves at the end (with two miniatures) originate from a different, possibly older manuscript. 
+                                    These leaves bear traces of modern conservation.</condition>
+                            </supportDesc>
+                        </objectDesc>
+                        
+                        <bindingDesc>
+                            <binding xml:id="binding">
+                                <decoNote xml:id="b1">Two wooden boards</decoNote>
+                                <decoNote xml:id="b2" type="SewingStations">4</decoNote>
+                                <decoNote xml:id="b3" type="bindingMaterial">
+                                    <material key="wood"/>
+                           
+                                </decoNote>
+                            </binding>
+                        </bindingDesc>                     
+                    </physDesc>              
+                    
+                        <history>
+                            <origin>
+                                <origDate notBefore="1550" notAfter="1650">Mid-15th/mid-16th century for both units.</origDate>                          
+                            </origin>
+                        </history>
+                        
+                    <msPart xml:id="p1">
+                        <msIdentifier/>
+                        <msContents>
+                            <summary/>
+                            
+                    <msItem xml:id="p1_i1">
+                        <locus from="1r" to="92v"></locus>
+                        <title type="complete" ref="LIT1560Gospel">Four Gospels, with miniatures of the Evangelists</title>
+                        <textLang mainLang="gez"/>
+                    </msItem>
+                       
+                            <decoDesc>
+                                <decoNote xml:id="d1" type="miniature">
+                                    <desc>Four miniatures of Evangelists</desc>
+                                </decoNote>
+                            </decoDesc>  
                         </msContents>
-                   <physDesc>
-                     <objectDesc form="Codex">
-                        <supportDesc>
-                           <support>                          
-                                           <material key="parchment"/>
-                                       </support>
-                                       <extent>
-                                           <measure unit="leaf">95</measure>                                            
-                                           <dimensions type="outer">
-                                               <height unit="mm">430</height>
-                                               <width unit="mm">335</width>
-                                               <depth unit="mm">10</depth>
-                                           </dimensions>
-                                       </extent>
-                            <foliation>Foliation by D. Nosnitsin.</foliation>
-                            <condition key="good">Three parchment leaves at the end (with two miniatures) originate from a different, possibly older manuscript. 
-                                These leaves bear traces of modern conservation.</condition>
-                         </supportDesc>
-                     </objectDesc>
-                      </physDesc>
-                      <history>
-                         <origin>
-                           <origDate notBefore="1550" notAfter="1650">Mid-15th/mid-16th century.</origDate>                          
-                         </origin>
-                      </history>
-                </msDesc>
+                    </msPart>
+                     
+                    <msPart xml:id="p2">
+                        <msIdentifier/>
+                        <msContents>
+                            <summary/>
+                            
+                            <msItem xml:id="p1_i2">
+                                <locus from="93r" to="95v"/>
+                                <title type="complete">Fragment of a hagiographical text</title>
+                                <textLang mainLang="gez"/>
+                            </msItem>
+                            
+                            
+                            <decoDesc>
+                                <decoNote xml:id="d2" type="miniature">
+                                    <desc>Two miniatures of saints</desc>
+                                </decoNote>
+                            </decoDesc>  
+                        </msContents>
+                    </msPart>
+                    
+                </msDesc>                                         
+                                        
+       
+                    
             </sourceDesc>
         </fileDesc>
         <encodingDesc>

--- a/MaaquddiYohannes/MaaquddiYohan002.xml
+++ b/MaaquddiYohannes/MaaquddiYohan002.xml
@@ -1,0 +1,96 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan002" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Acts and Miracles of ʾAbuna Zarʾa Buruk</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-002</idno>
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">
+                         <locus from="1r" to="92v"></locus>
+                           <title type="complete" ref="LIT1528GadlaZ">Acts and Miracles of ʾAbuna Zarʾa Buruk</title>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>
+                                           <measure unit="leaf">66</measure>                                            
+                                           <dimensions type="outer">
+                                               <height unit="mm">220</height>
+                                               <width unit="mm">192</width>
+                                               <depth unit="mm">70</depth>
+                                           </dimensions>
+                                       </extent>
+                            <foliation>Foliation by D. Nosnitsin.</foliation>
+                            <condition key="deficient"></condition>
+                         </supportDesc>
+                     </objectDesc>
+                      </physDesc>
+                      <history>
+                         <origin>
+                           <origDate notBefore="1700" notAfter="1799">18th century.</origDate>                          
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Hagiography"/>   
+                    <term key="Miracle"/>                 
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="DN" when="2023-11-15">Photographed the manuscript.</change>
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+              description.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan002.xml
+++ b/MaaquddiYohannes/MaaquddiYohan002.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-002</idno>
                     </msIdentifier>
                     <msContents>

--- a/MaaquddiYohannes/MaaquddiYohan003.xml
+++ b/MaaquddiYohannes/MaaquddiYohan003.xml
@@ -1,0 +1,96 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan003" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Homiliary for St Michael</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-003</idno>
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">
+                         <locus from="1r" to="102v"/>
+                           <title type="complete" ref="LIT1295Dersan">Homiliary for St Michael</title>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>
+                                           <measure unit="leaf">66</measure>                                            
+                                           <dimensions type="outer">
+                                               <height unit="mm">243</height>
+                                               <width unit="mm">180</width>
+                                               <depth unit="mm">72</depth>
+                                           </dimensions>
+                                       </extent>
+                            <foliation>Foliation by D. Nosnitsin.</foliation>
+                            <condition key="deficient">The upper board is split, repaired.</condition>
+                         </supportDesc>
+                     </objectDesc>
+                      </physDesc>
+                      <history>
+                         <origin>
+                           <origDate notBefore="1900" notAfter="1949">First half of the 20th century.</origDate>                          
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="MoPe"/> 
+                    <term key="Homily"/>  
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="DN" when="2023-11-15">Photographed the manuscript</change>
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+              description</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan003.xml
+++ b/MaaquddiYohannes/MaaquddiYohan003.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-003</idno>
                     </msIdentifier>
                     <msContents>

--- a/MaaquddiYohannes/MaaquddiYohan004.xml
+++ b/MaaquddiYohannes/MaaquddiYohan004.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-004</idno>
                     </msIdentifier>
                     <msContents>

--- a/MaaquddiYohannes/MaaquddiYohan004.xml
+++ b/MaaquddiYohannes/MaaquddiYohan004.xml
@@ -1,0 +1,97 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan004" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Psalter</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-004</idno>
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">
+                         <locus from="1r" to="159v"/>
+                           <title type="complete" ref="LIT2701Dawit"/>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>
+                                           <measure unit="leaf">159</measure>                                            
+                                           <dimensions type="outer">
+                                               <height unit="mm">190</height>
+                                               <width unit="mm">160</width>
+                                               <depth unit="mm">90</depth>
+                                           </dimensions>
+                                       </extent>
+                            <foliation>Foliation by D. Nosnitsin.</foliation>
+                            <condition key="deficient">Back board is missing; remains of animal threads.</condition>
+                         </supportDesc>
+                     </objectDesc>
+                      </physDesc>
+                      <history>
+                         <origin>
+                           <origDate notBefore="1600" notAfter="1699">17th century, possibly around the middle.</origDate>                          
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="OldTestament"/> 
+                    <term key="Paks2"/> 
+                    <term key="Gon"/>  
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="DN" when="2023-11-15">Photographed the manuscript.</change>
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+              description.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan005.xml
+++ b/MaaquddiYohannes/MaaquddiYohan005.xml
@@ -1,0 +1,98 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan005" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Psalter</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-005</idno>
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">
+                         <locus from="1r" to="155v"/>
+                           <title type="complete" ref="LIT2701Dawit">Psalter</title>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>
+                                           <measure unit="leaf">155</measure>                                            
+                                           <dimensions type="outer">
+                                               <height unit="mm">200</height>
+                                               <width unit="mm">130</width>
+                                               <depth unit="mm">73</depth>
+                                           </dimensions>
+                                       </extent>
+                            <foliation>Foliation by D. Nosnitsin.</foliation>
+                            <condition key="deficient">Half of the front board is missing; back board is broken. The boards are think, somewhat smaller than the 
+                            text block.</condition>
+                         </supportDesc>
+                     </objectDesc>
+                      </physDesc>
+                      <history>
+                         <origin>
+                           <origDate notBefore="1700" notAfter="1799">18th century.</origDate>                          
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="OldTestament"/> 
+                    <term key="Paks2"/> 
+                    <term key="Gon"/>  
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="DN" when="2023-11-15">Photographed the manuscript.</change>
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+              description on the basis of the images.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan005.xml
+++ b/MaaquddiYohannes/MaaquddiYohan005.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-005</idno>
                     </msIdentifier>
                     <msContents>

--- a/MaaquddiYohannes/MaaquddiYohan006.xml
+++ b/MaaquddiYohannes/MaaquddiYohan006.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-006</idno>
                     </msIdentifier>
                     <msContents>

--- a/MaaquddiYohannes/MaaquddiYohan006.xml
+++ b/MaaquddiYohannes/MaaquddiYohan006.xml
@@ -1,0 +1,99 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan005" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Psalter</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-006</idno>
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">
+                         <locus from="1r" to="172v"/>
+                           <title type="complete" ref="LIT2701Dawit"/>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>
+                                           <measure unit="leaf">172</measure>                                            
+                                           <dimensions type="outer">
+                                               <height unit="mm">172</height>
+                                               <width unit="mm">150</width>
+                                               <depth unit="mm">95</depth>
+                                           </dimensions>
+                                       </extent>
+                            <foliation>Foliation by D. Nosnitsin.</foliation>
+                            <condition key="deficient"></condition>
+                         </supportDesc>
+                     </objectDesc>
+                      </physDesc>
+                      <history>
+                         <origin>
+                           <origDate notBefore="1650" notAfter="1749">Mid-17th/mid-18th century</origDate>.
+                             Gabra ʾIyasus is mentioned as the owner of the manuscript; according to the local people, this is also the name of a painter
+                             who created the murals in the church. 
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="OldTestament"/> 
+                    <term key="Paks2"/> 
+                    <term key="Gon"/>  
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="DN" when="2023-11-15">Photographed the manuscript</change>
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+              description.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan007.xml
+++ b/MaaquddiYohannes/MaaquddiYohan007.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-007</idno>
                         <altIdentifier>
                             <idno>C3-IV-205</idno>

--- a/MaaquddiYohannes/MaaquddiYohan007.xml
+++ b/MaaquddiYohannes/MaaquddiYohan007.xml
@@ -1,0 +1,112 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan007" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Book of the Rite of the Holy Week</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-007</idno>
+                        <altIdentifier>
+                            <idno>C3-IV-205</idno>
+                        </altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">                        
+                           <title type="complete" ref="LIT1544Gebrah">Book of the Rite of the Holy Week</title>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>
+                                           <measure unit="leaf"></measure>                                            
+                                           <dimensions type="outer">
+                                               <height unit="mm">356</height>
+                                               <width unit="mm">170</width>
+                                               <depth unit="mm">90</depth>
+                                           </dimensions>
+                                       </extent>
+                            <foliation>Unfoliated.</foliation>
+                            <condition key="good"></condition>
+                         </supportDesc>
+                     </objectDesc>
+                         <bindingDesc>
+                             <binding contemporary="partly">
+                                 <decoNote xml:id="b1">Two wooden boards, blind-tooled leather cover; leather overback.</decoNote>
+                                 <decoNote xml:id="b2" type="bindingMaterial">
+                                     <material key="leather"/>
+                                 </decoNote>
+                                 
+                             </binding>
+                         </bindingDesc>
+                   </physDesc>
+                     
+                  
+                    
+                      <history>
+                         <origin>
+                           <origDate notBefore="1884" notAfter="1890">Around the years 1885 CE</origDate>.
+                             Commissioned by blāttā Māru (whose baptismal name was Walda Māryām) in the 13th year of the reign of <persName ref="PRS10378Yohanne">King Yoḥannǝs IV</persName>, the year of Matthew, 
+                             the date possibly referring to <date>1885 CE</date>.                            
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="MoPe"/> 
+                    <term key="Liturgy"/>
+                    <term key="Rituals"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>           
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+              description on the basis of an examination in situ</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan007.xml
+++ b/MaaquddiYohannes/MaaquddiYohan007.xml
@@ -36,6 +36,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            <title type="complete" ref="LIT1544Gebrah">Book of the Rite of the Holy Week</title>
                          <textLang mainLang="gez"/>
                          </msItem>
+                        
+                        <msItem xml:id="ms_i2">                        
+                            <title type="complete">A protective prayer against locusts, with an Amharic subscription 
+                                calling the text ʾabǝnnat</title>
+                            <textLang mainLang="gez"/>
+                        </msItem>
                         </msContents>
                    <physDesc>
                      <objectDesc form="Codex">
@@ -71,7 +77,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                       <history>
                          <origin>
                            <origDate notBefore="1884" notAfter="1890">Around the years 1885 CE</origDate>.
-                             Commissioned by blāttā Māru (whose baptismal name was Walda Māryām) in the 13th year of the reign of <persName ref="PRS10378Yohanne">King Yoḥannǝs IV</persName>, the year of Matthew, 
+                             Commissioned by blāttā Māru (whose baptismal name was Walda Māryām); 
+                             the colophon mentions the 13th year of the reign of <persName ref="PRS10378Yohanne">King Yoḥannǝs IV</persName>, the year of Matthew, 
                              the date possibly referring to <date>1885 CE</date>.                            
                          </origin>
                       </history>

--- a/MaaquddiYohannes/MaaquddiYohan007.xml
+++ b/MaaquddiYohannes/MaaquddiYohan007.xml
@@ -38,7 +38,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                          </msItem>
                         
                         <msItem xml:id="ms_i2">                        
-                            <title type="complete">A protective prayer against locusts, with an Amharic subscription 
+                            <title type="complete" ref="LIT6609ProtectPrayer">A protective prayer against locusts, with an Amharic subscription 
                                 calling the text ʾabǝnnat</title>
                             <textLang mainLang="gez"/>
                         </msItem>

--- a/MaaquddiYohannes/MaaquddiYohan008.xml
+++ b/MaaquddiYohannes/MaaquddiYohan008.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-008</idno>                        
                     </msIdentifier>
                     <msContents>

--- a/MaaquddiYohannes/MaaquddiYohan008.xml
+++ b/MaaquddiYohannes/MaaquddiYohan008.xml
@@ -1,0 +1,105 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan008" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Psalter</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-008</idno>                        
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">                        
+                           <title type="complete" ref="LIT2701Dawit">Psalter</title>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>
+                                           <measure unit="leaf"></measure>                                            
+                                           <dimensions type="outer"/>
+                                           <note>A small-size volume, written in a recent fine hand; very small script.</note>                                              
+                                       </extent>
+                            <foliation>Unfoliated.</foliation>
+                            <condition key="good"></condition>
+                                                    </supportDesc>
+                     </objectDesc>
+                     
+                         <bindingDesc>
+                             <binding contemporary="true">
+                                 <decoNote xml:id="b1">Two wooden boards, blind-tooled leather cover.</decoNote>
+                                 <decoNote xml:id="b2" type="bindingMaterial">
+                                     <material key="leather"/>
+                                     <material key="wood"/>
+                                 </decoNote>
+                                 
+                             </binding>
+                         </bindingDesc>
+                   </physDesc>
+                     
+                  
+                    
+                      <history>
+                         <origin>
+                           <origDate notBefore="1880" notAfter="1949">Late 19th/first half of the 20th century.</origDate>                                                      
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="MoPe"/> 
+                    <term key="OldTestament"/>               
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+                        <change who="DN" when="2023-12-01">Created entity with rudimentary
+              description on the basis of an examination in situ</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan009.xml
+++ b/MaaquddiYohannes/MaaquddiYohan009.xml
@@ -30,7 +30,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <msContents>
                        <summary/>
                        <msItem xml:id="ms_i1">                        
-                           <title type="complete" ref="LIT1690ActsofJohn">Acts of John Son of Thunder</title>
+                           <title type="complete" ref="LIT1690ActsofJohn" cert="low">Acts of John Son of Thunder</title>
                          <textLang mainLang="gez"/>
                          </msItem>
                         </msContents>
@@ -47,8 +47,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                            <width unit="mm">160</width>
                                            <depth unit="mm">155</depth>
                                        </extent>
-                            <foliation>Unfoliated.</foliation>
-                            <condition key="deficient">Damaged by humidity.</condition>
+                                                       <condition key="deficient">Damaged by humidity.</condition>
                                                     </supportDesc>
                      </objectDesc>
                      
@@ -68,7 +67,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                       <history>
                          <origin>
                            <origDate notBefore="1866" notAfter="1867">Around the years 1866/1867.</origDate>
-                             Donated in the time of <persName ref="PRS9434Tewodros">King Tewodros II</persName>, copied by the scribe Ḫāyla ʾIyasus, 
+                             Donated in the time of <persName ref="PRS9434Tewodros">King Tewodros II</persName> by 
+                             ʿAdma Giyorgis, copied by the scribe Ḫāyla ʾIyasus of 
+                             <placeName ref="LOC1039AbiyAd"></placeName>, 
                              <date>the year of mercy 1858 is mentioned (=1866/1867 CE)</date>.
                          </origin>
                       </history>

--- a/MaaquddiYohannes/MaaquddiYohan009.xml
+++ b/MaaquddiYohannes/MaaquddiYohan009.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-009</idno>                        
                     </msIdentifier>
                     <msContents>

--- a/MaaquddiYohannes/MaaquddiYohan009.xml
+++ b/MaaquddiYohannes/MaaquddiYohan009.xml
@@ -1,0 +1,108 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan009" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Acts of John Son of Thunder</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-009</idno>                        
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">                        
+                           <title type="complete" ref="LIT1690ActsofJohn">Acts of John Son of Thunder</title>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>
+                                           <measure unit="leaf"/>                                            
+                                           <dimensions type="outer"/>
+                                           <height unit="mm">240</height>
+                                           <width unit="mm">160</width>
+                                           <depth unit="mm">155</depth>
+                                       </extent>
+                            <foliation>Unfoliated.</foliation>
+                            <condition key="deficient">Damaged by humidity.</condition>
+                                                    </supportDesc>
+                     </objectDesc>
+                     
+                         <bindingDesc>
+                             <binding contemporary="true">
+                                 <decoNote xml:id="b1">Two wooden boards.</decoNote>
+                                 <decoNote xml:id="b2" type="bindingMaterial">
+                                     <material key="wood"/>
+                                 </decoNote>
+                                 
+                             </binding>
+                         </bindingDesc>
+                   </physDesc>
+                     
+                  
+                    
+                      <history>
+                         <origin>
+                           <origDate notBefore="1866" notAfter="1867">Around the years 1866/1867.</origDate>
+                             Donated in the time of <persName ref="PRS9434Tewodros">King Tewodros II</persName>, copied by the scribe Ḫāyla ʾIyasus, 
+                             <date>the year of mercy 1858 is mentioned (=1866/1867 CE)</date>.
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="MoPe"/> 
+                    <term key="Hagiography"/>               
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>           
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+              description on the basis of an examination in situ.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan010.xml
+++ b/MaaquddiYohannes/MaaquddiYohan010.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-010</idno>                        
                     </msIdentifier>
                     

--- a/MaaquddiYohannes/MaaquddiYohan010.xml
+++ b/MaaquddiYohannes/MaaquddiYohan010.xml
@@ -63,7 +63,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     
                       <history>
                          <origin>
-                           <origDate notBefore="1900" notAfter="1999">Recent, probably 20th century.</origDate>
+                           <origDate notBefore="1850" notAfter="1999"/>
+                             Unit 1 is of recent date, 20th century; unit 2 might be older, possibly 19th century.
                                                        
                          </origin>
                       </history>                    

--- a/MaaquddiYohannes/MaaquddiYohan010.xml
+++ b/MaaquddiYohannes/MaaquddiYohan010.xml
@@ -1,0 +1,129 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan010" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Homiliary for Sabbath, Book of the Letter which Descended from Heaven</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-010</idno>                        
+                    </msIdentifier>
+                    
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>
+                                           <measure unit="leaf"></measure>                                            
+                                           <dimensions type="outer">
+                                               <height unit="mm">156</height>
+                                               <width unit="mm">110</width>
+                                               <depth unit="mm">48</depth>
+                                           </dimensions>
+                                       </extent>
+                            <foliation>Unfoliated.</foliation>
+                            <condition key="good"></condition>
+                         </supportDesc>
+                     </objectDesc>
+                         <bindingDesc>
+                             <binding contemporary="partly">
+                                 <decoNote xml:id="b1">Two wooden boards of unit 1; unit 2, of slightly smaller size, is bound on two 
+                                     leather boards, and incorporated into the binding of unit 1.</decoNote>
+                                 <decoNote xml:id="b2" type="bindingMaterial">
+                                     <material key="wood"/>
+                                     <material key="leather"/>
+                                 </decoNote>
+                                 
+                             </binding>
+                         </bindingDesc>
+                   </physDesc>
+                     
+                  
+                    
+                      <history>
+                         <origin>
+                           <origDate notBefore="1900" notAfter="1999">Recent, probably 20th century.</origDate>
+                                                       
+                         </origin>
+                      </history>                    
+                        
+                        <msPart xml:id="p1">
+                            <msIdentifier/>
+                            <msContents>
+                                <summary/>
+                                
+                                <msItem xml:id="p1_i1">                              
+                            <title type="complete" ref="LIT6627DersanaS"/>
+                            <textLang mainLang="gez"/>
+                                </msItem>
+                            </msContents>
+                        </msPart>
+                    
+                    <msPart xml:id="p2">
+                        <msIdentifier/>
+                        <msContents>
+                            <summary/>
+                            <msItem xml:id="p1_i2">                        
+                            <title type="complete" ref="LIT1978Mashaf"/>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                    </msContents>
+                    </msPart>
+                    
+                </msDesc>
+                
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="MoPe"/> 
+                    <term key="Liturgy"/>
+                    <term key="Rituals"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>         
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+              description on the basis of an examination in situ.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan011.xml
+++ b/MaaquddiYohannes/MaaquddiYohan011.xml
@@ -1,0 +1,111 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan011" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Acts and Miracles of Gabra Manfas Qǝddus</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-011</idno>                        
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">                        
+                           <title type="complete" ref="LIT1119DossierQMQ">Acts and Miracles of Gabra Manfas Qǝddus</title>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>
+                                           <measure unit="leaf"/>                                            
+                                            <dimensions type="outer">
+                                               <height unit="mm">240</height>
+                                               <width unit="mm">200</width>
+                                               <depth unit="mm">60</depth>
+                                            </dimensions>
+                                       </extent>
+                            <foliation>Unfoliated.</foliation>
+                            <condition key="intact"/>
+                                                    </supportDesc>
+                     </objectDesc>
+                     
+                         <bindingDesc>
+                             <binding contemporary="partly">
+                                 <decoNote xml:id="b1">Two wooden boards; blind-tooled leather; textile inlays.</decoNote>
+                                 <decoNote xml:id="b2" type="bindingMaterial">
+                                     <material key="wood"/>
+                                     <material key="leather"/>
+                                     <material key="textile"/>
+                                 </decoNote>
+                                 
+                             </binding>
+                         </bindingDesc>
+                   </physDesc>
+                     
+                  
+                    
+                      <history>
+                         <origin>
+                           <origDate notBefore="1950" notAfter="2020">Very recent.</origDate>
+                             Donated by Walda Māryām.
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="MoPe"/> 
+                    <term key="OldTestament"/>               
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+          
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+              description on the basis of an examination in situ.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan011.xml
+++ b/MaaquddiYohannes/MaaquddiYohan011.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-011</idno>                        
                     </msIdentifier>
                     <msContents>

--- a/MaaquddiYohannes/MaaquddiYohan012.xml
+++ b/MaaquddiYohannes/MaaquddiYohan012.xml
@@ -1,0 +1,110 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan012" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Homily on the Covenant of Mercy</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-012</idno>                        
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">                        
+                           <title type="complete" ref="LIT1290Dersan">Homily on the Covenant of Mercy</title>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>
+                                           <measure unit="leaf"/>                                            
+                                            <dimensions type="outer">
+                                               <height unit="mm">240</height>
+                                               <width unit="mm">180</width>
+                                               <depth unit="mm">50</depth>
+                                            </dimensions>
+                                       </extent>
+                            <foliation>Unfoliated.</foliation>
+                            <condition key="intact"/>
+                                                    </supportDesc>
+                     </objectDesc>
+                     
+                         <bindingDesc>
+                             <binding contemporary="partly">
+                                 <decoNote xml:id="b1">Two wooden boards; blind-tooled leather; textile inlays.</decoNote>
+                                 <decoNote xml:id="b2" type="bindingMaterial">
+                                     <material key="wood"/>
+                                     <material key="leather"/>
+                                     <material key="textile"/>
+                                 </decoNote>
+                                 
+                             </binding>
+                         </bindingDesc>
+                   </physDesc>
+                     
+                  
+                    
+                      <history>
+                         <origin>
+                           <origDate notBefore="1975" notAfter="1976">Dated 1968 year of mercy (= 1975/76 CE).</origDate>
+                             </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Homily"/>
+                    <term key="Apocrypha"/>
+                    <term key="MoPe"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>           
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+              description on the basis of an examination in situ.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan012.xml
+++ b/MaaquddiYohannes/MaaquddiYohan012.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-012</idno>                        
                     </msIdentifier>
                     <msContents>

--- a/MaaquddiYohannes/MaaquddiYohan013.xml
+++ b/MaaquddiYohannes/MaaquddiYohan013.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-013</idno>   
                         <altIdentifier>
                             <idno>C3-IV-213</idno>

--- a/MaaquddiYohannes/MaaquddiYohan013.xml
+++ b/MaaquddiYohannes/MaaquddiYohan013.xml
@@ -1,0 +1,110 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan013" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Synaxarion for the first half of the year</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-013</idno>   
+                        <altIdentifier>
+                            <idno>C3-IV-213</idno>
+                        </altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">                        
+                           <title type="complete" ref="LIT2375Synaxa">Synaxarion for the first half of the year</title>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>
+                                           <measure unit="leaf"></measure>                                            
+                                           <dimensions type="outer"/>
+                                           <height unit="mm">360</height>
+                                           <width unit="mm">270</width>
+                                           <depth unit="mm">95</depth>                                                                     
+                                       </extent>
+                            <foliation>Unfoliated.</foliation>
+                            <condition key="good"></condition>
+                                                    </supportDesc>
+                     </objectDesc>
+                     
+                         <bindingDesc>
+                             <binding contemporary="partly">
+                                 <decoNote xml:id="b1">Two wooden boards, blind-tooled reddish leather cover.</decoNote>
+                                 <decoNote xml:id="b2" type="bindingMaterial">
+                                     <material key="leather"/>
+                                     <material key="wood"/>
+                                 </decoNote>
+                                 
+                             </binding>
+                         </bindingDesc>
+                   </physDesc>
+                     
+                  
+                    
+                      <history>
+                         <origin>
+                           <origDate notBefore="1950" notAfter="2020">Recent, second half of the 20th/21st century.</origDate>                                                      
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="MoPe"/> 
+                    <term key="OldTestament"/>               
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>           
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+              description on the basis of an examination in situ.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan014.xml
+++ b/MaaquddiYohannes/MaaquddiYohan014.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-014</idno>                        
                     </msIdentifier>
                     <msContents>

--- a/MaaquddiYohannes/MaaquddiYohan014.xml
+++ b/MaaquddiYohannes/MaaquddiYohan014.xml
@@ -1,0 +1,108 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan014" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Acts of the Apostles</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-014</idno>                        
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">                        
+                           <title type="complete" ref="LIT1019Actsof" cert="low">Acts of the Apostles</title>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>
+                                           <measure unit="leaf"/>                                            
+                                            <dimensions type="outer">
+                                               <height unit="mm">365</height>
+                                               <width unit="mm">300</width>
+                                               <depth unit="mm">75</depth>
+                                            </dimensions>
+                                       </extent>
+                             <condition key="intact"/>
+                                                    </supportDesc>
+                     </objectDesc>
+                     
+                         <bindingDesc>
+                             <binding contemporary="true">
+                                 <decoNote xml:id="b1">Two wooden boards; blind-tooled leathe cover; textile inlays.</decoNote>
+                                 <decoNote xml:id="b2" type="bindingMaterial">
+                                     <material key="wood"/>
+                                     <material key="leather"/>
+                                     <material key="textile"/>
+                                 </decoNote>
+                                 
+                             </binding>
+                         </bindingDesc>
+                   </physDesc>
+                     
+                  
+                    
+                      <history>
+                         <origin>
+                           <origDate notBefore="1999" notAfter="2000">Dated 1992 year (of mercy) (= 1999/2000 CE).</origDate>                             
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="MoPe"/> 
+                    <term key="NewTestament"/>               
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>           
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+              description on the basis of an examination in situ.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan014.xml
+++ b/MaaquddiYohannes/MaaquddiYohan014.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Acts of the Apostles</title>
+                <title>Apocryphal Acts of the Apostles</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="DN"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -30,7 +30,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <msContents>
                        <summary/>
                        <msItem xml:id="ms_i1">                        
-                           <title type="complete" ref="LIT1019Actsof" cert="low">Acts of the Apostles</title>
+                           <title type="complete" ref="LIT1461Gadlah" cert="medium">Apocryphal Acts of the Apostles</title>
                          <textLang mainLang="gez"/>
                          </msItem>
                         </msContents>

--- a/MaaquddiYohannes/MaaquddiYohan015.xml
+++ b/MaaquddiYohannes/MaaquddiYohan015.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-015</idno>
                     </msIdentifier>
                     <msContents>
@@ -57,7 +57,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                        
                        <bindingDesc>
                            <binding contemporary="true">
-                               <decoNote xml:id="b1">Two wooden boards, blind-tooled leather cover; textile inlays. Overback.</decoNote>
+                               <decoNote xml:id="b1">Two wooden boards, blind-tooled leather cover (tooling of poor quality); textile inlays. Blind-tooled leather overback.</decoNote>
                                <decoNote xml:id="b2" type="bindingMaterial">
                                    <material key="leather"/>
                                    <material key="wood"/>
@@ -69,7 +69,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                       <history>
                          <origin>
                            <origDate notBefore="1990" notAfter="2020">Late 20th/21st century.</origDate>
-                             A colophon is written at the end of the text.
+                             A colophon at the end of the text, on the penultimate folium,
+                             mentions the time of <persName ref="PRS10378Yohanne">Yoḥannǝs IV</persName>, and <date>the year of mercy 1885, of Matthew</date>which 
+                             may be equal to <date>1893 CE.</date>                            
                          </origin>
                       </history>
                 </msDesc>

--- a/MaaquddiYohannes/MaaquddiYohan015.xml
+++ b/MaaquddiYohannes/MaaquddiYohan015.xml
@@ -1,0 +1,108 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan015" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Missal</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-015</idno>
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">
+                         <locus from="1r" to="155v"/>
+                           <title type="complete" ref="LIT1960Mashaf">Missal</title>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>
+                                           <measure unit="leaf">155</measure>                                            
+                                           <dimensions type="outer">
+                                               <height unit="mm">250</height>
+                                               <width unit="mm">200</width>
+                                               <depth unit="mm">60</depth>
+                                           </dimensions>
+                                       </extent>
+                            <foliation>Foliation by D. Nosnitsin.</foliation>
+                            <condition key="intact"></condition>
+                         </supportDesc>
+                     </objectDesc>                      
+                
+                       
+                       <bindingDesc>
+                           <binding contemporary="true">
+                               <decoNote xml:id="b1">Two wooden boards, blind-tooled leather cover; textile inlays.</decoNote>
+                               <decoNote xml:id="b2" type="bindingMaterial">
+                                   <material key="leather"/>
+                                   <material key="wood"/>
+                               </decoNote>
+                               
+                           </binding>
+                       </bindingDesc>
+                      </physDesc>
+                      <history>
+                         <origin>
+                           <origDate notBefore="1990" notAfter="2020">Very recent, late 20th/21st century.</origDate>
+                             A colophon is written at the end of the text.
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Liturgy"/>                  
+                    <term key="MoPe"/>  
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>            
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+              description on the basis of an examination of the manuscript in situ</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan015.xml
+++ b/MaaquddiYohannes/MaaquddiYohan015.xml
@@ -57,7 +57,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                        
                        <bindingDesc>
                            <binding contemporary="true">
-                               <decoNote xml:id="b1">Two wooden boards, blind-tooled leather cover; textile inlays.</decoNote>
+                               <decoNote xml:id="b1">Two wooden boards, blind-tooled leather cover; textile inlays. Overback.</decoNote>
                                <decoNote xml:id="b2" type="bindingMaterial">
                                    <material key="leather"/>
                                    <material key="wood"/>
@@ -68,7 +68,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                       </physDesc>
                       <history>
                          <origin>
-                           <origDate notBefore="1990" notAfter="2020">Very recent, late 20th/21st century.</origDate>
+                           <origDate notBefore="1990" notAfter="2020">Late 20th/21st century.</origDate>
                              A colophon is written at the end of the text.
                          </origin>
                       </history>

--- a/MaaquddiYohannes/MaaquddiYohan016.xml
+++ b/MaaquddiYohannes/MaaquddiYohan016.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-016</idno>                        
                     </msIdentifier>
                     <msContents>
@@ -67,8 +67,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     
                       <history>
                          <origin>
-                           <origDate notBefore="1650" notAfter="1749">Mid-17th/mid-18th century.</origDate>
-                             Very finely written, donated to the church Yoḥannǝs ʿĀddi ʿĀynu by Nǝwāya Māryām.
+                             <origDate notBefore="1787" notAfter="1788">Second half of the 18th century, possibly 1787 or 1788.</origDate>
+                             Very finely written, donated to the church Yoḥannǝs ʿĀddi ʿĀynu by Nǝwāya Māryām, whose name is added by a secondary hand.
+                             Another donation note at the end is half-washed out but partly reinked, it contains the date which my read <date>the year 7279 of the world</date>, 
+                             possibly <date>1787 or 1788</date>.
+                             
                          </origin>
                       </history>
                 </msDesc>

--- a/MaaquddiYohannes/MaaquddiYohan016.xml
+++ b/MaaquddiYohannes/MaaquddiYohan016.xml
@@ -1,0 +1,107 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan016" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Four Gospels</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-016</idno>                        
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">                     
+                           <title type="complete" ref="LIT1560Gospel">Four Gospels, with prefatory texts</title>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>                                                                       
+                                           <dimensions type="outer">
+                                               <height unit="mm">300</height>
+                                               <width unit="mm">260</width>
+                                               <depth unit="mm">90</depth>
+                                           </dimensions>
+                                       </extent>
+                            
+                            <condition key="good"/>
+                         </supportDesc>
+                     </objectDesc>
+                       <bindingDesc>
+                           <binding contemporary="true">
+                               <decoNote xml:id="b1">Two wooden boards, blind-tooled leather cover; textile inlays.</decoNote>
+                               <decoNote xml:id="b2" type="bindingMaterial">
+                                   <material key="leather"/>
+                                   <material key="wood"/>
+                                   <material key="textile"/>
+                               </decoNote>
+                               
+                           </binding>
+                       </bindingDesc>
+                   </physDesc>               
+                    
+                    
+                      <history>
+                         <origin>
+                           <origDate notBefore="1650" notAfter="1749">Mid-17th/mid-18th century.</origDate>
+                             Very finely written, donated to the church Yoḥannǝs ʿĀddi ʿĀynu by Nǝwāya Māryām.
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                   <term key="NewTestament"/>
+                    <term key="Gon"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>          
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+                description on the basis of an examination in situ.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan017.xml
+++ b/MaaquddiYohannes/MaaquddiYohan017.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-017</idno>                        
                     </msIdentifier>
                     <msContents>

--- a/MaaquddiYohannes/MaaquddiYohan017.xml
+++ b/MaaquddiYohannes/MaaquddiYohan017.xml
@@ -1,0 +1,105 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan017" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Acts of ʾAbrǝhā and ʾAṣbǝḥa</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-017</idno>                        
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">                       
+                           <title type="complete" ref="LIT1409GadlaA">Acts of ʾAbrǝhā and ʾAṣbǝḥa</title>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>                                                                       
+                                           <dimensions type="outer">
+                                               <height unit="mm">300</height>
+                                               <width unit="mm">230</width>
+                                               <depth unit="mm">60</depth>
+                                           </dimensions>
+                                       </extent>
+                            
+                            <condition key="good"/>
+                         </supportDesc>
+                     </objectDesc>
+                       <bindingDesc>
+                           <binding contemporary="true">
+                               <decoNote xml:id="b1">Two wooden boards, blind-tooled leather cover.</decoNote>
+                               <decoNote xml:id="b2" type="bindingMaterial">
+                                   <material key="leather"/>
+                                   <material key="wood"/>                                   
+                               </decoNote>
+                               
+                           </binding>
+                       </bindingDesc>
+                   </physDesc>               
+                    
+                    
+                      <history>
+                         <origin>
+                           <origDate notBefore="1970" notAfter="2020">Late 20th/early 21th century; very recent.</origDate>                          
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Hagiography"/>                    
+                    <term key="MoPe"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>          
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+                description on the basis of an examination in situ.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan018.xml
+++ b/MaaquddiYohannes/MaaquddiYohan018.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-018</idno>                        
                     </msIdentifier>
                     <msContents>
@@ -53,7 +53,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                      </objectDesc>
                        <bindingDesc>
                            <binding contemporary="true">
-                               <decoNote xml:id="b1">Two wooden boards, blind-tooled leather cover; textile inlays; textile overcover.</decoNote>
+                               <decoNote xml:id="b1">Two wooden boards, blind-tooled leather cover; textile inlays; textile chemise.</decoNote>
                                <decoNote xml:id="b2" type="bindingMaterial">
                                    <material key="leather"/>
                                    <material key="wood"/>

--- a/MaaquddiYohannes/MaaquddiYohan018.xml
+++ b/MaaquddiYohannes/MaaquddiYohan018.xml
@@ -1,0 +1,106 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan018" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Homily in honour of Archangel Gabriel</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-018</idno>                        
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">                       
+                           <title type="complete" ref="LIT1284Dersan">Homily in honour of Archangel Gabriel</title>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>                                                                       
+                                           <dimensions type="outer">
+                                               <height unit="mm">270</height>
+                                               <width unit="mm">210</width>
+                                               <depth unit="mm">60</depth>
+                                           </dimensions>
+                                       </extent>
+                            
+                            <condition key="good"/>
+                         </supportDesc>
+                     </objectDesc>
+                       <bindingDesc>
+                           <binding contemporary="true">
+                               <decoNote xml:id="b1">Two wooden boards, blind-tooled leather cover; textile inlays; textile overcover.</decoNote>
+                               <decoNote xml:id="b2" type="bindingMaterial">
+                                   <material key="leather"/>
+                                   <material key="wood"/>
+                                   <material key="textile"/>
+                               </decoNote>
+                               
+                           </binding>
+                       </bindingDesc>
+                   </physDesc>               
+                    
+                    
+                      <history>
+                         <origin>
+                           <origDate notBefore="1970" notAfter="2020">Late 20th/early 21th century; very recent.</origDate>                          
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Homily"/>                    
+                    <term key="MoPe"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>          
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+                description on the basis of an examination in situ.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan019.xml
+++ b/MaaquddiYohannes/MaaquddiYohan019.xml
@@ -1,0 +1,106 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan019" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Pauline Epistles</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-019</idno>                        
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">                       
+                           <title type="complete" ref="LIT3505PaulineEpis">Pauline Epistles</title>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>                                                                       
+                                           <dimensions type="outer">
+                                               <height unit="mm">180</height>
+                                               <width unit="mm">135</width>
+                                               <depth unit="mm">50</depth>
+                                           </dimensions>
+                                       </extent>
+                            
+                            <condition key="good"/>
+                         </supportDesc>
+                     </objectDesc>
+                       <bindingDesc>
+                           <binding contemporary="true">
+                               <decoNote xml:id="b1">Two wooden boards, blind-tooled leather cover; textile inlays.</decoNote>
+                               <decoNote xml:id="b2" type="bindingMaterial">
+                                   <material key="leather"/>
+                                   <material key="wood"/>
+                                   <material key="textile"/>
+                               </decoNote>
+                               
+                           </binding>
+                       </bindingDesc>
+                   </physDesc>               
+                    
+                    
+                      <history>
+                         <origin>
+                           <origDate notBefore="1800" notAfter="1949">19th/first half of the 20th century.</origDate>                          
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="NewTestament"/>     
+                              <term key="MoPe"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>          
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+                description on the basis of an examination in situ.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan019.xml
+++ b/MaaquddiYohannes/MaaquddiYohan019.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-019</idno>                        
                     </msIdentifier>
                     <msContents>

--- a/MaaquddiYohannes/MaaquddiYohan020.xml
+++ b/MaaquddiYohannes/MaaquddiYohan020.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-020</idno>                        
                     </msIdentifier>
                     <msContents>

--- a/MaaquddiYohannes/MaaquddiYohan020.xml
+++ b/MaaquddiYohannes/MaaquddiYohan020.xml
@@ -1,0 +1,108 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan020" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Book of the Funeral Ritual</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-020</idno>                        
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">                       
+                           <title type="complete" ref="LIT1931Mashaf">Book of the Funeral Ritual</title>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>                                                                       
+                                           <dimensions type="outer">
+                                               <height unit="mm">280</height>
+                                               <width unit="mm">250</width>
+                                               <depth unit="mm">60</depth>
+                                           </dimensions>
+                                       </extent>
+                            
+                            <condition key="good"/>
+                         </supportDesc>
+                     </objectDesc>
+                       <bindingDesc>
+                           <binding contemporary="true">
+                               <decoNote xml:id="b1">Two wooden boards.</decoNote>
+                               <decoNote xml:id="b2" type="bindingMaterial">                                   
+                                   <material key="wood"/>
+                                   
+                               </decoNote>
+                               
+                           </binding>
+                       </bindingDesc>
+                   </physDesc>               
+                    
+                    
+                      <history>
+                         <origin>
+                           <origDate notBefore="1700" notAfter="1799">18th century.</origDate>
+                             Nicely produced, with additional texts on the guard leaves.
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Rituals"/>     
+                    <term key="Liturgy"/>
+                    <term key="Gon"/>
+                    <term key="ZaMa"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>          
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+                description on the basis of an examination in situ.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan021.xml
+++ b/MaaquddiYohannes/MaaquddiYohan021.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-021</idno>                        
                     </msIdentifier>
                     <msContents>

--- a/MaaquddiYohannes/MaaquddiYohan021.xml
+++ b/MaaquddiYohannes/MaaquddiYohan021.xml
@@ -1,0 +1,107 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan021" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>The Life-Giving Homily</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-021</idno>                        
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">                       
+                           <title type="complete" ref="LIT1291Dersan" cert="low"/>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>                                                                       
+                                           <dimensions type="outer">
+                                               <height unit="mm">255</height>
+                                               <width unit="mm">190</width>
+                                               <depth unit="mm">60</depth>
+                                           </dimensions>
+                                       </extent>
+                            
+                            <condition key="good"/>
+                         </supportDesc>
+                     </objectDesc>
+                       <bindingDesc>
+                           <binding contemporary="true">
+                               <decoNote xml:id="b1">Two wooden boards; blind-tooled leather cover; textile inlays; green textile overcover.</decoNote>
+                               <decoNote xml:id="b2" type="bindingMaterial">                                   
+                                   <material key="wood"/>
+                                   <material key="leather"/>
+                                   <material key="textile"/>
+                                   
+                               </decoNote>
+                               
+                           </binding>
+                       </bindingDesc>
+                   </physDesc>               
+                    
+                    
+                      <history>
+                         <origin>
+                           <origDate notBefore="1970" notAfter="2020">Late 20th or 21th century; very recent.</origDate>                            
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                         <term key="Homily"/>               
+                    <term key="MoPe"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>          
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+                description on the basis of an examination in situ.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan022.xml
+++ b/MaaquddiYohannes/MaaquddiYohan022.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-022</idno>                        
                     </msIdentifier>
                     <msContents>

--- a/MaaquddiYohannes/MaaquddiYohan022.xml
+++ b/MaaquddiYohannes/MaaquddiYohan022.xml
@@ -1,0 +1,107 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan022" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Acts of Takla Haymanot</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-022</idno>                        
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">                       
+                           <title type="complete" ref="LIT3973GadlaT">Acts of Takla Haymanot, possibly followed by his Miracles</title>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>                                                                       
+                                           <dimensions type="outer">
+                                               <height unit="mm">300</height>
+                                               <width unit="mm">240</width>
+                                               <depth unit="mm">85</depth>
+                                           </dimensions>
+                                       </extent>
+                            
+                            <condition key="good"/>
+                         </supportDesc>
+                     </objectDesc>
+                       <bindingDesc>
+                           <binding contemporary="true">
+                               <decoNote xml:id="b1">Two wooden boards; blind-tooled leather cover; textile inlays.</decoNote>
+                               <decoNote xml:id="b2" type="bindingMaterial">                                   
+                                   <material key="wood"/>
+                                   <material key="leather"/>
+                                   <material key="textile"/>
+                                   
+                               </decoNote>
+                               
+                           </binding>
+                       </bindingDesc>
+                   </physDesc>               
+                    
+                    
+                      <history>
+                         <origin>
+                           <origDate notBefore="1970" notAfter="2020">Late 20th/21th century; very recent.</origDate>                           
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                         <term key="Hagiography"/>               
+                    <term key="MoPe"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>          
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+                description on the basis of an examination in situ.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan023.xml
+++ b/MaaquddiYohannes/MaaquddiYohan023.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-023</idno>                        
                     </msIdentifier>
                     <msContents>
@@ -53,7 +53,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                      </objectDesc>
                        <bindingDesc>
                            <binding contemporary="true">
-                               <decoNote xml:id="b1">Two wooden boards; blind-tooled leather cover; textile inlays; textile overcover.</decoNote>
+                               <decoNote xml:id="b1">Two wooden boards; blind-tooled leather cover; textile inlays; textile chemise.</decoNote>
                                <decoNote xml:id="b2" type="bindingMaterial">                                   
                                    <material key="wood"/>
                                    <material key="leather"/>

--- a/MaaquddiYohannes/MaaquddiYohan023.xml
+++ b/MaaquddiYohannes/MaaquddiYohan023.xml
@@ -1,0 +1,107 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan023" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title> Homily in honour of Archangel Raphael</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-023</idno>                        
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">                       
+                           <title type="complete" ref="LIT1297Dersan" cert="low"/>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>                                                                       
+                                           <dimensions type="outer">
+                                               <height unit="mm">250</height>
+                                               <width unit="mm">200</width>
+                                               <depth unit="mm">40</depth>
+                                           </dimensions>
+                                       </extent>
+                            
+                            <condition key="good"/>
+                         </supportDesc>
+                     </objectDesc>
+                       <bindingDesc>
+                           <binding contemporary="true">
+                               <decoNote xml:id="b1">Two wooden boards; blind-tooled leather cover; textile inlays; textile overcover.</decoNote>
+                               <decoNote xml:id="b2" type="bindingMaterial">                                   
+                                   <material key="wood"/>
+                                   <material key="leather"/>
+                                   <material key="textile"/>
+                                   
+                               </decoNote>
+                               
+                           </binding>
+                       </bindingDesc>
+                   </physDesc>               
+                    
+                    
+                      <history>
+                         <origin>
+                           <origDate notBefore="1970" notAfter="2020">Late 20th/21th century.</origDate>                            
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                         <term key="Homily"/>               
+                    <term key="MoPe"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>          
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+                description on the basis of an examination in situ.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan024.xml
+++ b/MaaquddiYohannes/MaaquddiYohan024.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-024</idno>                        
                     </msIdentifier>
                     <msContents>

--- a/MaaquddiYohannes/MaaquddiYohan024.xml
+++ b/MaaquddiYohannes/MaaquddiYohan024.xml
@@ -1,0 +1,107 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan024" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Missal</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-024</idno>                        
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">                       
+                           <title type="complete" ref="LIT1960Mashaf"/>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>                                                                       
+                                           <dimensions type="outer">
+                                               <height unit="mm">250</height>
+                                               <width unit="mm">200</width>
+                                               <depth unit="mm">70</depth>
+                                           </dimensions>
+                                       </extent>
+                            
+                            <condition key="intact"/>
+                         </supportDesc>
+                     </objectDesc>
+                       <bindingDesc>
+                           <binding contemporary="true">
+                               <decoNote xml:id="b1" cert="low">Two wooden boards; blind-tooled leather cover; textile inlays.</decoNote>
+                               <decoNote xml:id="b2" type="bindingMaterial">                                   
+                                   <material key="wood"/>
+                                   <material key="leather"/>
+                                   <material key="textile"/>
+                                   
+                               </decoNote>
+                               
+                           </binding>
+                       </bindingDesc>
+                   </physDesc>               
+                    
+                    
+                      <history>
+                         <origin>
+                           <origDate notBefore="1970" notAfter="2020">Late 20th/21th century.</origDate>                            
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                         <term key="Homily"/>               
+                    <term key="MoPe"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>          
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+                description on the basis of an examination in situ.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan025.xml
+++ b/MaaquddiYohannes/MaaquddiYohan025.xml
@@ -1,0 +1,111 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan025" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Synaxarion for the second half of the year</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-025</idno>   
+                        <altIdentifier>
+                            <idno>C3-IV-206</idno>
+                        </altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">                       
+                           <title type="complete" ref="LIT1960Mashaf" cert="low"/>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>                                                                       
+                                           <dimensions type="outer">
+                                               <height unit="mm">370</height>
+                                               <width unit="mm">300</width>
+                                               <depth unit="mm">95</depth>
+                                           </dimensions>
+                                       </extent>
+                            
+                            <condition key="intact"/>
+                         </supportDesc>
+                     </objectDesc>
+                       <bindingDesc>
+                           <binding contemporary="true">
+                               <decoNote xml:id="b1">Two wooden boards.</decoNote>
+                               <decoNote xml:id="b2" type="bindingMaterial">                                   
+                                   <material key="wood"/>                                
+                                   
+                               </decoNote>
+                               
+                           </binding>
+                       </bindingDesc>
+                   </physDesc>               
+                    
+                    
+                      <history>
+                         <origin>
+                           <origDate notBefore="1750" notAfter="1800">Second half of the 18th century.</origDate>
+                             At the end it is said that the manuscript was written in the time of the king <persName ref="PRS9142TaklaGi">Takla Giyorgis</persName>.
+                             The name of the scribe is blotted out.
+                         </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                         <term key="Liturgy"/>       
+                    <term key="Hagiography"/> 
+                    <term key="ZaMa"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>          
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+                description on the basis of an examination in situ</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan025.xml
+++ b/MaaquddiYohannes/MaaquddiYohan025.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-025</idno>   
                         <altIdentifier>
                             <idno>C3-IV-206</idno>
@@ -70,8 +70,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                       <history>
                          <origin>
                            <origDate notBefore="1750" notAfter="1800">Second half of the 18th century.</origDate>
-                             At the end it is said that the manuscript was written in the time of the king <persName ref="PRS9142TaklaGi">Takla Giyorgis</persName>.
-                             The name of the scribe is blotted out.
+                             At the end there is a colophon which says that the manuscript was written in the time of the king <persName ref="PRS9142TaklaGi">Takla Giyorgis</persName>.
+                             The name of the scribe and some other words, probably names, are blotted out.
                          </origin>
                       </history>
                 </msDesc>

--- a/MaaquddiYohannes/MaaquddiYohan026.xml
+++ b/MaaquddiYohannes/MaaquddiYohan026.xml
@@ -1,0 +1,105 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan026" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Homily of the Holy Cross</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-026</idno>                        
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">                       
+                           <title type="complete" cert="medium">ድርሳነ፡ መስቀል፡</title>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>                                                                       
+                                           <dimensions type="outer">
+                                               <height unit="mm">290</height>
+                                               <width unit="mm">220</width>
+                                               <depth unit="mm">70</depth>
+                                           </dimensions>
+                                       </extent>
+                            
+                            <condition key="intact"/>
+                         </supportDesc>
+                     </objectDesc>
+                       <bindingDesc>
+                           <binding contemporary="true">
+                               <decoNote xml:id="b1">Two wooden boards, blind-tooled leather cover.</decoNote>
+                               <decoNote xml:id="b2" type="bindingMaterial">                                   
+                                   <material key="wood"/>                                
+                                   <material key="leather"/>
+                               </decoNote>
+                               
+                           </binding>
+                       </bindingDesc>
+                   </physDesc>               
+                    
+                    
+                      <history>
+                         <origin>
+                           <origDate notBefore="1990" notAfter="2020">Late 20th/early 21st century; very recent.</origDate>
+                                                      </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                         <term key="Homily"/>               
+                    <term key="MoPe"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>          
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+                description on the basis of an examination in situ.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan026.xml
+++ b/MaaquddiYohannes/MaaquddiYohan026.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-026</idno>                        
                     </msIdentifier>
                     <msContents>

--- a/MaaquddiYohannes/MaaquddiYohan027.xml
+++ b/MaaquddiYohannes/MaaquddiYohan027.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-027</idno>                        
                     </msIdentifier>
                     <msContents>

--- a/MaaquddiYohannes/MaaquddiYohan027.xml
+++ b/MaaquddiYohannes/MaaquddiYohan027.xml
@@ -1,0 +1,90 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan027" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Acts of John the Baptist</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-027</idno>                        
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">                       
+                           <title type="complete">Acts of John the Baptist</title>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>                                                                      
+                                              </extent>
+                            
+                            <condition key="intact"/>
+                         </supportDesc>
+                     </objectDesc>                       
+                   </physDesc>               
+                    
+                    
+                      <history>
+                         <origin>
+                           <origDate notBefore="1990" notAfter="2020">Late 20th/early 21st century; very recent.</origDate>
+                                                      </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                         <term key="Hagiography"/>               
+                    <term key="MoPe"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>          
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+                description on the basis of an examination in situ.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/MaaquddiYohannes/MaaquddiYohan028.xml
+++ b/MaaquddiYohannes/MaaquddiYohan028.xml
@@ -24,7 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <sourceDesc>
                 <msDesc xml:id="ms">
                     <msIdentifier>
-                        <repository ref="LOC4359Maaqud"/>
+                        <repository ref="INS1005Maaqud"/>
                         <idno>YOMA-028</idno>                        
                     </msIdentifier>
                     <msContents>

--- a/MaaquddiYohannes/MaaquddiYohan028.xml
+++ b/MaaquddiYohannes/MaaquddiYohan028.xml
@@ -1,0 +1,90 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="MaaquddiYohan028" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Acts and Miracles of Gabra Manfas Qǝddus</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="DN"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+               <pubPlace>Hamburg</pubPlace>
+               <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                  Forschungsumgebung / Beta maṣāḥǝft</publisher>
+               <availability>
+                  <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                     This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </licence>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="LOC4359Maaqud"/>
+                        <idno>YOMA-028</idno>                        
+                    </msIdentifier>
+                    <msContents>
+                       <summary/>
+                       <msItem xml:id="ms_i1">                       
+                           <title type="complete" corresp="LIT1119DossierQMQ">Acts of Gabra Manfas Qǝddus, probably followed by his Miracles</title>
+                         <textLang mainLang="gez"/>
+                         </msItem>
+                        </msContents>
+                   <physDesc>
+                     <objectDesc form="Codex">
+                        <supportDesc>
+                           <support>                          
+                                           <material key="parchment"/>
+                                       </support>
+                                       <extent>                                                                      
+                                              </extent>
+                            
+                            <condition key="intact"/>
+                         </supportDesc>
+                     </objectDesc>                       
+                   </physDesc>               
+                    
+                    
+                      <history>
+                         <origin>
+                           <origDate notBefore="1990" notAfter="2020">Late 20th/early 21st century; very recent.</origDate>
+                                                      </origin>
+                      </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                         <term key="Hagiography"/>               
+                    <term key="MoPe"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>          
+            <change who="DN" when="2023-12-01">Created entity with rudimentary
+                description on the basis of an examination in situ.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
An inventory of the collection of Maaquddi Yohannes YOMA (28 books; a certain number of manuscripts could not be recorded).