### PR TITLE
Update NLSms1894.xml

### DIFF
--- a/EdinburghNLS/NLSms1894.xml
+++ b/EdinburghNLS/NLSms1894.xml
@@ -29,13 +29,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <msDesc xml:id="ms">
                     <msIdentifier>
                         <repository ref="INS0990NLS"/>
-                        <idno>National Library of Scotland, Ms 1894</idno>
+                        <idno>Ms 1894</idno>
                     </msIdentifier>
                     
                     <msContents>
                        <summary/>
                       <msItem xml:id="ms_i1">
-                          <locus from="1r" to="202b"/>
+                          <locus from="1r" to="202vb"/>
                           <title type="incomplete" ref="LIT1560Gospel"/>
                           <note>The very last folios are missing, and the first leaves are partly disarranged.</note>
                           <textLang mainLang="gez"></textLang>
@@ -167,7 +167,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 </support>
                                                 <extent>
                                                     <measure unit="leaf">203</measure>
-                                                    <measure unit="page" type="blank">2</measure>
+                                                    <measure unit="leaf" type="blank">2</measure>
                                                     <locus target="#64r"/>
                                                     <locus target="#161r"/>
                                                     <dimensions type="outer" unit="mm">
@@ -306,38 +306,38 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                     <term key="arch">arch</term> resting on <term key="column">columns</term>. Atop the arch are 
                                                     four <foreign xml:lang="gez">ጢር፡</foreign> <term key="bird">birds</term> and four 
                                                     <foreign xml:lang="gez">ዱራ፡</foreign> birds. </desc>
-                                                <q n="1" xml:lang="gez">ነዋ፡ በግዑ፡ ለእግዚአብሔር፡ ዘያአ<unclear>ብ</unclear>ት፡ ኃጢአተ፡ ዓለም፡</q><q><foreign xml:lang="en">Behold the Lamb of God who takes away the sin of the world.</foreign></q>
-                                                <q n="2" xml:lang="gez">ፈያታዊ፡ ዘየማን፡</q><q><foreign xml:lang="en">The robber on the right (hand).</foreign></q>
-                                                <q n="3" xml:lang="gez">ፈያታዊ፡ ዘፀጋም፡</q><q><foreign xml:lang="en">The robber on the left (hand).</foreign></q>
-                                                <q n="4" xml:lang="gez">ሐራ፡ ዘወግኦ፡</q><q><foreign xml:lang="en">The soldier who pierced him.</foreign></q>
-                                                <q n="5" xml:lang="gez">መስቀለ፡ እግዚእነ፡</q><q><foreign xml:lang="en">The cross of Our Lord.</foreign></q>
-                                                <q n="6" xml:lang="gez">ሐራ፡ ዘአስተዮ፡ ሐሞተ፡</q><q><foreign xml:lang="en">The soldier who gave him gall to drink.</foreign></q>
+                                                <q n="1" xml:lang="gez">ነዋ፡ በግዑ፡ ለእግዚአብሔር፡ ዘያአ<unclear>ብ</unclear>ት፡ ኃጢአተ፡ ዓለም፡</q><q xml:lang="en">Behold the Lamb of God who takes away the sin of the world.</q>
+                                                <q n="2" xml:lang="gez">ፈያታዊ፡ ዘየማን፡</q><q xml:lang="en">The robber on the right (hand).</q>
+                                                <q n="3" xml:lang="gez">ፈያታዊ፡ ዘፀጋም፡</q><q xml:lang="en">The robber on the left (hand).</q>
+                                                <q n="4" xml:lang="gez">ሐራ፡ ዘወግኦ፡</q><q xml:lang="en">The soldier who pierced him.</q>
+                                                <q n="5" xml:lang="gez">መስቀለ፡ እግዚእነ፡</q><q xml:lang="en">The cross of Our Lord.</q>
+                                                <q n="6" xml:lang="gez">ሐራ፡ ዘአስተዮ፡ ሐሞተ፡</q><q xml:lang="en">The soldier who gave him gall to drink.</q>
                                             </decoNote>
                                             
                                             <decoNote type="miniature" xml:id="d11">
                                                 <locus target="#6r"></locus>
                                                 <desc>The upper part depicts three empty crosses and the sun and the moon, the lower part the <ref type="authFile" corresp="AT1017WomenAtTomb"/></desc>
