### PR TITLE
Created BLorient4930 (CH_march24)

### DIFF
--- a/EMIP/1-1000/EMIP00115.xml
+++ b/EMIP/1-1000/EMIP00115.xml
@@ -309,7 +309,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </item>
                         <item xml:id="a11">
                            <desc>
-                              <locus target="#142r" facs="146"/> Concluding prayer of Psalter, with a prayer for protection of cattle from wild animals interwoven, with incipit
+                             <locus target="#142r" facs="146"/> <ref type="work" corresp="LIT6946InvocationMary"/> as a concluding prayer of Psalter, with a prayer for protection of cattle from wild animals interwoven, with incipit
                               <foreign xml:lang="gez">
                           ስብሐት፡ ለአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ለዓለም፡ ወለዓለመ፡ ዓለም፡ ሰአሊ፡ ለነ፡ ቅድስት፡ <lb/>
                           ድንግል፡ ማርያም፡ ምሕረተ፡ ክርስቶስ፡ ወልድኪ፡ የሃውፀነ፡ እማርያም፡ ሰአል፡ ለነ፡ ዳዊት፡ ቅድመ፡ <lb/>

--- a/EMIP/1-1000/EMIP00175.xml
+++ b/EMIP/1-1000/EMIP00175.xml
@@ -251,7 +251,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                       <item xml:id="a6">
                       <desc>
                       <locus target="#120r" facs="122"/>:
-                        A concluding prayer to the Psalter which mentions <persName ref="PRS2533Baselyos"/>, <persName ref="PRS5226haylase"/>, and <persName ref="PRS6642MananAs"/>.
+                        <ref type="work" corresp="LIT6946InvocationMary"/> which mentions <persName ref="PRS2533Baselyos"/>, <persName ref="PRS5226haylase"/>, and <persName ref="PRS6642MananAs"/>.
                       Thus, the concluding prayer was written somewhere between 1951 and 1959.
                       The prayer is written in a well-trained hand and shows the essential elements of the genre,
                       <foreign xml:lang="gez">

--- a/ES/ESamm013.xml
+++ b/ES/ESamm013.xml
@@ -56,7 +56,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               Pray for us, Holy Virgin Mary! May the mercy of Christ, your Son, reach us
                               from the seventh heaven. O God of David! Protect our King Mǝnilǝk.</foreign>
                            <note>A supplication for King
-                                 Mǝnilǝk II has been added after P110 as its
+                              Mǝnilǝk II, similar to <ref type="work" corresp="LIT6946InvocationMary"/>, has been added after P110 as its
                                  continuation, in the main hand</note>
                         </explicit>
 

--- a/LondonBritishLibrary/orient/BLorient4930.xml
+++ b/LondonBritishLibrary/orient/BLorient4930.xml
@@ -285,7 +285,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </item>
                                 <item xml:id="a3">
                                     <locus target="#4v"/>
-                                    <desc type="GuestText"><ref type="work" corresp="LIT00000000000000000000000000000">A prayer to the Lord</ref></desc>
+                                    <desc type="GuestText"><ref type="work" corresp="LIT4691Prayer#Monday">A prayer to the Lord</ref></desc>
                                     <q xml:lang="gez">እግዚአብሔር፡ ዓቢይ፡ ወግሩም። ዘአልቦቱ፡ ጥንት፡ ወኢተፍጻሜት። ወይሄሉ፡ ለዓለመ፡ ዓለም። እስእለከ፡ ወአስተበቍዓከ። ከመ፡ 
                                         ትርድአኒ፡ ወትባልሐኒ። <gap reason="ellipsis"/></q>
                                 </item>
@@ -306,7 +306,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </item>
                                 <item xml:id="a6">
                                     <locus target="#84r"/>
-                                    <desc type="GuestText">Creed (Ṣalota hāymānot) after Psalm 100.</desc>
+                                    <desc type="GuestText"><ref type="work" corresp="LIT3308Nicene ">Creed (Ṣalota hāymānot)</ref> 
+                                        after Psalm 100.</desc>
                                 </item>
                                 <item xml:id="e1">
                                     <locus target="#5r #27r #50v #71r #97v #112r #125r"/>

--- a/LondonBritishLibrary/orient/BLorient4930.xml
+++ b/LondonBritishLibrary/orient/BLorient4930.xml
@@ -35,14 +35,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <title ref="LIT2701Dawit"/>
                             <msItem xml:id="ms_i1.1">
                                 <locus from="5r" to="124r"/>
