### PR TITLE
Update BLorient12467

### DIFF
--- a/LondonBritishLibrary/orient/BLorient12467.xml
+++ b/LondonBritishLibrary/orient/BLorient12467.xml
@@ -195,79 +195,79 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            <note>The general title is joined to that of the first Canticle.</note>
                                             <msItem xml:id="p3_i1.2.1.1">
                                                 <locus from="129v" to="130v"/>
-                                                <title ref="LIT2277salotu"/>
-                                                <note>Indicated by the title: <q xml:lang="gez">መኃልይ፡ 
-                                                    <supplied reason="undefined" resp="PRS8999Strelcyn">ዘ</supplied>ነቢያት፡ ወጸሎቱ፡ ለሙሴ።</q></note>
+                                                <title ref="LIT1828Mahale#Moses1"/>
+                                                <incipit xml:lang="gez"><title>መኃልይ፡ <supplied reason="undefined" resp="PRS8999Strelcyn">ዘ</supplied>ነቢያት፡ 
+                                                    ወጸሎቱ፡ ለሙሴ።</title></incipit>
                                             </msItem>
                                             <msItem xml:id="p3_i1.2.1.2">
                                                 <locus from="130v" to="132r"/>
-                                                <title ref="LIT2278salota"/>
-                                                <note>Indicated by the title: <q xml:lang="gez">ዘሙሴ፡ ዘዳግም፡ ሕግ።</q></note>
+                                                <title ref="LIT1828Mahale#Moses2"/>
+                                                <incipit xml:lang="gez"><title>ዘሙሴ፡ ዘዳግም፡ ሕግ።</title></incipit>
                                             </msItem>
                                             <msItem xml:id="p3_i1.2.1.3">
                                                <locus from="132r" to="133v"/>
-                                                <title ref="LIT2703salota"/>
-                                                <note>Indicated by the title: <q xml:lang="gez">ጸሎት፡ ዘሙሴ፡ ዘሣልስ፡ ሕግ።</q></note>
+                                                <title ref="LIT1828Mahale#Moses3"/>
+                                                <incipit xml:lang="gez"><title>ጸሎት፡ ዘሙሴ፡ ዘሣልስ፡ ሕግ።</title></incipit>
                                             </msItem>
                                             <msItem xml:id="p3_i1.2.1.4">
                                                 <locus from="133v" to="134v"/>
-                                                <title ref="LIT2257salota"/>
-                                                <note>Indicated by the title: <q xml:lang="gez">ጸሎተ፡ ሐና፡ እመ፡ ሳሙኤል።</q></note>
+                                                <title ref="LIT1828Mahale#Hannah"/>
+                                                <incipit xml:lang="gez"><title>ጸሎተ፡ ሐና፡ እመ፡ ሳሙኤል።</title></incipit>
                                             </msItem>
                                             <msItem xml:id="p3_i1.2.1.5">
                                                 <locus from="134v" to="135r"/>
-                                                <title ref="LIT2258salota"/>
-                                                <note>Indicated by the title: <q xml:lang="gez">ጸሎተ፡ ሕዝክያስ፡ ንጉሥ፡ ይሁዳ።</q></note>
+                                                <title ref="LIT1828Mahale#Hezekiah"/>
+                                                <incipit xml:lang="gez"><title>ጸሎተ፡ ሕዝክያስ፡ ንጉሥ፡ ይሁዳ።</title></incipit>
                                             </msItem>
                                             <msItem xml:id="p3_i1.2.1.6">
                                                 <locus from="135r" to="136r"/>
-                                                <title ref="LIT2265salota"/>
-                                                <note>Indicated by the title: <q xml:lang="gez">ጸሎተ፡ ምናሴ፡ ነቢይ።</q></note>
+                                                <title ref="LIT1828Mahale#Manasseh"/>
+                                                <incipit xml:lang="gez"><title>ጸሎተ፡ ምናሴ፡ ነቢይ።</title></incipit>
                                             </msItem>
                                             <msItem xml:id="p3_i1.2.1.7">
                                                 <locus from="136r" to="136v"/>
-                                                <title ref="LIT2274salota"/>
-                                                <note>Indicated by the title: <q xml:lang="gez">ጸሎተ፡ ዮናስ፡ ነቢይ። </q></note>
+                                                <title ref="LIT1828Mahale#Jonah"/>
+                                                <incipit xml:lang="gez"><title>ጸሎተ፡ ዮናስ፡ ነቢይ።</title></incipit>
                                             </msItem>
                                             <msItem xml:id="p3_i1.2.1.8">
                                                 <locus from="136v" to="137v"/>
