### PR TITLE
Create BLorient13269

### DIFF
--- a/LondonBritishLibrary/orient/BLorient13269.xml
+++ b/LondonBritishLibrary/orient/BLorient13269.xml
@@ -32,7 +32,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <msContents>
                         <msItem xml:id="ms_i1">
                             <locus from="1r" to="5r"/>
-                            <title ref="LIT00000000000000000"/>
+                            <title ref="LIT6957HassabaHegg"/>
                             <incipit xml:lang="gez">በዘንዜክር፡ ሐሳበ፡ ሕጉ፡ እምትእዛዙ፡ 
                                 ለእ<supplied reason="undefined" resp="PRS8999Strelcyn">ግ</supplied>ዚእነ፡ 
                                 ኢየሱ<supplied reason="undefined" resp="PRS8999Strelcyn">ስ፡</supplied> 

--- a/LondonBritishLibrary/orient/BLorient13269.xml
+++ b/LondonBritishLibrary/orient/BLorient13269.xml
@@ -32,7 +32,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <msContents>
                         <msItem xml:id="ms_i1">
                             <locus from="1r" to="5r"/>
-                            <title ref="LIT6563HassabHeg"/>
+                            <title ref="LIT00000000000000000"/>
                             <incipit xml:lang="gez">በዘንዜክር፡ ሐሳበ፡ ሕጉ፡ እምትእዛዙ፡ 
                                 ለእ<supplied reason="undefined" resp="PRS8999Strelcyn">ግ</supplied>ዚእነ፡ 
                                 ኢየሱ<supplied reason="undefined" resp="PRS8999Strelcyn">ስ፡</supplied> 
@@ -51,7 +51,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </msItem>
                         <msItem xml:id="ms_i2">
                             <locus from="5r" to="13r"/>
-                            <title ref="LIT0000000000000000000000000">Kidān</title>
+                            <title>Kidān</title>
+                            <note>Entitled <foreign xml:lang="gez">Kidān</foreign> in the catalague, what is in fact probably 
+                                <ref type="work" corresp="LIT2260salota "/> or <ref type="work" corresp="LIT1938Mashaf"/>, but cannot be verified,
+                                because of lack of available images.</note>
                         </msItem>
                         <msItem xml:id="ms_i3">
                             <locus from="13v" to="15v"/>