-                                <title ref="LIT2000Mazmur"/>
-                                <note>Psalms divided for the days of the week. The titles of the chapters are the new ones.</note>
-                                <incipit xml:lang="gez">እስመ፡ <title>መዝሙረ፡ ዳዊት፡ </title>ትመስል፡ ገነት።
-                                    አንተ፡ ታስተጋብእ፡ አቅማሐ፡ ፍሬያት።
-                                    ትሰድድ፡ አጋንንት፡ <handShift/>ለውርጃ፡ <sic>ጽፈሕ፡ </sic>በወገሻ፡ ቅሰር፡<handShift/>
-                                    ወታቀርብ፡ መላእክተ። ተግሣፅ፡ ለኵሱ፡
-                                    ፍካሬ፡ ዘጻድቃን፡ ወዘኃጥአን።
-                                    <title>መዝሙር፡ ዘዳዊት።</title> ሃሌ፡ ሉያ። </incipit>
+                                <title>Psalms</title>
+                                <note>The text is divided for the days of the week, preceded by an introductory supplication. The titles of the psalms are 
+                                    the new ones.</note>
+                                <msItem xml:id="ms_i1.1.1">
+                                    <locus target="#5r"/>
+                                    <title ref="LIT5884IntroHymnPs"/>
+                                    <incipit xml:lang="gez">እስመ፡ <title>መዝሙረ፡ ዳዊት፡ </title>ትመስል፡ ገነት።
+                                        አንተ፡ ታስተጋብእ፡ አቅማሐ፡ ፍሬያት።
+                                        ትሰድድ፡ አጋንንት፡ <handShift/>ለውርጃ፡ <sic>ጽፈሕ፡ </sic>በወገሻ፡ ቅሰር፡<handShift/>
+                                        ወታቀርብ፡ መላእክተ። ተግሣፅ፡ ለኵሱ፡
+                                        ፍካሬ፡ ዘጻድቃን፡ ወዘኃጥአን።</incipit>
+                                </msItem>
+                                <msItem xml:id="ms_i1.1.2">
+                                    <locus from="5r" to="124r"/>
+                                    <title ref="LIT2000Mazmur"/>
+                                    <incipit xml:lang="gez"><title>መዝሙር፡ ዘዳዊት።</title> ሃሌ፡ ሉያ። </incipit>
+                                </msItem>
                             </msItem>
                             <msItem xml:id="ms_i1.2">
                                 <locus from="125r" to="146v"/>
@@ -199,12 +208,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <note>Probably <ref type="work" corresp="LIT6865SalGabreel"/>, what cannot be ascertained, because image were not
                                     available during the cataloguing. According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/>
                                     <citedRange unit="page">40</citedRange></bibl>, this <foreign xml:lang="gez">salām</foreign> is missing in 
-                                    <bibl><ptr target="bm:bm:Chaine1913Rep"/></bibl>.</note>
+                                    <bibl><ptr target="bm:Chaine1913Rep"/></bibl>.</note>
                             </msItem>
                         </msItem>
                         <msItem xml:id="ms_i5">
                             <locus from="162va" to="165va"/>
-                            <title>Praises of the Virgin of Mary</title>
+                            <title>Praises of the Virgin Mary</title>
                             <msItem xml:id="ms_i5.1">
                                 <locus from="162va" to="163vb"/>
                                 <title ref="LIT3108RepCh388"/>
@@ -275,12 +284,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <list>
                                 <item xml:id="a1">
                                     <locus from="1va" to="2vb"/>
-                                    <desc type="GuestText"><ref type="work" corresp="LIT2940RepCh221"/> in strophes of four lines.</desc>
+                                    <desc type="GuestText"><ref type="work" corresp="LIT2940RepCh221"/> in stanzas of four lines.</desc>
                                     <q xml:lang="gez">ሰላም፡ ሰላም፡ ለዝክረ፡ ስምኪ፡ በአምኃ፡ ሰርከ፡ ወነግሃ። <gap reason="ellipsis"/></q>
                                 </item>
                                 <item xml:id="a2">
                                     <locus from="3ra" to="4ra"/>
-                                    <desc type="GuestText"><ref type="work" corresp="LIT2799RepCh83"/> in strophes of four verses.</desc>
+                                    <desc type="GuestText"><ref type="work" corresp="LIT2799RepCh83"/> in stanzas of four verses.</desc>
                                     <q xml:lang="gez">ሰላም፡ ለከ፡ ጊዮርጊስ፡ ዘልዳ፡ <gap reason="ellipsis"/></q>
                                 </item>
                                 <item xml:id="a3">
@@ -291,7 +300,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </item>
                                 <item xml:id="a4">
                                     <locus target="#172r"/>
-                                    <desc type="GuestText"><ref type="work" corresp="LIT2772RepCh56"/> in strophes of three verses.</desc>
+                                    <desc type="GuestText"><ref type="work" corresp="LIT2772RepCh56"/> in stanzas of three verses.</desc>
                                     <q xml:lang="gez">ሰላም፡ ለከ፡ ፩ሰማዕት፡ መዋዒ፡ እምነ፡ ኅሩያን፡ አዕላፍ። </q>
                                 </item>
                                 <item xml:id="a5">
@@ -330,7 +339,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <binding xml:id="binding">
                                 <decoNote type="bindingMaterial" xml:id="b1"><material key="wood"/></decoNote>
                                 <decoNote xml:id="b2" type="Boards"><material key="wood"/>Wooden boards.</decoNote>
-                                <decoNote xml:id="b3" type="Cover"><material key="leather"/>Stamped leather.</decoNote>
+                                <decoNote xml:id="b3" type="Cover"><material key="leather"/>Blind-tooled leather.</decoNote>
                             </binding>
                         </bindingDesc>
                     </physDesc>

