### PR TITLE
Corrected BL records (blank leaves)

### DIFF
--- a/LondonBritishLibrary/orient/BLorient12510.xml
+++ b/LondonBritishLibrary/orient/BLorient12510.xml
@@ -47,7 +47,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </support>
                                 <extent>
                                     <measure unit="leaf">1+73+1</measure>
-                                    <measure unit="leaf" type="blank" corresp="#2v #II">2</measure>
+                                    <measure unit="leaf" type="blank">2</measure><locus target="#2v #II"/>
                                     <dimensions type="outer" unit="mm">
                                         <height>145</height>
                                         <width>102</width>

--- a/LondonBritishLibrary/orient/BLorient12511.xml
+++ b/LondonBritishLibrary/orient/BLorient12511.xml
@@ -44,7 +44,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </support>
                                 <extent>
                                     <measure unit="leaf">104</measure>
-                                    <measure unit="leaf" type="blank" corresp="#3r #4v">2</measure>
+                                    <measure unit="leaf" type="blank">2</measure><locus target="#3r #4v"/>
                                     <dimensions type="outer" unit="mm">
                                         <height>75</height>
                                         <width>60</width>

--- a/LondonBritishLibrary/orient/BLorient12514.xml
+++ b/LondonBritishLibrary/orient/BLorient12514.xml
@@ -45,7 +45,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </support>
                                 <extent>
                                     <measure unit="leaf">52</measure>
-                                    <measure unit="leaf" type="blank" corresp="#1r #52v">2</measure>
+                                    <measure unit="leaf" type="blank">2</measure><locus target="#1r #52v"/>
                                     <dimensions type="outer" unit="mm">
                                         <height>77</height>
                                         <width>53</width>

--- a/LondonBritishLibrary/orient/BLorient13156.xml
+++ b/LondonBritishLibrary/orient/BLorient13156.xml
@@ -40,7 +40,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </support>
                                 <extent>
                                     <measure unit="leaf">161</measure>
-                                    <measure unit="page" type="blank">46r, 112r, 127r, 144r</measure>
+                                    <measure unit="page" type="blank">4</measure><locus target="#46r #112r #127r #144r"/>
                                     <dimensions type="outer" unit="mm">
                                         <height>115</height>
                                         <width>92</width>

--- a/LondonBritishLibrary/orient/BLorient13265.xml
+++ b/LondonBritishLibrary/orient/BLorient13265.xml
@@ -83,7 +83,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </support>
                                 <extent>
                                     <measure unit="leaf">90</measure>
-                                    <measure unit="leaf" type="blank" corresp="#1 #2r #57v #58r #89v #90">6</measure>
+                                    <measure unit="page" type="blank">8</measure><locus target="#1r #1v #2r #57v #58r #89v #90r #90v"/>
                                     <dimensions type="outer" unit="mm">
                                         <height>210</height>
                                         <width>115</width>

--- a/LondonBritishLibrary/orient/BLorient13271.xml
+++ b/LondonBritishLibrary/orient/BLorient13271.xml
@@ -50,7 +50,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </support>
                                 <extent>
                                     <measure unit="leaf">42</measure>
-                                    <measure unit="leaf" type="blank" corresp="#1 #2 #39 #42v">4</measure>
+                                    <measure unit="leaf" type="blank">4</measure><locus target="#1 #2 #39 #42v"/>
                                     <dimensions type="outer" unit="mm">
                                         <height>75</height>
                                         <width>55</width>

--- a/LondonBritishLibrary/orient/BLorient6466.xml
+++ b/LondonBritishLibrary/orient/BLorient6466.xml
@@ -341,7 +341,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </support>
                                     <extent>
                                         <measure unit="leaf">2</measure>
-                                        <measure unit="leaf" type="blank" corresp="#IIr">1</measure>
+                                        <measure unit="leaf" type="blank">1</measure><locus target="#IIr"/>
                                         <dimensions type="outer" unit="mm">
                                             <height>214</height>
                                             <width>80 98</width>

--- a/LondonBritishLibrary/orient/BLorient8822.xml
+++ b/LondonBritishLibrary/orient/BLorient8822.xml
@@ -66,7 +66,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </support>
                                 <extent>
                                     <measure unit="leaf">1+88+2</measure>
-                                    <measure unit="leaf" type="blank" corresp="#1v #III">2</measure>
+                                    <measure unit="leaf" type="blank">2</measure><locus target="#1v #III"/>
                                     <dimensions type="outer" unit="mm">
                                         <height>240</height>
                                         <width>190</width>

--- a/LondonBritishLibrary/orient/BLorient8824.xml
+++ b/LondonBritishLibrary/orient/BLorient8824.xml
@@ -278,7 +278,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </support>
                                 <extent>
                                     <measure unit="leaf">1+179+1</measure>
-                                    <measure unit="page" type="blank" corresp="#Iv #1r #83v #125v #178v #IIr #IIv">6</measure>
+                                    <measure unit="page" type="blank">7</measure><locus target="#Iv #1r #83v #125v #178v #IIr #IIv"/>
                                     <dimensions type="outer" unit="mm">
                                         <height>270</height>
                                         <width>240</width>


### PR DESCRIPTION
I corrected the encoding of blank leaves in nine records as requested by Eugenia in https://github.com/BetaMasaheft/Manuscripts/pull/2327. I had a look in all records of BL, that I have created in the last three months and that are already merged.