-                                                <title ref="LIT2250salota"/>
-                                                <note>Indicated by the title: <q xml:lang="gez">ጸሎተ፡ ዳንኤል፡ ነቢይ፡ ስብሐት፡ ዘእምአዛርያ።</q></note>
+                                                <title ref="LIT1828Mahale#ThreeYouths1"/>
+                                                <incipit xml:lang="gez"><title>ጸሎተ፡ ዳንኤል፡ ነቢይ፡ ስብሐት፡ ዘእምአዛርያ።</title></incipit>
                                             </msItem>
                                             <msItem xml:id="p3_i1.2.1.9">
                                                 <locus from="137v" to="138r"/>
-                                                <title ref="LIT2271salota"/>
-                                                <note>Indicated by the title: <q xml:lang="gez">ጸሎተ፡ ሠለስቱ፡ ደቂቅ። </q></note>
+                                                <title ref="LIT1828Mahale#ThreeYouths2"/>
+                                                <incipit xml:lang="gez"><title>ጸሎተ፡ ሠለስቱ፡ ደቂቅ።</title></incipit>
                                             </msItem>
                                             <msItem xml:id="p3_i1.2.1.10">
                                                 <locus from="138r" to="139v"/>
-                                                <title ref="LIT1566hababa"/>
-                                                <note>Indicated by the title: <q xml:lang="gez">ኀበ፡ ባረኩ፡ አናንያ፡ ወአዛርያ፡ ወሚሳኤል፡ ለእግዚአብሔር። </q></note>
+                                                <title ref="LIT1828Mahale#ThreeYouths3"/>
+                                                <incipit xml:lang="gez">ኀበ፡ ባረኩ፡ አናንያ፡ ወአዛርያ፡ ወሚሳኤል፡ ለእግዚአብሔር። </incipit>
                                             </msItem>
                                             <msItem xml:id="p3_i1.2.1.11">
                                                 <locus from="139v" to="141r"/>
-                                                <title ref="LIT2251salota"/>
-                                                <note>Indicated by the title: <q xml:lang="gez">ትንቢት፡ ዘዕንባቆም፡ ነገር፡ ዘክርስቶስ፡ ወዘ፡ ዘሩባቤል።</q></note>
+                                                <title ref="LIT1828Mahale#Habakkuk"/>
+                                                <incipit xml:lang="gez"><title>ትንቢት፡ ዘዕንባቆም፡ ነገር፡ ዘክርስቶስ፡ ወዘ፡ ዘሩባቤል።</title></incipit>
                                             </msItem>
                                             <msItem xml:id="p3_i1.2.1.12">
                                                 <locus from="141r" to="141v"/>
-                                                <title ref="LIT2259salota"/>
-                                                <note>Indicated by the title: <q xml:lang="gez">ጸሎተ፡ ኢሳይያስ፡ ነቢይ።</q></note>
+                                                <title ref="LIT1828Mahale#Isaiah"/>
+                                                <incipit xml:lang="gez"><title>ጸሎተ፡ ኢሳይያስ፡ ነቢይ።</title></incipit>
                                             </msItem>
                                             <msItem xml:id="p3_i1.2.1.13">
                                                 <locus from="141v" to="142r"/>
-                                                <title ref="LIT1827Magnif"/>
-                                                <note>Indicated by the title: <q xml:lang="gez">ጸሎተ፡ እግዚእትነ፡ ማርያም፡ ድንግል።</q></note>
+                                                <title ref="LIT1828Mahale#Mary"/>
+                                                <incipit xml:lang="gez"><title>ጸሎተ፡ እግዚእትነ፡ ማርያም፡ ድንግል።</title></incipit>
                                             </msItem>
                                             <msItem xml:id="p3_i1.2.1.14">
                                                 <locus from="142r" to="142v"/>
-                                                <title ref="LIT2275salota"/>
-                                                <note>Indicated by the title: <q xml:lang="gez">ጸሎተ፡ ዘካርያስ፡ ነቢይ።</q></note>
+                                                <title ref="LIT1828Mahale#Zachariah"/>
+                                                <incipit xml:lang="gez">ጸሎተ፡ ዘካርያስ፡ ነቢይ።</incipit>
                                            </msItem>
                                             <msItem xml:id="p3_i1.2.1.15">
                                                 <locus target="#142v"/>
-                                                <title ref="LIT2272salota"/>
-                                                <note>Indicated by the title: <q xml:lang="gez">ጸሎተ፡ ስምዖን፡ ነቢይ። </q></note>
+                                                <title ref="LIT1828Mahale#Simeon"/>
+                                                <incipit xml:lang="gez"><title>ጸሎተ፡ ስምዖን፡ ነቢይ።</title></incipit>
                                             </msItem>
                                     </msItem>
                                     <msItem xml:id="p3_i1.2.2">