--- a/LondonBritishLibrary/orient/BLorient13269.xml
+++ b/LondonBritishLibrary/orient/BLorient13269.xml
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="BLorient13269" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Computus, Kidān, Poem in Honour of the Virgin Mary and one of her Miracles, Wǝddāse Māryām, ʾAnqaṣa bǝrhān</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS00001BL"/>
+                        <collection>Oriental</collection>
+                        <idno>BL Oriental 13269</idno>
+                        <altIdentifier><idno>Strelcyn 35</idno></altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                        <msItem xml:id="ms_i1">
+                            <locus from="1r" to="5r"/>
+                            <title ref="LIT6563HassabHeg"/>
+                            <incipit xml:lang="gez">በዘንዜክር፡ ሐሳበ፡ ሕጉ፡ እምትእዛዙ፡ 
+                                ለእ<supplied reason="undefined" resp="PRS8999Strelcyn">ግ</supplied>ዚእነ፡ 
+                                ኢየሱ<supplied reason="undefined" resp="PRS8999Strelcyn">ስ፡</supplied> 
+                                ክር<supplied reason="undefined" resp="PRS8999Strelcyn">ስቶስ፡</supplied> እንዘ፡ ሀሎነ፡ 
+                                በዘመ<supplied reason="undefined" resp="PRS8999Strelcyn">ነ</supplied>፡ 
+                                ቅዱ<supplied reason="undefined" resp="PRS8999Strelcyn">ስ</supplied>፡ 
+                                ዮሐን<supplied reason="undefined" resp="PRS8999Strelcyn">ስ</supplied>፡ 
+                                ወንጌ<supplied reason="undefined" resp="PRS8999Strelcyn">ላዊ</supplied>፡ 
+                                ይበጽ<supplied reason="undefined" resp="PRS8999Strelcyn">ሕ</supplied>፡
+                                እስከ፡ ዘመ<supplied reason="undefined" resp="PRS8999Strelcyn">ነ</supplied>፡ ቅዱስ፡ 
+                                ማቴ<supplied reason="undefined" resp="PRS8999Strelcyn">ዎስ</supplied>፡ ዜና፡ በ፶፡ ፻ወ፭፻፡ ወ፲ዓመተ፡ 
+                                ዓለ<supplied reason="undefined" resp="PRS8999Strelcyn">ም</supplied>፡ አዝማናቲሃ፡ ለለዕለት፡ ቅድስት፡ ፲፻ወሰቡዑ፡ ፻፡ እም፲ዓመተ፡ 
+                                ምሕረት፡ ወመዋዕሊሁ፤ ለሚል፡ መንግሥተ፡ ሰማያት፡ ሠረቀ፡ ወርኀ፡ ኔሳን፡ ንሕነ፡ በግዕዝ፡ ዘንሰምዮ፡ ሚያዝያ፡ ፳በሠርቀ፡ ሌሊት፡ ፲እምረቡዑ፡ በሠርቀ፡ መዓልት፡ 
+                                ዘተጽሕፈ፡ ዝኩ፡ መጽሐፍ፡ በዛቲ፡ ዕለት፡ ስረዊሆሙ፡ ለአበቅቲ፡ ወመጥ<supplied reason="undefined" resp="PRS8999Strelcyn">ቅዕ</supplied>፡ 
+                                ይወጽኡ፡ እምፊደላት፡ ፻፹፪አቅላማት፡ እም፳ወ፩፡ መጻሕፍት፡ </incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <locus from="5r" to="13r"/>
+                            <title ref="LIT0000000000000000000000000">Kidān</title>
+                        </msItem>
+                        <msItem xml:id="ms_i3">
+                            <locus from="13v" to="15v"/>
+                            <title ref="LIT3058RepCh338"/>
+                            <incipit xml:lang="gez">እሰግድ፡ ለኪ፡ እሰ<supplied reason="undefined" resp="PRS8999Strelcyn">ግድ</supplied>፡ ለኪ፡ 
+                                እ<supplied reason="undefined" resp="PRS8999Strelcyn">ሰግድ</supplied>፡ 
+                                ለ<supplied reason="undefined" resp="PRS8999Strelcyn">ኪ</supplied>ኪ፡ ኦእግዝእትየ፡ ማርያም፡ ለፀሐየ፡ ጽድቅ፡ ሠረገላሁ። እሰግድ፡ 
+                                ለኪ፡ ወእዌድሰኪ፡ ኦእግዝእትየ፡ ማርያም፡ ለመርዓዌ፡ ሰማይ፡ ጽርሑ፡ ለአዳም፡ ተስፋሁ፡ ናዝዝኒ፡ በበሁ፡ አስምዕኒ፡ ቃለ፡ ፍሥሐሁ፡ ለኃጥእ፡ ገብርኪ፡ 
+                                <gap reason="illegible"/> እሰግድ፡ ለኪ፡ ኦእግ<supplied reason="undefined" resp="PRS8999Strelcyn">ዝ</supplied>እትየ፡
+                                ማርያም፡ በከመ፡ ወደሰኪ፡ ዮሐንስ፡ አፈ፡ ወርቅ፡ በድርሳኑ፡ ኢንዘ፡ ይብል፡ በጥዑም፡ ከናፍሪሁ። ተፈሥሒ፡ ኦእግዝእትየ፡ ማርያም፡ ዘተሰገወ፡ እምኔኪ፡ እግዚአብሔር፡
+                                ቃል፡ ወወፅዓ፡ እምከርሥኪ፡ ከመ፡ መርዓዊ፡ ዘይወጽዕ፡ እምጽርሑ። </incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i4">
+                            <locus from="16r" to="16v"/>
+                            <title ref="LIT3865Miracle"/>
+                            <incipit xml:lang="gez">ተአምሪሃ፡ ለእግዝእትነ፡ ማር<supplied reason="undefined" resp="PRS8999Strelcyn">ያም፡</supplied>
+                                ወሀሎ፡ ፩ብእሲ፡ እንዘ፡ የሀጽብ፡ ልብሰ፡ ወመጽአ፡ ፩ብእሲ፡ ወሜጠ፡ ማየ፡ እንተ፡ ካልዕ፡ ፍኖት። ወይቤሉ፡ ውእቱ፡ ብእሲ፡ በጸሎታ፡ ለእግዝእትነ፡ 
+                                ማርያ<supplied reason="undefined" resp="PRS8999Strelcyn">ም</supplied>፡ ቅድስት፡ ድንግል፡</incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3">
+                            <locus from="17r" to="55v"/>
+                            <title ref="LIT2509Weddas"/>
+                            <note>Arranged by the days of the week, with Monday's lesson first.</note>
+                            <msItem xml:id="ms_i1.3.1">
+                                <locus from="17v"/>
+                                <title ref="LIT2509Weddas#Monday"/>
+                            </msItem>
+                            <msItem xml:id="ms_i1.3.2">
+                                <locus from="20v"/>
+                                <title ref="LIT2509Weddas#Tuesday"/>
+                            </msItem>
+                            <msItem xml:id="ms_i1.3.3">
+                                <locus from="25v"/>
+                                <title ref="LIT2509Weddas#Wednesday"/>
+                            </msItem>
+                            <msItem xml:id="ms_i1.3.4">
+                                <locus from="32v"/>
+                                <title ref="LIT2509Weddas#Thursday"/>
+                            </msItem>
+                            <msItem xml:id="ms_i1.3.5">
+                                <locus from="40v"/>
+                                <title ref="LIT2509Weddas#Friday"/>
+                            </msItem>
+                            <msItem xml:id="ms_i1.3.6">
+                                <locus from="46r"/>
+                                <title ref="LIT2509Weddas#Saturday"/>
+                            </msItem>     
+                            <msItem xml:id="ms_i1.3.7">
+                                <locus from="50v"/>
+                                <title ref="LIT2509Weddas#Sunday"/>
+                            </msItem>
+                        </msItem>
+                        <msItem xml:id="ms_i1.4">
+                            <locus from="55v" to="73v"/>
+                            <title ref="LIT1113Anqasa"/>
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Codex">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf">73</measure>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>130</height>
+                                        <width>80</width>
+                                    </dimensions>
+                                </extent>
+                                <condition key="deficient">Unbound.</condition>
+                            </supportDesc>
+                            <layoutDesc>
+                                <layout columns="1" writtenLines="13 15"/>
+                            </layoutDesc>
+                        </objectDesc> 
+                        <handDesc>
+                            <handNote script="Ethiopic" xml:id="h1">
+                                <desc>Less regular and smaller than the latter hand.</desc>
+                                <date notBefore="1600" notAfter="1700" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                            <handNote script="Ethiopic" xml:id="h2">
+                                <desc>Less regular and smaller than the latter hand.</desc>
+                                <date notBefore="1600" notAfter="1700" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                            <handNote script="Ethiopic" xml:id="h3">
+                                <desc>More regular and larger than the others with a height of about 4mm.</desc>
+                                <date notBefore="1600" notAfter="1700" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                        </handDesc>
+                        <additions>
+                            <list>
+                                <item xml:id="a1">
+                                    <locus target="#73v"/>
+                                    <desc type="GuestText">Traces of the beginning of a <foreign xml:lang="gez">salām</foreign> to the Archangel
+                                        Michael.</desc>
+                                </item>
+                                <item xml:id="e1">
+                                    <locus target="#15v"/>
+                                    <desc type="OwnershipNote">The owner was 
+                                        <persName role="owner" ref="PRS14393SayfaMikael">Sayfa Mikāʾel</persName>.</desc>
+                                </item>
+                            </list>
+                        </additions>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1600" notAfter="1700">17th century</origDate>
+                        </origin>
+                        <provenance>Presented by the <placeName ref="INS0775LWC">Wellcome Institute</placeName>
+                            in <date when="1970">1970</date>.</provenance>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                            <citedRange unit="page">51</citedRange>
+                                        </bibl> 
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianContent"/>
+                    <term key="ChristianLiterature"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-02-02">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/>   
+        </body>
+    </text>
+</TEI>
+

