### PR TITLE
Create BLorient8814 (CH_march24)

### DIFF
--- a/LondonBritishLibrary/orient/BLorient8814.xml
+++ b/LondonBritishLibrary/orient/BLorient8814.xml
@@ -207,7 +207,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </msItem>
                         <msItem xml:id="ms_i9">
                             <locus from="77ra" to="78rb"/>
-                            <title ref="LIT6948GenealogyMonks"/>
+                            <title ref="LIT3143Ledata"/>
                             <note>The following note <q xml:lang="gez">እምደብረ፡ ሊባኖስ፡ </q> was written at the end of this text, in the margin. The 
                                 name 'Dabra Libānos' can be identified with either <placeName ref="INS0346DL"/> or 
                                 <placeName ref="INS0341DL"/>.</note>

--- a/LondonBritishLibrary/orient/BLorient8814.xml
+++ b/LondonBritishLibrary/orient/BLorient8814.xml
@@ -439,29 +439,24 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <roleName type="title">Baroness</roleName> Zouche</persName>. <date when="1917">13 Oct. 1917</date>.</q>
                                 </item>
                                 <item xml:id="e2">
-                                    <locus target="#65rb"/>
-                                    <desc type="OwnershipNote">The first owner was <persName role="owner" ref="PRS14385WaldaMadhen"/>. 
-                                        His name is inscribed on several folios.</desc>
-                                </item>
-                                <item xml:id="e3">
                                     <locus target="#39rb"/>
                                     <desc type="OwnershipNote">The second owner was <persName role="owner" ref="PRS14386WalattaYohannes"/>.
                                         Her name is inscribed on several folios.</desc>
                                 </item>
-                                <item xml:id="e4">
+                                <item xml:id="e3">
                                     <desc type="OwnershipNote">Name of an owner: <persName role="owner" ref="PRS14387KenfaMikael"/></desc>
                                 </item>
-                                <item xml:id="e5">
+                                <item xml:id="e4">
                                     <desc type="OwnershipNote">Name of an owner: <persName role="owner" ref="PRS14388DemsaMikael"/></desc>
                                 </item>
-                                <item xml:id="e6">
+                                <item xml:id="e5">
                                     <desc type="OwnershipNote">Name of an owner: <persName role="owner" ref="PRS14389GabraMQ"/></desc>
                                 </item>
-                                <item xml:id="e7">
+                                <item xml:id="e6">
                                     <locus target="#2v"/>
                                     <desc>Pen trials.</desc>  
                                 </item>
-                                <item xml:id="e8">
+                                <item xml:id="e7">
                                     <locus target="#2v"/>
                                     <desc type="StampExlibris">Note</desc>
                                     <q xml:lang="la">Liturgia et Cantica Ecclesiae Aethiopicae</q>
@@ -481,13 +476,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <origin>
                             <origDate notBefore="1700" notAfter="1799">18th century</origDate>
                         </origin>
-                        <provenance>According to <bibl><ptr target="bm:Emmel2023Curzon"/><citedRange unit="page">236-241</citedRange>
-                            </bibl> acquired by <persName ref="PRS3244Curzon"/> during his stay in Egypt in 
-                            <date notBefore="1837" notAfter="1838">1837-1838</date>. Three years after his death on 
-                            <date when="1876-04-19">19 April 1876</date>the codex was given as a deposit on loan to the British Museum 
-                            (later: <placeName ref="INS00001BL">British Library</placeName>), then as a bequest from his daughter 
-                            <persName ref="PRS14320DareaCurzon">Darea</persName> in <date when="1917-10-13">13 October 1917</date> 
-                            as inscribed in a note on the front flyleaf.</provenance>
+                        <provenance>The first owner was <persName role="owner" ref="PRS14385WaldaMadhen"/>. His name is inscribed on 
+                            several folios as for instance on <locus target="#65rb"/>.
+                            According to <bibl><ptr target="bm:Emmel2023Curzon"/><citedRange unit="page">236-241</citedRange></bibl> 
+                            the manuscript was acquired by <persName ref="PRS3244Curzon"/> during his stay in Egypt in 
+                            <date notBefore="1837" notAfter="1838">1837-1838</date>. 
+                            Three years after his death on <date when="1876-04-19">19 April 1876</date>the codex was given as a deposit on loan to 
+                            the British Museum (later: <placeName ref="INS00001BL">British Library</placeName>), then as a bequest from his 
+                            daughter <persName ref="PRS14320DareaCurzon">Darea</persName> in <date when="1917-10-13">13 October 1917</date> 
+                            as inscribed in a note on the front endleaf.</provenance>
                     </history>
                     <additional>
                         <adminInfo>

--- a/LondonBritishLibrary/orient/BLorient8814.xml
+++ b/LondonBritishLibrary/orient/BLorient8814.xml
@@ -160,6 +160,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <msItem xml:id="ms_i6">
                             <locus from="56vb" to="63vb"/>
                             <title>Prayer for all the days of the week</title>