@@ -278,28 +278,28 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             Indicated by the title: <q xml:lang="gez">መኃልየ፡ መኃልይ፡ ዝውእቱ፡ ዘሰሎሞን።</q></note>
                                                 <msItem xml:id="p3_i1.2.2.1">
                                                     <locus from="143r" to="144v"/>
-                                                    <title>First section (I, I - II, 7)</title>
+                                                    <title ref="LIT2362Songof#FirstCanticle">First Canticle (I, I - II, 7)</title>
                                                     <note>Without title.</note>
                                                 </msItem>
                                                 <msItem xml:id="p3_i1.2.2.2">
                                                     <locus from="144v" to="145v"/>
-                                                    <title>Second section (II, 8 - III,5)</title>
+                                                    <title ref="LIT2362Songof#SecondCanticle">Second Canticle (II, 8 - III,5)</title>
                                                     <note>Indicated by the title: <q xml:lang="gez">መኃልይ፡ ዘይዜኑ፡ ርደቶ፡ ለወልድ፡ ወተሠግዎቶ፡ እምድንግል።</q></note>
                                                 </msItem>
                                                 <msItem xml:id="p3_i1.2.2.3">
                                                     <locus from="145v" to="148r"/>
-                                                    <title>Third section (III, 6 - V, 8)</title>
+                                                    <title ref="LIT2362Songof#ThirdCanticle">Third Canticle (III, 6 - V, 8)</title>
                                                     <note>Indicated by the title: <q xml:lang="gez">ማኅልይ፡ ዘይዜኑ፡ ዕርገተ፡ ትስብእት፡ ምስለ፡ መለኮት፡ እምድኅረ፡ አሐዱ፡ 
                                                         ከዊ<supplied reason="undefined" resp="PRS8999Strelcyn">ን</supplied>።</q></note>
                                                 </msItem>
                                                 <msItem xml:id="p3_i1.2.2.4">
                                                     <locus from="148r" to="150v"/>
-                                                    <title>Fourth section (V, 9 - VIII, 4)</title>
+                                                    <title ref="LIT2362Songof#FourthCanticle">Fourth Canticle (V, 9 - VIII, 4)</title>
                                                     <note>Indicated by the title: <q xml:lang="gez">ማኅልይ፡ ዘይዜኑ፡ ውዳሴ፡ መርዐት፡ ለመርዓዊሃ።</q></note>
                                                 </msItem>
                                                 <msItem xml:id="p3_i1.2.2.5">
                                                     <locus from="150v" to="151v"/>
-                                                    <title>Fifth section (VIII, 5-14)</title>
+                                                    <title ref="LIT2362Songof#FifthCanticle">Fifth Canticle (VIII, 5-14)</title>
                                                     <note>Indicated by the title: <q xml:lang="gez">ማኅልይ፡ ዘይዜኑ፡ እምዚአሃ፡ ዘዚአሃ፡ ለቤተ፡ ክርስቲያን፡</q></note>
                                                 </msItem>
                                     </msItem>
@@ -308,6 +308,34 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <locus from="152ra" to="161va"/>
                                    <title ref="LIT2509Weddas"/>
                                    <note>Arranged by the days of the week, with Monday's lesson first.</note>
+                            <msItem xml:id="ms_i1.3.1">
+                                <locus from="152ra"/>
+                                <title ref="LIT2509Weddas#Monday"/>
+                            </msItem>
+                            <msItem xml:id="ms_i1.3.2">
+                                <locus from="152vb"/>
+                                <title ref="LIT2509Weddas#Tuesday"/>
+                            </msItem>
+                            <msItem xml:id="ms_i1.3.3">
+                                <locus from="154va"/>
+                                <title ref="LIT2509Weddas#Wednesday"/>
+                            </msItem>
+                            <msItem xml:id="ms_i1.3.4">
+                                <locus from="156ra"/>
+                                <title ref="LIT2509Weddas#Thursday"/>
+                            </msItem>
+                            <msItem xml:id="ms_i1.3.5">
+                                <locus from="158ra"/>
+                                <title ref="LIT2509Weddas#Friday"/>
+                            </msItem>
+                            <msItem xml:id="ms_i1.3.6">
+                                <locus from="159rb"/>
+                                <title ref="LIT2509Weddas#Saturday"/>
+                            </msItem>
+                            <msItem xml:id="ms_i1.3.7">
+                                <locus from="160rb"/>
+                                <title ref="LIT2509Weddas#Sunday"/>
+                            </msItem>       
                          </msItem>
                          <msItem xml:id="p3_i1.4">
                                    <locus from="161va" to="166ra"/>