--- a/LondonBritishLibrary/orient/BLorient4930.xml
+++ b/LondonBritishLibrary/orient/BLorient4930.xml
@@ -1,0 +1,390 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="BLorient4930" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Psalter</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS00001BL"/>
+                        <collection>Oriental</collection>
+                        <idno>BL Oriental 4930</idno>
+                        <altIdentifier><idno>Strelcyn 28</idno></altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                        <msItem xml:id="ms_i1">
+                            <locus from="5r" to="124r"/><locus from="125r" to="162rb"/>
+                            <title ref="LIT2701Dawit"/>
+                            <msItem xml:id="ms_i1.1">
+                                <locus from="5r" to="124r"/>
+                                <title ref="LIT2000Mazmur"/>
+                                <note>Psalms divided for the days of the week. The titles of the chapters are the new ones.</note>
+                                <incipit xml:lang="gez">እስመ፡ <title>መዝሙረ፡ ዳዊት፡ </title>ትመስል፡ ገነት።
+                                    አንተ፡ ታስተጋብእ፡ አቅማሐ፡ ፍሬያት።
+                                    ትሰድድ፡ አጋንንት፡ <handShift/>ለውርጃ፡ <sic>ጽፈሕ፡ </sic>በወገሻ፡ ቅሰር፡<handShift/>
+                                    ወታቀርብ፡ መላእክተ። ተግሣፅ፡ ለኵሱ፡
+                                    ፍካሬ፡ ዘጻድቃን፡ ወዘኃጥአን።
+                                    <title>መዝሙር፡ ዘዳዊት።</title> ሃሌ፡ ሉያ። </incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.2">
+                                <locus from="125r" to="146v"/>
+                                <title ref="LIT1233Cantic"/>
+                                <msItem xml:id="ms_i1.2.1">
+                                    <locus from="125r" to="137v"/>
+                                    <title ref="LIT1828Mahale"/>
+                                    <msItem xml:id="ms_i1.2.1.1">
+                                        <locus from="125r" to="126r"/>
+                                        <title ref="LIT1828Mahale#Moses1"/> 
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.1.2">
+                                        <locus from="126r" to="127v"/>
+                                        <title ref="LIT1828Mahale#Moses2"/>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.1.3">
+                                        <locus from="127v" to="129r"/>
+                                        <title ref="LIT1828Mahale#Moses3"/>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.1.4">
+                                        <locus from="129r" to="130r"/>
+                                        <title ref="LIT1828Mahale#Hannah"/>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.1.5">
+                                        <locus from="130r" to="131r"/>
+                                        <title ref="LIT1828Mahale#Hezekiah"/>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.1.6">
+                                        <locus from="131r" to="132r"/>
+                                        <title ref="LIT1828Mahale#Manasseh"/>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.1.7">
+                                        <locus target="#132r"/>
+                                        <title ref="LIT1828Mahale#Jonah"/>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.1.8">
+                                        <locus from="132r" to="133v"/>
+                                        <title ref="LIT1828Mahale#ThreeYouths1"/>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.1.9">
+                                        <locus target="#133v"/>
+                                        <title ref="LIT1828Mahale#ThreeYouths2"/>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.1.10">
+                                        <locus from="133v" to="134v"/>
+                                        <title ref="LIT1828Mahale#ThreeYouths3"/>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.1.11">
+                                        <locus from="134v" to="136r"/>
+                                        <title ref="LIT1828Mahale#Habakkuk"/>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.1.12">
+                                        <locus from="136r" to="136v"/>
+                                        <title ref="LIT1828Mahale#Isaiah"/>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.1.13">
+                                        <locus from="136v" to="137r"/>
+                                        <title ref="LIT1828Mahale#Mary"/>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.1.14">
+                                        <locus from="137r" to="137v"/>
+                                        <title ref="LIT1828Mahale#Zachariah"/>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.1.15">
+                                        <locus target="#137v"/>
+                                        <title ref="LIT1828Mahale#Simeon"/>
+                                    </msItem>
+                                </msItem>
+                                <msItem xml:id="ms_i1.2.2">
+                                    <locus from="138r" to="146v"/>
+                                    <title ref="LIT2362Songof"/>
+                                    <note>The text is divided into five sections.</note>
+                                    <msItem xml:id="ms_i1.2.2.1">
+                                        <title ref="LIT2362Songof#FirstCanticle"/>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.2.2">
+                                        <title ref="LIT2362Songof#SecondCanticle"/>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.2.3">
+                                        <title ref="LIT2362Songof#ThirdCanticle"/>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.2.4">
+                                        <title ref="LIT2362Songof#FourthCanticle"/>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.2.2.5">
+                                        <title ref="LIT2362Songof#FifthCanticle"/>
+                                    </msItem>
+                                </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i1.3">
+                                <locus from="147ra" to="158ra"/>
+                                <title ref="LIT2509Weddas"/>
+                                <note>Arranged by the days of the week, with Monday's lesson first.</note>
+                                <msItem xml:id="ms_i1.3.1"> 
+                                    <locus from="147ra"/>
+                                    <title ref="LIT2509Weddas#Monday"/>
+                                </msItem>
+                                <msItem xml:id="ms_i1.3.2">
+                                    <locus from="148ra"/>
+                                    <title ref="LIT2509Weddas#Tuesday"/>
+                                </msItem>
+                                <msItem xml:id="ms_i1.3.3">
+                                    <locus from="149vb"/>
+                                    <title ref="LIT2509Weddas#Wednesday"/>
+                                </msItem>
+                                <msItem xml:id="ms_i1.3.4">
+                                    <locus from="151vb"/>
+                                    <title ref="LIT2509Weddas#Thursday"/>
+                                </msItem>
+                                <msItem xml:id="ms_i1.3.5">
+                                    <locus from="154rb"/>
+                                    <title ref="LIT2509Weddas#Friday"/>
+                                </msItem>
+                                <msItem xml:id="ms_i1.3.6">
+                                    <locus from="155va"/>
+                                    <title ref="LIT2509Weddas#Saturday"/>
+                                </msItem>  
+                                <msItem xml:id="ms_i1.3.7">
+                                    <locus from="156rb"/>
+                                    <title ref="LIT2509Weddas#Sunday"/>
+                                </msItem>
+                            </msItem>
+                            <msItem xml:id="p1_i1.4">
+                                <locus from="158ra" to="162rb"/>
+                                <title ref="LIT1113Anqasa"/>
+                            </msItem>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <locus from="124v" to="125r"/>
+                            <title ref="LIT4261Prayer"/>
+                            <incipit xml:lang="gez">እግዚአብሔር፡ እግዚእየ፡ ወአምላኪየ፡ እስእለከ፡ በፍቁር፡ ወልድከ፡ እግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ እግዚእየ፡ ወአምላኪየ፡ ወመድኃንየ፡
+                                ወበአስማቲከ፡ ቅዱሳት። ትስማዕ፡ ጸሎትየ፡ ወአስተበቍዖትየ። አርኅቅ፡ እምኔየ፡ ሰይጣነ፡ ወሠራዊቶ።</incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i3">
+                            <locus target="#137v"/>
+                            <title ref="LIT6946InvocationMary"/>
+                            <incipit xml:lang="gez">ስብሐት፡ ለአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ።   
+                                ለዓለም፡ ወለዓለመ፡ ዓለም።
+                                ሰአሊ፡ ለነ፡ ቅድስት፡ ድንግል፡ ማርያም። 
+                                ምሕረተ፡ ክርስቶስ፡ ወልድኪ፡ የሐውጸነ፡ እምአርያም።
+                                ኦአምላከ፡ ዳዊት፡ ወአምላከ፡ ነቢያት።
+                                ዕቀበኒ፡ ለገብርከ፡ <gap reason="illegible"/> እምዕለት፡ እኪት።</incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i4">
+                            <locus target="#146v"/>
+                            <title>Two Salāms</title>
+                            <msItem xml:id="ms_i4.1">
+                                <title ref="LIT2762RepCh46"/>
+                                <incipit xml:lang="gez">ሰላም፡ ለከ፡ ሚካኤል፡ መልአከ፡ አድኅኖ።</incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i4.2">
+                                <title>Salām to the Archangel Gabriel</title>
+                                <incipit xml:lang="gez">ሰላም፡ ለከ፡ ገብርኤል፡ ብስራታዊ። </incipit>
+                                <note>Probably <ref type="work" corresp="LIT6865SalGabreel"/>, what cannot be ascertained, because image were not
+                                    available during the cataloguing. According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                    <citedRange unit="page">40</citedRange></bibl>, this <foreign xml:lang="gez">salām</foreign> is missing in 
+                                    <bibl><ptr target="bm:bm:Chaine1913Rep"/></bibl>.</note>
+                            </msItem>
+                        </msItem>
+                        <msItem xml:id="ms_i5">
+                            <locus from="162va" to="165va"/>
+                            <title>Praises of the Virgin of Mary</title>
+                            <msItem xml:id="ms_i5.1">
+                                <locus from="162va" to="163vb"/>
+                                <title ref="LIT3108RepCh388"/>
+                                <incipit xml:lang="gez">ይዌድስዋ፡ መላእክት፡ ለማርያም፡ በውስተ፡ ውሣጤ፡ መንጦላዕት። ወይብልዋ፡ በሐኪ፡ ማርያም፡ ሐዳስዩ፡ ጣዕዋ። </incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i5.2">
+                                <locus from="163vb" to="165rb"/>
+                                <title ref="LIT3058RepCh338"/>
+                                <incipit xml:lang="gez">እስግድ፡ ለኪ፡ እስግድ፡ ለኪ፡ እስግድ፡ ለኪ፡ ወእዌድስኪ፡ ኦእግዝእትየ፡ ማርያም፡ በከመ፡ ወደስኪ፡ ዮሐንስ፡ አፈ፡ ወርቅ፡ በድርሳኑ፡ 
+                                    በጥዑም፡ ከናፍሪሁ። ተፈሥሒ፡ ኦእግዝእትየ፡ </incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i5.3">
+                                <locus from="165rb" to="165va"/>
+                                <title ref="LIT5344MiracleFeeding"/>
+                                <incipit xml:lang="gez"><title>ተአምሪሃ፡ ለእግዝእትነ፡ ማርያም፡ </title><gap reason="ellipsis"/> ተብህለ፡ ከመ፡ ሀሎ፡ ፩ርኁብ፡ ዘያፈቅራ፡ 
+                                    ለእግዝእትነ፡ ማርያም፡</incipit>
+                            </msItem>
+                        </msItem>
+                        <msItem xml:id="ms_i6">
+                            <locus from="165va" to="166rb"/>
+                            <title ref="LIT6416MJLionsAshkelon"/>
+                            <incipit xml:lang="gez"><title>ተአምሪሁ፡ ለእግዚእነ፡ ወአምላክነ፡ ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡ ዘገብረ፡ በምድረ፡ አስቃላን፡</title>
+                                <gap reason="ellipsis"/> ወሀለዉ፡ አናብስት፡ ብዙኃን፡ በምድረ፡ አስቃላን፡ እስከ፡ ኢክህሉ፡ ሰብአ፡ ሀገር፡ ይጻኡ፡ እምአንቀጸ፡ ቤቶሙ፡ </incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i7">
+                            <locus from="166rb" to="171vb"/>
+                            <title ref="LIT2891RepCh172"/>
+                            <incipit xml:lang="gez">ሰላም፡ ሰላም፡ ለዝክረ፡ ስምኪ፡ ሐዋዝ። </incipit>
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Codex">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf">2+172+2</measure>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>180</height>
+                                        <width>120</width>
+                                    </dimensions>
+                                </extent>
+                                <condition key="good">A piece of <locus target="#93"/> has been cut out of the bottom of the leaf.</condition>
+                            </supportDesc>
+                            <layoutDesc>
+                                <layout columns="2" writtenLines="23"><locus from="1v" to="4r"/></layout>
+                                <layout columns="1" writtenLines="23"><locus from="4v" to="146v"/></layout>
+                                <layout columns="2" writtenLines="23"><locus from="147r" to="172r"/></layout>
+                            </layoutDesc>    
+                        </objectDesc> 
+                        <handDesc>
+                            <handNote script="Ethiopic" xml:id="h1">
+                                <desc>Written in good hand.</desc>
+                                <date notBefore="1800" notAfter="1895" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                        </handDesc>
+                        <decoDesc>
+                            <decoNote xml:id="d1" type="drawing">
+                                <locus target="#1r"/>
+                                <desc>A drawing in black representing <persName ref="PRS3417David"/> (<q xml:lang="gez">ቅዱስ፡ ዳዊት፡</q>).</desc>
+                            </decoNote>
+                            <decoNote xml:id="d2" type="band">
+                                <desc>Narrow coloured ornamental bands on various pages.</desc>
+                            </decoNote>
+                        </decoDesc>
+                        <additions>
+                            <list>
+                                <item xml:id="a1">
+                                    <locus from="1va" to="2vb"/>
+                                    <desc type="GuestText"><ref type="work" corresp="LIT2940RepCh221"/> in strophes of four lines.</desc>
+                                    <q xml:lang="gez">ሰላም፡ ሰላም፡ ለዝክረ፡ ስምኪ፡ በአምኃ፡ ሰርከ፡ ወነግሃ። <gap reason="ellipsis"/></q>
+                                </item>
+                                <item xml:id="a2">
+                                    <locus from="3ra" to="4ra"/>
+                                    <desc type="GuestText"><ref type="work" corresp="LIT2799RepCh83"/> in strophes of four verses.</desc>
+                                    <q xml:lang="gez">ሰላም፡ ለከ፡ ጊዮርጊስ፡ ዘልዳ፡ <gap reason="ellipsis"/></q>
+                                </item>
+                                <item xml:id="a3">
+                                    <locus target="#4v"/>
+                                    <desc type="GuestText"><ref type="work" corresp="LIT00000000000000000000000000000">A prayer to the Lord</ref></desc>
+                                    <q xml:lang="gez">እግዚአብሔር፡ ዓቢይ፡ ወግሩም። ዘአልቦቱ፡ ጥንት፡ ወኢተፍጻሜት። ወይሄሉ፡ ለዓለመ፡ ዓለም። እስእለከ፡ ወአስተበቍዓከ። ከመ፡ 
+                                        ትርድአኒ፡ ወትባልሐኒ። <gap reason="ellipsis"/></q>
+                                </item>
+                                <item xml:id="a4">
+                                    <locus target="#172r"/>
+                                    <desc type="GuestText"><ref type="work" corresp="LIT2772RepCh56"/> in strophes of three verses.</desc>
+                                    <q xml:lang="gez">ሰላም፡ ለከ፡ ፩ሰማዕት፡ መዋዒ፡ እምነ፡ ኅሩያን፡ አዕላፍ። </q>
+                                </item>
+                                <item xml:id="a5">
+                                    <locus target="#1r #2r"></locus>
+                                    <desc type="MagicFormula">A few marginal notes in Amharic on the first pages of the Psalter, giving indications of a
+                                        medical or magical use of certain psalms as it is also supported by the Preface to the Psalms recorded above.
+                                        Examples: <q xml:lang="am">አጽንት፡ ለአነቀው፡ በቅብዓ፡ ቅዱስ፡ መላሱን፡ ቅባ።</q> (at the end of Ps. 1 in <locus target="#1r"/>),
+                                        <q xml:lang="am">፯ጊዜ፡ ድግም፡</q> (at the end of Ps. 2,1 in <locus target="#1r"/>),
+                                        <q xml:lang="am">እግዚእ፡ ሚበዝኁን፡ መንገድ፡ ስትሄድ፡ በቅብዓ፡ ሜሮን፡ ደግመህ፡ ተቀባ፡ ወበውሀ፡ ታጽብ።</q> 
+                                                    (<locus target="#2r"/> in the upper margin),
+                                        <q xml:lang="am">የቤትህ፡ ሰዎች፡ ቢጻሉህ፡ ፯ጊዜ፡</q> (at the end of Psalm 3).</desc>
+                                </item>
+                                <item xml:id="a6">
+                                    <locus target="#84r"/>
+                                    <desc type="GuestText">Creed (Ṣalota hāymānot) after Psalm 100.</desc>
+                                </item>
+                                <item xml:id="e1">
+                                    <locus target="#5r #27r #50v #71r #97v #112r #125r"/>
+                                    <desc type="findingAid">Marks for days of the week for the reading of the Psalms.</desc>
+                                </item>
+                                <item xml:id="e2">
+                                    <locus target="#IIr"/>
+                                    <desc type="AcquisitionNote"/>
+                                    <q>Bought of <persName role="owner" ref="PRS14378WQuaritch">W. Quaritch</persName>.
+                                        <date when="1895-06-18"/></q>
+                                </item>
+                                <item xml:id="e3">
+                                    <desc type="OwnershipNote">The name of the first owner has been erased. In a few places that of the second owner
+                                        <persName role="owner" ref="PRS14377WalattaEgz">Walatta ʾƎgziʾabǝḥer</persName>has been substituted 
+                                        for it.</desc>
+                                </item>
+                            </list>
+                        </additions>        
+                        <bindingDesc>
+                            <binding xml:id="binding">
+                                <decoNote type="bindingMaterial" xml:id="b1"><material key="wood"/></decoNote>
+                                <decoNote xml:id="b2" type="Boards"><material key="wood"/>Wooden boards.</decoNote>
+                                <decoNote xml:id="b3" type="Cover"><material key="leather"/>Stamped leather.</decoNote>
+                            </binding>
+                        </bindingDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1800" notAfter="1895">19th century</origDate>
+                        </origin>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                            <citedRange unit="page">39-41</citedRange>
+                                        </bibl> 
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="Bible"/>
+                    <term key="ChristianContent"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="AmharicLiterature"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language> 
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-02-08">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>
+

