### PR TITLE
Update BNFabb161.xml

### DIFF
--- a/ParisBNF/abb/BNFabb161.xml
+++ b/ParisBNF/abb/BNFabb161.xml
@@ -235,13 +235,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <locus from="133r" to="181r">2-94</locus>
                        <title type="complete" ref="LIT2077Nuzhat"/>
                         <textLang mainLang="ar"/>
-                       <colophon xml:lang="ar" xml:id="coloph2"/>                       
+                       <colophon xml:lang="ar" xml:id="coloph2">                       
                                        
-                        <note>Paginated from right to left. The colophon indicates that
+                        <note>The colophon indicates that
                           the copying was completed in the time from 9 December 1847 to 7 January 1848, 
                           for <persName ref="PRS1072dAbbadi">Michel d’Abbadie</persName>. Recorded falsely in 
                           <bibl><ptr target="bm:Chaine1912Catalogue"/><citedRange unit="page">97</citedRange></bibl>.
-                        </note>
+                        </note></colophon>
                                      </msItem>
                     </msContents>
                     
@@ -255,6 +255,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                 <measure unit="page" quantity="96">94+2</measure>
                                 <measure unit="page" type="blank">4</measure>
                               </extent>
+                              <foliation>Paginated from right to left. </foliation>
                             </supportDesc>
                             
                                                     


### PR DESCRIPTION
note that the `colophon `may not be empty. it needs either some text, or at least a `locus`, or a `note`.