-                                                <q n="1" xml:lang="gez">መልአክ፡ ኃበ፡ ተናገሮን፡ ለአንስት።</q><q><foreign xml:lang="en">How the angel spoke to the women.</foreign></q>
-                                                <q n="2" xml:lang="gez">ፀሐይ<supplied reason="subaudible">፡</supplied> ኀበ፡ ኀብአ፡ ብርሃኑ፡</q><q><foreign xml:lang="en">How the light of the sun was hidden.</foreign></q>
-                                                <q n="3" xml:lang="gez">ወወርኅኒ፡ ደመ፡ ኮነ፡</q><q><foreign xml:lang="en">And the moon became blood.</foreign></q>
-                                                <q n="4" xml:lang="gez">ማርያ፡</q><q><foreign xml:lang="en">Mary.</foreign></q>
-                                                <q n="5" xml:lang="gez">ማርታ፡</q><q><foreign xml:lang="en">Martha.</foreign></q>
-                                                <q n="6" xml:lang="gez">ሐራ፡ ዘየዐቅብ<supplied reason="subaudible">፡</supplied></q><q><foreign xml:lang="en">The soldier who guards.</foreign></q>
-                                                <q n="7" xml:lang="gez">መቃብረ፡ እግዚእነ፡</q><q><foreign xml:lang="en">The grave of Our Lord.</foreign></q>
-                                                <q n="8" xml:lang="gez">ሐራ፡ ዘየዐቅብ፡</q><q><foreign xml:lang="en">The soldier who guards.</foreign></q>
+                                                <q n="1" xml:lang="gez">መልአክ፡ ኃበ፡ ተናገሮን፡ ለአንስት።</q><q xml:lang="en">How the angel spoke to the women.</q>
+                                                <q n="2" xml:lang="gez">ፀሐይ<supplied reason="subaudible">፡</supplied> ኀበ፡ ኀብአ፡ ብርሃኑ፡</q><q xml:lang="en">How the light of the sun was hidden.</q>
+                                                <q n="3" xml:lang="gez">ወወርኅኒ፡ ደመ፡ ኮነ፡</q><q xml:lang="en">And the moon became blood.</q>
+                                                <q n="4" xml:lang="gez">ማርያ፡</q><q xml:lang="en">Mary.</q>
+                                                <q n="5" xml:lang="gez">ማርታ፡</q><q xml:lang="en">Martha.</q>
+                                                <q n="6" xml:lang="gez">ሐራ፡ ዘየዐቅብ<supplied reason="subaudible">፡</supplied></q><q xml:lang="en">The soldier who guards.</q>
+                                                <q n="7" xml:lang="gez">መቃብረ፡ እግዚእነ፡</q><q xml:lang="en">The grave of Our Lord.</q>
+                                                <q n="8" xml:lang="gez">ሐራ፡ ዘየዐቅብ፡</q><q xml:lang="en">The soldier who guards.</q>
                                             </decoNote>
                                             
                                             <decoNote type="miniature" xml:id="d12">
                                                 <locus target="#6v"></locus>
                                                 <desc>The upper part contains a <ref type="authFile" corresp="AT1040Ancient"/>. The lower part depicts <ref type="authFile" corresp="AT1099StMary"/> surrounded by St Michael and St Gabriel.</desc>