--- a/LondonBritishLibrary/orient/BLorient4930.xml
+++ b/LondonBritishLibrary/orient/BLorient4930.xml
@@ -36,8 +36,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <msItem xml:id="ms_i1.1">
                                 <locus from="5r" to="124r"/>
                                 <title>Psalms</title>
-                                <note>The text is divided for the days of the week, preceded by an introductory supplication. The titles of the psalms are 
-                                    the new ones.</note>
+                                <note>The text is divided for the days of the week, preceded by an introductory supplication and a supplication in the end. 
+                                    The titles of the psalms are the new ones.</note>
                                 <msItem xml:id="ms_i1.1.1">
                                     <locus target="#5r"/>
                                     <title ref="LIT5884IntroHymnPs"/>
@@ -51,6 +51,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <locus from="5r" to="124r"/>
                                     <title ref="LIT2000Mazmur"/>
                                     <incipit xml:lang="gez"><title>መዝሙር፡ ዘዳዊት።</title> ሃሌ፡ ሉያ። </incipit>
+                                </msItem>
+                                <msItem xml:id="ms_i1.1.3">
+                                    <locus from="124v" to="125r"/>
+                                    <title ref="LIT4261Prayer"/>
+                                    <incipit xml:lang="gez">እግዚአብሔር፡ እግዚእየ፡ ወአምላኪየ፡ እስእለከ፡ በፍቁር፡ ወልድከ፡ እግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ እግዚእየ፡ ወአምላኪየ፡ ወመድኃንየ፡
+                                        ወበአስማቲከ፡ ቅዱሳት። ትስማዕ፡ ጸሎትየ፡ ወአስተበቍዖትየ። አርኅቅ፡ እምኔየ፡ ሰይጣነ፡ ወሠራዊቶ።</incipit>
                                 </msItem>
                             </msItem>
                             <msItem xml:id="ms_i1.2">
