### PR TITLE
Create BLorient13273 according to Strelcyn

### DIFF
--- a/EMIP/1001-2000/EMIP01909.xml
+++ b/EMIP/1001-2000/EMIP01909.xml
@@ -32,7 +32,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <idno facs="EMIP/Codices/1909/">Hazen Codex 5</idno>
                </msIdentifier>
                <msContents>
-                  <summary>Image of the Covenant of Mercy. Image of Saint Mark. Image of Gabriel. Image of Gabra Manfas Qǝddus. Image of Peter and Paul. Image of Rufāʾel. Image of the Savior of the World. Layman's Prayer</summary>
+                  <summary>Image of the Covenant of Mercy; Image of Saint Mark; Image of Gabriel; Image of Gabra Manfas Qǝddus; Image of Peter and Paul; Image of Rufāʾel; Image of the Savior of the World; Layman's Prayer</summary>
                   <msItem xml:id="ms_i1"><locus from="1r" to="17v" facs="003"/><locus target="89r" facs="091"/><title type="complete" ref="LIT3082RepCh362">Corrections are provided in pencil on folio 89r</title>
                   <textLang mainLang="gez"/>
                   <incipit xml:lang="gez">በስመ: እግዚአብሔር: አብ: ወኀቤ ብርሃን: ዘይሴለስ በአካሉ።</incipit>

--- a/EMIP/1001-2000/EMIP01909.xml
+++ b/EMIP/1001-2000/EMIP01909.xml
@@ -32,37 +32,37 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <idno facs="EMIP/Codices/1909/">Hazen Codex 5</idno>
                </msIdentifier>
                <msContents>
-                  <summary>Image of the Covenant of Mercy. Image of Saint Mark. Image of Gabriel. Image of Gäbrä Mänfas Qǝddus. Image of Peter and Paul. Image of Rufa’e፡. Image of the Savior of the World. Layman's Prayer</summary>
+                  <summary>Image of the Covenant of Mercy. Image of Saint Mark. Image of Gabriel. Image of Gabra Manfas Qǝddus. Image of Peter and Paul. Image of Rufāʾel. Image of the Savior of the World. Layman's Prayer</summary>
                   <msItem xml:id="ms_i1"><locus from="1r" to="17v" facs="003"/><locus target="89r" facs="091"/><title type="complete" ref="LIT3082RepCh362">Corrections are provided in pencil on folio 89r</title>
-                  <textLang mainLang="gez">Gǝ'ǝz</textLang>
+                  <textLang mainLang="gez"/>
                   <incipit xml:lang="gez">በስመ: እግዚአብሔር: አብ: ወኀቤ ብርሃን: ዘይሴለስ በአካሉ።</incipit>
                 </msItem>
                   <msItem xml:id="ms_i2"><locus from="17v" to="24r" facs="020"/><title>Image of Märqos</title>
-                  <textLang mainLang="gez">Gǝ'ǝz</textLang>
+                  <textLang mainLang="gez"/>
                   <incipit xml:lang="gez">ሰላም: ለጽንሰትከ: በሀገረ: ዓባይ: ገሊላ።</incipit>
                 </msItem>
                   <msItem xml:id="ms_i3"><locus from="24v" to="32v" facs="027"/><title type="complete" ref="LIT2965RepCh246"/>
-                  <textLang mainLang="gez">Gǝ'ǝz</textLang>
+                  <textLang mainLang="gez"/>
                   <incipit xml:lang="gez">ሰላመ: ገብርኤል: መልአክ: በላእለ: ማርያም: ዘአእረፈ።</incipit>
                 </msItem>
                   <msItem xml:id="ms_i4"><locus from="32v" to="48r" facs="035"/><title type="complete" ref="LIT2836RepCh120"/>
-                  <textLang mainLang="gez">Gǝ'ǝz</textLang>
+                  <textLang mainLang="gez"/>
                   <incipit xml:lang="gez">ሰላ: ለዝክረ: ስምከ: ምክንያተ ድሒን: እምደይን።</incipit>
                 </msItem>
                   <msItem xml:id="ms_i5"><locus from="48v" to="60v" facs="051"/><title type="complete" ref="LIT2906RepCh187"/>