+                            <note>Possibly <ref type="work" corresp="LIT4691Prayer"/> also attested elsewhere in the 
+                                <ref type="work" corresp="LIT3985Mazmura"/>, which cannot be determined as no images were available when this 
+                                record was made.</note>
                             <msItem xml:id="ms_i6.1">
                                 <locus from="56vb"/>
                                 <title>Monday</title>
@@ -208,9 +211,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <msItem xml:id="ms_i9">
                             <locus from="77ra" to="78rb"/>
                             <title ref="LIT3143Ledata"/>
-                            <note>The following note <q xml:lang="gez">እምደብረ፡ ሊባኖስ፡ </q> was written at the end of this text, in the margin. The 
-                                name 'Dabra Libānos' can be identified with either <placeName ref="INS0346DL"/> or 
-                                <placeName ref="INS0341DL"/>.</note>
+                            <note>The following note <foreign xml:lang="gez">እምደብረ፡ ሊባኖስ፡ </foreign> was written at the end of this text, in the 
+                                margin referring to <placeName ref="INS0341DL"/>.</note>
                             <incipit xml:lang="gez">ወእምድኅሬሁ፡ ያንብቡ፡ ዘንተ፡ መጽሐፈ፡ ልደቶሙ፡ ለአበው፡ መ<cb n="77rb"/>ነኮሳት፡ 
                                 እንጦ<supplied reason="undefined" resp="PRS8999Strelcyn">ን</supplied>ስ፡ ወልዶ፡ ለመቃርስ፡ መቃርስ፡ ወለዶ፡ ለጳኵሚስ፡ 
                                 ጳኵሚስ፡ ወለዶ፡ ለአረጋዊ፡ ዘደሞ፡ አረጋዊ፡ ወለዶ፡ ለመስቀል፡ ሞአ። ወመስቀል፡ ሞአ፡ ወለዶ፡ ለክርስቶስ፡ ቤዛነ። ወክርስቶስ፡ ቤዛነ፡ ወለዶ፡ ለዮሐኒ። ዮሐኒ፡ ወለዶ፡ 
@@ -407,8 +409,20 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </handDesc>
                         <decoDesc>
                             <decoNote xml:id="d1" type="miniature">
-                                <locus target="#64r #64v #78r #93v"/>
-                                <desc>Miniatures.</desc>
+                                <locus target="#64r"/>
+                                <desc>One or several miniatures.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d2" type="miniature">
+                                <locus target="#64v"/>
+                                <desc>One or several miniatures.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d3" type="miniature">
+                                <locus target="#78r"/>
+                                <desc>One or several miniatures.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d4" type="miniature">
+                                <locus target="#93v"/>
+                                <desc>One or several miniatures.</desc>
                             </decoNote>
                         </decoDesc>
                         <additions>

--- a/LondonBritishLibrary/orient/BLorient8814.xml
+++ b/LondonBritishLibrary/orient/BLorient8814.xml
@@ -439,26 +439,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <roleName type="title">Baroness</roleName> Zouche</persName>. <date when="1917">13 Oct. 1917</date>.</q>
                                 </item>
                                 <item xml:id="e2">
-                                    <locus target="#39rb"/>
-                                    <desc type="OwnershipNote">The second owner was <persName role="owner" ref="PRS14386WalattaYohannes"/>.
-                                        Her name is inscribed on several folios.</desc>
-                                </item>
-                                <item xml:id="e3">
-                                    <desc type="OwnershipNote">Name of an owner: <persName role="owner" ref="PRS14387KenfaMikael"/></desc>
-                                </item>
-                                <item xml:id="e4">
-                                    <desc type="OwnershipNote">Name of an owner: <persName role="owner" ref="PRS14388DemsaMikael"/></desc>
-                                </item>
-                                <item xml:id="e5">
-                                    <desc type="OwnershipNote">Name of an owner: <persName role="owner" ref="PRS14389GabraMQ"/></desc>
-                                </item>
-                                <item xml:id="e6">
                                     <locus target="#2v"/>
                                     <desc>Pen trials.</desc>  
                                 </item>
-                                <item xml:id="e7">
+                                <item xml:id="e3">
                                     <locus target="#2v"/>
-                                    <desc type="StampExlibris">Note</desc>
+                                    <desc type="StampExlibris"/>
                                     <q xml:lang="la">Liturgia et Cantica Ecclesiae Aethiopicae</q>
                                 </item>
                             </list>
@@ -477,14 +463,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <origDate notBefore="1700" notAfter="1799">18th century</origDate>
                         </origin>
                         <provenance>The first owner was <persName role="owner" ref="PRS14385WaldaMadhen"/>. His name is inscribed on 