@@ -119,11 +125,21 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <locus target="#137v"/>
                                         <title ref="LIT1828Mahale#Simeon"/>
                                     </msItem>
+                                    <msItem xml:id="ms_i1.2.1.16">
+                                        <locus target="#137v"/>
+                                        <title ref="LIT6946InvocationMary"/>
+                                        <incipit xml:lang="gez">ስብሐት፡ ለአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ።   
+                                            ለዓለም፡ ወለዓለመ፡ ዓለም።
+                                            ሰአሊ፡ ለነ፡ ቅድስት፡ ድንግል፡ ማርያም። 
+                                            ምሕረተ፡ ክርስቶስ፡ ወልድኪ፡ የሐውጸነ፡ እምአርያም።
+                                            ኦአምላከ፡ ዳዊት፡ ወአምላከ፡ ነቢያት።
+                                            ዕቀበኒ፡ ለገብርከ፡ <gap reason="illegible"/> እምዕለት፡ እኪት።</incipit>
+                                    </msItem>
                                 </msItem>
                                 <msItem xml:id="ms_i1.2.2">
                                     <locus from="138r" to="146v"/>
                                     <title ref="LIT2362Songof"/>
-                                    <note>The text is divided into five sections.</note>
+                                    <note>The text is divided into five sections, followed by two <foreign xml:lang="gez">salām</foreign>.</note>
                                     <msItem xml:id="ms_i1.2.2.1">
                                         <title ref="LIT2362Songof#FirstCanticle"/>
                                     </msItem>
