### PR TITLE
Create BLorient6466 (CH_march24)

### DIFF
--- a/LondonBritishLibrary/orient/BLorient6466.xml
+++ b/LondonBritishLibrary/orient/BLorient6466.xml
@@ -39,7 +39,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <locus target="#Ir"/>
                                     <desc type="AcquisitionNote"/>
                                     <q xml:lang="en">Bought from <persName role="owner" ref="PRS14360Owen">
-                                        <roleName type="title">Rev.</roleName>G. W. Owen</persName>. 
+                                        <roleName type="title">Rev.</roleName> G. W. Owen</persName>. 
                                         <date when="1902-11-13">Nov. 13. 1902</date>.</q>
                                 </item>
                             </list>
@@ -66,6 +66,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <idno/>
                         </msIdentifier>
                         <msContents>
+                            <summary/>
                             <msItem xml:id="p1_i1">
                                 <locus target="#i"/>
                                 <title ref="LIT2765RepCh49" type="incomplete"/>
@@ -83,7 +84,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <objectDesc form="Codex">
                                 <supportDesc>
                                     <support>
-                                        <watermark/>
                                         <material key="parchment"/>
                                     </support>
                                     <extent>
@@ -119,6 +119,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <idno/>
                         </msIdentifier>
                         <msContents>
+                            <summary/>
                             <msItem xml:id="p2_i1">
                                 <locus target="#1r"/>                                
                                 <title type="incomplete" ref="LIT0000000000000000000000">Magic Prayer against snake venom, measles, smallpox,
@@ -131,7 +132,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <objectDesc form="Codex">
                                 <supportDesc>
                                     <support>
-                                        <watermark/>
                                         <material key="parchment"/>
                                     </support>
                                     <extent>

--- a/LondonBritishLibrary/orient/BLorient6466.xml
+++ b/LondonBritishLibrary/orient/BLorient6466.xml
@@ -60,7 +60,24 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <origin>
                             <origDate notBefore="1600" notAfter="1800">17th to 18th century</origDate>
                         </origin> 
+                        <provenance>Bought from <persName role="owner" ref="PRS14360Owen">
+                            <roleName type="title">Rev.</roleName> G. W. Owen</persName> on 
+                            <date when="1902-11-13">Nov. 13. 1902</date>.</provenance>
                     </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                            <citedRange unit="page">26-27</citedRange>
+                                        </bibl> 
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
                     <msPart xml:id="p1">
                         <msIdentifier>
                             <idno/>
@@ -99,20 +116,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <provenance>This piece of vellum is a fragment of a magic scroll, that was added as a front flyleaf to the codex. 
                             </provenance>
                         </history>
-                        <additional>
-                            <adminInfo>
-                                <recordHist>
-                                    <source>
-                                        <listBibl type="catalogue">
-                                            <bibl>
-                                                <ptr target="bm:Strelcyn1978BritishLibrary"/>
-                                                <citedRange unit="page">27</citedRange>
-                                            </bibl> 
-                                        </listBibl>
-                                    </source>
-                                </recordHist>
-                            </adminInfo>
-                        </additional>
                     </msPart>
                     <msPart xml:id="p2">
                         <msIdentifier>
@@ -150,20 +153,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </list>
                             </additions>
                         </physDesc>
-                        <additional>
-                            <adminInfo>
-                                <recordHist>
-                                    <source>
-                                        <listBibl type="catalogue">
-                                            <bibl>
-                                                <ptr target="bm:Strelcyn1978BritishLibrary"/>
-                                                <citedRange unit="page">27</citedRange>
-                                            </bibl> 
-                                        </listBibl>
-                                    </source>
-                                </recordHist>
-                            </adminInfo>
-                        </additional>
                     </msPart>
                     <msPart xml:id="p3">
                         <msIdentifier>
@@ -331,20 +320,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </list>
                         </additions>
                     </physDesc>
-                        <additional>
-                            <adminInfo>
-                                <recordHist>
-                                    <source>
-                                        <listBibl type="catalogue">
-                                            <bibl>
-                                                <ptr target="bm:Strelcyn1978BritishLibrary"/>
-                                                <citedRange unit="page">26-27</citedRange>
-                                            </bibl> 
-                                        </listBibl>
-                                    </source>
-                                </recordHist>
-                            </adminInfo>
-                        </additional>
                     </msPart>
                     <msPart xml:id="p4">
                         <msIdentifier>
@@ -376,20 +351,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </supportDesc>
                             </objectDesc>  
                         </physDesc>
