### PR TITLE
Create BLorient11601

### DIFF
--- a/LondonBritishLibrary/orient/BLorient11601.xml
+++ b/LondonBritishLibrary/orient/BLorient11601.xml
@@ -35,7 +35,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </support>
                                     <extent>
                                         <measure unit="leaf">85</measure>
+                                        <measure unit="leaf" type="blank">85v</measure>
                                     </extent>
+                                    <condition key="good"><locus target="#45 #75"/> restored in the Britisch Museum.</condition>
                                 </supportDesc>
                             </objectDesc>
                             <additions>
@@ -81,12 +83,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <item xml:id="a7">
                                         <locus from="82ra" to="83ra"/>
                                         <desc type="GuestText" xml:lang="gez">Explanation of the Lord's Prayer.</desc>
+                                        <note>Written by the same hand as the following note <ref target="#a8"/>.</note>
                                         <q xml:lang="gez">አቡነ፡ ዘበሰማያት፡ ወብሂሎቱኒ፡ አቡነ፡ ይትረጐም፡ ኀበ፡ ክልኤ፡ ፍና፡ ፬በእንተ፡ ዘክህለ፡ ፈጢሮትነ፡ እመኀበ፡ አልቦ፤ 
                                             <gap reason="ellipsis"/></q>
                                     </item>
                                     <item xml:id="a8">
                                         <locus from="83va" to="85rb"/>
                                         <desc type="GuestText" xml:lang="gez"><ref type="work" corresp="LIT3308Nicene"/></desc>
+                                        <note>Written by the same hand as the preceding note <ref target="#a7"/>.</note>
+                                    </item>
+                                    <item xml:id="e1">
+                                        <locus target="#I"/>
+                                        <desc type="AcquisitionNote">A note on the recto of the front flyleaf: "Bought of 
+                                            <persName ref="PRS14317Rowe">W. G. H. Lowe</persName>. 15 Aug. 1936".</desc>
                                     </item>
                                 </list>
                             </additions>
@@ -122,6 +131,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <msItem xml:id="p1_i1">
                                 <locus from="1ra" to="45va"/>
                                 <title ref="LIT1315Dodeka"/>
+                                <note>Various explanatory notes in the margins.</note>
                                 <msItem xml:id="p1_i1.1">
                                     <locus from="1ra" to="7rb"/>
                                     <title ref="LIT3144Hosea"/>
@@ -192,7 +202,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <objectDesc>
                                 <layoutDesc>  
                                     <layout columns="2" writtenLines="20">
-                                        <locus from="1" to="76"></locus>
+                                        <locus from="1" to="75"/>
+                                        <note>Dimensions below refer to the size of a folio.</note>
+                                        <note>Number of written lines varies between 17 and 23.</note>
+                                        <dimensions unit="mm">
+                                            <height>145</height>
+                                            <width>130</width>
+                                        </dimensions>
+                                    </layout>
+                                    <layout columns="1" writtenLines="20">
+                                        <locus target="#76"/>
                                         <note>Dimensions below refer to the size of a folio.</note>
                                         <note>Number of written lines varies between 17 and 23.</note>
                                         <dimensions unit="mm">
@@ -206,6 +225,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <handNote xml:id="h1" script="Ethiopic">
                                     <locus from="1ra" to="45va"/>
                                     <date notBefore="1700" notAfter="1799"/>
+                                    <seg type="rubrication"/>
                                     <desc>Very good raqiq.</desc>
                                 </handNote>
                                 <handNote xml:id="h2" script="Ethiopic">
@@ -240,6 +260,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <handNote xml:id="h3" script="Ethiopic">
                                     <locus from="77ra" to="82rb"/>
                                     <date notBefore="1700" notAfter="1799"/>
+                                    <seg type="rubrication"/>
                                 </handNote>  
                             </handDesc>
                         </physDesc>

--- a/LondonBritishLibrary/orient/BLorient11601.xml
+++ b/LondonBritishLibrary/orient/BLorient11601.xml
@@ -24,6 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <msDesc xml:id="ms">
                     <msIdentifier>
                         <repository ref="INS00001BL"/>
+                        <collection>Oriental</collection>
                         <idno>BL Oriental 11601</idno>
                     </msIdentifier>
                         <physDesc>