@@ -138,6 +154,22 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </msItem>
                                     <msItem xml:id="ms_i1.2.2.5">
                                         <title ref="LIT2362Songof#FifthCanticle"/>
+                                    </msItem>
+                                    <msItem xml:id="ms_i2.2.6">
+                                        <locus target="#146v"/>
+                                        <title>Two Salāms</title>
+                                        <msItem xml:id="ms_i1.2.2.6.1">
+                                            <title ref="LIT2762RepCh46"/>
+                                            <incipit xml:lang="gez">ሰላም፡ ለከ፡ ሚካኤል፡ መልአከ፡ አድኅኖ።</incipit>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.2.2.6.2">
+                                            <title>Salām to the Archangel Gabriel</title>
+                                            <incipit xml:lang="gez">ሰላም፡ ለከ፡ ገብርኤል፡ ብስራታዊ። </incipit>
+                                            <note>Probably <ref type="work" corresp="LIT6865SalGabreel"/>, what cannot be ascertained, because image were not
+                                                available during the cataloguing. According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                                    <citedRange unit="page">40</citedRange></bibl>, this <foreign xml:lang="gez">salām</foreign> is missing in 
+                                                <bibl><ptr target="bm:Chaine1913Rep"/></bibl>.</note>
+                                        </msItem>
                                     </msItem>
                                 </msItem>
                             </msItem>
@@ -180,65 +212,33 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </msItem>
                         </msItem>
                         <msItem xml:id="ms_i2">