-                  <textLang mainLang="gez">Gǝ'ǝz</textLang>
+                  <textLang mainLang="gez"/>
                   <incipit xml:lang="gez">ሰላም: ለዝክረ: ስምክሙ: ዘአልባስጥሮስ: አፈው።</incipit>
                 </msItem>
                   <msItem xml:id="ms_i6"><locus from="61r" to="65r" facs="063"/><title type="complete" ref="LIT2934RepCh215"/>
-                  <textLang mainLang="gez">Gǝ'ǝz</textLang>
+                  <textLang mainLang="gez"/>
                   <incipit xml:lang="gez">ሰላም: ለ(ተ)ፈጥሮትከ: በከርሠ: ቀዳሚት: እሁድ።</incipit>
                 </msItem>
                   <msItem xml:id="ms_i7"><locus from="65r" to="76r" facs="067"/><title type="complete" ref="LIT3059RepCh339"/>
-                  <textLang mainLang="gez">Gǝ'ǝz</textLang>
+                  <textLang mainLang="gez"/>
                   <incipit xml:lang="gez">እሰግድ: ለዝክረ: ስምከ: መልአከ: ምሥጢር: ዘተርጐሞ።</incipit>
                 </msItem>
-                  <msItem xml:id="ms_i8"><locus from="76r" to="79v" facs="078"/><title>Prayer on the Passion of Jesus Christ, which Jesus revealed to Matilda, Bridget and Elizabeth</title>
-                  <textLang mainLang="gez">Gǝ'ǝz</textLang>
+                 <msItem xml:id="ms_i8"><locus from="76r" to="79v" facs="078"/><title ref="LIT6967PrayerPassion"/>
+                  <textLang mainLang="gez"/>
                   <incipit xml:lang="gez">ኦ: እግዚእየ: ኢየሱስ: መድኃ: ዓለም: ኁልቈ: ሕማማቲከ: ዘከሠትከ: ሎን: ለሠላስ: ደናግል: ቅዱሳት: ቤርዚዳ: ወቅድስት: ሚልቲዳ: ወቅድስት: ኤልሳቤጥ:</incipit>
                 </msItem>
                </msContents>
@@ -215,6 +215,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <change when="2020-04-17" who="RL">corrected ǝ character</change>
          <change when="2020-06-29" who="ABe">Added items</change>
          <change when="2021-05-13" who="JS">Added ms dims, quire maps, margin dims, columns/lines, binding desc, dating info.</change>
+        <change when="2024-04-19" who="CH">Update contents: MsItem ms_i8.</change>
     </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">

--- a/Kop/KopCodEtiopAdd13.xml
+++ b/Kop/KopCodEtiopAdd13.xml
@@ -28,7 +28,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <msContents>
                   <summary>
                      <p>Production unit I</p>
-                     <p>I) ዜና᎓ሕማማቲሁ᎓ለመድኃኔ᎓ዓለም“Story of the Sufferings of the Savior of the World”, revealed to Mary Magdalen, Birgit (Barzeda) and Elizabeth (fols. <locus from="2ra" to="5va"/>), a version of the apocryphal “Story of the Passions of Christ”, see Piovanelli <locus target="#2014 #2015"/>
+                     <p>I) <title ref="LIT6967PrayerPassion">ዜና᎓ሕማማቲሁ᎓ለመድኃኔ᎓ዓለም“Story of the Sufferings of the Savior of the World”</title>, revealed to Mary Magdalen, Birgit (Barzeda) and Elizabeth (fols. <locus from="2ra" to="5va"/>), a version of the apocryphal “Story of the Passions of Christ”, see Piovanelli <locus target="#2014 #2015"/>
                      </p>
                      <p>II) የኢትዮያ፡ ታሪክ “A History of Ethiopia” (fols. <locus from="5v" to="12v"/>), in Gǝˁǝz and Amharic, starting with the genealogy of Adam and ending with the battle of Sägäle (<locus target="#27"/>October <locus target="#1916"/>)</p>
                      <p>Production unit II</p>