-                            several folios as for instance on <locus target="#65rb"/>.
-                            According to <bibl><ptr target="bm:Emmel2023Curzon"/><citedRange unit="page">236-241</citedRange></bibl> 
+                            several folios as for instance on <locus target="#65rb"/>. 
+                            The second owner was <persName role="owner" ref="PRS14386WalattaYohannes"/>. Her name is inscribed on several 
+                            folios as for instance on <locus target="#39rb"/>.
+                            The names of other owners are <persName role="owner" ref="PRS14387KenfaMikael"/>, 
+                            <persName role="owner" ref="PRS14388DemsaMikael"/> and <persName role="owner" ref="PRS14389GabraMQ"/>.
+                        </provenance>
+                        <acquisition>According to <bibl><ptr target="bm:Emmel2023Curzon"/><citedRange unit="page">236-241</citedRange></bibl> 
                             the manuscript was acquired by <persName ref="PRS3244Curzon"/> during his stay in Egypt in 
                             <date notBefore="1837" notAfter="1838">1837-1838</date>. 
                             Three years after his death on <date when="1876-04-19">19 April 1876</date>the codex was given as a deposit on loan to 
                             the British Museum (later: <placeName ref="INS00001BL">British Library</placeName>), then as a bequest from his 
                             daughter <persName ref="PRS14320DareaCurzon">Darea</persName> in <date when="1917-10-13">13 October 1917</date> 
-                            as inscribed in a note on the front endleaf.</provenance>
+                            as inscribed in a note on the front endleaf.</acquisition>
                     </history>
                     <additional>
                         <adminInfo>

--- a/LondonBritishLibrary/orient/BLorient8814.xml
+++ b/LondonBritishLibrary/orient/BLorient8814.xml
@@ -195,14 +195,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </msItem>
                         <msItem xml:id="ms_i7">
                             <locus from="65ra" to="75rb"/>
-                            <title ref="LIT000000000000000000000000000000000000">Prayer</title>
+                            <title>Prayer</title>
                             <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ዓለም፡ ልብና፡ እግዚአብሔር፡ ዘክዱን፡ ብከ፡ ዕበይከ፡ ወስውር፡ ብከ፡ ኃይልከ፡ በከመ፡ ሰወርኮ፡
                                 እምዓይነ፡ ሞት፡ ለሄኖክ፡ ነቢይ፡ በተአምኖ፡ ዘአስመረከ፡ ክድነኒ፡ ወሰውረኒ፡ በክንፈ፡ ረድኤትከ፡ እምኀፅ፡ ዘይሰርር፡ በመዓልት፡ ወእምግብር፡ ዘየሐውር፡ በጽልመት፡ 
                             </incipit>
                         </msItem>
                         <msItem xml:id="ms_i8">
                             <locus from="75rb" to="77ra"/>
-                            <title ref="LIT000000000000000000000000000000000000" type="incomplete">Litany to the Virgin Mary</title>
+                            <title type="incomplete">Litany to the Virgin Mary</title>
                             <incipit xml:lang="gez">ማርያም፡ ድንግል፡ ሰአሊ፡ ለነ፡
                                 ወላዲተ፡ አምላክ፡ ሰአሊ፡ ለነ፡
                                 ማርያም፡ ቅድስት፡ ሰአሊ፡ ለነ፡
@@ -222,7 +222,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </msItem>
                         <msItem xml:id="ms_i10">
                             <locus from="79ra" to="85vb"/>
-                            <title ref="LIT000000000000000000000000000000000">Hymn to the Virgin Mary</title>
+                            <title>Hymn to the Virgin Mary</title>
                             <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ኦነፍስ፡ ኦነፍስ፡ ሶበሰ፡ ተአምሪ፡ መካነ፡ ደይን፡ ዘየኀድሩ፡ ውስቴታ፡ ዕቡያን፡ ወውስተ፡ 
                                 አጽናፊሃ፡ መፍርህ፡ እንዘ፡ ያንኵረኵርዎሙ፡ ለዝኁራን፡ ርእስኪ፡ </incipit>
                         </msItem>