--- a/LondonBritishLibrary/orient/BLorient13269.xml
+++ b/LondonBritishLibrary/orient/BLorient13269.xml
@@ -149,7 +149,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <list>
                                 <item xml:id="a1">
                                     <locus target="#73v"/>
-                                    <desc type="GuestText">Traces of the beginning of a <foreign xml:lang="gez">salām</foreign> to the Archangel
+                                    <desc type="PoemSalam">Traces of the beginning of a <foreign xml:lang="gez">salām</foreign> to the Archangel
                                         Michael.</desc>
                                 </item>
                                 <item xml:id="e1">
@@ -196,6 +196,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <keywords>
                     <term key="ChristianContent"/>
                     <term key="ChristianLiterature"/>
+                    <term key="Chronography"/>
+                    <term key="Poetry"/>
+                    <term key="Liturgy"/>
                 </keywords>
             </textClass>
             <langUsage>


### PR DESCRIPTION
I created this record according to S. Strelcyns catalogue. 

I was not quite sure whether LIT6563HassabHeg was the correct ID for Ḥasāba ḥǝgg (movable feast calendar) in ms_i1. I think it is the ID for all calendar calculations for movable festivals, no matter if these calculations start and end in different years and use different cycles. 

I was even less sure about ms_i2. Strelcyn refers to it simply as "Kidan", as was the case in BLorient8813. But here there is no incipit or other information, so I can only speculate whether it is LIT2260salota again, or LIT1938Mashaf, or some other work with that name. I think it would be better to leave it unmarked.