-                        <additional>
-                            <adminInfo>
-                                <recordHist>
-                                    <source>
-                                        <listBibl type="catalogue">
-                                            <bibl>
-                                                <ptr target="bm:Strelcyn1978BritishLibrary"/>
-                                                <citedRange unit="page">27</citedRange>
-                                            </bibl> 
-                                        </listBibl>
-                                    </source>
-                                </recordHist>
-                            </adminInfo>
-                        </additional>
                     </msPart>     
                 </msDesc>
             </sourceDesc>

--- a/LondonBritishLibrary/orient/BLorient6466.xml
+++ b/LondonBritishLibrary/orient/BLorient6466.xml
@@ -122,8 +122,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <summary/>
                             <msItem xml:id="p2_i1">
                                 <locus target="#1r"/>                                
-                                <title type="incomplete" ref="LIT0000000000000000000000">Magic Prayer against snake venom, measles, smallpox,
-                                    and manṭaṭa</title>
+                                <title type="incomplete" ref="LIT6944MagicPrayer"/>
                                 <incipit xml:lang="gez">በስመ፡ አብ፡ በል። ሕብዘ፡ አርዌ፡ ምድር፡ በሊህ፡ እግርኪ፡ ታሕተ፡ ከናፍርኪ፡ <gap reason="ellipsis"/> ኢትሕምም፡ 
                                     አባለ፡ ሥጋሃ፡ <gap reason="ellipsis"/> እምፈንፃፃ፡ ወኩፍኝ፡ ወእመንጣጣ፡ </incipit>
                             </msItem>

--- a/LondonBritishLibrary/orient/BLorient6466.xml
+++ b/LondonBritishLibrary/orient/BLorient6466.xml
@@ -29,6 +29,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <idno>BL Oriental 6466</idno>
                         <altIdentifier><idno>Strelcyn 19</idno></altIdentifier>
                     </msIdentifier>
+                    <msContents>
+                        <summary/>
+                    </msContents>
                     <physDesc>
                         <additions>
                             <list>