-                                                <q n="1" xml:lang="gez">ሥዕለ፡ እግዚእነ።</q><q><foreign xml:lang="en">Image of Our Lord.</foreign></q>
-                                                <q n="2" xml:lang="gez"><gap reason="lost"/><unclear>ጸ፡</unclear> ሰብእ፡</q><q><foreign xml:lang="en">The face of a man.</foreign></q>
-                                                <q n="3" xml:lang="gez">ገጸ፡ ንስር፡</q><q><foreign xml:lang="en">The face of an eagle.</foreign></q>
-                                                <q n="4" xml:lang="gez">ገጸ፡ <gap reason="lost"/>ንበ<gap reason="lost"/></q><q><foreign xml:lang="en">The face of a lion.</foreign></q>
-                                                <q n="5" xml:lang="gez">ገጸ፡ <unclear>ላ</unclear>ህም<gap reason="lost"/></q><q><foreign xml:lang="en">The face of an ox.</foreign></q>
-                                                <q n="6" xml:lang="gez"><gap reason="lost"/>ለ፡ ቅዱስ፡ ማከ<gap reason="lost"/></q><q><foreign xml:lang="en">Image of St Michael (?).</foreign></q>
-                                                <q n="7" xml:lang="gez">ሥዕ<gap reason="lost"/> ቅ<gap reason="lost"/>ስ <unclear>ገ</unclear>ብ<gap reason="lost"/></q><q><foreign xml:lang="en">Image of St Gabriel (?).</foreign></q>
-                                                <q n="8" xml:lang="gez">ሥዕለ፡ እ<gap reason="lost"/>እ<unclear>ት</unclear>ነ፡ ማ<gap reason="lost"/>ያም።</q><q><foreign xml:lang="en">The face of an eagle.</foreign></q>
+                                                <q n="1" xml:lang="gez">ሥዕለ፡ እግዚእነ።</q><q xml:lang="en">Image of Our Lord.</q>
+                                                <q n="2" xml:lang="gez"><gap reason="lost"/><unclear>ጸ፡</unclear> ሰብእ፡</q><q xml:lang="en">The face of a man.</q>
+                                                <q n="3" xml:lang="gez">ገጸ፡ ንስር፡</q><q xml:lang="en">The face of an eagle.</q>
+                                                <q n="4" xml:lang="gez">ገጸ፡ <gap reason="lost"/>ንበ<gap reason="lost"/></q><q xml:lang="en">The face of a lion.</q>
+                                                <q n="5" xml:lang="gez">ገጸ፡ <unclear>ላ</unclear>ህም<gap reason="lost"/></q><q xml:lang="en">The face of an ox.</q>
+                                                <q n="6" xml:lang="gez"><gap reason="lost"/>ለ፡ ቅዱስ፡ ማከ<gap reason="lost"/></q><q xml:lang="en">Image of St Michael (?).</q>
+                                                <q n="7" xml:lang="gez">ሥዕ<gap reason="lost"/> ቅ<gap reason="lost"/>ስ <unclear>ገ</unclear>ብ<gap reason="lost"/></q><q xml:lang="en">Image of St Gabriel (?).</q>
+                                                <q n="8" xml:lang="gez">ሥዕለ፡ እ<gap reason="lost"/>እ<unclear>ት</unclear>ነ፡ ማ<gap reason="lost"/>ያም።</q><q xml:lang="en">The face of an eagle.</q>
                                             </decoNote>
                                             
                                             <decoNote type="miniature" xml:id="d13">
@@ -366,25 +366,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <decoNote type="miniature" xml:id="d16">
                                                 <locus target="#8v"></locus>
                                                 <desc><ref type="authFile" corresp="AT1014Evangelists">St Matthew.</ref></desc>
-                                                <q n="1" xml:lang="gez"><sic>ሠ</sic>ዕለ፡ ቅዱስ፡ ማቴዎስ።</q><q><foreign xml:lang="en">Image of St Matthew.</foreign></q>
+                                                <q n="1" xml:lang="gez"><sic>ሠ</sic>ዕለ፡ ቅዱስ፡ ማቴዎስ።</q><q xml:lang="en">Image of St Matthew.</q>
                                             </decoNote>
                                             
                                             <decoNote type="miniature" xml:id="d17">
                                                 <locus target="#64v"></locus>
                                                 <desc><ref type="authFile" corresp="AT1014Evangelists">St Mark.</ref></desc>
-                                                <q n="1" xml:lang="gez">ሥዕለ፡ ቅዱስ፡ ማርቆስ፡=</q><q><foreign xml:lang="en">Image of St Mark.</foreign></q>
+                                                <q n="1" xml:lang="gez">ሥዕለ፡ ቅዱስ፡ ማርቆስ፡=</q><q xml:lang="en">Image of St Mark.</q>
                                             </decoNote>
                                             
                                             <decoNote type="miniature" xml:id="d18">
                                                 <locus target="#107v"></locus>
                                                 <desc><ref type="authFile" corresp="AT1014Evangelists">St Luke.</ref></desc>
-                                                <q n="1" xml:lang="gez">ሥዕለ፡ ቅዱስ፡ ሉቃስ።</q><q><foreign xml:lang="en">Image of St Luke.</foreign></q>
+                                                <q n="1" xml:lang="gez">ሥዕለ፡ ቅዱስ፡ ሉቃስ።</q><q xml:lang="en">Image of St Luke.</q>
                                             </decoNote>
                                             
                                             <decoNote type="miniature" xml:id="d19">
                                                 <locus target="#161v"></locus>
                                                 <desc><ref type="authFile" corresp="AT1014Evangelists">St John.</ref></desc>
-                                                <q n="1" xml:lang="gez">ስዕለ፡ ዮሐንስ</q><q><foreign xml:lang="en">Image of John.</foreign></q>
+                                                <q n="1" xml:lang="gez">ስዕለ፡ ዮሐንስ</q><q xml:lang="en">Image of John.</q>
                                             </decoNote>
                                         </decoDesc>
                                         <bindingDesc>


### PR DESCRIPTION
small corrections:
- we only use unit="page" to mark paginated mss
- for translated captions we only use `q xml:lang="en"` see Ex. 3 at https://betamasaheft.eu/Guidelines/?q=caption&id=decorationDescription, `foreign `means another language used inside of a passage