--- a/LondonBritishLibrary/orient/BLorient13273.xml
+++ b/LondonBritishLibrary/orient/BLorient13273.xml
@@ -49,7 +49,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <note>Arranged by the days of the week, with Monday's lesson first.</note>
                             <msItem xml:id="ms_i3.1">
                                 <locus from="24v"/>
-                                <title>Introduction</title>
+                                <title ref="LIT2811RepCh95"/>
                                 <incipit xml:lang="gez">ሰላም፡ ለኪ፡ እንዘ፡ ንሰግድ፡ ንብለኪ፡ ማርያም፡ እምነ፡ ናስተበቍዓኪ። እምአርዌ፡ ነአዊ፡ ተማኅፀነ፡ ብኪ። በእንተ፡ ሐና፡ እምኪ፡ 
                                     ወኢያቂም፡ አቡኪ። ማኅበረነ፡ ዮም፡ ድንግል፡ ባርኪ። </incipit>
                             </msItem>

--- a/LondonBritishLibrary/orient/BLorient13273.xml
+++ b/LondonBritishLibrary/orient/BLorient13273.xml
@@ -109,7 +109,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </msItem>
                         <msItem xml:id="ms_i8">
                             <locus from="121v" to="127r"/>
-                            <title ref="LIT0000000000000000000000000000000">Prayer to Jesus commemorating the Passion</title>
+                            <title ref="LIT6967PrayerPassion"/>
                             <note>In twenty-six stanzas.</note>
                             <incipit xml:lang="gez">ኦእግዚእየ፡ ኢየሱስ፡ ክርስቶስ፡ መድኅነ፡ ዓለም። ኈልቈ፡ ሕማማቲከ፡ ዘከሠትከ፡ ሎን፡ ለሠላስ፡ ደናግል፡ ቅዱሳት፡ እለ፡ ይሰመያ፡ ቅድስት፡ 
                                 ቢርዜዳ። ወቅድስ<supplied reason="undefined" resp="PRS8999Strelcyn">ት</supplied>፡ ሚልቲዳ። ወቅድስት፡ ኤልሳቤጥ፡ እላ፡ እማንቱ፡ 