--- a/LondonBritishLibrary/orient/BLorient6466.xml
+++ b/LondonBritishLibrary/orient/BLorient6466.xml
@@ -1,0 +1,425 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="BLorient6466" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Psalter</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS00001BL"/>
+                        <collection>Oriental</collection>
+                        <idno>BL Oriental 6466</idno>
+                        <altIdentifier><idno>Strelcyn 19</idno></altIdentifier>
+                    </msIdentifier>
+                    <physDesc>
+                        <additions>
+                            <list>
+                                <item xml:id="e5">
+                                    <locus target="#Ir"/>
+                                    <desc type="AcquisitionNote"/>
+                                    <q xml:lang="en">Bought from <persName role="owner" ref="PRS14360Owen">
+                                        <roleName type="title">Rev.</roleName>G. W. Owen</persName>. 
+                                        <date when="1902-11-13">Nov. 13. 1902</date>.</q>
+                                </item>
+                            </list>
+                        </additions>
+                        <bindingDesc>
+                            <binding xml:id="binding">
+                                <decoNote xml:id="b1"/>
+                                <decoNote type="bindingMaterial" xml:id="b2"><material key="wood"/></decoNote>
+                                <decoNote xml:id="b3" type="Boards"><material key="wood"/>Wooden boards repaired in the  
+                                    <placeName ref="INS00001BL">British Museum</placeName>.</decoNote>
+                                <decoNote xml:id="b4" type="SlipCase"><material key="leather"/>Preserved in a leather case.</decoNote>
+                                <decoNote xml:id="b5" type="Other"><term key="leafStringMark">small pieces of violet, green, and yellow yarn</term>
+                                </decoNote>
+                            </binding>
+                        </bindingDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1600" notAfter="1800">17th to 18th century</origDate>
+                        </origin> 
+                    </history>
+                    <msPart xml:id="p1">
+                        <msIdentifier>
+                            <idno/>
+                        </msIdentifier>
+                        <msContents>
+                            <msItem xml:id="p1_i1">
+                                <locus target="#i"/>
+                                <title ref="LIT2765RepCh49" type="incomplete"/>
+                                <note>Written on the verso of the front flyleaf. Text edited in 
+                                    <bibl><ptr target="bm:Worrell1914Zauberwesen"/></bibl>.</note>
+                                <incipit xml:lang="gez">ሰላም፡ ለከ፡ ሰዳዴ፡ አጋንንት፡ ፋኑኤል፡ እምገጸ፡ ፈጣሪ፡ ልዑል፡</incipit>
+                            </msItem>
+                            <msItem xml:id="p1_i2">
+                                <locus target="#i"/>
+                                <title type="incomplete">Magical prayer</title>
+                                <note>Written on the verso. Only the beginning is recorded.</note>
+                            </msItem>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Codex">
+                                <supportDesc>
+                                    <support>
+                                        <watermark/>
+                                        <material key="parchment"/>
+                                    </support>
+                                    <extent>
+                                        <measure unit="leaf">1</measure>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>190</height>
+                                        <width>85</width>
+                                    </dimensions>
+                                    </extent></supportDesc>
+                            </objectDesc>
+                        </physDesc>
+                        <history>
+                            <provenance>This piece of vellum is a fragment of a magic scroll, that was added as a front flyleaf to the codex. 
+                            </provenance>
+                        </history>
+                        <additional>
+                            <adminInfo>
+                                <recordHist>
+                                    <source>
+                                        <listBibl type="catalogue">
+                                            <bibl>
+                                                <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                                <citedRange unit="page">27</citedRange>
+                                            </bibl> 
+                                        </listBibl>
+                                    </source>
+                                </recordHist>
+                            </adminInfo>
+                        </additional>
+                    </msPart>
+                    <msPart xml:id="p2">
+                        <msIdentifier>
+                            <idno/>
+                        </msIdentifier>
+                        <msContents>
+                            <msItem xml:id="p2_i1">
+                                <locus target="#1r"/>                                
+                                <title type="incomplete" ref="LIT0000000000000000000000">Magic Prayer against snake venom, measles, smallpox,
+                                    and manṭaṭa</title>
+                                <incipit xml:lang="gez">በስመ፡ አብ፡ በል። ሕብዘ፡ አርዌ፡ ምድር፡ በሊህ፡ እግርኪ፡ ታሕተ፡ ከናፍርኪ፡ <gap reason="ellipsis"/> ኢትሕምም፡ 
+                                    አባለ፡ ሥጋሃ፡ <gap reason="ellipsis"/> እምፈንፃፃ፡ ወኩፍኝ፡ ወእመንጣጣ፡ </incipit>
+                            </msItem>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Codex">
+                                <supportDesc>
+                                    <support>
+                                        <watermark/>
+                                        <material key="parchment"/>
+                                    </support>
+                                    <extent>
+                                        <measure unit="leaf">1</measure>
+                                        <dimensions type="outer" unit="mm">
+                                            <height>210</height>
+                                            <width>145</width>
+                                        </dimensions>
+                                    </extent></supportDesc>
+                            </objectDesc>
+                            <additions>
+                                <list>
+                                    <item xml:id="e2">
+                                        <locus target="#1v"/>
+                                        <desc>Pen trials</desc>
+                                    </item>
+                                </list>
+                            </additions>
+                        </physDesc>
+                        <additional>
+                            <adminInfo>
+                                <recordHist>
+                                    <source>
+                                        <listBibl type="catalogue">
+                                            <bibl>
+                                                <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                                <citedRange unit="page">27</citedRange>
+                                            </bibl> 
+                                        </listBibl>
+                                    </source>
+                                </recordHist>
+                            </adminInfo>
+                        </additional>
+                    </msPart>
+                    <msPart xml:id="p3">
+                        <msIdentifier>
+                            <idno/>
+                        </msIdentifier>
+                    <msContents>
+                        <msItem xml:id="p3_i1">
+                            <locus from="8r" to="166ra"/>
+                            <title ref="LIT2701Dawit"/>
+                            <msItem xml:id="p3_i1.1">
+                                <locus from="2r" to="145v"/>
+                                <title ref="LIT2000Mazmur"/>
+                                <note>The chapter titles are the new ones, but slightly different from those given by 
+                                    <bibl><ptr target="bm:Schneider1970LesTitres"/></bibl>.</note>
+                            </msItem>
+                            <msItem xml:id="p3_i1.2">
+                                <locus from="146r" to="169v"/>
+                                <title ref="LIT1233Cantic"/>
+                                <msItem xml:id="p3_i1.2.1">
+                                    <locus from="146r" to="161r"/>
+                                    <title ref="LIT1828Mahale"/>
+                                    <msItem xml:id="p3_i1.2.1.1">
+                                        <locus from="146r" to="147r"/>
+                                        <title ref="LIT2277salotu"/>
+                                    </msItem>
+                                    <msItem xml:id="p3_i1.2.1.2">
+                                        <locus from="147r" to="149r"/>
+                                        <title ref="LIT2278salota"/>
+                                    </msItem>
+                                    <msItem xml:id="p3_i1.2.1.3">
+                                        <locus from="149r" to="151r"/>
+                                        <title ref="LIT2703salota"/>
+                                    </msItem>
+                                    <msItem xml:id="p3_i1.2.1.4">
+                                        <locus from="151r" to="152r"/>
+                                        <title ref="LIT2257salota"/>
+                                        <incipit xml:lang="gez"><title ref="LIT2257salota">ጸሎተ፡ ሐና፡ እመ፡ ሳሙኤል።</title></incipit>
+                                    </msItem>
+                                    <msItem xml:id="p3_i1.2.1.5">
+                                        <locus from="152r" to="153r"/>
+                                        <title ref="LIT2258salota"/>
+                                    </msItem>
+                                    <msItem xml:id="p3_i1.2.1.6">
+                                        <locus from="153r" to="154r"/>
+                                        <title ref="LIT2265salota"/>
+                                    </msItem>
+                                    <msItem xml:id="p3_i1.2.1.7">
+                                        <locus from="154r" to="154v"/>
+                                        <title ref="LIT2274salota"/>
+                                    </msItem>
+                                    <msItem xml:id="p3_i1.2.1.8">
+                                        <locus from="154v" to="156r"/>
+                                        <title ref="LIT2250salota"/>
+                                    </msItem>
+                                    <msItem xml:id="p3_i1.2.1.9">
+                                        <locus target="#156r"/>
+                                        <title ref="LIT2271salota"/>
+                                    </msItem>
+                                    <msItem xml:id="p3_i1.2.1.10">
+                                        <locus from="156r" to="157r"/>
+                                        <title ref="LIT1566hababa"/>
+                                    </msItem>
+                                    <msItem xml:id="p3_i1.2.1.11">
+                                        <locus from="157r" to="159r"/>
+                                        <title ref="LIT2251salota"/>
+                                        <incipit xml:lang="gez"><title ref="LIT2251salota">ትንቢት፡ ዘዕንባቆም፡ ነገር፡ ዘክርስቶስ፡ ወዘ፡ ዘሩባቤል።</title></incipit>
+                                    </msItem>
+                                    <msItem xml:id="p3_i1.2.1.12">
+                                        <locus from="159r" to="160r"/>
+                                        <title ref="LIT2259salota"/>
+                                    </msItem>
+                                    <msItem xml:id="p3_i1.2.1.13">
+                                        <locus target="#160r"/>
+                                        <title ref="LIT1827Magnif"/>
+                                    </msItem>
+                                    <msItem xml:id="p3_i1.2.1.14">
+                                        <locus from="160v" to="161r"/>
+                                        <title ref="LIT2275salota"/>
+                                    </msItem>
+                                    <msItem xml:id="p3_i1.2.1.15">
+                                        <locus target="#161r"/>
+                                        <title ref="LIT2272salota"/>
+                                    </msItem>
+                                </msItem>
+                                <msItem xml:id="p3_i1.2.2">
+                                    <locus from="161r" to="169v"/>
+                                    <title ref="LIT2362Songof"/>
+                                    <note>The text is divided into five sections, all but the first of which are preceded by the following doxology: 
+                                        <q xml:lang="gez">ስብሐት፡ ለአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ። </q>.</note>
+                                    <msItem xml:id="p3_i1.2.2.1">
+                                        <locus from="161r"/>
+                                        <title>First section</title>
+                                    </msItem>
+                                    <msItem xml:id="p3_i1.2.2.2">
+                                        <locus from="162v"/>
+                                        <title>Second section</title>
+                                    </msItem>
+                                    <msItem xml:id="p3_i1.2.2.3">
+                                        <locus from="164r"/>
+                                        <title>Third section</title>
+                                    </msItem>
+                                    <msItem xml:id="p3_i1.2.2.4">
+                                        <locus from="166v"/>
+                                        <title>Fourth section</title>
+                                    </msItem>
+                                    <msItem xml:id="p3_i1.2.2.5">
+                                        <locus from="169v"/>
+                                        <title>Fifth section</title>
+                                    </msItem>
+                                </msItem>
+                            </msItem>
+                            <msItem xml:id="p3_i1.3">
+                                <locus from="170ra" to="181va"/>
+                                <title ref="LIT2509Weddas"/>
+                                <note>Arranged by the days of the week, with Monday's lesson first.</note>
+                            </msItem>
+                            <msItem xml:id="p3_i1.4">
+                                <locus from="181va" to="186v"/>
+                                <title ref="LIT1113Anqasa"/>
+                            </msItem>
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Codex">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf">186</measure>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>218</height>
+                                        <width>185</width>
+                                    </dimensions>
+                                </extent></supportDesc>
+                            <layoutDesc>
+                                <layout columns="1" writtenLines="19"><locus from="2r" to="169v"/></layout>
+                                <layout columns="2" writtenLines="19"><locus from="170r" to="186v"/></layout>
+                            </layoutDesc>
+                        </objectDesc> 
+                        <handDesc>
+                            <handNote script="Ethiopic" xml:id="h1">
+                                <desc>Written in good hand.</desc>
+                                <date notBefore="1600" notAfter="1800" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                        </handDesc>
+                        <decoDesc>
+                            <decoNote xml:id="d1" type="drawing">
+                                <locus target="#145v"/>
+                                <desc>A drawing in black ink representing the owner seeking protection of <persName ref="PRS9162TaklaHa"/>.
+                                    </desc>
+                            </decoNote>   
+                        </decoDesc>
+                        <additions>
+                            <list>
+                                <item xml:id="e3">
+                                    <locus target="#145r #146r"/>
+                                    <desc type="OwnershipNote">The name of the owner is <persName role="owner" ref="PRS14359GabraSellase"/>.
+                                        </desc>
+                                </item>
+                                <item xml:id="e4">
+                                    <locus target="#170ra #171ra #173ra #175ra #177rb #179ra #180rb"/>
+                                    <desc type="findingAid">The text is divided into the days of the week.</desc>
+                                </item>
+                            </list>
+                        </additions>
+                    </physDesc>
+                        <additional>
+                            <adminInfo>
+                                <recordHist>
+                                    <source>
+                                        <listBibl type="catalogue">
+                                            <bibl>
+                                                <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                                <citedRange unit="page">26-27</citedRange>
+                                            </bibl> 
+                                        </listBibl>
+                                    </source>
+                                </recordHist>
+                            </adminInfo>
+                        </additional>
+                    </msPart>
+                    <msPart xml:id="p4">
+                        <msIdentifier>
+                            <idno/>
+                        </msIdentifier>
+                        <msContents>
+                            <msItem xml:id="p4_i1">
+                                <locus from="ii" to="iii"/>
+                                <title ref="LIT2248salota"/>
+                                <note>Written on the verso of the first end flyleaf and on the recto and verso of the second end flyleaf.</note>
+                                <incipit xml:lang="gez">ነአኵቶ፡ ለገባሬ፡ ሠናያት፡ በላዕሌነ፡ ለእግዚአብሔር፡ መሐሪ፡ አቡሁ፡ ለእግዚእነ፡ ወአምላክነ፡ ወመድኃኒነ፡ ኢያሱስ፡ ክርስቶስ፡</incipit>
+                            </msItem>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Codex">
+                                <supportDesc>
+                                    <support>
+                                        <material key="paper">Oriental paper</material>
+                                    </support>
+                                    <extent>
+                                        <measure unit="leaf">2</measure>
+                                        <measure unit="leaf" type="blank" corresp="#IIr">1</measure>
+                                        <dimensions type="outer" unit="mm">
+                                            <height>214</height>
+                                            <width>80 98</width>
+                                        </dimensions>
+                                    </extent>
+                                    <foliation>not numbered</foliation>
+                                </supportDesc>
+                            </objectDesc>  
+                        </physDesc>
+                        <additional>
+                            <adminInfo>
+                                <recordHist>
+                                    <source>
+                                        <listBibl type="catalogue">
+                                            <bibl>
+                                                <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                                <citedRange unit="page">27</citedRange>
+                                            </bibl> 
+                                        </listBibl>
+                                    </source>
+                                </recordHist>
+                            </adminInfo>
+                        </additional>
+                    </msPart>     
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="Bible"/>
+                    <term key="ChristianContent"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="NewTestament"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-02-08">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I have created a record for BLorient6466. I decided to make up the record as for a composite manuscript. p1, p2 and p4 are certainly nothing more than flyleaves attached to the codex in order to protect the psalter as the main part (p3). However, Strelcyn's description gives some information about these flyleaves (dimensions of the folios, provenance as a magical scroll), so I wanted to add this to the record. 
I have not been able to identify the prayer in p2_i1, which was recently posted on https://github.com/BetaMasaheft/Documentation/issues/2497, and I suggest that a new LIT ID be created for it.