### PR TITLE
facs from emip to cbd

### DIFF
--- a/Dublin/CBD911.xml
+++ b/Dublin/CBD911.xml
@@ -24,11 +24,11 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   <msIdentifier>
                      <repository ref="INS0422Chester_Beatty_Library"/>
                      <collection>Ethiopian</collection>
-                     <idno>CBD W 911</idno>
+                     <idno facs="https://viewer.cbl.ie/viewer/api/v1/records/W_911/manifest/">CBD W 911</idno> <!-- facs="EMIP/Codices/3165/" n="199" -->
                      <altIdentifier>
                         <repository ref="INS0447EMIP"/>
                         <collection>EMIP</collection>
-                        <idno facs="EMIP/Codices/3165/">EMIP 3165</idno>
+                        <idno>EMIP 3165</idno>
                      </altIdentifier>
                   </msIdentifier>
                <msContents><summary>Zena Sellase, Sayfa Malakot, Gospel of Mark, ወንጌል፡ ዘማርቆስ፡, Image of Saint George, መልክአ፡ ጊዮርጊስ፡, Gospel of John, ወንጌል፡ ዘዮሐንስ፡, with many miniatures</summary></msContents>
@@ -108,6 +108,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          <change when="2022-05-04" who="ES">added EMIP</change>
       </revisionDesc>
    </teiHeader>
+   <facsimile>
+      <graphic url="https://viewer.cbl.ie/viewer/mirador/?pi=W_911"></graphic>
+   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <listRelation><relation name="betmas:formerlyAlsoListedAs" active="CBD911" passive="EMIP03165"></relation></listRelation>
       <body>

--- a/Dublin/CBD912.xml
+++ b/Dublin/CBD912.xml
@@ -24,11 +24,11 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   <msIdentifier>
                      <repository ref="INS0422Chester_Beatty_Library"/>
                      <collection>Ethiopian</collection>
-                     <idno facs="https://viewer.cbl.ie/viewer/api/v1/records/W_912/manifest/">CBD W 912</idno>
+                     <idno facs="https://viewer.cbl.ie/viewer/api/v1/records/W_912/manifest/">CBD W 912</idno><!-- facs="EMIP/Codices/3166/" n="47" -->
                      <altIdentifier>
                         <repository ref="INS0447EMIP"/>
                         <collection>EMIP</collection>
-                        <idno facs="EMIP/Codices/3166/">EMIP 3166</idno>
+                        <idno>EMIP 3166</idno>
                      </altIdentifier>
                   </msIdentifier>
                <msContents><summary>Gospel of Matthew, ወንጌል፡ ዘማቴዎስ፡, Gospel of Mark, ወንጌል፡ ዘማርቆስ፡</summary></msContents>

--- a/Dublin/CBD914.xml
+++ b/Dublin/CBD914.xml
@@ -24,7 +24,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   <msIdentifier>
                      <repository ref="INS0422Chester_Beatty_Library"/>
                      <collection>Ethiopian</collection>
-                     <idno facs="EMIP/Codices/3168/" n="113">CBD W 914</idno>
+                     <idno facs="https://viewer.cbl.ie/viewer/api/v1/records/W_916/manifest/">CBD W 914</idno> <!-- facs="EMIP/Codices/3168/" n="113" -->
                      <altIdentifier>
                         <idno>Lady Meux 3</idno>
                      </altIdentifier>
@@ -95,6 +95,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          <change when="2022-05-04" who="ES">added EMIP</change>
       </revisionDesc>
    </teiHeader>   
+   <facsimile>
+      <graphic url="https://viewer.cbl.ie/viewer/mirador/?pi=W_914"></graphic>
+   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <listRelation><relation name="betmas:formerlyAlsoListedAs" active="CBD914" passive="EMIP03168"></relation></listRelation>
       <body>

--- a/Dublin/CBD916.xml
+++ b/Dublin/CBD916.xml
@@ -24,11 +24,11 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   <msIdentifier>
                      <repository ref="INS0422Chester_Beatty_Library"/>
                      <collection>Ethiopian</collection>
-                     <idno facs="https://viewer.cbl.ie/viewer/api/v1/records/W_916/manifest/">CBD W 916</idno>                     
+                     <idno facs="https://viewer.cbl.ie/viewer/api/v1/records/W_916/manifest/">CBD W 916</idno>                     <!-- facs="EMIP/Codices/3170/" n="48" -->
                      <altIdentifier>
                         <repository ref="INS0447EMIP"/>
                         <collection>EMIP</collection>
-                        <idno facs="EMIP/Codices/3170/">EMIP 3170</idno>
+                        <idno>EMIP 3170</idno> 
                      </altIdentifier>
                   </msIdentifier>
                <msContents><summary>Praises of Mary, ውዳሴ፡ ማርያም፡, Gate of Light, አንቀጸ፡ ብርሃን፡, with many miniatures</summary>

--- a/Dublin/CBD922.xml
+++ b/Dublin/CBD922.xml
@@ -24,11 +24,11 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   <msIdentifier>
                      <repository ref="INS0422Chester_Beatty_Library"/>
                      <collection>Ethiopian</collection>
-                     <idno>CBD W 922</idno>                     
+                     <idno facs="https://viewer.cbl.ie/viewer/api/v1/records/W_922/manifest/">CBD W 922</idno>                     <!-- facs="EMIP/Codices/3176/" n="70" -->
                      <altIdentifier>
                         <repository ref="INS0447EMIP"/>
                         <collection>EMIP</collection>
-                        <idno facs="EMIP/Codices/3176/">EMIP 3176</idno>
+                        <idno>EMIP 3176</idno>
                      </altIdentifier>
                   </msIdentifier>
                <msContents><summary>Horologium, Maṣḥafa Saʿātāt</summary>
@@ -78,6 +78,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
          <change when="2022-05-04" who="ES">added EMIP</change>
       </revisionDesc>
    </teiHeader>   
+   <facsimile>
+      <graphic url="https://viewer.cbl.ie/viewer/mirador/?pi=W_922"></graphic>
+   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <listRelation><relation name="betmas:formerlyAlsoListedAs" active="CBD922" passive="EMIP03176"></relation></listRelation>
       <body>


### PR DESCRIPTION
since for the moment the app does not support multiple manifests we must have one in the viewer
we could leave emip (black and white) as the main one and have a link to CBD or just have the coloured CBD in our viewer where the manifest is available (as proposed here)
https://github.com/BetaMasaheft/Documentation/issues/2100
https://github.com/BetaMasaheft/Manuscripts/pull/2248