--- a/LondonBritishLibrary/orient/BLorient13273.xml
+++ b/LondonBritishLibrary/orient/BLorient13273.xml
@@ -1,0 +1,243 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="BLorient13273" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Kidān - Tǝmhǝrta ḫǝbuʾat - Wǝddāse Māryām - ʾAnqaṣa bǝrhān - 
+                    the Anaphora of the Virgin Mary by Cyriacus, bishop of Behnesa - Hymn to Jesus, the Saviour of the World - 
+                    Malkǝʾa Madḫane ʿAlam - Prayer to Jesus Christ - Secret names revealed by Jesus to St Andrew - Malkǝʾa ʾIyasus Krǝstos</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS00001BL"/>
+                        <collection>Oriental</collection>
+                        <idno>BL Oriental 13273</idno>
+                        <altIdentifier><idno>Strelcyn 36</idno></altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                        <msItem xml:id="ms_i1">
+                            <locus from="5r" to="15r"/>
+                            <title ref="LIT2260salota"/>
+                            <incipit xml:lang="gez">ኪዳን፡ ዘመሐሮሙ፡ እግዚእነ፡ ለአርዳኢሁ፡ እምድኅረ፡ ተንሣኤሁ። ቅዱስ፡ እግዚአብሔር፡ ቅዱስ፡ ኃያል፡ ቅዱስ፡ ሕያው፡ 
+                                ዘኢይመውት፡ ዘተወልደ፡ እማርያም፡ እምቅድስት፡ ድንግል፡ ተሣሃለነ፡ እግዚኦ። </incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <locus from="15v" to="24r"/>
+                            <title ref="LIT2444Temher"/>
+                            <incipit xml:lang="gez">በእንተ፡ ትምሕርተ፡ ኅቡዓት፡</incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i3">
+                            <locus from="24v" to="58r"/>
+                            <title ref="LIT2509Weddas"/>
+                            <note>Arranged by the days of the week, with Monday's lesson first.</note>
+                            <msItem xml:id="ms_i3.1">
+                                <locus from="24v"/>
+                                <title>Introduction</title>
+                                <incipit xml:lang="gez">ሰላም፡ ለኪ፡ እንዘ፡ ንሰግድ፡ ንብለኪ፡ ማርያም፡ እምነ፡ ናስተበቍዓኪ። እምአርዌ፡ ነአዊ፡ ተማኅፀነ፡ ብኪ። በእንተ፡ ሐና፡ እምኪ፡ 
+                                    ወኢያቂም፡ አቡኪ። ማኅበረነ፡ ዮም፡ ድንግል፡ ባርኪ። </incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i3.2">
+                                <locus from="25v"/>
+                                <title ref="LIT2509Weddas#Monday"/>
+                            </msItem>
+                            <msItem xml:id="ms_i3.3">
+                                <locus from="29v"/>
+                                <title ref="LIT2509Weddas#Tuesday"/>
+                            </msItem>
+                            <msItem xml:id="ms_i3.4">
+                                <locus from="34v"/>
+                                <title ref="LIT2509Weddas#Wednesday"/>
+                            </msItem>
+                            <msItem xml:id="ms_i3.5">
+                                <locus from="40r"/>
+                                <title ref="LIT2509Weddas#Thursday"/>
+                            </msItem>
+                            <msItem xml:id="ms_i3.6">
+                                <locus from="46v"/>
+                                <title ref="LIT2509Weddas#Friday"/>
+                            </msItem>
+                            <msItem xml:id="ms_i3.7">
+                                <locus from="51r"/>
+                                <title ref="LIT2509Weddas#Saturday"/>
+                            </msItem>     
+                            <msItem xml:id="ms_i3.8">
+                                <locus from="54v"/>
+                                <title ref="LIT2509Weddas#Sunday"/>
+                            </msItem>
+                        </msItem>
+                        <msItem xml:id="ms_i4">
+                            <locus from="58v" to="74v"/>
+                            <title ref="LIT1113Anqasa"/>
+                        </msItem>
+                        <msItem xml:id="ms_i5">
+                            <locus from="75r" to="98v"/>
+                            <title ref="LIT1099Anapho"/>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> አኰቴተ፡ ቍርባን፡ ዘእግዝእትነ፡ ቅድስት፡ ድንግል፡ ማርያም፡ ወላዲተ፡ አምላክ፡ ዘነበበ፡ 
+                                በመንፈስ፡ ቅዱስ፡ አባ፡ ሕርያቆስ፡ ኤጲስ፡ ቆጶስ፡ ዘሀገረ፡ ብሕንሳ። </incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i6">
+                            <locus from="99r" to="108v"/>
+                            <title ref="LIT00000000000000000000" type="incomplete">Malkǝʾa Madḫane ʿAlam - ʾƎsaggǝd</title>
+                            <note>In 33 stanzas, 29 of which beginning with <foreign xml:lang="gez">እሰግድ፡ </foreign>.</note>
+                            <incipit xml:lang="gez">ሰላም፡ ዕብል፡ ለልደትከ፡ መድምም።
+                                                                         እምድንጋሌ፡ ሥጋ፡ ኅቱም፤
+                                                                         ኢየሱስ፡ ክርስቶስ፡ መድኃኔ፡ ዓለም።
+                                                                         ልብየ፡ አንቅህ፡ ወነፍስየ፡ ለስብሐቲከ፡ አዳም።
+                                                                         ለሥጋየስ፡ አኃዞ፡ ድካም።</incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i7">
+                            <locus from="109r" to="121r"/>
+                            <title ref="LIT2883RepCh164"/>
+                            <incipit xml:lang="gez">ሰላም፡ ለዝክረ፡ ስምከ፡ ዘኢረከቡ፡ ተፍጻሜተ። </incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i8">
+                            <locus from="121v" to="127r"/>
+                            <title ref="LIT0000000000000000000000000000000">Prayer to Jesus commemorating the Passion</title>
+                            <note>In twenty-six stanzas.</note>
+                            <incipit xml:lang="gez">ኦእግዚእየ፡ ኢየሱስ፡ ክርስቶስ፡ መድኅነ፡ ዓለም። ኈልቈ፡ ሕማማቲከ፡ ዘከሠትከ፡ ሎን፡ ለሠላስ፡ ደናግል፡ ቅዱሳት፡ እለ፡ ይሰመያ፡ ቅድስት፡ 
+                                ቢርዜዳ። ወቅድስ<supplied reason="undefined" resp="PRS8999Strelcyn">ት</supplied>፡ ሚልቲዳ። ወቅድስት፡ ኤልሳቤጥ፡ እላ፡ እማንቱ፡ 
+                                ዘነጸራከ፡ ሥራይ፡ ኃጢአትየ። እስመ፡ አነ፡ ኃጥእ፡ ገብርከ፡ <gap reason="illegible"/></incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i9">
+                            <locus from="127v" to="132r"/>
+                            <title ref="LIT4154Prayer"/>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> አስማተ፡ ዘነገሮ፡ እግዚእነ፡ ለቅዱስ፡ እንድርያስ፡ ረድእ፡ ሐዋርያ፡ ወሰማዕት፡ ጸሎቱ፡ 
+                                ወበረከቱ፡ የሃሉ፡ ምስለ፡ ፍቁሩ፡ <gap reason="illegible"/> ለዓለመ፡ ዓለም፡ አሜን፡ </incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i10">
+                            <locus from="132r" to="146r"/>
+                            <title ref="LIT2839RepCh123"/>
+                            <incipit xml:lang="gez">ሰላም፡ ለዝክረ፡ ስምከ፡ ስመ፡ መሐላ፡ ዘኢይኄሱ። </incipit>
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Codex">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf">148</measure>
+                                    <measure unit="page" type="blank">3</measure><locus target="#147v #148r #148v"/>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>145</height>
+                                        <width>75</width>
+                                    </dimensions>
+                                    <note>Dimensions for <locus from="147" to="148"/> much small measuring <height>80</height> x
+                                        <width>47</width>.</note>
+                                </extent>
+                                <collation>The manuscript is composed of fourteen quires of which eleven are numbered.</collation>
+                            </supportDesc>
+                            <layoutDesc>
+                                <layout columns="1" writtenLines="24 31"><locus from="1r" to="4v"/></layout>
+                                <layout columns="1" writtenLines="20"><locus from="5r" to="148v"/></layout>
+                            </layoutDesc>
+                        </objectDesc> 
+                        <handDesc>
+                            <handNote script="Ethiopic" xml:id="h1">
+                                <desc>Good handwriting.</desc>
+                                <date notBefore="1700" notAfter="1800" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                        </handDesc>
+                        <decoDesc>
+                            <decoNote xml:id="d1" type="band">
+                                <desc>Coloured ornamentation at the head of chapters.</desc>
+                            </decoNote>
+                        </decoDesc>
+                        <additions>
+                            <list>
+                                <item xml:id="a1">
+                                    <locus from="1r" to="4v"/>
+                                    <desc type="GuestText"><ref type="work" corresp="LIT3090RepCh370"/>.</desc>
+                                    <q xml:lang="gez">ኦእግዚእየ፡ ኢየሱስ፡ ክርስቶስ፡ ወልደ፡ እግዚአብሔር፡ ሕያው፡ በእንተ፡ ማርያም፡ ወላዲትከ፡ ርድአኒ።
+                                                              ኦእግዚእየ፡ ኢየሱስ፡ ክርስቶስ፡ ወልደ፡ እግዚአብሔር፡ ሕያው፡ በእንተ፡ ማርያም፡ ወላዲትከ፡ ተሣሃለኒ። <gap reason="ellipsis"/></q>
+                                </item>
+                                <item xml:id="a2">
+                                    <locus from="146r" to="147r"/>
+                                    <desc type="GuestText">Magical prayer to St Michael for expelling devils</desc>
+                                    <q xml:lang="gez">በስመ፡ አብ፡ በል፡ ሚካኤል፡ ሊቆሙ፡ ለመላእክት፡ ሰዳዲሆሙ፡ ለአጋንንት። መያጢሆሙ፡ ለመሰርያን፡ በሆልናሆር፡ ስምከ፡ 
+                                        <gap reason="ellipsis"/></q>
+                                </item>
+                            </list>
+                        </additions>
+                        <bindingDesc>
+                            <binding xml:id="binding">
+                                <decoNote xml:id="b1"/>
+                                <decoNote type="bindingMaterial" xml:id="b2"><material key="wood">Wooden boards.</material></decoNote>
+                                <decoNote xml:id="b3" type="Cover"><material key="leather">Blind-tooled leather.</material></decoNote>
+                            </binding>
+                        </bindingDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1700" notAfter="1800">18th century</origDate>
+                        </origin>
+                        <provenance>Presented by the <placeName ref="INS0775LWC">Wellcome Institute</placeName> 
+                            in <date when="1970">1970</date>.</provenance>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                            <citedRange unit="page">52-53</citedRange>
+                                        </bibl> 
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianContent"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="Magic"/>
+                    <term key="Chants"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-02-02">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/>
+        </body>
+    </text>
+</TEI>
+