--- a/LondonBritishLibrary/orient/BLorient12467.xml
+++ b/LondonBritishLibrary/orient/BLorient12467.xml
@@ -278,28 +278,28 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             Indicated by the title: <q xml:lang="gez">መኃልየ፡ መኃልይ፡ ዝውእቱ፡ ዘሰሎሞን።</q></note>
                                                 <msItem xml:id="p3_i1.2.2.1">
                                                     <locus from="143r" to="144v"/>
-                                                    <title ref="LIT2362Songof#FirstCanticle">First Canticle (I, I - II, 7)</title>
+                                                    <title ref="LIT2362Songof#FirstCanticle">First Section (I, I - II, 7)</title>
                                                     <note>Without title.</note>
                                                 </msItem>
                                                 <msItem xml:id="p3_i1.2.2.2">
                                                     <locus from="144v" to="145v"/>
-                                                    <title ref="LIT2362Songof#SecondCanticle">Second Canticle (II, 8 - III,5)</title>
+                                                    <title ref="LIT2362Songof#SecondCanticle">Second Section (II, 8 - III,5)</title>
                                                     <note>Indicated by the title: <q xml:lang="gez">መኃልይ፡ ዘይዜኑ፡ ርደቶ፡ ለወልድ፡ ወተሠግዎቶ፡ እምድንግል።</q></note>
                                                 </msItem>
                                                 <msItem xml:id="p3_i1.2.2.3">
                                                     <locus from="145v" to="148r"/>
-                                                    <title ref="LIT2362Songof#ThirdCanticle">Third Canticle (III, 6 - V, 8)</title>
+                                                    <title ref="LIT2362Songof#ThirdCanticle">Third Section (III, 6 - V, 8)</title>
                                                     <note>Indicated by the title: <q xml:lang="gez">ማኅልይ፡ ዘይዜኑ፡ ዕርገተ፡ ትስብእት፡ ምስለ፡ መለኮት፡ እምድኅረ፡ አሐዱ፡ 
                                                         ከዊ<supplied reason="undefined" resp="PRS8999Strelcyn">ን</supplied>።</q></note>
                                                 </msItem>
                                                 <msItem xml:id="p3_i1.2.2.4">
                                                     <locus from="148r" to="150v"/>
-                                                    <title ref="LIT2362Songof#FourthCanticle">Fourth Canticle (V, 9 - VIII, 4)</title>
+                                                    <title ref="LIT2362Songof#FourthCanticle">Fourth Section (V, 9 - VIII, 4)</title>
                                                     <note>Indicated by the title: <q xml:lang="gez">ማኅልይ፡ ዘይዜኑ፡ ውዳሴ፡ መርዐት፡ ለመርዓዊሃ።</q></note>
                                                 </msItem>
                                                 <msItem xml:id="p3_i1.2.2.5">
                                                     <locus from="150v" to="151v"/>
-                                                    <title ref="LIT2362Songof#FifthCanticle">Fifth Canticle (VIII, 5-14)</title>
+                                                    <title ref="LIT2362Songof#FifthCanticle">Fifth Section (VIII, 5-14)</title>
                                                     <note>Indicated by the title: <q xml:lang="gez">ማኅልይ፡ ዘይዜኑ፡ እምዚአሃ፡ ዘዚአሃ፡ ለቤተ፡ ክርስቲያን፡</q></note>
                                                 </msItem>
                                     </msItem>


### PR DESCRIPTION
I updated the subdivision and title markup for LIT1828Mahale, LIT2362Songof and LIT2509Weddas as discussed in https://github.com/BetaMasaheft/Manuscripts/pull/2312. 

I intended to do the same for BLorient6466, but that record was recently merged and is not yet in the master. 

Personally, I am not convinced that marking LIT2362Songof should be done in this way without consulting the manuscripts and edition. I wonder why Strelcyn has divided the text into five sections, but for each section gives a number such as (I, I - II, 7) etc. If the 'sections' in Strelcyn's description are 'canticles' according to our Bm definition, what do the Roman numbers in brackets refer to? Presumably the numbers in brackets refer to what is described as 'canticles' in the edition (and in the BM), and the 'sections' are subdivisions according to the prescribed reading in the service. Do you think I should leave it as it is, or do you think it would be better to return to the more careful encoding and describe the subdivisions as 'sections', as Strelcyn did?