### PR TITLE
Create BLorient8813 according to Strelcyn

### DIFF
--- a/EMIP/1-1000/EMIP00126.xml
+++ b/EMIP/1-1000/EMIP00126.xml
@@ -43,8 +43,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                     </msItem>
                     <msItem xml:id="ms_i1.2"><locus from="94v" to="104r" facs="097"/><title type="complete" ref= "LIT1828Mahale"/></msItem>
                     <msItem xml:id="ms_i1.3"><locus from="105r" to="111v" facs="107"/><title type="complete" ref="LIT2362Songof"/><note>The variant form known as ǝbǝrayǝsṭ, or Hebraic version</note></msItem>
-                    <msItem xml:id="ms_i1.4"><locus from="105r" to="111v" facs="107"/><title type="complete" ref="LIT2509Weddas"/><note>arranged for the days of the week</note></msItem>
-                    <msItem xml:id="ms_i1.5"><locus from="123r" to="126v" facs="125"/><title type="complete" ref="LIT1113Anqasa"/></msItem>
+                    <msItem xml:id="ms_i1.4"><locus from="112ra" to="123ra" facs="107"/><title type="complete" ref="LIT2509Weddas"/><note>arranged for the days of the week</note></msItem>
+                    <msItem xml:id="ms_i1.5"><locus from="123ra" to="126vb" facs="125"/><title type="complete" ref="LIT1113Anqasa"/></msItem>
                   </msItem>
                <msItem xml:id="ms_i2">
                     <locus from="112r" to="114r" facs="114"/>

--- a/LondonBritishLibrary/orient/BLorient8813.xml
+++ b/LondonBritishLibrary/orient/BLorient8813.xml
@@ -34,13 +34,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <msContents>
                         <msItem xml:id="ms_i1">
                             <locus from="1r" to="16v"/>
-                            <title ref="LIT1938Mashaf">Kidān</title>
-                            <note>VelatI, pp. 1-6; II, pp. 170-4.</note>
+                            <title ref="LIT2260salota"/>
                         </msItem>
                         <msItem xml:id="ms_i2">
                             <locus from="17r" to="29r"/>
-                            <title ref="LIT2444Temher">Tǝmḥǝrta ḫǝbuʾat</title>
-                            <note>Cf. Velat I, pp. 30-3; II pp. 279-283.</note>
+                            <title ref="LIT2444Temher"/>
                         </msItem>
                         <msItem xml:id="ms_i3">
                             <locus from="29r" to="36r"/>

--- a/LondonBritishLibrary/orient/BLorient8813.xml
+++ b/LondonBritishLibrary/orient/BLorient8813.xml
@@ -109,7 +109,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <item xml:id="e1">
                                     <locus target="#I"/>
                                     <desc type="OwnershipNote"/>
-                                    <q>Bequeathed by <persName role="bequeather" ref="PRS14320DareaCurzon">Darea
+                                    <q xml:lang="en">Bequeathed by <persName role="bequeather" ref="PRS14320DareaCurzon">Darea
                                         <roleName type="title">Baroness</roleName> Zouche</persName>. <date when="1917-10-13">13 Oct. 1917</date>.</q>
                                 </item>
                             </list>