@@ -35,9 +36,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </support>
                                     <extent>
                                         <measure unit="leaf">85</measure>
-                                        <measure unit="leaf" type="blank">85v</measure>
+                                        <measure unit="leaf" type="blank">1</measure><locus target="#85v"/>
                                     </extent>
-                                    <condition key="good"><locus target="#45 #75"/> restored in the Britisch Museum.</condition>
+                                    <condition key="good">Two folia (<locus target="#45"/> and <locus target="#75"/> restored in the 
+                                        <placeName ref="INS00001BL">Britisch Museum</placeName>.</condition>
                                 </supportDesc>
                             </objectDesc>
                             <additions>
@@ -46,7 +48,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <locus target="#45v"/>
                                         <desc type="GuestText" xml:lang="gez">Chronology of the kings of Ethiopia from 
                                             <persName ref="PRS10303Yekunno"/>. The last mentioned is <persName ref="PRS5617IyasuII"/>, which 
-                                            proves that this list was added after <date when="1755">1755 A.D.</date>. Written in a very poor hand.</desc>
+                                            proves that this list was added after <date when="1755">1755 CE</date>. Written in a very poor hand.</desc>
                                     </item>
                                     <item xml:id="a2">
                                         <locus target="#75v"/>
@@ -109,7 +111,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <origin>
                                     <origDate notBefore="1700" notAfter="1799">18th century</origDate>
                             </origin>
-                            <provenance>According to a note on <locus target="1"/> bought from a person with the name 
+                            <provenance>According to a note on <locus target="#Ir"/> bought from a person with the name 
                                 <persName ref="PRS14317Rowe">W. G. H. Lowe</persName> on <date when="1936">15 Aug. 1936</date>.</provenance>
                             <provenance/>
                         </history>
@@ -122,6 +124,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 <ptr target="bm:Strelcyn1978BritishLibrary "/>
                                                 <citedRange unit="page">2-3</citedRange>
                                             </bibl>
+                                            <bibl>
+                                                <ptr target="bm:Donzel1969Enbaqom"/>
+                                            </bibl>
                                         </listBibl>
                                     </source>
                                 </recordHist>
@@ -131,61 +136,49 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <msItem xml:id="p1_i1">
                                 <locus from="1ra" to="45va"/>
                                 <title ref="LIT1315Dodeka"/>
-                                <note>Various explanatory notes in the margins.</note>
                                 <msItem xml:id="p1_i1.1">
                                     <locus from="1ra" to="7rb"/>
                                     <title ref="LIT3144Hosea"/>
-                                    <note>The beginning is missing; the text starts with chapter II, 8.</note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.2">
                                     <locus from="7rb" to="13vb"/>
                                     <title ref="LIT3145Amos"/>
-                                    <note>In the upper margin of <locus target="#7r"/>: <foreign xml:lang="gez">አመ፭ለጰግሜን፡ አሞጽ።</foreign></note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.3">
                                     <locus from="13vb" to="18va"/>
                                     <title ref="LIT3146Micah"/>
-                                    <note>In the upper margin of <locus target="#13v"/>: <foreign xml:lang="gez">አመ፡ ፳ወ፪፡ ለነሐሴ፡ ሚክያስ።</foreign></note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.4">
                                     <locus from="18va" to="21va"/>
                                     <title ref="LIT1689Joel"/>
-                                    <note>In the upper margin of <locus target="#18v"/>: <foreign xml:lang="gez">አመ፡ ፳ወ፩ለጥቅምት፡ ኢዩኤል።</foreign></note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.5">
                                     <locus from="21va" to="22va"/>
                                     <title ref="LIT3147Obadiah"/>
-                                    <note>In the upper margin of <locus target="#21va"/>: <foreign xml:lang="gez">አመ፡ ፳ወ፫ለኅዳር፡ አብድዩ።</foreign></note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.6">
                                     <locus from="22va" to="24va"/>
                                     <title ref="LIT1694Jonah"/>
-                                    <note>In the upper margin of <locus target="#22v"/>: <foreign xml:lang="gez">አመ፡ ፳ወ፭ለመስከረም፡ ዮናስ።</foreign></note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.7">
                                     <locus from="24va" to="26va"/>
                                     <title ref="LIT2057Bookof"/>
-                                    <note>In the upper margin of <locus target="#24v"/>: <foreign xml:lang="gez">አመ፡ ፭ለታኅሣሥ፡ ናሆም።</foreign></note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.8">
                                     <locus from="26va" to="29ra"/>
                                     <title ref="LIT1567Bookof"/>
-                                    <note>In the upper margin of <locus target="#26v"/>: <foreign xml:lang="gez">አመ፡ ፫ለኅዳር፡ እንባቆም።</foreign></note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.9">
                                     <locus from="29ra" to="31va"/>
-                                    <title ref="LIT3148Zephan"/>
-                                    <note>In the upper margin of <locus target="#29r"/>: <foreign xml:lang="gez">አመ፡ ፬ለሐምሌ፡ ሶፎንያስ።</foreign></note>
+                                    <title ref="LIT3148Zephan"/> 
                                 </msItem>
                                 <msItem xml:id="p1_i1.10">
                                     <locus from="31va" to="33rb"/>
                                     <title ref="LIT3149Haggai"/>
-                                    <note>In the upper margin of <locus target="#31v"/>: <foreign xml:lang="gez">አመ፡ ፳ለታኅሣሥ፡ ።</foreign></note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.11">
                                     <locus from="33rb" to="42va"/>
                                     <title ref="LIT3150Zechar"/>
-                                    <note>In the upper margin of <locus target="#33r"/>: <foreign xml:lang="gez">አመ፡ ፲ወ፭፡ ለየካቲት፡ ዘካርያስ።</foreign></note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.12">
                                     <locus from="42va" to="45va"/>
@@ -196,24 +189,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <locus from="46ra" to="75rb"/>
                                 <title ref="LIT1109Anqasa"/>
                                 <textLang mainLang="gez"/>
+                                <note>Used by <bibl><ptr target="bm:Donzel1969Enbaqom"/></bibl> in his edition.</note>
                             </msItem>
                     </msContents>
                         <physDesc>
                             <objectDesc>
                                 <layoutDesc>  
-                                    <layout columns="2" writtenLines="20">
+                                    <layout columns="2" writtenLines="17 23">
                                         <locus from="1" to="75"/>
                                         <note>Dimensions below refer to the size of a folio.</note>
-                                        <note>Number of written lines varies between 17 and 23.</note>
                                         <dimensions unit="mm">
                                             <height>145</height>
                                             <width>130</width>
                                         </dimensions>
                                     </layout>
-                                    <layout columns="1" writtenLines="20">
+                                    <layout columns="1" writtenLines="17 23">
                                         <locus target="#76"/>
                                         <note>Dimensions below refer to the size of a folio.</note>
-                                        <note>Number of written lines varies between 17 and 23.</note>
                                         <dimensions unit="mm">
                                             <height>145</height>
                                             <width>130</width>
@@ -233,6 +225,54 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <date notBefore="1700" notAfter="1799"/>
                                 </handNote>
                             </handDesc>
+                            <additions>
+                                <list>
+                                    <item xml:id="e2">
+                                        <locus target="#7r"></locus>
+                                        <q xml:lang="gez">አመ፭ለጰግሜን፡ አሞጽ።</q>
+                                    </item>
+                                    <item xml:id="e3">
+                                        <locus target="#13v"></locus>
+                                        <q xml:lang="gez">አመ፡ ፳ወ፪፡ ለነሐሴ፡ ሚክያስ።</q>
+                                    </item>
+                                    <item xml:id="e4">
+                                        <locus target="#18v"></locus>
+                                        <q xml:lang="gez">አመ፡ ፳ወ፩ለጥቅምት፡ ኢዩኤል።</q>
+                                    </item>
+                                    <item xml:id="e5">
+                                        <locus target="#21va"></locus>
+                                        <q xml:lang="gez">አመ፡ ፳ወ፫ለኅዳር፡ አብድዩ።</q>
+                                    </item>
+                                    <item xml:id="e6">
+                                        <locus target="#22v"></locus>
+                                        <q xml:lang="gez">አመ፡ ፳ወ፭ለመስከረም፡ ዮናስ።</q>
+                                    </item>
+                                    <item xml:id="e7">
+                                        <locus target="#24v"></locus>
+                                        <q xml:lang="gez">አመ፡ ፭ለታኅሣሥ፡ ናሆም።</q>
+                                    </item>
+                                    <item xml:id="e8">
+                                        <locus target="#26v"></locus>
+                                        <q xml:lang="gez">አመ፡ ፫ለኅዳር፡ እንባቆም።</q>
+                                    </item>
+                                    <item xml:id="e9">
+                                        <locus target="#29r"></locus>
+                                        <q xml:lang="gez">አመ፡ ፬ለሐምሌ፡ ሶፎንያስ።</q>
+                                    </item>
+                                    <item xml:id="e10">
+                                        <locus target="#31v"></locus>
+                                        <q xml:lang="gez">አመ፡ ፳ለታኅሣሥ፡ ሐጌ።</q>
+                                    </item>
+                                    <item xml:id="e11">
+                                        <locus target="#33r"></locus>
+                                        <q xml:lang="gez">አመ፡ ፲ወ፭፡ ለየካቲት፡ ዘካርያስ።</q>
+                                    </item>
+                                    <item xml:id="e12">
+                                        <locus from="1" to="45"/>
+                                        <desc type="findingAid">Various explanatory notes in the margins.</desc>
+                                    </item>
+                                </list>
+                            </additions>
                         </physDesc>
                     </msPart>
                     <msPart xml:id="p2"><msIdentifier/><msContents><summary/>
@@ -245,10 +285,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <physDesc>
                             <objectDesc>
                                 <layoutDesc>  
-                                    <layout columns="2" writtenLines="20">
+                                    <layout columns="2" writtenLines="17 23">
                                         <locus from="77" to="82"></locus>
                                         <note>Dimensions below refer to the size of a folio.</note>
-                                        <note>Number of written lines varies between 17 and 23.</note>
                                         <dimensions unit="mm">
                                             <height>135</height>
                                             <width>120</width>
@@ -296,9 +335,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <div type="bibliography">
-                <listRelation>
-                    <relation name="saws:hasOwned" active="PRS14317Rowe" passive="BLorient11601"/>
-                </listRelation>
+                
             </div><!---->
         </body>
     </text>

--- a/LondonBritishLibrary/orient/BLorient11601.xml
+++ b/LondonBritishLibrary/orient/BLorient11601.xml
@@ -1,0 +1,284 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="BLorient11601" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>The Minor Prophets, Anqaṣa amin, Anaphora of St John Chrysostom, Chronology of the Kings of Ethiopia, Prayers</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS00001BL"/>
+                        <idno>BL Oriental 11601</idno>
+                    </msIdentifier>
+                        <physDesc>
+                            <objectDesc form="Codex">
+                                <supportDesc>
+                                    <support>
+                                        <material key="parchment"/>
+                                        <material key="paper"/>
+                                    </support>
+                                    <extent>
+                                        <measure unit="leaf">85</measure>
+                                    </extent>
+                                </supportDesc>
+                            </objectDesc>
+                            <additions>
+                                <list>
+                                    <item xml:id="a1">
+                                        <locus target="#45v"/>
+                                        <desc type="GuestText" xml:lang="gez">Chronology of the kings of Ethiopia from 
+                                            <persName ref="PRS10303Yekunno"/>. The last mentioned is <persName ref="PRS5617IyasuII"/>, which 
+                                            proves that this list was added after <date when="1755">1755 A.D.</date>. Written in a very poor hand.</desc>
+                                    </item>
+                                    <item xml:id="a2">
+                                        <locus target="#75v"/>
+                                        <desc type="GuestText" xml:lang="gez"><ref type="work" corresp="LIT4523Prayer"/>.</desc>
+                                        <q xml:lang="gez">ጸሎተ፡ ንስሓ፡ እግዚአብሔር፡ አምላክነ፡ አኃዜ፡ ኵሉ፡ ፈዋሴ፡ ነፍሳቲነ፡ ወሥጋነ፡ ወመንፈስነ። እስመ፡ ትቤሎ፡ ለአቡነ፡ ጴጥሮስ፡ በአፈ፡ 
+                                            ወልድከ፡ ዋህድ፡ እግዚእነ፡ ወአምላክነ፡ ኢየሱስ፡ ክርስቶስ፡ <gap reason="ellipsis"/></q>
+                                        <note>Edited in <bibl><ptr target="bm:YabetaKrestiyanSalot1944"/><citedRange unit="page">27-28</citedRange>
+                                            </bibl>.</note>
+                                    </item>
+                                    <item xml:id="a3">
+                                        <locus target="#76r"/>
+                                        <desc type="GuestText" xml:lang="gez"><ref type="work" corresp="LIT3020RepCh300"/></desc>
+                                        <q xml:lang="gez">ተስቅለ፡ ወሐመ፡ ዘእንበለ፡ ኃጢአት፡ ተረግዘ፡ ገቦሁ፡ ዘእንበለ፡ ደዌ፡ እስመ፡ መለኮቱ፡ ኢሐመ፡ <gap reason="ellipsis"/> 
+                                            ከመ፡ ያግዕዘነ፡ እምኃጢአት፡ ዮም፡ መስቀል፡ ተሰብሐ፡ ዓለም፡ ተሰብሐ፡ ወእግዚአብሔር፡ ተአኵተ፡ ወግዕዘ፡ ወሰይጣን፡ ተአስረ፡ በኃይለ፡ መስቀሉ፡ ለኢያሱስ፡ 
+                                            ክርስቶስ።</q>
+                                    </item>
+                                    <item xml:id="a4">
+                                        <locus target="#76r"/>
+                                        <desc type="GuestText" xml:lang="gez">Prayer</desc>
+                                        <q xml:lang="gez">ኦዘክርስቶስ፡ አፍቅሮተ፡ ሰብእ፡ ንዜኑ፡ ኦትሕትና፡ ዘእንበለ፡ አቅም፡ ዘተአየረ፡ ልሕኵት፡ ዲበ፡ ለሐኪሁ፡ <gap reason="ellipsis"/>
+                                            ተጸውዓ፡ ዮም፡ መስቀል፡ ለአኃው፡ አብርሀ፡ ወእግዚአብሔር፡ ተሰብሐ፡ ወሰብእ፡ ግዕዘ፡ በተንሣኤሁ።</q>
+                                    </item>
+                                    <item xml:id="a5">
+                                        <locus target="#76r"/>
+                                        <desc type="GuestText" xml:lang="gez">Prayer</desc>
+                                        <q xml:lang="gez">ንዜኑ፡ ለአምላክነ፡ ኂሩት፡ ትሕትና፡ ወየውሐት፡ ወተአገሰ፡ በእንተ፡ አፍቅሮተ፡ ሰብእ፡ ዘሰቀሎ፡ ለሰማይ፡ <gap reason="ellipsis"/>
+                                            ወሰብእ፡ ኢተሐጐለ፡ ወኵሎ፡ ዓለም፡ በቅጽበት፡ አቅመ።</q>
+                                    </item>
+                                    <item xml:id="a6">
+                                        <locus target="#76v"/>
+                                        <desc type="GuestText" xml:lang="gez">Prayer by the virtue of the secret names of the Trinity.</desc>
+                                        <q xml:lang="gez">አስማተ፡ ይሬስይዎን፡ በቅድስት፡ ሥላሴ። ተብህለ፡ በቅዱስ፡ እምሐጸ፡ አስማተ፡ ሥላሴ። <gap reason="ellipsis"/></q>
+                                    </item>
+                                    <item xml:id="a7">
+                                        <locus from="82ra" to="83ra"/>
+                                        <desc type="GuestText" xml:lang="gez">Explanation of the Lord's Prayer.</desc>
+                                        <q xml:lang="gez">አቡነ፡ ዘበሰማያት፡ ወብሂሎቱኒ፡ አቡነ፡ ይትረጐም፡ ኀበ፡ ክልኤ፡ ፍና፡ ፬በእንተ፡ ዘክህለ፡ ፈጢሮትነ፡ እመኀበ፡ አልቦ፤ 
+                                            <gap reason="ellipsis"/></q>
+                                    </item>
+                                    <item xml:id="a8">
+                                        <locus from="83va" to="85rb"/>
+                                        <desc type="GuestText" xml:lang="gez"><ref type="work" corresp="LIT3308Nicene"/></desc>
+                                    </item>
+                                </list>
+                            </additions>
+                            <bindingDesc>
+                                <binding contemporary="false" xml:id="binding">
+                                    <decoNote xml:id="b1" type="Boards">European binding.</decoNote>
+                                </binding>
+                            </bindingDesc>
+                        </physDesc>
+                        <history>
+                            <origin>
+                                    <origDate notBefore="1700" notAfter="1799">18th century</origDate>
+                            </origin>
+                            <provenance>According to a note on <locus target="1"/> bought from a person with the name 
+                                <persName ref="PRS14317Rowe">W. G. H. Lowe</persName> on <date when="1936">15 Aug. 1936</date>.</provenance>
+                            <provenance/>
+                        </history>
+                        <additional>
+                            <adminInfo>
+                                <recordHist>
+                                    <source>
+                                        <listBibl type="catalogue">
+                                            <bibl>
+                                                <ptr target="bm:Strelcyn1978BritishLibrary "/>
+                                                <citedRange unit="page">2-3</citedRange>
+                                            </bibl>
+                                        </listBibl>
+                                    </source>
+                                </recordHist>
+                            </adminInfo>
+                        </additional>
+                    <msPart xml:id="p1"><msIdentifier/><msContents><summary/>
+                            <msItem xml:id="p1_i1">
+                                <locus from="1ra" to="45va"/>
+                                <title ref="LIT1315Dodeka"/>
+                                <msItem xml:id="p1_i1.1">
+                                    <locus from="1ra" to="7rb"/>
+                                    <title ref="LIT3144Hosea"/>
+                                    <note>The beginning is missing; the text starts with chapter II, 8.</note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.2">
+                                    <locus from="7rb" to="13vb"/>
+                                    <title ref="LIT3145Amos"/>
+                                    <note>In the upper margin of <locus target="#7r"/>: <foreign xml:lang="gez">አመ፭ለጰግሜን፡ አሞጽ።</foreign></note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.3">
+                                    <locus from="13vb" to="18va"/>
+                                    <title ref="LIT3146Micah"/>
+                                    <note>In the upper margin of <locus target="#13v"/>: <foreign xml:lang="gez">አመ፡ ፳ወ፪፡ ለነሐሴ፡ ሚክያስ።</foreign></note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.4">
+                                    <locus from="18va" to="21va"/>
+                                    <title ref="LIT1689Joel"/>
+                                    <note>In the upper margin of <locus target="#18v"/>: <foreign xml:lang="gez">አመ፡ ፳ወ፩ለጥቅምት፡ ኢዩኤል።</foreign></note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.5">
+                                    <locus from="21va" to="22va"/>
+                                    <title ref="LIT3147Obadiah"/>
+                                    <note>In the upper margin of <locus target="#21va"/>: <foreign xml:lang="gez">አመ፡ ፳ወ፫ለኅዳር፡ አብድዩ።</foreign></note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.6">
+                                    <locus from="22va" to="24va"/>
+                                    <title ref="LIT1694Jonah"/>
+                                    <note>In the upper margin of <locus target="#22v"/>: <foreign xml:lang="gez">አመ፡ ፳ወ፭ለመስከረም፡ ዮናስ።</foreign></note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.7">
+                                    <locus from="24va" to="26va"/>
+                                    <title ref="LIT2057Bookof"/>
+                                    <note>In the upper margin of <locus target="#24v"/>: <foreign xml:lang="gez">አመ፡ ፭ለታኅሣሥ፡ ናሆም።</foreign></note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.8">
+                                    <locus from="26va" to="29ra"/>
+                                    <title ref="LIT1567Bookof"/>
+                                    <note>In the upper margin of <locus target="#26v"/>: <foreign xml:lang="gez">አመ፡ ፫ለኅዳር፡ እንባቆም።</foreign></note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.9">
+                                    <locus from="29ra" to="31va"/>
+                                    <title ref="LIT3148Zephan"/>
+                                    <note>In the upper margin of <locus target="#29r"/>: <foreign xml:lang="gez">አመ፡ ፬ለሐምሌ፡ ሶፎንያስ።</foreign></note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.10">
+                                    <locus from="31va" to="33rb"/>
+                                    <title ref="LIT3149Haggai"/>
+                                    <note>In the upper margin of <locus target="#31v"/>: <foreign xml:lang="gez">አመ፡ ፳ለታኅሣሥ፡ ።</foreign></note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.11">
+                                    <locus from="33rb" to="42va"/>
+                                    <title ref="LIT3150Zechar"/>
+                                    <note>In the upper margin of <locus target="#33r"/>: <foreign xml:lang="gez">አመ፡ ፲ወ፭፡ ለየካቲት፡ ዘካርያስ።</foreign></note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.12">
+                                    <locus from="42va" to="45va"/>
+                                    <title ref="LIT3151Malachi"/>
+                                </msItem>
+                            </msItem>
+                            <msItem xml:id="p1_i2">
+                                <locus from="46ra" to="75rb"/>
+                                <title ref="LIT1109Anqasa"/>
+                                <textLang mainLang="gez"/>
+                            </msItem>
+                    </msContents>
+                        <physDesc>
+                            <objectDesc>
+                                <layoutDesc>  
+                                    <layout columns="2" writtenLines="20">
+                                        <locus from="1" to="76"></locus>
+                                        <note>Dimensions below refer to the size of a folio.</note>
+                                        <note>Number of written lines varies between 17 and 23.</note>
+                                        <dimensions unit="mm">
+                                            <height>145</height>
+                                            <width>130</width>
+                                        </dimensions>
+                                    </layout>
+                                </layoutDesc>
+                            </objectDesc>
+                            <handDesc>
+                                <handNote xml:id="h1" script="Ethiopic">
+                                    <locus from="1ra" to="45va"/>
+                                    <date notBefore="1700" notAfter="1799"/>
+                                    <desc>Very good raqiq.</desc>
+                                </handNote>
+                                <handNote xml:id="h2" script="Ethiopic">
+                                    <locus from="46ra" to="75rb"/>
+                                    <date notBefore="1700" notAfter="1799"/>
+                                </handNote>
+                            </handDesc>
+                        </physDesc>
+                    </msPart>
+                    <msPart xml:id="p2"><msIdentifier/><msContents><summary/>
+                        <msItem xml:id="p2_i1">
+                            <locus from="77ra" to="82rb"/>
+                            <title ref="LIT3120Anapho"/>
+                            <incipit xml:lang="gez">አኰቴተ፡ ቍርባን፡ ዘዮሐንስ፡ ቅዱስ፡ አፈ፡ ወርቅ፡</incipit>
+                        </msItem> 
+                    </msContents>
+                        <physDesc>
+                            <objectDesc>
+                                <layoutDesc>  
+                                    <layout columns="2" writtenLines="20">
+                                        <locus from="77" to="82"></locus>
+                                        <note>Dimensions below refer to the size of a folio.</note>
+                                        <note>Number of written lines varies between 17 and 23.</note>
+                                        <dimensions unit="mm">
+                                            <height>135</height>
+                                            <width>120</width>
+                                        </dimensions>
+                                    </layout>
+                                </layoutDesc>
+                            </objectDesc>
+                            <handDesc>
+                                <handNote xml:id="h3" script="Ethiopic">
+                                    <locus from="77ra" to="82rb"/>
+                                    <date notBefore="1700" notAfter="1799"/>
+                                </handNote>  
+                            </handDesc>
+                        </physDesc>
+                    </msPart>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="Bible"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="Chronicles"/>
+                    <term key="Prayers"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-01-31">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="saws:hasOwned" active="PRS14317Rowe" passive="BLorient11601"/>
+                </listRelation>
+            </div><!---->
+        </body>
+    </text>
+</TEI>

--- a/LondonBritishLibrary/orient/BLorient11601.xml
+++ b/LondonBritishLibrary/orient/BLorient11601.xml
@@ -112,7 +112,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <origDate notBefore="1700" notAfter="1799">18th century</origDate>
                             </origin>
                             <provenance>According to a note on <locus target="#Ir"/> bought from a person with the name 
-                                <persName ref="PRS14317Rowe">W. G. H. Lowe</persName> on <date when="1936">15 Aug. 1936</date>.</provenance>
+                                <persName role="owner" ref="PRS14317Rowe">W. G. H. Lowe</persName> on <date when="1936">15 Aug. 1936</date>.</provenance>
                             <provenance/>
                         </history>
                         <additional>

--- a/LondonBritishLibrary/orient/BLorient11601.xml
+++ b/LondonBritishLibrary/orient/BLorient11601.xml
@@ -228,48 +228,58 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <additions>
                                 <list>
                                     <item xml:id="e2">
-                                        <locus target="#7r"></locus>
+                                        <locus target="#7r"/>
+                                        <desc type="findingAid"/>
                                         <q xml:lang="gez">አመ፭ለጰግሜን፡ አሞጽ።</q>
                                     </item>
                                     <item xml:id="e3">
-                                        <locus target="#13v"></locus>
+                                        <locus target="#13v"/>
+                                        <desc type="findingAid"/>
                                         <q xml:lang="gez">አመ፡ ፳ወ፪፡ ለነሐሴ፡ ሚክያስ።</q>
                                     </item>
                                     <item xml:id="e4">
-                                        <locus target="#18v"></locus>
+                                        <locus target="#18v"/>
+                                        <desc type="findingAid"/>
                                         <q xml:lang="gez">አመ፡ ፳ወ፩ለጥቅምት፡ ኢዩኤል።</q>
                                     </item>
                                     <item xml:id="e5">
-                                        <locus target="#21va"></locus>
+                                        <locus target="#21va"/>
+                                        <desc type="findingAid"/>
                                         <q xml:lang="gez">አመ፡ ፳ወ፫ለኅዳር፡ አብድዩ።</q>
                                     </item>
                                     <item xml:id="e6">
-                                        <locus target="#22v"></locus>
+                                        <locus target="#22v"/>
+                                        <desc type="findingAid"/>
                                         <q xml:lang="gez">አመ፡ ፳ወ፭ለመስከረም፡ ዮናስ።</q>
                                     </item>
                                     <item xml:id="e7">
-                                        <locus target="#24v"></locus>
+                                        <locus target="#24v"/>
+                                        <desc type="findingAid"/>
                                         <q xml:lang="gez">አመ፡ ፭ለታኅሣሥ፡ ናሆም።</q>
                                     </item>
                                     <item xml:id="e8">
-                                        <locus target="#26v"></locus>
+                                        <locus target="#26v"/>
+                                        <desc type="findingAid"/>
                                         <q xml:lang="gez">አመ፡ ፫ለኅዳር፡ እንባቆም።</q>
                                     </item>
                                     <item xml:id="e9">
-                                        <locus target="#29r"></locus>
+                                        <locus target="#29r"/>
+                                        <desc type="findingAid"/>
                                         <q xml:lang="gez">አመ፡ ፬ለሐምሌ፡ ሶፎንያስ።</q>
                                     </item>
                                     <item xml:id="e10">
-                                        <locus target="#31v"></locus>
+                                        <locus target="#31v"/>
+                                        <desc type="findingAid"/>
                                         <q xml:lang="gez">አመ፡ ፳ለታኅሣሥ፡ ሐጌ።</q>
                                     </item>
                                     <item xml:id="e11">
-                                        <locus target="#33r"></locus>
+                                        <locus target="#33r"/>
+                                        <desc type="findingAid"/>
                                         <q xml:lang="gez">አመ፡ ፲ወ፭፡ ለየካቲት፡ ዘካርያስ።</q>
                                     </item>
                                     <item xml:id="e12">
                                         <locus from="1" to="45"/>
-                                        <desc type="findingAid">Various explanatory notes in the margins.</desc>
+                                        <desc type="Gloss">Various explanatory notes in the margins.</desc>
                                     </item>
                                 </list>
                             </additions>


### PR DESCRIPTION
I have created a record for Or. 11601 according to Strelcyns catalogue. I had no images to compare, but I think it is safe to assume two codicological units, given that the dimensions of the folios and hands change after folio 76. 

In the case of the numerous additions, I do not know whether they were added before or after the last binding. Since this is not clear, I thought it safer to add them to the physdesc of the codex rather than to one of the codicological units. The question of whether or not to include some of the prayers in these editions has been discussed on https://github.com/BetaMasaheft/Documentation/issues/2475 and https://github.com/BetaMasaheft/Documentation/issues/2474.