-                            <locus from="124v" to="125r"/>
-                            <title ref="LIT4261Prayer"/>
-                            <incipit xml:lang="gez">እግዚአብሔር፡ እግዚእየ፡ ወአምላኪየ፡ እስእለከ፡ በፍቁር፡ ወልድከ፡ እግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ እግዚእየ፡ ወአምላኪየ፡ ወመድኃንየ፡
-                                ወበአስማቲከ፡ ቅዱሳት። ትስማዕ፡ ጸሎትየ፡ ወአስተበቍዖትየ። አርኅቅ፡ እምኔየ፡ ሰይጣነ፡ ወሠራዊቶ።</incipit>
-                        </msItem>
-                        <msItem xml:id="ms_i3">
-                            <locus target="#137v"/>
-                            <title ref="LIT6946InvocationMary"/>
-                            <incipit xml:lang="gez">ስብሐት፡ ለአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ።   
-                                ለዓለም፡ ወለዓለመ፡ ዓለም።
-                                ሰአሊ፡ ለነ፡ ቅድስት፡ ድንግል፡ ማርያም። 
-                                ምሕረተ፡ ክርስቶስ፡ ወልድኪ፡ የሐውጸነ፡ እምአርያም።
-                                ኦአምላከ፡ ዳዊት፡ ወአምላከ፡ ነቢያት።
-                                ዕቀበኒ፡ ለገብርከ፡ <gap reason="illegible"/> እምዕለት፡ እኪት።</incipit>
-                        </msItem>
-                        <msItem xml:id="ms_i4">
-                            <locus target="#146v"/>
-                            <title>Two Salāms</title>
-                            <msItem xml:id="ms_i4.1">
-                                <title ref="LIT2762RepCh46"/>
-                                <incipit xml:lang="gez">ሰላም፡ ለከ፡ ሚካኤል፡ መልአከ፡ አድኅኖ።</incipit>
-                            </msItem>
-                            <msItem xml:id="ms_i4.2">
-                                <title>Salām to the Archangel Gabriel</title>
-                                <incipit xml:lang="gez">ሰላም፡ ለከ፡ ገብርኤል፡ ብስራታዊ። </incipit>
-                                <note>Probably <ref type="work" corresp="LIT6865SalGabreel"/>, what cannot be ascertained, because image were not
-                                    available during the cataloguing. According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/>
-                                    <citedRange unit="page">40</citedRange></bibl>, this <foreign xml:lang="gez">salām</foreign> is missing in 
-                                    <bibl><ptr target="bm:Chaine1913Rep"/></bibl>.</note>
-                            </msItem>
-                        </msItem>
-                        <msItem xml:id="ms_i5">
                             <locus from="162va" to="165va"/>
                             <title>Praises of the Virgin Mary</title>
-                            <msItem xml:id="ms_i5.1">
+                            <msItem xml:id="ms_i2.1">
                                 <locus from="162va" to="163vb"/>
                                 <title ref="LIT3108RepCh388"/>
                                 <incipit xml:lang="gez">ይዌድስዋ፡ መላእክት፡ ለማርያም፡ በውስተ፡ ውሣጤ፡ መንጦላዕት። ወይብልዋ፡ በሐኪ፡ ማርያም፡ ሐዳስዩ፡ ጣዕዋ። </incipit>
                             </msItem>
-                            <msItem xml:id="ms_i5.2">
+                            <msItem xml:id="ms_i2.2">
                                 <locus from="163vb" to="165rb"/>
                                 <title ref="LIT3058RepCh338"/>
                                 <incipit xml:lang="gez">እስግድ፡ ለኪ፡ እስግድ፡ ለኪ፡ እስግድ፡ ለኪ፡ ወእዌድስኪ፡ ኦእግዝእትየ፡ ማርያም፡ በከመ፡ ወደስኪ፡ ዮሐንስ፡ አፈ፡ ወርቅ፡ በድርሳኑ፡ 
                                     በጥዑም፡ ከናፍሪሁ። ተፈሥሒ፡ ኦእግዝእትየ፡ </incipit>
                             </msItem>
-                            <msItem xml:id="ms_i5.3">
+                            <msItem xml:id="ms_i2.3">
                                 <locus from="165rb" to="165va"/>
                                 <title ref="LIT5344MiracleFeeding"/>
                                 <incipit xml:lang="gez"><title>ተአምሪሃ፡ ለእግዝእትነ፡ ማርያም፡ </title><gap reason="ellipsis"/> ተብህለ፡ ከመ፡ ሀሎ፡ ፩ርኁብ፡ ዘያፈቅራ፡ 
                                     ለእግዝእትነ፡ ማርያም፡</incipit>
                             </msItem>
                         </msItem>
-                        <msItem xml:id="ms_i6">
+                        <msItem xml:id="ms_i3">
                             <locus from="165va" to="166rb"/>
                             <title ref="LIT6416MJLionsAshkelon"/>
                             <incipit xml:lang="gez"><title>ተአምሪሁ፡ ለእግዚእነ፡ ወአምላክነ፡ ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡ ዘገብረ፡ በምድረ፡ አስቃላን፡</title>
                                 <gap reason="ellipsis"/> ወሀለዉ፡ አናብስት፡ ብዙኃን፡ በምድረ፡ አስቃላን፡ እስከ፡ ኢክህሉ፡ ሰብአ፡ ሀገር፡ ይጻኡ፡ እምአንቀጸ፡ ቤቶሙ፡ </incipit>
                         </msItem>
-                        <msItem xml:id="ms_i7">
+                        <msItem xml:id="ms_i4">
                             <locus from="166rb" to="171vb"/>
                             <title ref="LIT2891RepCh172"/>
                             <incipit xml:lang="gez">ሰላም፡ ሰላም፡ ለዝክረ፡ ስምኪ፡ ሐዋዝ። </incipit>

--- a/VaticanBAV/et/BAVet105.xml
+++ b/VaticanBAV/et/BAVet105.xml
@@ -69,7 +69,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   <msItem xml:id="ms_i4">
                      <locus from="41" to="69v"/>
                      <title type="complete" ref="LIT2362Songof"/>