--- a/LondonBritishLibrary/orient/BLorient8813.xml
+++ b/LondonBritishLibrary/orient/BLorient8813.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="BLorient8813" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Liturgical Prayers</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS00001BL"/>
+                        <collection>Oriental</collection>
+                        <idno>BL Oriental 8813</idno>
+                        <altIdentifier><idno>Strelcyn 34</idno></altIdentifier>
+                        <altIdentifier><idno>Curzon, Cat. E8</idno></altIdentifier>
+                        <altIdentifier><idno>Parham 62</idno></altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                        <msItem xml:id="ms_i1">
+                            <locus from="1r" to="16v"/>
+                            <title ref="LIT1938Mashaf">Kidān</title>
+                            <note>VelatI, pp. 1-6; II, pp. 170-4.</note>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <locus from="17r" to="29r"/>
+                            <title ref="LIT2444Temher">Tǝmḥǝrta ḫǝbuʾat</title>
+                            <note>Cf. Velat I, pp. 30-3; II pp. 279-283.</note>
+                        </msItem>
+                        <msItem xml:id="ms_i3">
+                            <locus from="29r" to="36r"/>
+                            <title ref="LIT3083RepCh363">ʾƎgziʾabǝḥer za-bǝrhānāt</title>
+                        </msItem>
+                        <msItem xml:id="ms_i4">
+                            <locus from="36r" to="43v"/>
+                            <title ref="LIT1960Mashaf"/>
+                            <incipit xml:lang="gez">በእንተ፡ ቅድስት፡ ሰማያዊት፡ ሰላመ፡ ናስተበቍዕ፡ ከመ፡ እግዚአብሔር፡ ያስተሳልመነ፡ በሣህለ፡ ዚአሁ፡ </incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i5">
+                            <locus from="43v" to="64v"/>
+                            <title ref="LIT1398Fethat"/>
+                        </msItem>
+                        <msItem xml:id="ms_i6">
+                            <locus from="65r" to="77v"/>
+                            <title ref="LIT3012RepCh292"/>
+                            <incipit xml:lang="gez">ንዒ፡ ማርያም። 
+                                እንዘ፡ ትነብሪ፡ በአር<supplied reason="undefined" resp="PRS8999Strelcy">ያ</supplied>ም፡ 
+                                ወንዒ፡ ፍቅርየ፡ ዘገነት፡ ኤዶም። 
+                                ሃሌ፡ ሉያ፡ ሃሌ፡ ሉያ፡ ሃሌ፡ ሉያ፡ 
+                                ብፀዕት፡ አንቲ፡ ወንግሥተ፡ ጽድቅ። 
+                                ዘትሜንንኒ፡ ማርያም፡ መንገለ፡ ምስራቅ። 
+                                ታቦትነ፡ አንቲ፡ እንተ፡ ወርቅ። 
+                                ሃሃሃ። </incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i7">
+                            <locus from="77v" to="84r"/>
+                            <title ref="LIT2801RepCh85"/>
+                            <incipit xml:lang="gez">ሰላም፡ ለከ፡ ጊዮርጊስ፡ ናሁ፡ ወጠንኩ፡ ዝክረ፡ ውዳሴከ፡ ባሕቱ፡ ምንትኑ፡ ውዳሴከ። ወምንት፡ ውእቱ፡ አምሳ<pb n="78r"/>ሊከ። 
+                                ሃሃሃ፡ ዘሐረጸከ፡ ዱድያኖስ፡ ወወገረከ፡ ደብረ፡ ይድራስ። </incipit>
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Codex">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>
+                                    <material key="paper">Paper endleaves added during repair in the 
+                                        <placeName ref="INS00001BL">British Museum</placeName>.</material>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf">1+1+84</measure>
+                                    <measure unit="page" type="blank">2</measure><locus target="#IIv #84v"/>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>120</height>
+                                        <width>67</width>
+                                    </dimensions>
+                                </extent></supportDesc>
+                            <layoutDesc>
+                                <layout columns="1" writtenLines="13"></layout>
+                            </layoutDesc>
+                        </objectDesc> 
+                        <handDesc>
+                            <handNote script="Ethiopic" xml:id="h1">
+                                <desc>Careful handwriting.</desc>
+                                <date notBefore="1600" notAfter="1800" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                        </handDesc>
+                        <additions>
+                            <list>
+                                <item xml:id="a1">
+                                    <locus target="#IIr"/>
+                                    <desc type="GuestText">A medical prescription.</desc>
+                                </item>
+                                <item xml:id="e1">
+                                    <locus target="#I"/>
+                                    <desc type="OwnershipNote"/>
+                                    <q>Bequeathed by <persName role="bequeather" ref="PRS14320DareaCurzon">Darea
+                                        <roleName type="title">Baroness</roleName> Zouche</persName>. <date when="1917-10-13">13 Oct. 1917</date>.</q>
+                                </item>
+                            </list>
+                        </additions>
+                        <bindingDesc>
+                            <binding xml:id="binding">
+                                <decoNote xml:id="b1"/>
+                                <decoNote type="bindingMaterial" xml:id="b2"><material key="wood">Wooden boards with engraved ornamentation</material>.</decoNote>
+                                <decoNote xml:id="b3" type="Cover"><material key="leather">Leather back added during repair in the 
+                                    <placeName ref="INS00001BL">British Museum</placeName>.</material></decoNote>
+                            </binding>
+                        </bindingDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1600" notAfter="1800">17th/18th century</origDate>
+                        </origin>
+                        <provenance>According to <bibl><ptr target="bm:Emmel2023Curzon"/><citedRange unit="page">236-241</citedRange>
+                        </bibl> acquired by <persName ref="PRS3244Curzon"/> during his stay in Egypt in 
+                            <date notBefore="1837" notAfter="1838">1837-1838</date>. Three years after his death on 
+                            <date when="1876-04-19">19 April 1876</date>the codex was given as a deposit on loan to the British Museum 
+                            (later: <placeName ref="INS00001BL">British Library</placeName>), then as a bequest from his daughter 
+                            <persName ref="PRS14320DareaCurzon">Darea</persName> in <date when="1917-10-13">13 October 1917</date> 
+                            as inscribed in a note on the front endleaf.</provenance>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                            <citedRange unit="page">50</citedRange>
+                                        </bibl> 
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianContent"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="Chants"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-02-02">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listBibl type="catalogue">
+                    <bibl>
+                        <ptr target="bm:Curzon1849Catalogue"/>
+                    </bibl>
+                </listBibl>
+                <listBibl type="secondary">
+                    <bibl>
+                        <ptr target="bm:Emmel2023Curzon"/>
+                        <citedRange unit="page">236-241</citedRange>
+                    </bibl>
+                </listBibl>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/LondonBritishLibrary/orient/BLorient8813.xml
+++ b/LondonBritishLibrary/orient/BLorient8813.xml
@@ -44,12 +44,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </msItem>
                         <msItem xml:id="ms_i3">
                             <locus from="29r" to="36r"/>