--- a/LondonBritishLibrary/orient/BLorient13273.xml
+++ b/LondonBritishLibrary/orient/BLorient13273.xml
@@ -94,7 +94,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </msItem>
                         <msItem xml:id="ms_i6">
                             <locus from="99r" to="108v"/>
-                            <title ref="LIT00000000000000000000" type="incomplete">Malkǝʾa Madḫane ʿAlam - ʾƎsaggǝd</title>
+                            <title ref="LIT6956MalkeaMadAlam"/>
                             <note>In 33 stanzas, 29 of which beginning with <foreign xml:lang="gez">እሰግድ፡ </foreign>.</note>
                             <incipit xml:lang="gez">ሰላም፡ ዕብል፡ ለልደትከ፡ መድምም።
                                                                          እምድንጋሌ፡ ሥጋ፡ ኅቱም፤

--- a/LondonBritishLibrary/orient/BLorient13273.xml
+++ b/LondonBritishLibrary/orient/BLorient13273.xml
@@ -6,9 +6,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Kidān - Tǝmhǝrta ḫǝbuʾat - Wǝddāse Māryām - ʾAnqaṣa bǝrhān - 
-                    the Anaphora of the Virgin Mary by Cyriacus, bishop of Behnesa - Hymn to Jesus, the Saviour of the World - 
-                    Malkǝʾa Madḫane ʿAlam - Prayer to Jesus Christ - Secret names revealed by Jesus to St Andrew - Malkǝʾa ʾIyasus Krǝstos</title>
+                <title>Kidān; Tǝmhǝrta ḫǝbuʾat; Wǝddāse Māryām; ʾAnqaṣa bǝrhān; 
+                    the Anaphora of the Virgin Mary by Cyriacus, bishop of Behnesa; Hymn to Jesus, the Saviour of the World; 
+                    Malkǝʾa Madḫane ʿAlam; Prayer to Jesus Christ; Secret names revealed by Jesus to St Andrew; Malkǝʾa ʾIyasus Krǝstos</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>


### PR DESCRIPTION
I made a record according to S. Strelcyns catalogue. 

I could not identify ms_i6 (https://github.com/BetaMasaheft/Documentation/issues/2508), ms_i8 (https://github.com/BetaMasaheft/Documentation/issues/2509) and a2. For the first and the second I suggest to create new LIT-IDs as argued in the issues. The magic prayer in a2 is probably also a candidate for a new LIT ID, but I have found no other witness. I have checked manuscripts containing LIT4302Prayer and LIT5876AsmatPrayer, but in my opinion this piece is too different to be identified as one of them.