--- a/LondonBritishLibrary/orient/BLorient8814.xml
+++ b/LondonBritishLibrary/orient/BLorient8814.xml
@@ -1,0 +1,538 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="BLorient8814" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Mazmura Dǝngǝl, Wǝddāse Māryām, ʾAnqaṣa bǝrhān, Sǝbḥata Dǝngǝl, prayers and hymns, genealogy of Ethiopian monks,
+                    Maṣḥafa śǝrʿat, Malkǝʾ of the Trinity, Miracles of the Virgin Mary</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS00001BL"/>
+                        <collection>Oriental</collection>
+                        <idno>BL Oriental 8814</idno>
+                        <altIdentifier><idno>Strelcyn 32</idno></altIdentifier>
+                        <altIdentifier><idno>Curzon, Cat. E7</idno></altIdentifier>
+                        <altIdentifier><idno>Parham 61</idno></altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                        <msItem xml:id="ms_i1">
+                            <locus from="1ra" to="36rb"/>
+                            <title ref="LIT3985Mazmura" type="incomplete"/>
+                            <msItem xml:id="ms_i1.1">
+                                <title type="incomplete">Interpolations to the Psalms</title>
+                                <note>Interpolations from <ref type="work" corresp="LIT3985Mazmura"/> to the 
+                                    <ref type="work" corresp="LIT2000Mazmur"/>.</note>
+                                <msItem xml:id="ms_i1.1.1">
+                                    <title ref="LIT6054MazDenIntro"/>
+                                    <incipit xml:lang="gez"><title>ተግሣጽ፡ ወሐተታ፡ ላዕለ፡ ምግባረ፡ ሠናያት።</title>
+                                        ውዳሴ፡ ዕበይኪ፡ ማርያም፡ እንተ፡ ጸሐፊ፡ በዐቅሙ። 
+                                        እስመ፡ ዖፈ፡ ሕለት፡ ገብርኪ፡ ለወልድኪ፡ ሤጠ፡ ደሙ።
+                                        መዝሙረ፡ ድንግል፡ ይኩን፡ እንዘ፡ ይብል፡ ትርጓሜ፡ ስሙ።
+                                        እምቃለ፡ ዳዊት፡ አስተዋጺኦ፡ እምጥንቱ፡ ወእስከ፡ ተፍጻሙ።
+                                        ለዘወደስኪ፡ ባርኪዮ፡ እሙ።</incipit>
+                                </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i1.2">
+                                <locus from="36va" to="38rb"/>
+                                <title type="incomplete">Interpolations to the Canticles</title>
+                                <note>Interpolations from <ref type="work" corresp="LIT3985Mazmura"/> to the 
+                                    <ref type="work" corresp="LIT1828Mahale"/>.</note>
+                                <incipit xml:lang="gez">ንሴብሖ፡ ለእግዚአብሔር፡ በስብሐተ፡ ነቢይ፡ ሙሴ።
+                                    ወእምዝ፡ ናተሉ፡ በእበይኪ፡ ውዳሴ።
+                                    ማርያም፡ በትር፡ ዘሠረፅኪ፡ እምስርወ፡ እሴ።
+                                    <supplied reason="undefined" resp="PRS8999Strelcyn">መፈ</supplied>ውሰ፡ ነፍስ፡ ወዘያነጽሕ፡ አባሴ።
+                                    እምውስተ፡ ጕንድኪ፡ ፀገየ፡ ቅዳሴ።</incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.3">
+                                <locus from="38va" to="39rb"/>
+                                <title type="incomplete">Interpolations to the Song of Songs</title>
+                                <note>Interpolations from <ref type="work" corresp="LIT3985Mazmura"/> to the 
+                                    <ref type="work" corresp="LIT2362Songof"/>.</note>
+                                <incipit xml:lang="gez">መኃልየ፡ መኃልይ፡ ዝውእቱ፡ ዘሰሎሞን፤
+                                    እምዝሙረ፡ ዳዊት፡ ዘይትሉ፡ ወእምስብሐተ፡ ሙሴ፡ ካህን።
+                                    አዳም፡ ይቤ፡ ጥበ፡ ዚአኪ፡ እምወይን።
+                                    ማርያም፡ ጥዕምተ፡ ስም፡ እምዕቍረ፡ ማይ፡ ዘልብን።
+                                    ወእምነ፡ ፀበል፡ በስሒን፡ ለምሥዋዕ፡ ዕዩን። </incipit>
+                            </msItem>    
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <locus from="39rb" to="42v"/>
+                            <title ref="LIT3622Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i3">
+                            <locus from="43ra" to="51ra"/>
+                            <title ref="LIT2509Weddas" type="incomplete"/>
+                            <note>Arranged by the days of the week, with Monday's lesson first.</note>
+                            <msItem xml:id="ms_i3.1">
+                                <locus from="43ra"/>
+                                <title ref="LIT2509Weddas#Monday" type="incomplete"/>
+                                <note>The beginning is missing.</note>
+                            </msItem>
+                            <msItem xml:id="ms_i3.2">
+                                <locus from="44rb"/>
+                                <title ref="LIT2509Weddas#Tuesday"/>
+                            </msItem>
+                            <msItem xml:id="ms_i3.3">
+                                <locus from="46rb"/>
+                                <title ref="LIT2509Weddas#Wednesday"/>
+                            </msItem>
+                            <msItem xml:id="ms_i3.4">
+                                <locus from="47ra"/>
+                                <title ref="LIT2509Weddas#Thursday"/>
+                            </msItem>
+                            <msItem xml:id="ms_i3.5">
+                                <locus from="48ra"/>
+                                <title ref="LIT2509Weddas#Friday"/>
+                            </msItem>
+                            <msItem xml:id="ms_i3.6">
+                                <locus from="48vb"/>
+                                <title ref="LIT2509Weddas#Saturday"/>
+                            </msItem>
+                            <msItem xml:id="ms_i3.7">
+                                <locus from="50ra"/>
+                                <title ref="LIT2509Weddas#Sunday"/>
+                            </msItem>       
+                        </msItem>
+                        <msItem xml:id="ms_i4">
+                            <locus from="51rb" to="53ra"/>
+                            <title ref="LIT1113Anqasa"/>
+                        </msItem>
+                        <msItem xml:id="ms_i5">
+                            <locus from="53rb" to="56va"/>
+                            <title ref="LIT4855SebhataDengel"/>
+                            <note>The composition is arranged for the days of the week beginning with Monday</note>
+                            <msItem xml:id="ms_i5.1">
+                                <locus from="54va"/>
+                                <title>Monday</title>
+                                <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ድርሳን፡ ዘስሙ፡ ስብሐተ፡ ድንግል፡ 
+                                    ዘደረሰ፡ <persName role="author" ref="PRS14380BahreyaDengel">ባሕርየ፡ ድንግል፡</persName> 
+                                    በኍልቈ፡ ፳ወ፪ዘመደ፡ ፈጥረታት፡ ዘፈጠሮሙ፡ እግዚአብሔር፡ በሰብዓቱ፡ ዕለታት፡ <gap reason="ellipsis"/>
+                                    ይሴብሐኪ፡ ጽልመት፡ እስመ፡ ወልድኪ፡ አቅደሞ።
+                                    እምፍትረተ፡ እሑድ፡ ሰመንቱ፡ ዘነቢብ፡ ወዘአርምሞ።
+                                    አኮኑ፡ ኃይልኪ፡ ለወጢን፡ ይፌጽሞ።
+                                    እስከ፡ ይፌጽም፡ ዘወጠ<pb n="53va"/>ንኩ፡ ስብሐታተኪ፡ ተርጕሞ።
+                                    መዓዛ፡ ቅዳሴ፡ ቅብዕኒ፡ ማርያም፡ አበሞ። <gap reason="ellipsis"/>
+                                </incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i5.2">
+                                <locus from="54vb"/>
+                                <title>Tuesday</title>
+                            </msItem>
+                            <msItem xml:id="ms_i5.3">
+                                <locus from="55ra"/>
+                                <title>Wednesday</title>
+                            </msItem>
+                            <msItem xml:id="ms_i5.4">
+                                <locus from="55va"/>
+                                <title>Thursday</title>
+                            </msItem>
+                            <msItem xml:id="ms_i5.5">
+                                <locus from="56ra"/>
+                                <title>Friday</title>
+                            </msItem>
+                            <msItem xml:id="ms_i5.6">
+                                <locus from="56rb"/>
+                                <title>Saturday</title>
+                            </msItem>
+                            <msItem xml:id="ms_i5.7">
+                                <locus from="56va"/>
+                                <title>Sunday</title>
+                            </msItem>
+                        </msItem>
+                        <msItem xml:id="ms_i6">
+                            <locus from="56vb" to="63vb"/>
+                            <title>Prayer for all the days of the week</title>
+                            <msItem xml:id="ms_i6.1">
+                                <locus from="56vb"/>
+                                <title>Monday</title>
+                                <incipit xml:lang="gez">ጸሎት፡ ዘሰኑይ፡ ኦእግዚእየ፡ ሔር፡ አምላክ፡ ዓቢይ፡ ወግሩም። ዘአልቦ፡ ጥንተ፡ ወኢተፍጻሜተ።</incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i6.2">
+                                <locus from="57ra"/>
+                                <title>Tuesday</title>
+                            </msItem>
+                            <msItem xml:id="ms_i6.3">
+                                <locus from="58ra"/>
+                                <title>Wednesday</title>
+                            </msItem>
+                            <msItem xml:id="ms_i6.4">
+                                <locus from="59ra"/>
+                                <title>Thursday</title>
+                            </msItem>
+                            <msItem xml:id="ms_i6.5">
+                                <locus from="60rb"/>
+                                <title>Friday</title>
+                            </msItem>
+                            <msItem xml:id="ms_i6.6">
+                                <locus from="61rb"/>
+                                <title>Saturday</title>
+                            </msItem>
+                            <msItem xml:id="ms_i6.7">
+                                <locus from="62ra"/>
+                                <title>Sunday</title>
+                            </msItem>
+                        </msItem>
+                        <msItem xml:id="ms_i7">
+                            <locus from="65ra" to="75rb"/>
+                            <title ref="LIT000000000000000000000000000000000000">Prayer</title>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ዓለም፡ ልብና፡ እግዚአብሔር፡ ዘክዱን፡ ብከ፡ ዕበይከ፡ ወስውር፡ ብከ፡ ኃይልከ፡ በከመ፡ ሰወርኮ፡
+                                እምዓይነ፡ ሞት፡ ለሄኖክ፡ ነቢይ፡ በተአምኖ፡ ዘአስመረከ፡ ክድነኒ፡ ወሰውረኒ፡ በክንፈ፡ ረድኤትከ፡ እምኀፅ፡ ዘይሰርር፡ በመዓልት፡ ወእምግብር፡ ዘየሐውር፡ በጽልመት፡ 
+                            </incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i8">
+                            <locus from="75rb" to="77ra"/>
+                            <title ref="LIT000000000000000000000000000000000000" type="incomplete">Litany to the Virgin Mary</title>
+                            <incipit xml:lang="gez">ማርያም፡ ድንግል፡ ሰአሊ፡ ለነ፡
+                                ወላዲተ፡ አምላክ፡ ሰአሊ፡ ለነ፡
+                                ማርያም፡ ቅድስት፡ ሰአሊ፡ ለነ፡
+                                ማርያም፡ ንጽሕት፡ ሰአሊ፡ ለነ፡ </incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i9">
+                            <locus from="77ra" to="78rb"/>
+                            <title ref="LIT6948GenealogyMonks"/>
+                            <note>The following note <q xml:lang="gez">እምደብረ፡ ሊባኖስ፡ </q> was written at the end of this text, in the margin. The 
+                                name 'Dabra Libānos' can be identified with either <placeName ref="INS0346DL"/> or 
+                                <placeName ref="INS0341DL"/>.</note>
+                            <incipit xml:lang="gez">ወእምድኅሬሁ፡ ያንብቡ፡ ዘንተ፡ መጽሐፈ፡ ልደቶሙ፡ ለአበው፡ መ<cb n="77rb"/>ነኮሳት፡ 
+                                እንጦ<supplied reason="undefined" resp="PRS8999Strelcyn">ን</supplied>ስ፡ ወልዶ፡ ለመቃርስ፡ መቃርስ፡ ወለዶ፡ ለጳኵሚስ፡ 
+                                ጳኵሚስ፡ ወለዶ፡ ለአረጋዊ፡ ዘደሞ፡ አረጋዊ፡ ወለዶ፡ ለመስቀል፡ ሞአ። ወመስቀል፡ ሞአ፡ ወለዶ፡ ለክርስቶስ፡ ቤዛነ። ወክርስቶስ፡ ቤዛነ፡ ወለዶ፡ ለዮሐኒ። ዮሐኒ፡ ወለዶ፡ 
+                                ለኢየሱስ፡ ሞአ፡ በቀሚስ፡ ወበቅናት። ኢየሱስ፡ ሞአ፡ ወለዶ፡ ለአቡነ፡ ተክለ፡ ሃይማኖት፡ በቀሚስ፡ ወበቅናት፡ ነሥአ፡ ቆብዓ፡ ወአስኬማ፡ በደብረ፡ ዳሞ፡ በእደ፡ አቡነ፡ ዮሐኒ። 
+                                ወእምዝ፡ አቡነ፡ <pb n="77va"/> ተክለ፡ ሃይማኖት፡ ተመይጠ፡ እምድኅረ፡ ነሥአ፡ ቆብዐ፡ ወአስኬማ፡ ኀበ፡ 
+                                <placeName ref="LOC3832Hayq">ሐይቅ፡ ባሕር፡</placeName> ወወሀቦ፡ ለአቡሁ፡ ኢየሱስ፡ ሞአ፡ </incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i10">
+                            <locus from="79ra" to="85vb"/>
+                            <title ref="LIT000000000000000000000000000000000">Hymn to the Virgin Mary</title>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ኦነፍስ፡ ኦነፍስ፡ ሶበሰ፡ ተአምሪ፡ መካነ፡ ደይን፡ ዘየኀድሩ፡ ውስቴታ፡ ዕቡያን፡ ወውስተ፡ 
+                                አጽናፊሃ፡ መፍርህ፡ እንዘ፡ ያንኵረኵርዎሙ፡ ለዝኁራን፡ ርእስኪ፡ </incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i11">
+                            <locus from="86ra" to="92v"/>
+                            <title ref="LIT1968Mashaf"/>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ዝንቱ፡ መጸሐፈ፡ ሥርዓት፡ ዘይትነበብ፡ እምቅድመ፡ ያንብቡ፡ ተአምሪሃ፡ ለእግዝእትነ፡ 
+                                ማርያም፡ ወላዲተ፡ አምላክ። ዘወፅአ፡ እመንበረ፡ ማርቆስ፡ ሐዋርያ፡ እመካነ፡ ማዕለቃ፡ ዘምስር። ዘአንበሩ፡ መምህራን፡ ወሊቃውንት፡ ሊቃነ፡ ጳጳሳት፡ ክቡራን። መጋብያነ፡ 
+                                ምሥጢር፡ ርቱዓነ፡ ሃይማኖት፡ ዘትትናገሮሙ፡ እግ<cb n="86rb"/>ዝእትነ፡ ማርያም፡ ዘልፈ።</incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i12">
+                            <locus from="94ra" to="96ra"/>
+                            <title ref="LIT2908RepCh189" type="incomplete"/>
+                            <note>One stanza is missing. A part of <locus from="95rb" to="95va"/> and <locus target="#96ra"/> has been left blank.</note>
+                        </msItem>
+                        <msItem xml:id="ms_i13">
+                            <locus from="96ra" to="97vb"/>
+                            <title ref="LIT6947HymnJesus" type="incomplete">Hymn to Jesus Christ</title>
+                            <note>The beginnings of all the twelve stanzas are missing, the spaces for rubrication having been left unfilled.</note>
+                            <incipit xml:lang="gez"><supplied reason="lost" resp="CH">ይትባረክ፡ እግዚአብሔር፡ ለባሕረ፡ ኤርትራ፡</supplied>
+                                ዘ<supplied reason="omitted" resp="CH">ሠ</supplied>ጠጣ። 
+                                እስራኤል፡ ወይሁዳ፡ ኃለፉ፡ በውሥጣ፤
+                                በክቡር፡ ደሙ፡ ለነፍስየ፡ ዘተሣየጣ።
+                                ካዕበኒ፡ በሰበነ፡ ርእሱ፡ ዘሦጣ።
+                                ለማር<supplied reason="undefined" resp="PRS8999Strelcyn">ያም</supplied>፡ ድንግል፡ አፍአ፡ ወውሥጣ። </incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i14">
+                            <locus from="98ra" to="166vb"/>
+                            <title ref="LIT2384Taamme"/>
+                            <note>Thirty-two in number. Each Miracle is accompanied by a stanza of four lines relevant to the story.</note>
+                            <msItem xml:id="ms_i14.1">
+                                <locus from="98ra"/>
+                                <title ref="LIT3586Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.2">
+                                <locus from="100vb"/>
+                                <title ref="LIT3588Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.3">
+                                <locus from="101ra"/>
+                                <title ref="LIT3589Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.4">
+                                <locus from="103va"/>
+                                <title ref="LIT3590Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.5">
+                                <locus from="104vb"/>
+                                <title ref="LIT3591Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.6">
+                                <locus from="106va"/>
+                                <title ref="LIT3592Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.7">
+                                <locus from="108vb"/>
+                                <title ref="LIT3593Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.8">
+                                <locus from="110vb"/>
+                                <title ref="LIT3594Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.9">
+                                <locus from="112vb"/>
+                                <title ref="LIT3595Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.10">
+                                <locus from="114ra"/>
+                                <title ref="LIT3596Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.11">
+                                <locus from="117vb"/>
+                                <title ref="LIT3597Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.12">
+                                <locus from="119va"/>
+                                <title ref="LIT3598Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.13">
+                                <locus from="121vb"/>
+                                <title ref="LIT3599Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.14">
+                                <locus from="123va"/>
+                                <title ref="LIT3600Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.15">
+                                <locus from="126ra"/>
+                                <title ref="LIT3601Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.16">
+                                <locus from="128ra"/>
+                                <title ref="LIT3602Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.17">
+                                <locus from="131ra"/>
+                                <title ref="LIT3603Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.18">
+                                <locus from="133va"/>
+                                <title ref="LIT3604Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.19">
+                                <locus from="135ra"/>
+                                <title ref="LIT3605Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.20">
+                                <locus from="136rb"/>
+                                <title ref="LIT3606Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.21">
+                                <locus from="138rb"/>
+                                <title ref="LIT3607Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.22">
+                                <locus from="140vb"/>
+                                <title ref="LIT3608Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.23">
+                                <locus from="142rb"/>
+                                <title ref="LIT3609Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.24">
+                                <locus from="144ra"/>
+                                <title ref="LIT3610Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.25">
+                                <locus from="146ra"/>
+                                <title ref="LIT3617Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.26">
+                                <locus from="149vb"/>
+                                <title ref="LIT3612Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.27">
+                                <locus from="150ra"/>
+                                <title ref="LIT3613Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.28">
+                                <locus from="153rb"/>
+                                <title ref="LIT5102MiracleIconQalamon"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.29">
+                                <locus from="156vb"/>
+                                <title ref="LIT3615Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.30">
+                                <locus from="160rb"/>
+                                <title ref="LIT3616Miracle"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.31">
+                                <locus from="163ra"/>
+                                <title ref="LIT5110MiraclePilgrimage"/>
+                            </msItem>
+                            <msItem xml:id="ms_i14.32">
+                                <locus from="165va"/>
+                                <title ref="LIT3618Miracle"/>
+                            </msItem>
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Codex">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf">3+166+2</measure>
+                                    <measure unit="page" type="blank">7</measure>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>140</height>
+                                        <width>125</width>
+                                    </dimensions>
+                                </extent></supportDesc>
+                            <layoutDesc>
+                                <layout columns="2" writtenLines="17"/>
+                            </layoutDesc>
+                        </objectDesc> 
+                        <handDesc>
+                            <handNote script="Ethiopic" xml:id="h1">
+                                <desc>Good handwriting.</desc>
+                                <date notBefore="1700" notAfter="1799" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                        </handDesc>
+                        <decoDesc>
+                            <decoNote xml:id="d1" type="miniature">
+                                <locus target="#64r #64v #78r #93v"/>
+                                <desc>Miniatures.</desc>
+                            </decoNote>
+                        </decoDesc>
+                        <additions>
+                            <list>
+                                <item xml:id="a1">
+                                    <desc type="GuestText">Magical prayer against hail written by a second hand</desc>
+                                    <q xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> አብ፡ ቍሔት፡ ወልድ፡ ቍሔት፡ መንፈስ፡ ቅዱስ፡ ቍሔት፡ <gap reason="ellipsis"/>
+                                        ኢታወርድ፡ በረደ፡ በምድረ፡ እገሌ፡ ዘእንበለ፡ ጽሩየ፡ ማየ፡ <gap reason="ellipsis"/></q>
+                                </item>
+                                <item xml:id="e1">
+                                    <locus target="#Ir"/>
+                                    <desc type="AcquisitionNote"/>
+                                    <q xml:lang="en">Bequeathed by <persName role="bequeather" ref="PRS14320DareaCurzon">Darea 
+                                        <roleName type="title">Baroness</roleName> Zouche</persName>. <date when="1917">13 Oct. 1917</date>.</q>
+                                </item>
+                                <item xml:id="e2">
+                                    <locus target="#65rb"/>
+                                    <desc type="OwnershipNote">The first owner was <persName role="owner" ref="PRS14385WaldaMadhen"/>. 
+                                        His name is inscribed on several folios.</desc>
+                                </item>
+                                <item xml:id="e3">
+                                    <locus target="#39rb"/>
+                                    <desc type="OwnershipNote">The second owner was <persName role="owner" ref="PRS14386WalattaYohannes"/>.
+                                        Her name is inscribed on several folios.</desc>
+                                </item>
+                                <item xml:id="e4">
+                                    <desc type="OwnershipNote">Name of an owner: <persName role="owner" ref="PRS14387KenfaMikael"/></desc>
+                                </item>
+                                <item xml:id="e5">
+                                    <desc type="OwnershipNote">Name of an owner: <persName role="owner" ref="PRS14388DemsaMikael"/></desc>
+                                </item>
+                                <item xml:id="e6">
+                                    <desc type="OwnershipNote">Name of an owner: <persName role="owner" ref="PRS14389GabraMQ"/></desc>
+                                </item>
+                                <item xml:id="e7">
+                                    <locus target="#2v"/>
+                                    <desc>Pen trials.</desc>  
+                                </item>
+                                <item xml:id="e8">
+                                    <locus target="#2v"/>
+                                    <desc type="StampExlibris">Note</desc>
+                                    <q xml:lang="la">Liturgia et Cantica Ecclesiae Aethiopicae</q>
+                                </item>
+                            </list>
+                        </additions>
+                        <bindingDesc>
+                            <binding xml:id="binding">
+                                <decoNote xml:id="b1"/>
+                                <decoNote type="bindingMaterial" xml:id="b2"><material key="wood">Wooden boards</material>, repaired in the
+                                    <placeName ref="INS00001BL">British Museum</placeName>.</decoNote>
+                                <decoNote xml:id="b3" type="Cover"><material key="leather">Leather back.</material></decoNote>
+                            </binding>
+                        </bindingDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1700" notAfter="1799">18th century</origDate>
+                        </origin>
+                        <provenance>According to <bibl><ptr target="bm:Emmel2023Curzon"/><citedRange unit="page">236-241</citedRange>
+                            </bibl> acquired by <persName ref="PRS3244Curzon"/> during his stay in Egypt in 
+                            <date notBefore="1837" notAfter="1838">1837-1838</date>. Three years after his death on 
+                            <date when="1876-04-19">19 April 1876</date>the codex was given as a deposit on loan to the British Museum 
+                            (later: <placeName ref="INS00001BL">British Library</placeName>), then as a bequest from his daughter 
+                            <persName ref="PRS14320DareaCurzon">Darea</persName> in <date when="1917-10-13">13 October 1917</date> 
+                            as inscribed in a note on the front flyleaf.</provenance>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                            <citedRange unit="page">44-48</citedRange>
+                                        </bibl> 
+                                    </listBibl>
+                                    <listBibl type="secondary">
+                                        <bibl>
+                                            <ptr target="bm:Emmel2023Curzon"/>
+                                            <citedRange unit="page">236-241</citedRange>
+                                        </bibl>
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="Apocrypha"/>
+                    <term key="Miracle"/>
+                    <term key="ChristianContent"/>
+                    <term key="ChristianLiterature"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+                <language ident="la">Latin</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-02-02">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listBibl type="catalogue">
+                    <bibl>
+                        <ptr target="bm:Curzon1849Catalogue"/>
+                    </bibl>
+                </listBibl>
+            </div>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I created a record for BLorient8814 as described in S. Strelcyns catalogue.

I created two LIT IDs for ms_i9 and ms_i13 as described in https://github.com/BetaMasaheft/Documentation/issues/2505. For the other texts in question (ms_i7, ms_i8 and ms_i10 = a), b), d) in the issue) I preferred to wait for your opinion before creating LIT IDs for them.