-                            <title ref="LIT3083RepCh363">ʾƎgziʾabǝḥer za-bǝrhānāt</title>
+                            <title ref="LIT3083RepCh363"/>
                         </msItem>
                         <msItem xml:id="ms_i4">
                             <locus from="36r" to="43v"/>
-                            <title ref="LIT1960Mashaf"/>
+                            <title ref="LIT1960Mashaf#SerataQeddaseChapter3" type="incomplete">Excerpt from Śǝrʿāta Qǝddāse</title>
                             <incipit xml:lang="gez">በእንተ፡ ቅድስት፡ ሰማያዊት፡ ሰላመ፡ ናስተበቍዕ፡ ከመ፡ እግዚአብሔር፡ ያስተሳልመነ፡ በሣህለ፡ ዚአሁ፡ </incipit>
+                            <note>Excerpt from chapter III, starting from §66 as attested in 
+                                <bibl><ptr target="bm:1962Qeddase"/><citedRange unit="page">26</citedRange></bibl>.</note>
                         </msItem>
                         <msItem xml:id="ms_i5">
                             <locus from="43v" to="64v"/>

--- a/LondonBritishLibrary/orient/BLorient8824.xml
+++ b/LondonBritishLibrary/orient/BLorient8824.xml
@@ -339,7 +339,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <decoNote type="bindingMaterial" xml:id="b2"><material key="wood"/></decoNote>
                                 <decoNote xml:id="b3" type="Cover"><material key="leather">Stamped leather over wooden boards, repaired in the 
                                     <placeName ref="INS00001BL">British Museum</placeName>.</material></decoNote>
-                                <decoNote xml:id="b4" type="EndLeaves">Flyleaves of paper added in rebinding in the 
+                                <decoNote xml:id="b4" type="EndLeaves">Endleaves of paper added in rebinding in the 
                                     <placeName ref="INS00001BL"/>.</decoNote>
                             </binding>
                         </bindingDesc>
@@ -354,7 +354,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <date when="1876-04-19">19 April 1876</date>the codex was given as a deposit on loan to the British Museum 
                             (later: <placeName ref="INS00001BL">British Library</placeName>), then as a bequest from his daughter 
                             <persName ref="PRS14320DareaCurzon">Darea</persName> in <date when="1917-10-10">10 October 1917</date> 
-                            as inscribed in a note on the front flyleaf.</provenance>
+                            as inscribed in a note on the front endleaf.</provenance>
                     </history>
                     <additional>
                         <adminInfo>


### PR DESCRIPTION
I created a record for BLorient8813 according to S. Strelcyns description. For ms_i1 and ms_i2, I am not pretty sure, whether my assumptions are correct and I would like to have a glance to Velats edition before merging, as I outlined in https://github.com/BetaMasaheft/Documentation/issues/2507. For ms_i4, I LIT1960Mashaf, as we discussed in https://github.com/BetaMasaheft/Documentation/issues/2506. Furthermore, I made some minor correction in EMIP00126 and BLorient8824, which I came across.