-                     <note>The text is followed by a short doxology and invocations:
+                     <note>The text is followed by a short doxology and an <ref type="work" corresp="LIT6946InvocationMary">invocation of Mary</ref>:
                      <q xml:lang="gez">ስብሐት፡ ለአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ። ለዓለም። ወለዓለመ፡ ዓለም። ሰአሊ፡ ለነ፡ ቅድስት፡ ድንግል፡ ማርያም፡ ምሕረተ፡ ክርስቶስ፡ ወልድኪ፡ የሃውጸነ፡ እምአርያም። 
                      ኦአምላከ፡ ሰሎሞን፡ ወዳዊት፡ አድኅነነ፡ እምዕለት፡ እኪት፡ ወባልሀነ፡ እምኵሉ፡ መንሱት።</q>.
                      </note>

--- a/VaticanBAV/et/BAVet15.xml
+++ b/VaticanBAV/et/BAVet15.xml
@@ -924,7 +924,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <title>Readings and prayers for Sunday</title>
                         <msItem xml:id="p1_i12.1">
                            <locus from="118b" facs="0121"/>
-                           <title ref="LIT4261Prayer"/>
+                           <title ref="LIT4261Prayer">ጸሎት፡ በሰንበተ፡ ክርስቲያን፡</title>
                            <note>
                               <q xml:lang="gez">እግዚአብሔር፡ እግዚእየ፡ ወአምላኪየ፡ እስእለከ፡ በፍቁር፡ ወልድከ፡ ኢየሱስ፡ ክርስቶስ። እግዚእነ፡ ወአምላክነ፡ ወመድኀኒነ።
                            ወበአስማቲከ፡ ቅዱሳት፡ ትስማዕ፡ ጸሎትየ፡</q>

--- a/VaticanBAV/et/BAVet15.xml
+++ b/VaticanBAV/et/BAVet15.xml
@@ -924,7 +924,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <title>Readings and prayers for Sunday</title>
                         <msItem xml:id="p1_i12.1">
                            <locus from="118b" facs="0121"/>
-                           <title>ጸሎት፡ በሰንበተ፡ ክርስቲያን፡</title>
+                           <title ref="LIT4261Prayer"/>
                            <note>
                               <q xml:lang="gez">እግዚአብሔር፡ እግዚእየ፡ ወአምላኪየ፡ እስእለከ፡ በፍቁር፡ ወልድከ፡ ኢየሱስ፡ ክርስቶስ። እግዚእነ፡ ወአምላክነ፡ ወመድኀኒነ።
                            ወበአስማቲከ፡ ቅዱሳት፡ ትስማዕ፡ ጸሎትየ፡</q>

--- a/VaticanBAV/et/BAVet17.xml
+++ b/VaticanBAV/et/BAVet17.xml
@@ -145,7 +145,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   
                   <msItem xml:id="ms_i4">
                      <locus from="30v" to="33v"/>
-                     <title type="complete">Prayer for Sunday</title>
+                     <title ref="LIT4261Prayer" type="complete"/>
                      <note/>
                      <incipit xml:lang="gez">
                         ጸሎት፡ ቡርክት፡ ዘይትነበብ፡ በዕለተ፡ እሑድ፡ ሰንበተ፡ ክርስቲያን። እግዚአብሔር፡ እግዚእየ፡ ወአምላክየ፡ እስእለከ፡ በፍቁር፡ ወልድከ፡ ኢየሱስ፡ ክርስቶስ፡ እግዚእነ፡ ወአምላክነ፡ ወመድኀኒነ፡ ወበአስማቲከ፡ 

--- a/VaticanBAV/et/BAVet72.xml
+++ b/VaticanBAV/et/BAVet72.xml
@@ -258,7 +258,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            </note>
                         </item>
                         <item xml:id="a2">
-                           <desc type="Invocation"/>
+                           <desc type="Invocation"><ref type="work" corresp="LIT6946InvocationMary"/></desc>
                            <locus target="#128v"/>
                            <q xml:lang="gez">
                               ስብሐት፡ ለአብ፡ <gap reason="omitted" extent="unknown" resp="PRS4805Grebaut PRS9530Tisseran"/> ወለዓለመ፡ ዓለም፡ ሰአሊ፡ ለነ፡ ቅድስት፡ ድንግል፡ ማርያም፡ 


### PR DESCRIPTION
I created a record for BLorient4930 according to Strelcyns catalogue.

For ms_i3, I created a new LIT according to our discussion in https://github.com/BetaMasaheft/Documentation/issues/2501 and added this new ID to every manuscript record that came to my attention.

For ms_i4.2 I was not sure, but I think it is likely that this is LIT6865SalGabreel. The incipit in the manuscript according to Strelcyn is ሰላም፡ ለከ፡ ገብርኤል፡ ብስራታዊ። The incipit in the work record is ሰላም፡ ገብርኤል፡ ብስራታዊ።.

For a prayer to the Lord in a3, I have just opened https://github.com/BetaMasaheft/Documentation/issues/2502 a minute ago and I would like to read your opinions on that, before creating a new LIT ID.

For a6, I did not know if it was a fair use of LIT3308Nicene or some other LIT for the creed, because I did not know if it was the conventional EOTC creed (which is very likely) or some alternative creed, since Strelcyn did not quote it or refer to it in any specific way.

I struggled with the question of whether ms_i2, ms_i3, ms_i4 and ms_i5 should be coded as part of ms_i1, as they were defined as supplication, doxology or explicit in other Psalter manuscript records (e.g. ESamm013 or BAVet105). I have preferred to define them as separate msItems because I feel they are individual, even though they are embedded in or immediately following the Psalter.