### PR TITLE
Revision condition

### DIFF
--- a/OxfordBodleian/BodNewMSS/BDLaethf35.xml
+++ b/OxfordBodleian/BodNewMSS/BDLaethf35.xml
@@ -10,13 +10,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!--  
+                <!--
                     <title xml:lang="gez" xml:id="title1">ብስራተ፡ ዮሐንስ፡, አኰቴተ፡ ቍርባን፡ ዘቅዱስ፡ ህርያቆስ፡ ዘሀገረ፡ ብህንሳ፡, ኪዳን፡ ዘነግህ፡, ኪዳን፡ ዘሰርክ፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Bǝsrāta Yoḥannǝs, ʾAkkʷateta qʷǝrbān za-qǝddus Hǝryāqos za-hagara Bǝhnǝsā, Kidān za-nagh, Kidān za-sark</title>
                 -->
-                <title xml:lang="en" xml:id="title1">Gospel of John, Anaphora of Our Lady Mary by Cyriacus of Behnesa, Covenant of the Morning 
+                <title xml:lang="en" xml:id="title1">Gospel of John, Anaphora of Our Lady Mary by Cyriacus of Behnesa, Covenant of the Morning
                     (<hi rendition="simple:italic">Kidān za-nagh</hi>), Covenant of the Evening (<hi rendition="simple:italic">Kidān za-sark</hi>)</title>
-                <!--  The last two texts might be unified as ጸሎተ፡ ኪዳን፡/ Ṣalota kidān /"Prayer of the Covenant", but many photos are missing --> 
+                <!--  The last two texts might be unified as ጸሎተ፡ ኪዳን፡/ Ṣalota kidān /"Prayer of the Covenant", but many photos are missing -->
                 <editor key="DR"/>
                 <editor key="JG"/>
                 <editor key="MV"/>
@@ -224,7 +224,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </item>
                                     </list>
                                 </collation>
-                                <condition key="good">The manuscript is in good condition. It only shows traces of use in the lower external corners
+                                <condition key="good">The manuscript shows traces of use in the lower external corners
                                   and the back cover is split vertically in half. The two parts are held together by threads passing through pairs of holes
                                   drilled through the board.
                                 </condition>

--- a/OxfordBodleian/BodNewMSS/BDLaethg47.xml
+++ b/OxfordBodleian/BodNewMSS/BDLaethg47.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0"
     xml:id="BDLaethg47"
@@ -36,17 +36,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <idno>Or. lang. e. 45</idno>
                         </altIdentifier>
                     </msIdentifier>
-                    
+
                     <msContents>
                         <summary/>
-                        
+
                         <msItem xml:id="ms_i1">
                       <locus from="1r1" to="1r60"/>
                             <title ref="LIT1763Legend" type="complete"/>
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez">
                                 <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ሥላሴ፡ ዋሕድ፡ እሩያን፡ በአካል፡ ጸሎ</hi>ት፡ በእንተ፡ ሕማመ፡ <sic>ሸቶላ<supplied reason="omitted">፡</supplied></sic>
-                                ወባርያ፡ ወአየረ፡ ሰማይ፡ በስመ፡ እግዚአብሔር፡ 
+                                ወባርያ፡ ወአየረ፡ ሰማይ፡ በስመ፡ እግዚአብሔር፡
                                 ሕያው<supplied reason="omitted">፡</supplied> ነባቢ፡ ወተናጋሪ፡ ጸሎቱ፡ ለቅዱስ፡ ሱስንዮስ፡ በእንተ<supplied reason="omitted">፡</supplied> አሰስሎ፡ ደዌ፡
                                 እምሕፃናት<supplied reason="omitted">፡</supplied>
                                 እለ<supplied reason="omitted">፡</supplied> ይጠብው፡ ጥበ፡ እሞሙ<supplied reason="omitted">፡</supplied> አዲ፡ ዘየሐይዋ፡ ላቲ፡ ወዘትጽሕፎ፡ ለደቂቃ፡ ወዘትሰቅሎ፡ ላእሌሃ፡
@@ -59,10 +59,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 ወኪሩቤል፡ አናንያ፡ ወሰዳክያል፡ እሉ፡ እሙንቱ፡ እለ<supplied reason="omitted">፡</supplied> ይቀውሙ፡ ቅድመ፡ መንበሩ<supplied reason="omitted">፡</supplied>
                                 መእግዚአብሔር፡ እብ፡ አሐዜ<supplied reason="omitted">፡</supplied> ኵሉ፡ ዘልፈ፡ ጸሎቱ፡ ወበረከቱ፡ የሀሉ፡ ምስለ፡ ዓመቱ፡
                                 <persName ref="PRS14043WalattaS"> ወለተ፡ <hi rend="rubric">ሥላሴ፡</hi></persName> <hi rend="rubric">ሾር፡</hi>
-                                
+
                             </explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i2">
                             <locus from="1r60" to="1r108"/>
                             <title ref="LIT5690MagicPrayer" type="complete"/>
@@ -79,7 +79,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <hi rend="rubric">ሮህ፡ ሸር፡ <gap reason="illegible" unit="chars" quantity="2"/></hi>
                             </explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i3">
                             <locus from="1r108" to="1r123"/>
                             <title ref="LIT6844PPHemorrhage" type="complete"/>
@@ -94,9 +94,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <persName ref="PRS14043WalattaS">ወለተ፡ <hi rend="rubric">ሥላሴ፡</hi></persName>
                                     <hi rend="rubric"><gap reason="illegible" unit="chars" quantity="1"/>ር፡</hi>
                             </incipit>
-                           
+
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i4">
                             <locus from="1r124" to="1r154"/>
                             <title ref="LIT6845PPSatolay" type="complete"/>
@@ -107,14 +107,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     አምላክ<supplied reason="omitted">፡</supplied> ጸሎት፡ በእንተ፡ ሕማመ<supplied reason="omitted">፡</supplied></hi>
                                 ሸቶላይ፡ አንተ፡ ሸቶላይ፡ ወሸቶላዊ፡ ጋኔን፡ ዘ<sic>ትቀት<supplied reason="omitted">፡</supplied></sic> ሕፃናተ፡ ወትቋርጽ፡ አማሉተ፡ ወትጦዊ፡ አንጀተ፡
                                 ወትቆረጥም፡ አካላተ፡ ወተሐምም፡ አባላተ፡ አምሐልኩከ፡ ወአውገዝኩከ፡ ወለጐምኩከ፡ ወአሰርኩከ፡ ወቆለፍኩከ፡ ወሐተምኩከ፡ በማሕተመ<supplied reason="omitted">፡</supplied>
-                                አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ በእግዚአብሔር<supplied reason="omitted">፡</supplied> መለኮት፡ ወካእበ፡ አሰርኩከ፡ አንተ፡ ሸቶላይ፡ ጋኔን፡ በዝንቱ፡ አስማት፡ 
+                                አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ በእግዚአብሔር<supplied reason="omitted">፡</supplied> መለኮት፡ ወካእበ፡ አሰርኩከ፡ አንተ፡ ሸቶላይ፡ ጋኔን፡ በዝንቱ፡ አስማት፡
                                 መሐጀን፡ መሐጀን፡ መሐጀን፡ ፲ ጊዜ፡ አመአጃም፡ ቀለጀም፡ ሸጀም፡ ሹን፡ ሸድን። ማው፡ ማውካ፡ ያሐጀ፡ ያሐጀ፡ የሐጀ፡ የሐቱደጀ፡ አአጠጨታሕ፡ በጉሎንቃርሌውስ፡ ማር፡ በኃይለ፡
                                 ዝንቱ፡ እንቱ፡ አስማቲከ፡ ቀጥቀጦ፡ ወአርኅቆ፡ ወሰድዶ<supplied reason="omitted">፡</supplied> ለዝንቱ፡ ጋኔን፡ ዘስሙ፡ ሸቶላይ፡ ከነ፡ ይጾእ፡ ወኢይቀረብ፡ ኀበ፡
                                 አመትከ፡ <persName ref="PRS14043WalattaS" role="owner">ወ<hi rend="rubric">ለተ፡ ሥላሴ፡</hi></persName> <hi rend="rubric">ሾር።</hi>
                             </incipit>
-                          
+
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i5">
                             <locus from="1r154" to="1r189"/>
                             <title ref="LIT2765RepCh49" type="complete"/>
@@ -127,13 +127,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </incipit>
                             <explicit xml:lang="gez">
                                 <hi rend="rubric">ሰላም፡ ለኪ፡</hi> መቅደሰ፡ እሳት፡ <hi rend="rubric">ማርያም፡</hi> ዘብኪ ድኅነ፡ በሕጽነ፡ ሐና፡ እምኪ<supplied reason="omitted">፡</supplied>
-                                ተማኅጸነ፡ ፈገውዮ፡ ለፋኑኤል፡ ገብርኪ፡ ከመ፡ ይእቀብ፡ ኪያነ፡ በርምኃ፡ መስቀሉ፡ ሰገዘ<supplied reason="omitted">፡</supplied> ሰይጣነ፡ አምላክ፡ 
-                                ፋኑኤል፡ አድኅነኒ፡ እምእደ፡ አጋንንት፡ እኩያን፡ <gap reason="illegible"/> ለአመት<hi rend="rubric"><gap reason="illegible"/>እማ፡ 
+                                ተማኅጸነ፡ ፈገውዮ፡ ለፋኑኤል፡ ገብርኪ፡ ከመ፡ ይእቀብ፡ ኪያነ፡ በርምኃ፡ መስቀሉ፡ ሰገዘ<supplied reason="omitted">፡</supplied> ሰይጣነ፡ አምላክ፡
+                                ፋኑኤል፡ አድኅነኒ፡ እምእደ፡ አጋንንት፡ እኩያን፡ <gap reason="illegible"/> ለአመት<hi rend="rubric"><gap reason="illegible"/>እማ፡
                                     <persName ref="PRS14044WalattaM">ወለተ፡ ሚካኤል፡</persName></hi>
                             </explicit>
                         </msItem>
                     </msContents>
-                    
+
                     <physDesc>
                         <objectDesc form="Scroll">
                             <supportDesc>
@@ -161,7 +161,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <measure unit="g" type="weight">50</measure> <!--without case-->
                              <!--       <measure unit="g" type="weight">69</measure> <!-\-with case-\->-->
                                 </extent>
-                                <condition key="good">The scroll is in a good state of preservation. </condition>
+                                <condition key="good">Small losses are present along the left margin in the bottom area of the scroll.</condition>
                             </supportDesc>
                             <layoutDesc>
                                 <layout columns="1" writtenLines="50" corresp="#sec">
@@ -205,18 +205,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </layout>
                             </layoutDesc>
                         </objectDesc>
-                        
+
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <date notBefore="1800" notAfter="2020"/>
                                 <desc>Trained hand. Bulky, widely spaced characters.</desc>
                            <seg type="ink">Black, red.</seg>
-                                <seg type="rubrication">The first two–three lines of prayers; holy names; the complete name of the owner or only the holy name contained in it; 
-                                <foreign xml:lang="gez">ሰላም፡ ለከ፡</foreign>/<foreign xml:lang="gez">ለኪ፡</foreign>; parts of numerals. In the final supplication, the illegible 
+                                <seg type="rubrication">The first two–three lines of prayers; holy names; the complete name of the owner or only the holy name contained in it;
+                                <foreign xml:lang="gez">ሰላም፡ ለከ፡</foreign>/<foreign xml:lang="gez">ለኪ፡</foreign>; parts of numerals. In the final supplication, the illegible
                                     name of the owner is followed by <foreign xml:lang="gez">ወእማ፡ ወለተ፡ ሚካኤል፡</foreign>, "and her mother <persName ref="PRS14044WalattaM"/>".</seg>
                             </handNote>
                         </handDesc>
-                        
+
                         <!--          <decoDesc>
                             <decoNote xml:id="d1" type="miniature" corresp="#pic1">
                                 <desc></desc>
@@ -225,7 +225,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <width>88</width>
                                 </dimensions>
                             </decoNote>
-                            
+
                             <decoNote xml:id="d2" type="miniature" corresp="#pic2">
                                 <desc></desc>
                                 <dimensions unit="mm">
@@ -233,7 +233,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <width>90</width>
                                 </dimensions>
                             </decoNote>
-                            
+
                                 <decoNote xml:id="d3" type="miniature" corresp="#pic3">
                                 <desc></desc>
                                 <dimensions unit="mm">
@@ -242,37 +242,37 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </dimensions>
                             </decoNote>
                         </decoDesc>-->
-                        
+
                         <additions>
                             <list>
                                 <item xml:id="e1">
                                     <desc>The name of the owner, mentioned in supplications throughout, was
-                                        <persName ref="PRS14043WalattaS" role="owner"/>. The name <foreign xml:lang="gez">ወለተ፡ ሥላሴ፡</foreign> is always followed by 
+                                        <persName ref="PRS14043WalattaS" role="owner"/>. The name <foreign xml:lang="gez">ወለተ፡ ሥላሴ፡</foreign> is always followed by
                                         the words <foreign xml:lang="gez">ሮህ፡</foreign> or <foreign xml:lang="gez">ሾር፡</foreign>/<foreign xml:lang="am">ሸር፡</foreign>.
                                         It is unclear whether
                                     these form part of the personal name or have a different meaning, possibly connected to Amharic (via Arabic)
                                         <foreign xml:lang="am">ሩሕ፡</foreign>, "spirit", and  <foreign xml:lang="am">ሸር፡</foreign>, "wickedness".</desc>
                                 </item>
-                                
+
                                 <item xml:id="e2">
                                     <desc>The manuscript contains no scribal corrections.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e3">
                                     <desc>The verso is empty.</desc>
                                 </item>
                             </list>
                         </additions>
-                        
+
                         <bindingDesc>
                             <binding xml:id="binding">
                                 <decoNote xml:id="b1">The three parchment strips are slightly overlapping and sewn together with a running stitch using a narrow parchment strip each.</decoNote>
                                 <decoNote xml:id="b2">The manuscript is kept in a leather case composed of two parts which are attached to each other with blue yarn.</decoNote>
                             </binding>
                         </bindingDesc>
-                        
+
                     </physDesc>
-                    
+
                     <history>
                         <origin>
                             <origDate notBefore="1800" notAfter="2020" evidence="lettering"/>
@@ -280,7 +280,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <provenance>The manuscript can only be dated palaeographically. The circumstances of its production and acquisition by the library are not
                         known.</provenance>
                     </history>
-                    
+
                     <additional>
                         <adminInfo>
                             <recordHist>
@@ -292,7 +292,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </recordHist>
                         </adminInfo>
                     </additional>
-                    
+
                 </msDesc>
             </sourceDesc>
         </fileDesc>
@@ -340,29 +340,29 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <div type="textpart" subtype="section" n="1" xml:id="sec1">
                         <div type="textpart" subtype="picture" n="1" xml:id="pic1" corresp="#d1"/>
                     </div>
-                    
-                    
+
+
                     <div type="textpart" subtype="section" n="2" xml:id="sec2">
                         <div type="textpart" subtype="text" n="1" corresp="#ms_i1" xml:id="text1part1">
                             <ab/>
                         </div>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="3" xml:id="sec3">
                         <div type="textpart" subtype="picture" n="2" xml:id="pic2" corresp="#d2">
                             <milestone unit="parchmentStrip" n="2"/>
                         </div>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="4" xml:id="sec4">
                         <div type="textpart" subtype="text" n="2" corresp="#ms_i1" xml:id="text1part2">
                             <ab/>
                         </div>
-                        
+
                         <div type="textpart" subtype="text" n="2" corresp="#ms_i2" xml:id="text2">
-                            <ab/>    
+                            <ab/>
                         </div>
-                        
+
                         <div type="textpart" subtype="text" n="3" corresp="#ms_i3" xml:id="text3part1">
                             <ab>    <hi rend="rubric">በስመ፡ አብ<supplied reason="omitted">፡</supplied> ወወልድ፡ ወመንፈስ፡ ቅዱስ<supplied reason="omitted">፡</supplied>
                                 ፩ አምላክ፡ ጸሎት፡</hi> አርግኦ<supplied reason="omitted">፡</supplied> ደም፡ ለደም፡ ለደም<supplied reason="omitted">፡</supplied>
@@ -370,13 +370,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 ኢስ፡ አፍሊስ፡ ሚልዮስ፡ <gap reason="illegible" unit="chars" quantity="3"/></ab>
                         </div>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="5" xml:id="sec5">
                         <div type="textpart" subtype="picture" n="3" xml:id="pic3" corresp="#d3">
                                 <milestone unit="parchmentStrip" n="3"/>
                         </div>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="6" xml:id="sec6">
                         <div type="textpart" subtype="text" n="4" corresp="#ms_i3" xml:id="text3part2">
                             <ab>
@@ -392,7 +392,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     አምላክ<supplied reason="omitted">፡</supplied> ጸሎት፡ በእንተ፡ ሕማመ<supplied reason="omitted">፡</supplied></hi>
                                 ሸቶላይ፡ አንተ፡ ሸቶላይ፡ ወሸቶላዊ፡ ጋኔን፡ ዘ<sic>ትቀት<supplied reason="omitted">፡</supplied></sic> ሕፃናተ፡ ወትቋርጽ፡ አማሉተ፡ ወትጦዊ፡ አንጀተ፡
                                 ወትቆረጥም፡ አካላተ፡ ወተሐምም፡ አባላተ፡ አምሐልኩከ፡ ወአውገዝኩከ፡ ወለጐምኩከ፡ ወአሰርኩከ፡ ወቆለፍኩከ፡ ወሐተምኩከ፡ በማሕተመ<supplied reason="omitted">፡</supplied>
-                                አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ በእግዚአብሔር<supplied reason="omitted">፡</supplied> መለኮት፡ ወካእበ፡ አሰርኩከ፡ አንተ፡ ሸቶላይ፡ ጋኔን፡ በዝንቱ፡ አስማት፡ 
+                                አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ በእግዚአብሔር<supplied reason="omitted">፡</supplied> መለኮት፡ ወካእበ፡ አሰርኩከ፡ አንተ፡ ሸቶላይ፡ ጋኔን፡ በዝንቱ፡ አስማት፡
                                 መሐጀን፡ መሐጀን፡ መሐጀን፡ ፲ ጊዜ፡ አመአጃም፡ ቀለጀም፡ ሸጀም፡ ሹን፡ ሸድን። ማው፡ ማውካ፡ ያሐጀ፡ ያሐጀ፡ የሐጀ፡ የሐቱደጀ፡ አአጠጨታሕ፡ በጉሎንቃርሌውስ፡ ማር፡ በኃይለ፡
                                 ዝንቱ፡ እንቱ፡ አስማቲከ፡ ቀጥቀጦ፡ ወአርኅቆ፡ ወሰድዶ<supplied reason="omitted">፡</supplied> ለዝንቱ፡ ጋኔን፡ ዘስሙ፡ ሸቶላይ፡ ከነ፡ ይጾእ፡ ወኢይቀረብ፡ ኀበ፡
                                 አመትከ፡ <persName ref="PRS14043WalattaS" role="owner">ወ<hi rend="rubric">ለተ፡ ሥላሴ፡</hi></persName> <hi rend="rubric">ሾር።</hi>
@@ -402,7 +402,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <ab/>
                         </div>
                     </div>
-                    
+
                 </div>
             </div>
         </body>

--- a/OxfordBodleian/Juel-Jensen/BDLaethb3.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethb3.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!--  
+                <!--
                 <title xml:lang="gez" xml:id="title1">አርባዕቱ፡ ወንጌል፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">ʾArbāʿtu wangel</title>
                  -->
@@ -47,19 +47,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <note>The manuscript was partially photographed by EMIP as 03453.</note><!-- facs="EMIP/Codices/3453/" n="17" -->
                         </altIdentifier>
                     </msIdentifier>
-                    
+
                     <msContents>
                         <summary/>
-                        
+
                              <msItem xml:id="ms_i1">
                                  <locus from="5ra" to="293vb"/>
                                  <title type="complete" ref="LIT1560Gospel"/>
                                <textLang xml:lang="gez"/>
-                                 
+
                                  <msItem xml:id="ms_i1.1">
                                      <locus from="5ra" to="14ra"/>
                                      <title type="complete" ref="LIT2705Introd"/>
-                                 
+
                                  <msItem xml:id="ms_i1.1.1">
                                      <locus from="5ra" to="9vb"/>
                                      <title type="complete" ref="LIT4872MaqdemaWangel"/>
@@ -79,48 +79,48 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                          <hi rend="rubric">፲ወ፩</hi> መስመር። ሉቃስ፡ <hi rend="rubric">፸፪</hi> መስመር<hi rend="rubric" rendition="#partialRubric">፨</hi> ዮሐንስ፡ ፺ወ፰
                                          መስመር<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                      </explicit>
-                                     
+
                                 <!--     <msItem xml:id="ms_i1.1.1.1">
                                          <locus from="5ra" to="5rb"/>
                                          <title type="complete" ref="LIT4872MaqdemaWangel#Preface"/>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.1.1.2">
                                          <locus from="5rb" to="5va"/>
                                          <title type="complete" ref="LIT4872MaqdemaWangel#Chapter1"/>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.1.1.3">
                                          <locus from="5va" to="8va"/>
                                          <title type="complete" ref="LIT4872MaqdemaWangel#Chapter2"/>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.1.1.4">
                                          <locus from="8va" to="8vb"/>
                                          <title type="complete" ref="LIT4872MaqdemaWangel#Chapter3"/>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.1.1.5">
                                          <locus from="8vb" to="8vc"/>
                                          <title type="complete" ref="LIT4872MaqdemaWangel#Chapter4"/>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.1.1.6">
                                          <locus from="8vc" to="9ra"/>
                                          <title type="complete" ref="LIT4872MaqdemaWangel#Chapter5"/>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.1.1.7">
                                          <locus from="9ra" to="9rb"/>
                                          <title type="complete" ref="LIT4872MaqdemaWangel#Chapter6"/>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.1.1.8">
                                          <locus from="9rb" to="9vb"/>
                                          <title type="complete" ref="LIT4872MaqdemaWangel#Chapter7"/>
                                      </msItem>-->
                                  </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.1.2">
                                          <locus target="#9vb"/>
                                          <title type="complete" ref="LIT4873Stichometry"/>
@@ -132,7 +132,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                              ለዓለመ፡ ዓለም<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                          </explicit>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.1.3">
                                          <locus target="#9vb"/>
                                          <title type="complete" ref="LIT4870EvangelistsSymbols"/>
@@ -142,7 +142,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                              አሜን<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                          </incipit>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.1.4">
                                          <locus from="9vc" to="10rb"/>
                                          <title type="complete" ref="LIT1548Gessaw"/>
@@ -158,20 +158,20 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                              ቃላት፡ ዘቅዱሳን፡ <hi rend="rubric">፬</hi> ወንጌል<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                          </explicit>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.1.5">
                                          <locus target="#10rb"/>
                                          <title type="complete" ref="LIT4869Disciples"/>
                                          <incipit xml:lang="gez">
                                              <hi rend="rubric"><hi rend="rubric">ዘእምሐዋርያተ፡ እግዚእነ፡ አርድእት፡ ዘእምኍልቈ፡ ፸ወ፪</hi>
-                                             እምኔሆሙ፡ ቀሌምንጦስ፡ ሰበከ፡ ወጸሐፈ፡ ሕገ፡ ቤተ፡ ክርስቲያን፡ 
+                                             እምኔሆሙ፡ ቀሌምንጦስ፡ ሰበከ፡ ወጸሐፈ፡ ሕገ፡ ቤተ፡ ክርስቲያን፡
                                              ለጳጳሳት፡ ወለቀሳውስት፡ ወለኵሉ፡ ፍጻሜ፡ ሢመተ፡ ቤተ፡ ክርስቲያን<hi rend="rubric" rendition="#partialRubric">፨</hi></hi>
                                          </incipit>
                                          <explicit xml:lang="gez">
                                              ማቴዎስ፡ <hi rend="rubric">፩</hi> በርናባስ፡ <hi rend="rubric">፩</hi> ቃሊኖስ፡ ጸሐፈ፡ በእንቲአሁ፡ ኀበ፡ ጢሞቴዎስ፡ ረድኡ፡ ለጳውሎስ፡ ታዴዎስ፡ ወቀለዮጳ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                          </explicit>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.1.6">
                                          <locus from="10rb" to="10rc"/>
                                          <title type="complete" ref="LIT4871OriginalLanguage"/>
@@ -184,17 +184,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                              ወግብረ፡ ሐዋርያትኒ፡ ሉቃስ፡ ወንጌላዊ፡ ተርጐመ፡ በነገረ፡ ጽርዕ፡ እንዘ፡ ዕብራይስጥ፡ ሀሎ፡ ወንጌል፡ ዘዜነወ፡ ዮሐንስ፡ ተርጐመ፡ ዮሐንስ፡ ጳጳስ፡ በነገረ፡ ጽርዕ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                          </explicit>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.1.7">
                                          <locus target="#10rc"/>
                                          <title type="complete" ref="LIT4874EpiscopalSees"/>
                                          <incipit xml:lang="gez">
                                              <locus target="#10rc"/>
                                              <!--this is the entire text-->
-                                             መናብርቲሆሙ፡ ለለአሐዱ<hi rend="rubric" rendition="#partialRubric">፨</hi> ዘማቴዎስ፡ ሮሜ፡ ዘማርቆስ፡ እለ፡ እስክንድርያ፡ ዘሉቃስ፡ አንጾኪያ፡ ዘዮሐንስ፡ ኤፌሶን<hi rend="rubric" rendition="#partialRubric">፨</hi> 
+                                             መናብርቲሆሙ፡ ለለአሐዱ<hi rend="rubric" rendition="#partialRubric">፨</hi> ዘማቴዎስ፡ ሮሜ፡ ዘማርቆስ፡ እለ፡ እስክንድርያ፡ ዘሉቃስ፡ አንጾኪያ፡ ዘዮሐንስ፡ ኤፌሶን<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                          </incipit>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.1.8">
                                          <locus from="10rc" to="10vc"/>
                                          <title type="complete" ref="LIT1349EpistlEusebius">
@@ -203,7 +203,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                          <incipit xml:lang="gez">
                                              <locus target="#10rc"/>
                                              አሞንዮስ፡ እስክንድርያዊ፡ በብዙኅ፡ አስተሐምሞ፡ ወጽሒቅ፡ ገብረ፡ ወኃደገ፡ ለነ፡
-                                             ቃለ፡ ዘከመ፡ ኃብሩ፡ <hi rend="rubric">፬</hi> ወንጌላት<hi rend="rubric" rendition="#partialRubric">፨</hi> ወእምዝ፡ አርእስተ፡ 
+                                             ቃለ፡ ዘከመ፡ ኃብሩ፡ <hi rend="rubric">፬</hi> ወንጌላት<hi rend="rubric" rendition="#partialRubric">፨</hi> ወእምዝ፡ አርእስተ፡
                                              <add place="above">ም</add>ንባባት<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                          </incipit>
                                          <explicit xml:lang="gez">
@@ -213,7 +213,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                              ወትእምርት፡ ኀበ፡ አኀዙ፡ ትእምርተ፡ መስቀል<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                          </explicit>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.1.9">
                                          <locus from="10vc" to="11ra"/>
                                          <title type="complete" ref="LIT4875Reliability"/>
@@ -226,7 +226,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                              ወውእቶሙ፡ ማቴዎስ፡ ወማርቆስ፡ ሉቃስ፡ ወዮሐንስ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                          </explicit>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.1.10">
                                          <locus from="11ra" to="11rb"/>
                                          <title type="complete" ref="LIT1558Matthew#BiographyMatthew"/>
@@ -240,7 +240,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                              ወሰበከ፡ ባቲ፡ በህንድ፡ ወበኢየሩሳሌም<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                          </explicit>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.1.11">
                                          <locus target="#11rb"/>
                                          <title type="complete" ref="LIT1558Matthew#EusebianSectionsMatthew"/>
@@ -251,17 +251,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                              ወምዕራፋቲሁ፡ በልሳነ፡ ሮሜ፡ <hi rend="rubric">፷፰</hi>ቱ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                          </explicit>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.1.12">
                                          <locus from="12ra" to="14ra"/>
                                          <title type="complete" ref="LIT1224Canons"/>
                                      </msItem>
                                  </msItem>
-                                 
+
                                  <msItem xml:id="ms_i1.2">
                                      <locus from="15ra" to="94vb"/>
                                      <title type="complete" ref="LIT1558Matthew"/>
-                                     
+
                                      <msItem xml:id="ms_i1.2.1">
                                          <locus from="15ra" to="94va"/>
                                          <title type="complete" ref="LIT1558Matthew#MatthewGospel"/>
@@ -286,29 +286,29 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                              አሜን<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                          </explicit>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.2.2">
                                          <locus from="94va" to="94vb"/>
                                          <title type="complete" ref="LIT1558Matthew#PostscriptMatthew"/>
                                          <incipit xml:lang="gez">
                                              <locus target="#44va"/>
-                                             <hi rend="rubric">ተፈጸመ፡ ጽሕፈተ፡</hi> <seg type="title subscriptio"><hi rend="rubric">ብስራቱ፡ ለማቴዎስ፡ 
+                                             <hi rend="rubric">ተፈጸመ፡ ጽሕፈተ፡</hi> <seg type="title subscriptio"><hi rend="rubric">ብስራቱ፡ ለማቴዎስ፡
                                                  ሐዋር</hi>ያ<hi rend="rubric" rendition="#partialRubric">፨</hi></seg> ወኮነ፡ ጽሒፎቱ፡ በምድረ፡ ፍልስጥኤም፡
                                          </incipit>
                                          <explicit xml:lang="gez">
                                              <locus target="#94vb"/>
-                                             በቀዳሚሁ፡ <sic>ዓም፡</sic> 
+                                             በቀዳሚሁ፡ <sic>ዓም፡</sic>
                                              ዘእምቀላውዴዎስ፡
                                              ቄሳር፡ ንጉሠ፡ ሮም<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                              ወስብሐት፡ ለእግዚአብሔር፡ ለዓለመ፡ ዓለም፡ ዘልፈ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                          </explicit>
                                      </msItem>
                                  </msItem>
-                                 
+
                                  <msItem xml:id="ms_i1.3">
                                      <locus from="95ra" to="145rb"/>
                                      <title type="complete" ref="LIT1882MarkGo"/>
-                                     
+
                                      <msItem xml:id="ms_i1.3.1">
                                          <locus from="95ra" to="95va"/>
                                          <title type="complete" ref="LIT1882MarkGo#BiographyMark"/>
@@ -319,13 +319,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                          </incipit>
                                          <explicit xml:lang="gez">
                                              <locus target="#95va"/>
-                                             ወአዕረፈ፡ አመ፡ <hi rend="rubric" rendition="#partialRubric">፴</hi>ሁ፡ ለሚያዝያ፡ 
+                                             ወአዕረፈ፡ አመ፡ <hi rend="rubric" rendition="#partialRubric">፴</hi>ሁ፡ ለሚያዝያ፡
                                              በ<hi rend="rubric" rendition="#partialRubric">፲</hi>ወ<hi rend="rubric" rendition="#partialRubric">፬</hi>፡
-                                                 ዓመተ፡ መንግሥቱ፡ ለቀላውዴዎስ፡ ቄሳር፡ ወኵሉ፡ ኑኃ፡ ንብረቱ፡ 
+                                                 ዓመተ፡ መንግሥቱ፡ ለቀላውዴዎስ፡ ቄሳር፡ ወኵሉ፡ ኑኃ፡ ንብረቱ፡
                                              <add place="overstrike"><hi rend="rubric">፸</hi></add> ዓመት<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                          </explicit>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.3.2">
                                          <locus target="#95va"/>
                                          <title type="complete" ref="LIT1882MarkGo#EusebianSectionsMark"/>
@@ -338,7 +338,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                              ወምዕራፋቲሁ፡ እንተ፡ ተተርጐመት፡ በልሳነ፡ ቅብጥ፡ <hi rend="rubric" rendition="#partialRubric">፶</hi>ወ<hi rend="rubric" rendition="#partialRubric">፬</hi> ወበሮሜ፡ <hi rend="rubric" rendition="#partialRubric">፵</hi>ወ<hi rend="rubric" rendition="#partialRubric">፰</hi><hi rend="rubric" rendition="#partialRubric">፨</hi>
                                          </explicit>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.3.3">
                                          <locus from="95va" to="95vb"/>
                                          <title type="complete" ref="LIT1882MarkGo#TituliMark"/>
@@ -354,7 +354,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                              <lb n="48"/><hi rend="rubric">፵፰</hi> ስእለተ፡ ሥጋሁ፡ ለእግዚእነ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                          </explicit>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.3.4">
                                          <locus from="96ra" to="96vb"/>
                                          <title type="complete" ref="LIT6725Letter"/>
@@ -362,27 +362,27 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                              <locus target="#96ra"/>
                                              መጽሐፈ፡ መልእክት፡ ዘተፈነወት፡ እም<persName ref="PRS5712JohnXVI">ዮሐንስ፡</persName> ገብረ፡ እግዚአብሔር፡ ዘተሰምየ፡
                                              ዘጸጋሁ፡ ወተሠይመ፡ <add place="overstrike">በፈቃዱ፡</add> ለተልእኮ፡ መንበር፡ ማርቆሳዊ፡ በሀገረ፡ ዓባይ፡
-                                             እለ፡ እስክንድርያ፡ ወትዕይንተ፡ ኢየሩሳሌም፡ ወገዳማተ፡ ምስር፡ ወበሐውርተ፡ ኢትዮጵያ፡ ሰላመ፡ እግዚአብሔር፡ ቅዱስ፡ ሕይወተ፡ ሥጋ፡ ወኵሉ፡ ነፍስ፡ 
+                                             እለ፡ እስክንድርያ፡ ወትዕይንተ፡ ኢየሩሳሌም፡ ወገዳማተ፡ ምስር፡ ወበሐውርተ፡ ኢትዮጵያ፡ ሰላመ፡ እግዚአብሔር፡ ቅዱስ፡ ሕይወተ፡ ሥጋ፡ ወኵሉ፡ ነፍስ፡
                                              <sic>ይኀድር፡</sic> ዝንቱ፡
                                              ሰላም፡ መንፈሳዊ፡ ላዕለ፡ ውሉድነ፡ ውሉደ፡ መንግሥት፡ ልዑላን፡ በሥልጣን፡ ወዕበይ፡ ወክብር፡ ወዓዲ፡ ይኀድር፡ ጸጋ፡
-                                             <add place="overstrike">አ</add>ምላካዊ፡ ወበረከት፡ ሰማያዊ፡ ላዕሌከ፡ ኦወልድነ፡ 
+                                             <add place="overstrike">አ</add>ምላካዊ፡ ወበረከት፡ ሰማያዊ፡ ላዕሌከ፡ ኦወልድነ፡
                                              ቡሩክ፡ ወወሬዛ፡ ሠናይ፡ ዘነበርከ፡ በመንበረ፡ ነገሥት፡ መሲሐዊያን፡
                                          </incipit>
                                          <explicit xml:lang="gez">
                                              <locus target="#96vb"/>
                                              ወይኩን፡ ፍቱሐ፡ ወቡሩከ፡ በአፈ፡ አበዊነ፡ ሐዋርያት፡ ንጹሐን፡ ወበአፈ፡ ሊቃውንተ፡ ቤተ፡ ክርስቲያን፡ ቅድስት፡ ወበአፈ፡ ኵሎሙ፡ ሊቃነ፡ ጳጳሳት፡ ቅዱሳን፡ ወአፉየ፡ አነ፡ ዮሐንስ፡
                                              ላዕክ፡ በጸጋ፡ መንበር፡ ማርቆሳዊ፡ ወሰላመ፡ እግዚአብሔር፡ <sic>ይኀድር፡</sic> ላዕሌክሙ፡ ወስብሐት፡ ለእግዚአብሔር፡ ለዓለመ፡ ዓለም፡ አሜን።
-                                             ወተጽሕፈ፡ በዘመነ፡ ዮሐንስ፡ ወንጌላዊ፡ በእደ፡ 
+                                             ወተጽሕፈ፡ በዘመነ፡ ዮሐንስ፡ ወንጌላዊ፡ በእደ፡
                                              <persName ref="PRS5712JohnXVI"><roleName type="title">አባ፡</roleName> ዮሐንስ፡</persName> ሊቀ፡ ጳጳሳት፡
-                                             ዘእለ፡ እስክንድርያ፡ አመ፡ ፳ወ፭ ለመስከረም፡ ወበ<date when="1743" when-custom="1460" calendar="diocletian">፲፻ወበ፬፻ወ፷ እምዓመተ፡ 
-                                             ሰማዕታት፡</date> ንጹሐን። 
+                                             ዘእለ፡ እስክንድርያ፡ አመ፡ ፳ወ፭ ለመስከረም፡ ወበ<date when="1743" when-custom="1460" calendar="diocletian">፲፻ወበ፬፻ወ፷ እምዓመተ፡
+                                             ሰማዕታት፡</date> ንጹሐን።
                                          </explicit>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.3.5">
                                          <locus from="97ra" to="145rb"/>
                                          <title type="complete" ref="LIT1882MarkGo"/>
-                                         
+
                                          <msItem xml:id="ms_i1.3.5.1">
                                              <locus from="97ra" to="145rb"/>
                                              <title type="complete" ref="LIT1882MarkGo#MarkGospel"/>
@@ -390,14 +390,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <hi rend="rubric">ብስራተ፡ አብ፡ ቅዱስ፡ ማ</hi>ሪ፡ ማርቆስ፡ ወንጌላዊ<hi rend="rubric" rendition="#partialRubric">።</hi>
     <hi rend="rubric">አሐዱ፡ እምሰብአ፡ ወክ</hi>ልኤቱ፡
     አርድእት<hi rend="rubric" rendition="#partialRubric">፨</hi>
-    በረ<cb n="b"/><hi rend="rubric">ከቱ፡ አምላኩ፡ ወሀብተ፡</hi> ረድኤቱ፡ ትኩን፡ ምስለ፡ 
-    <hi rend="rubric">ንጉሥነ፡ <persName ref="PRS5617IyasuII">ኢያሱ፡</persName> ወንግሥ</hi>ትነ፡ 
+    በረ<cb n="b"/><hi rend="rubric">ከቱ፡ አምላኩ፡ ወሀብተ፡</hi> ረድኤቱ፡ ትኩን፡ ምስለ፡
+    <hi rend="rubric">ንጉሥነ፡ <persName ref="PRS5617IyasuII">ኢያሱ፡</persName> ወንግሥ</hi>ትነ፡
     <persName ref="PRS2682BerhanM"><hi rend="rubric">ወለተ፡ ጊዮርጊስ፡</hi></persName> ለዓለመ፡ ዓለም፡
     አሜን<hi rend="rubric" rendition="#partialRubric">፨</hi>
-    <cb n="a"/> ወአሜን<hi rend="rubric" rendition="#partialRubric">፨</hi> 
+    <cb n="a"/> ወአሜን<hi rend="rubric" rendition="#partialRubric">፨</hi>
     ለይኩን<hi rend="rubric" rendition="#partialRubric">፨</hi>
-</incipit>                                            
-                                             
+</incipit>
+
                                              <incipit xml:lang="gez">
                                                  <hi rend="rubric">ቀዳሚሁ፡ ለወንጌለ፡ እ</hi>ግዚእነ፡ ኢየሱስ፡ ክርስ<hi rend="rubric">ቶስ፡ ወልደ፡
                                                      እግዚኣብ</hi>ሔር፡ በከመ፡ ጽሑፍ<hi rend="rubric" rendition="#partialRubric">፨</hi> <hi rend="rubric">ውስተ፡ መጽሐፈ፡
@@ -408,7 +408,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                  ወቃሎ፡ ያጸንዕ፡ በተአምር፡ ዘይተሉ፡ አሜን<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                              </explicit>
                                          </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.3.5.2">
                                          <locus target="#145rb"/>
                                          <title type="complete" ref="LIT1882MarkGo#MarkPostscript"/>
@@ -427,22 +427,22 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                          </explicit>
                                      </msItem>
                                  </msItem>
-                            
-                             
+
+
                                  <msItem xml:id="ms_i1.4">
                                      <locus from="145va" to="228ra"/>
                                      <title type="complete" ref="LIT1812GospelLuke"/>
-                                     
+
                                      <msItem xml:id="ms_i1.4.1">
                                          <locus target="#145va"/>
                                          <title type="complete" ref="LIT1812GospelLuke#LukeGospelPreface"/>
-                                         
+
                                          <msItem xml:id="ms_i1.4.1.1">
                                              <locus target="#145va"/>
                                              <title type="complete" ref="LIT1812GospelLuke#SupplicationPrefaceLuke"/>
                                              <incipit xml:lang="gez">
-                                                 <hi rend="rubric">በስመ፡ አብ፡ እግዚአብሔር፡ ዘይት</hi>ወሐድ፡ <add place="overstrike">በህላዌ፡ መለ</add>ኮት፡ 
-                                                 ወይ<hi rend="rubric">ሤለስ፡ በአካላት፡ 
+                                                 <hi rend="rubric">በስመ፡ አብ፡ እግዚአብሔር፡ ዘይት</hi>ወሐድ፡ <add place="overstrike">በህላዌ፡ መለ</add>ኮት፡
+                                                 ወይ<hi rend="rubric">ሤለስ፡ በአካላት፡
                                                      ወበገጻት፡ ሕ</hi>ያው፡ ወማሕየዌ፡ ዘመሐረነ፡ በስንዓአሁ፡ እምድኅረ፡
                                                      ስሕተት፡ <sic>ወፁረት፡</sic> ወመርሐነ፡ ድኅረ፡ ተኃጐልነ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                              </incipit>
@@ -451,15 +451,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                  ሎቱ፡ ይደሉ፡ ስብሐት፡ ለክቡረ፡ ክቡራን፡ ወአልቦ፡ ካልእ፡ አምላክ፡ ዘእንበሌሁ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                              </explicit>
                                          </msItem>
-                                         
+
                                          <msItem xml:id="ms_i1.4.1.2">
                                              <locus target="#145va"/>
-                                             <title type="complete" ref="LIT1812GospelLuke#TitlePrefaceLuke">ንወጥን፡ በረድኤተ፡ እግዚአብሔር፡ 
+                                             <title type="complete" ref="LIT1812GospelLuke#TitlePrefaceLuke">ንወጥን፡ በረድኤተ፡ እግዚአብሔር፡
                                                  በጽሒፈ፡ ወንጌል<hi rend="rubric" rendition="#partialRubric">፤</hi>
                                              መብስር፡ እንተ፡ ዘሉቃስ፡ ኅሩይ፡ ወሥሙር፡</title>
                                          </msItem>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.4.2">
                                          <locus from="145va" to="146ra"/>
                                          <title type="complete" ref="LIT1812GospelLuke#BiographyLuke"/>
@@ -472,28 +472,28 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                          </incipit>
                                          <explicit xml:lang="gez">
                                              <locus target="#67rb"/>
-                                             ወአእረፈ፡ ከዊኖ፡ ሰማዕተ፡ በሮምያ፡ አመ፡ 
+                                             ወአእረፈ፡ ከዊኖ፡ ሰማዕተ፡ በሮምያ፡ አመ፡
                                              <hi rend="rubric" rendition="#partialRubric">፲</hi>ወ<hi rend="rubric" rendition="#partialRubric">፪</hi>፡
                                              ለወርኃ፡ ለጥቅምት፡
                                          </explicit>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.4.3">
                                          <locus target="#146ra"/>
                                          <title type="complete" ref="LIT1812GospelLuke#EusebianSectionsLuke"/>
                                          <incipit xml:lang="gez">
                                              <locus target="#146ra"/>
-                                             ወኍልቈ፡ ምዕራፉሰ፡ ዘኀብሩ፡ ባቲ፡  
+                                             ወኍልቈ፡ ምዕራፉሰ፡ ዘኀብሩ፡ ባቲ፡
                                              <hi rend="rubric" rendition="#partialRubric">፹</hi>ወ <hi rend="rubric" rendition="#partialRubric">፫</hi>፡
                                          </incipit>
                                          <explicit>
                                              <locus target="#146ra"/>
-                                             ወበካልዕሰ፡ ጽሕፈት፡ 
+                                             ወበካልዕሰ፡ ጽሕፈት፡
                                              <hi rend="rubric" rendition="#partialRubric">፴፻</hi>፡
                                              ውእቱ <hi rend="rubric" rendition="#partialRubric">፨</hi>
                                          </explicit>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.4.4">
                                          <locus from="146ra" to="146va"/>
                                          <title type="complete" ref="LIT1812GospelLuke#TituliLuke"/>
@@ -510,11 +510,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                              <hi rend="rubric">፹፫</hi> ቀለዮጳ፡ ወካልኡ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                          </explicit>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.4.5">
                                          <locus from="147ra" to="227vc"/>
                                          <title type="complete" ref="LIT2713Luke"/>
-                                         
+
                                          <msItem xml:id="ms_i1.4.5.1">
                                              <locus from="147ra" to="227vb"/>
                                              <title type="complete" ref="LIT1812GospelLuke#LukeGospel"/>
@@ -522,8 +522,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                  <hi rend="rubric">ብስራተ፡ አብ፡ ትሩፍ፡</hi> ሉቃስ፡ ወንጌላዊ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                                  አ<hi rend="rubric">ሐዱ፡ እምሰብዓ፡ ወክ</hi>ልኤቱ፡
                                                  አርድእት<hi rend="rubric" rendition="#partialRubric">፨</hi>
-                                                 ጸሎቱ፡ በረከቱ፡ የ<cb n="b"/><hi rend="rubric">ሀሉ፡ ምስለ፡ 
-                                                     ንጉሥነ፡ <persName ref="PRS5617IyasuII">ኢያሱ፡</persName></hi> ወንግሥትነ፡ 
+                                                 ጸሎቱ፡ በረከቱ፡ የ<cb n="b"/><hi rend="rubric">ሀሉ፡ ምስለ፡
+                                                     ንጉሥነ፡ <persName ref="PRS5617IyasuII">ኢያሱ፡</persName></hi> ወንግሥትነ፡
                                                  <persName ref="PRS2682BerhanM"><hi rend="rubric">ወለተ፡ ጊዮርጊስ።</hi></persName>
                                                  <hi rend="rubric">ለዓ</hi>ለመ፡ ዓለም፡ አሜን<hi rend="rubric" rendition="#partialRubric">፨</hi> ወአሜን<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                                  <hi rend="rubric" rendition="#partialRubric">፨</hi>
@@ -540,7 +540,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                  ወነበሩ፡ በቤተ፡ መቅደስ፡ እንዘ፡ ይሴብሕዎ፡ ወይባርክዎ፡ ለእግዚአብሔር፡ ዘልፈ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                              </explicit>
                                          </msItem>
-                                         
+
                                          <msItem xml:id="ms_i1.4.5.2">
                                              <locus target="#228ra"/>
                                              <title type="complete" ref="LIT1812GospelLuke#PostscriptLuke"/>
@@ -556,18 +556,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                          </msItem>
                                      </msItem>
                                  </msItem>
-                             
+
                                  <msItem xml:id="ms_i1.5">
                                      <locus from="229ra" to="293vb"/>
                                      <title type="complete" ref="LIT1693John"/>
-                                     
+
                                      <msItem xml:id="ms_i1.5.1">
                                          <locus from="229ra" to="293va"/>
                                          <title type="complete" ref="LIT1693John#JohnGospel"/>
                                          <incipit xml:lang="gez" type="inscriptio expanded">
                                              <hi rend="rubric">በስመ፡ እግዚአብሔ</hi>ር፡ ፈጣሪ፡ ሕያው፡ ቀዳ<hi rend="rubric">ማዊ፡ ዘሀሎ፡ ወይሄ</hi>ሉ፡ እስከ፡ ለዓለም<hi rend="rubric" rendition="#partialRubric">፤</hi>
                                              ብስራተ፡ ዮሐንስ፡ ሐዋ<hi rend="rubric">ርያ፡ ፈጻሜ፡ ብስራት፡ </hi>
-                                             በረከተ፡ አምላኩ፡ ት<hi rend="rubric">ኩን፡ ምስለ፡ ንጉሥነ፡ <persName ref="PRS5617IyasuII">ኢያሱ፡</persName></hi> ወንግሥትነ፡ 
+                                             በረከተ፡ አምላኩ፡ ት<hi rend="rubric">ኩን፡ ምስለ፡ ንጉሥነ፡ <persName ref="PRS5617IyasuII">ኢያሱ፡</persName></hi> ወንግሥትነ፡
                                              <persName ref="PRS2682BerhanM"><hi rend="rubric">ወለተ፡ ጊዮርጉስ፡</hi></persName>
                                              ለ<cb n="a"/>ዓለመ፡ ዓለም፡ አሜን፡ <cb n="b"/>ወአሜን፡ ለይኩን<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                          </incipit>
@@ -582,29 +582,29 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                              ወሶበ፡ ተጽሕፈ፡ ኵሉ፡ <add place="overstrike">በበ፡</add>  አሐዱ፡ እምኢያግመሮ፡ ዓለም፡ ጥቀ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                              መጻሕፍቲሁ፡ ዘተጽሕፈ<hi rend="rubric" rendition="#partialRubric">፨</hi> አሜን<hi rend="rubric" rendition="#partialRubric">፨</hi> ወአሜን<hi rend="rubric" rendition="#partialRubric">፨</hi>                                         </explicit>
                                      </msItem>
-                                     
+
                                      <msItem xml:id="ms_i1.5.2">
                                          <locus target="#293vb"/>
                                          <title type="complete" ref="LIT1693John#Postscript"/>
                                          <incipit xml:lang="gez">
                                              <locus target="#293vb"/>
-                                             <hi rend="rubric">መልአ፡</hi> <seg type="title subscriptio"><hi rend="rubric">ስብከተ፡ ዮሐንስ፡ ወልደ፡ ዘብዴዎስ፡</hi> ሐዋርያ፡ 
+                                             <hi rend="rubric">መልአ፡</hi> <seg type="title subscriptio"><hi rend="rubric">ስብከተ፡ ዮሐንስ፡ ወልደ፡ ዘብዴዎስ፡</hi> ሐዋርያ፡
                                                  እምዓሠርቱ፡ ወክልኤቱ<hi rend="rubric" rendition="#partialRubric">፨</hi></seg> እንተ፡ ጸሐፋ፡ በዮናኒ፡ ለሰብአ፡ ሀገረ፡ ኤፌሶን።
                                          </incipit>
                                          <explicit xml:lang="gez">
                                              <locus target="#293vb"/>
                                              በሰመንቱ፡ ዓመተ፡ መንግሥቱ፡ ለኔሮን፡ ቄሳር<hi rend="rubric" rendition="#partialRubric">፨</hi>
-                                             ወስብሐት፡ ለእግዚአብሔር፡ 
+                                             ወስብሐት፡ ለእግዚአብሔር፡
                                              ለዓለመ፡ ዓለም<hi rend="rubric" rendition="#partialRubric">፨</hi> ወትረ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                              አሜን<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                          </explicit>
                                      </msItem>
                                  </msItem>
-                                 
+
                              </msItem>
                              </msItem>
                     </msContents>
-                    
+
 
                     <physDesc>
                         <objectDesc form="Codex">
@@ -612,9 +612,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <support>
                                     <material key="parchment"/>
                                     <p>Few tears resulting from parchment making are found on <locus target="#133 #176 #202"/>
-                                       and have been repaired by sewing. <locus target="#14"/> is cut off after the first column. 
+                                       and have been repaired by sewing. <locus target="#14"/> is cut off after the first column.
                                         <persName ref="PRS6665Mangasa">Leul Ras Mangashia Seyoum</persName>, who provided his expertise on the manuscript to Bent Juel-Jensen,
-                                    takes the material to be horse vellum (cp. 
+                                    takes the material to be horse vellum (cp.
                                         <bibl><ptr target="bm:JuelJensen1981Gospels"/><citedRange unit="page">65</citedRange></bibl>).</p>
      </support>
                                 <extent>
@@ -765,10 +765,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </collation>
 
                                 <condition key="good">
-                                  The manuscript is in a good state of preservation. The folios are intact and show only minor distortion around the margin due to the extremely hygroscopic nature of parchment. 
-                                  The damage is affecting only the binding.
-                                  The sewing is broken at the attachment of the second, third, and fourth sewing station with the front board and at
-                                  the attachment of the third and fourth sewing station with the back board. <locus target="#q31">The last quire</locus> is only attached at the last sewing station.
+                                  The leaves are intact and show only minor distortion around the margin due to humidity.
+                                  Most damage is affecting the binding.
+                                  The sewing is broken in many points so that <locus target="#q31">the last quire</locus> is almost detached from the bookblock.
                                   Insects caused the losses present on the cover, especially on the spine. The spine is torn and a part is missing at the head.
                                   A tear on the tail edge has been repaired by sewing it with a black thread. The tailband is fragmentary.
                                   Water stains are present on the upper board.
@@ -782,13 +781,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <locus from="15ra" to="94vb"/>
                                     <locus from="97ra" to="145vb"/>
                                     <locus from="147ra" to="294rb"/>
-                                    <note corresp="#textarea #margin">This is the main layout of the text of the Gospels. 
+                                    <note corresp="#textarea #margin">This is the main layout of the text of the Gospels.
                                         Data on text area and margin dimensions taken from <locus target="#23r"/>.</note>
                                     <dimensions unit="mm" xml:id="textarea">
                                         <height>294</height>
                                         <width>287</width>
                                     </dimensions>
-                                    <note>The characters per line per column are 11–13. On <locus target="#95r"/> and <locus target="#145v"/>, 
+                                    <note>The characters per line per column are 11–13. On <locus target="#95r"/> and <locus target="#145v"/>,
                                         which are written in a smaller script on the same layout, the characters per line per column are
                                         16–18.</note>
                                     <dimensions type="margin" unit="mm" xml:id="margin">
@@ -802,7 +801,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A-1A1A/0-0/0-0/C.</ab>
                                     <ab type="ruling"> The upper line is written above the ruling. The bottom line is written above the ruling.</ab>
                                 </layout>
-                                
+
                                 <layout columns="3" writtenLines="27">
                                     <locus from="5ra" to="11rb"/>
                                     <!--<note corresp="#textarea #margin">Data on text area and margin dimensions taken from <locus target="#"/>.</note>-->
@@ -822,7 +821,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A-1A1A-1A1A/0-0/0-0/C.</ab>
                                     <ab type="ruling"> The upper line is written above the ruling. The bottom line is written above the ruling.</ab>
                                 </layout>
-                                
+
                                 <layout>
                                     <locus from="12ra" to="14ra"/>
                                   <!--  <note corresp="#textarea #margin">Data on text area and margin dimensions taken from <locus target="#"/>.</note>-->
@@ -841,8 +840,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are visible.</ab>
                                     <ab type="ruling" subtype="pattern">Grid ruling pattern to accomodate the layout of the Eusebian canons.</ab>
                                 </layout>
-                            
-                            
+
+
                                 <layout columns="2" writtenLines="33">
                                     <locus from="95va" to="96vb"/>
                                       <note corresp="#textarea #margin">Data on text area and margin dimensions taken from <locus target="#96r"/>.</note>
@@ -863,7 +862,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <ab type="ruling"> The upper line is written above the ruling. The bottom line is written above the ruling.</ab>
                                     <note>The number of ruled lines is 17. An additional line of text is written between ruled lines.</note>
                                 </layout>
-                            
+
                                 <layout columns="3" writtenLines="33">
                                     <locus from="146ra" to="146va"/>
                                     <note corresp="#textarea #margin">Data on text area and margin dimensions taken from <locus target="#146r"/>.</note>
@@ -887,108 +886,108 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </layout>
                             </layoutDesc>
                         </objectDesc>
-                        
+
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <persName ref="PRS13901Zaparaqlitos" role="scribe"/>
                                 <persName ref="PRS13900WaldaD" role="scribe"/>
                                 <date notBefore="1730" notAfter="1755"/>
-                                <desc>Regular handwriting, trained hand, <foreign xml:lang="gez">gʷǝlḥ</foreign> script. Big and evenly spaced characters. The two different names indicated in the bottom margins 
-                                    of <locus target="#117r #138v"/> and <locus target="#148r"/> indicate that at least two scribes were involved in the copying, 
+                                <desc>Regular handwriting, trained hand, <foreign xml:lang="gez">gʷǝlḥ</foreign> script. Big and evenly spaced characters. The two different names indicated in the bottom margins
+                                    of <locus target="#117r #138v"/> and <locus target="#148r"/> indicate that at least two scribes were involved in the copying,
                                 but no differences in the hand can be observed throughout the manuscript. The script of the introductions to the Gospels is smaller than that of the main text.</desc>
                                 <seg type="ink">Black, red.</seg>
-                                <seg type="rubrication">Single lines and groups of lines at the beginning of sections; single lines alternating with black lines 
+                                <seg type="rubrication">Single lines and groups of lines at the beginning of sections; single lines alternating with black lines
                                     at the beginning of each Gospel; chapter indications; holy names; names mentioned in the supplications;
                                     numerals and elements of numerals and punctuation signs.</seg>
                             </handNote>
                         </handDesc>
-                        
+
                         <additions>
                             <list>
                                 <item xml:id="a1">
                                     <locus from="1va" to="1vb"/>
-                                    <desc type="LandGrant">Record in Gǝʿǝz and Amharic by <persName ref="PRS5636IyoasI"/> and <persName ref="PRS2682BerhanM"/>, granting lands to 
+                                    <desc type="LandGrant">Record in Gǝʿǝz and Amharic by <persName ref="PRS5636IyoasI"/> and <persName ref="PRS2682BerhanM"/>, granting lands to
                                         daǧǧāzmāčč ʾƎšate, probably to be identified with <persName ref="PRS3856esateof"/>, in recognition of his deeds in war. The record mentions ‘the children of
                                         daǧǧ ʾazmāč Waraññā’, who might possibly be identified with <persName ref="PRS9880Waldaew"/>.</desc>
-                                    <q xml:lang="gez">ንሕነ፡ ንጉሠ፡ ነገሥት፡ <persName ref="PRS5636IyoasI">ኢዮአስ፡</persName> ወንግሥት፡ 
-                                        <persName ref="PRS2682BerhanM">ወለተ፡ ጊዮርጊስ፡</persName> ናሁ፡ ወሀብናሁ፡ ለደጃዝማች፡ <persName ref="PRS3856esateof">እሸቴ፡</persName> እምብሔረ፡ 
+                                    <q xml:lang="gez">ንሕነ፡ ንጉሠ፡ ነገሥት፡ <persName ref="PRS5636IyoasI">ኢዮአስ፡</persName> ወንግሥት፡
+                                        <persName ref="PRS2682BerhanM">ወለተ፡ ጊዮርጊስ፡</persName> ናሁ፡ ወሀብናሁ፡ ለደጃዝማች፡ <persName ref="PRS3856esateof">እሸቴ፡</persName> እምብሔረ፡
                                         አገው፡ <foreign xml:lang="am">ደሮምን። ድማማን። ሶሪትን። አነጉሳን። ዲኃን።
-                                        መንገሃን። ቻጃን። ኩንዘናን። አልችን። ቻጃ፡ ሙሃን። ሙልን። <placeName ref="LOC7009Zobent">ዞብንትን።</placeName> ናጽጋሪን። 
-                                        <placeName ref="LOC3569Gomar">ጎመርን።</placeName> የጃዎች<add place="above">ን</add>፡ አገር።  ስህሳን። እነባበራን።  ደገሐን። 
+                                        መንገሃን። ቻጃን። ኩንዘናን። አልችን። ቻጃ፡ ሙሃን። ሙልን። <placeName ref="LOC7009Zobent">ዞብንትን።</placeName> ናጽጋሪን።
+                                        <placeName ref="LOC3569Gomar">ጎመርን።</placeName> የጃዎች<add place="above">ን</add>፡ አገር።  ስህሳን። እነባበራን።  ደገሐን።
                                         ጆመራን። ድኩን። ባሪችችን። ደረብብን።
                                         የ<persName ref="PRS9880Waldaew"><roleName type="title">ደጅ፡ አዝማች፡</roleName> ወረኛ፡</persName> ልጃች፡ አካፍለው፡ ካስር፡ አንድ፡ ያነሱትን፡ አገር፡ ጉደራን። ባርዛፍላን። ከመ፡ ይቀድስ፡ ቦሙ፡ በታቦተ፡ ቍስቋም፡ እንተ፡ ይእቲ፡ ደብረ፡ ፀሐይ።
                                         <cb n="b"/> ምክንያተ፡ ውሂቦትነሰ፡ ፍዳ፡ ዘመቻሁ፡ መንገለ፡ ጋላ፡ ወቀተሎሙ፡ ለጂዳ፡ ወጨሌሐ፡ ወአእመኖሙ፡ ለኵሎሙ፡ ሰብአ፡ ጋላ።</foreign>
                                     </q>
                                 </item>
-                                
+
                                 <item xml:id="a2">
                                     <locus target="#1vb"/>
                                     <desc type="RecordTransaction">Amharic record of a transaction dated to 1767, in which
-                                        <persName ref="PRS13903Hirut"/> pawns land 
+                                        <persName ref="PRS13903Hirut"/> pawns land
                                         to <persName ref="PRS13904Baytafa"/>, with an extensive list of witnesses.</desc>
                                     <q xml:lang="am"><date when-custom="7260" calendar="world" when="1767-10-06">በ፸፻ወ፪፻፺ አመተ፡ ዓለም፡ በዘመነ፡ ዮሐንስ፡ በመስከረም፡ በ፳፯ ቀን፡</date>
-                                        ማክሰኞ፡ 
-                                        የ<persName ref="PRS13902Mammo"><roleName type="title">ሊቄ፡</roleName> ማሞ፡</persName> ልጅ፡ 
+                                        ማክሰኞ፡
+                                        የ<persName ref="PRS13902Mammo"><roleName type="title">ሊቄ፡</roleName> ማሞ፡</persName> ልጅ፡
                                         <persName ref="PRS13903Hirut"><roleName type="title">ወይዘሮ፡</roleName> ሂሩት፡</persName> የበለሳውን፡ ፩ ጋሻ፡ ሪም፡ የጋሻ፡ እኩል፡ ጃኑህ፡ የጋሻ፡
-                                        እኩል፡ እንጨናቆ፡ በ፪ ወቄት፡ ካላድ፡ <persName ref="PRS13904Baytafa"><roleName type="title">ላቤቶ፡</roleName> ባይጠፋ፡</persName> አሲዛለች፡ 
+                                        እኩል፡ እንጨናቆ፡ በ፪ ወቄት፡ ካላድ፡ <persName ref="PRS13904Baytafa"><roleName type="title">ላቤቶ፡</roleName> ባይጠፋ፡</persName> አሲዛለች፡
                                         መሳክርቱ፡ <persName ref="PRS13905Batru">ሊቀ፡ ጠበብት፡ በትሩ፡</persName> <persName ref="PRS13906Maqabo">ርእሰ፡ ደብር፡ ማቀቦ፡</persName>
-                                        <persName ref="PRS13907WaldaG">መምሕር፡ ወልደ፡ ጌርጊስ፡</persName> <persName ref="PRS13908WaldaE">ግራ፡ ጌታ፡ ወልደ፡ እግዚእ፡</persName> 
+                                        <persName ref="PRS13907WaldaG">መምሕር፡ ወልደ፡ ጌርጊስ፡</persName> <persName ref="PRS13908WaldaE">ግራ፡ ጌታ፡ ወልደ፡ እግዚእ፡</persName>
                                         <persName ref="PRS13922Mikael"><roleName type="title">አባ፡ </roleName>ሚካኤል፡</persName>
                                         <persName ref="PRS13913Semrat">ሥምረት፡</persName> <persName ref="PRS13914Yared">ያሬድ፡</persName>
                                         <persName ref="PRS13915Salomon">ሰሎሞን፡</persName>
                                         <persName ref="PRS13916Zaffaru">ዘፈሩ፡</persName> <persName ref="PRS13917WaldaY">ወልደ፡ ዮሐንስ፡</persName>
-                                        <persName ref="PRS13918Seffet">ጽፍጥ፡</persName> <persName ref="PRS13919Biyadgo"><roleName type="title">አባ፡</roleName> ቢያድጎ፡</persName> 
-                                        <persName ref="PRS13920Wasan">ወሰን፡</persName> የሊቀ፡ ጠበብት፡ ሎሌ፡ 
+                                        <persName ref="PRS13918Seffet">ጽፍጥ፡</persName> <persName ref="PRS13919Biyadgo"><roleName type="title">አባ፡</roleName> ቢያድጎ፡</persName>
+                                        <persName ref="PRS13920Wasan">ወሰን፡</persName> የሊቀ፡ ጠበብት፡ ሎሌ፡
                                         <persName ref="PRS13921WaldaK">ወልደ፡ ኪሮስ፡</persName> <persName ref="PRS13910WaldaM">አለቃ፡ ወልደ፡ መለኮት፡</persName>
                                         <persName ref="PRS13909HabtaR">አለቃ፡ ሐብተ፡ ሩፋኤል፡</persName><persName ref="PRS13911Keflu"> አለቃ፡
-                                            ክፍሉ፡</persName> <persName ref="PRS13912TaklaG">አቤቶ፡ ተክለ፡ ጌርጊስ፡</persName> ጻፊ፡ <persName ref="PRS13911Keflu">ክፍሉ፡ ወልደ፡ አረጋይ፡</persName> የቃሐ፡ ዘወልድ፡ ልጅ፡ አደሩ፡ 
+                                            ክፍሉ፡</persName> <persName ref="PRS13912TaklaG">አቤቶ፡ ተክለ፡ ጌርጊስ፡</persName> ጻፊ፡ <persName ref="PRS13911Keflu">ክፍሉ፡ ወልደ፡ አረጋይ፡</persName> የቃሐ፡ ዘወልድ፡ ልጅ፡ አደሩ፡
                                         የበጋውን፡ አዝመራ፡ የምድሩን፡ ይብላ፡ በሰኔ፡ ወርቁ፡ ባልሰጥ፡ ምድሩን፡ ለቅቄአለሁ፡ ብለው፡
                                     አፄ፡ ይሙቱ፡ አሉ፡</q>
                                 </item>
-                                
+
                                 <item xml:id="a3">
                                     <locus target="#11va"/>
-                                    <desc type="Record">Amharic record on the appointment of an official by <persName ref="PRS10450YosabI"/>, dated to a year and seven months 
+                                    <desc type="Record">Amharic record on the appointment of an official by <persName ref="PRS10450YosabI"/>, dated to a year and seven months
                                         after <persName ref="PRS5618IyasuII"/>’s reign.</desc>
-                                    <q xml:lang="am"><persName ref="PRS5618IyasuII"><roleName type="title">አፄ፡</roleName> ኢያሱ፡</persName> በነገሡ፡ በዓመት፡ ከ፯ ወርኅ፡ እኔ፡ 
+                                    <q xml:lang="am"><persName ref="PRS5618IyasuII"><roleName type="title">አፄ፡</roleName> ኢያሱ፡</persName> በነገሡ፡ በዓመት፡ ከ፯ ወርኅ፡ እኔ፡
                                         <persName ref="PRS10450YosabI">ኢዮሳብ፡</persName> ባደባባይ፡ ቁሜ፡ ከንጉሡ፡ ከእጨጌው፡ ከሊቃውንቱ፡ ከመኳንንቱ፡ ያድባራቱ፡
                                     ሊቃውንት፡ እዱግነት፡ የሾመ፡ ንጉሥ፡ የተላከ፡ መኰነን፡ እሾማለሁ፡ ያለ፡ በ ፫፻፲ወ፰ በ ፲ወ፪ ሐዋርያት፡ እጨጌም፡ አቡን፡ ገዝተዋሉ፡</q>
                                 </item>
-                                
+
                                 <item xml:id="a4">
                                     <locus target="#11va"/>
-                                    <desc type="LandGrant">Amharic record in the same hand as <ref target="#a3">Addition 3</ref>, possibly of a donation from 
+                                    <desc type="LandGrant">Amharic record in the same hand as <ref target="#a3">Addition 3</ref>, possibly of a donation from
                                         <persName ref="PRS5618IyasuII"/> to the Church. Five lines have been erased in the middle of the text. </desc>
-                                    <q xml:lang="am"><placeName ref="LOC6168Walaqa">የወለቃውንም፡</placeName> መሰክ፡ ቀደሞም፡ የጳጳሳት፡ ነበር፡ አሁንም፡ አፄ፡ ኢያሱ፡ ላቡን፡ ሰጥተዋሉ፡ 
+                                    <q xml:lang="am"><placeName ref="LOC6168Walaqa">የወለቃውንም፡</placeName> መሰክ፡ ቀደሞም፡ የጳጳሳት፡ ነበር፡ አሁንም፡ አፄ፡ ኢያሱ፡ ላቡን፡ ሰጥተዋሉ፡
                                         <del rend="erasure" unit="lines" quantity="5"/>
                                         የታዘዙቱ፡ <persName ref="PRS13923Basalotu"><roleName type="title">ሌቄ፡</roleName> በጸሎቱ፡</persName> ነዎ፡
-                                        አብዝኃራንም፡ <persName ref="PRS13924YabboB"><roleName type="title">ባዛዥ፡</roleName> ያቦ፡ ባርያ፡</persName> እጅ፡ የነበረውን፡ 
+                                        አብዝኃራንም፡ <persName ref="PRS13924YabboB"><roleName type="title">ባዛዥ፡</roleName> ያቦ፡ ባርያ፡</persName> እጅ፡ የነበረውን፡
                                         ፲፭ ጋሻ፡ <persName ref="PRS8073Ramha"><roleName type="title">ባላምበራስ፡</roleName> ረምኃና፡</persName>
-                                        <persName ref="PRS13923Basalotu"><roleName type="title">ሌቄ፡</roleName> በጸሎቱ፡</persName> ቍስቋም፡ ይቀድሱበት፡ ብለዋል፡ ይሕነን፡ ያፈረሰ፡ 
+                                        <persName ref="PRS13923Basalotu"><roleName type="title">ሌቄ፡</roleName> በጸሎቱ፡</persName> ቍስቋም፡ ይቀድሱበት፡ ብለዋል፡ ይሕነን፡ ያፈረሰ፡
                                     በ ፫፻፲ወ፰፡ በ፲ወ፪ ሐዋርያት፡ ቃል፡ በ<persName ref="PRS10450YosabI"><roleName type="title">አቡነ፡</roleName> ዮሳብ፡</persName>
-                                        በ<persName ref="PRS13628Tasfu"><roleName type="title">እጨጌ፡</roleName> ተስፉ፡</persName> ቃል፡ እንደ፡ ንስጥሮስ፡ ውጉዝ፡ ነው፡  
+                                        በ<persName ref="PRS13628Tasfu"><roleName type="title">እጨጌ፡</roleName> ተስፉ፡</persName> ቃል፡ እንደ፡ ንስጥሮስ፡ ውጉዝ፡ ነው፡
                                     </q>
                                 </item>
-                                
+
                                 <item xml:id="a5">
                                     <locus target="#11v #96r"/>
                                     <desc type="StampExlibris">Two stamps, hardly legible, probably by <persName ref="PRS10450YosabI"/>, whose name
-                                        (<foreign xml:lang="ar">ʾAnbā</foreign> Yūsāb) is given next to them. Between the stamps is written, from right to left, on 
+                                        (<foreign xml:lang="ar">ʾAnbā</foreign> Yūsāb) is given next to them. Between the stamps is written, from right to left, on
                                         <locus target="#11v"/>:
                                     <foreign xml:lang="ar">انبا يوساب</foreign>, <foreign xml:lang="ar">بسم الله الرووف الرحيم المجد لله في العلا</foreign>,
                                         and <foreign xml:lang="ar">حَرمة</foreign>, and on <locus target="#96r"/> <foreign xml:lang="ar">بسم الله الرووف الرحيم المجد لله في العلا</foreign> .</desc>
                                     <q xml:lang="ar"/>
                                 </item>
-                                
+
                                 <item xml:id="a6">
                                     <locus target="#294ra"/>
-                                    <desc type="Inventory">Inventory in Amharic, listing books produced during the tenure of 
+                                    <desc type="Inventory">Inventory in Amharic, listing books produced during the tenure of
                                         <persName ref="PRS2266Ayente"/>.</desc>
-                                    <q xml:lang="am">በ<persName ref="PRS2266Ayente"><roleName type="title">መምህሬ፡</roleName> አይንቴ፡</persName> 
+                                    <q xml:lang="am">በ<persName ref="PRS2266Ayente"><roleName type="title">መምህሬ፡</roleName> አይንቴ፡</persName>
                                         ሽመት፡ የተጻፈ፡ ፪ <ref type="work" corresp="LIT4035SenkessarDL">ስንክሳር፡</ref> ፩ ታምር፡
                                         ፪ <ref corresp="LIT1850Malkea" type="work">ጉባኤ፡ መልክ፡</ref> ፩ <ref type="work" corresp="LIT1560Gospel">ወንጌል፡</ref></q>
                                 </item>
-                                
+
                                 <item xml:id="a7">
                                     <locus target="#5r"/>
                                     <desc type="OwnershipNote">Note written in black ink in the
@@ -997,53 +996,53 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <q xml:lang="gez">ወንጌል፡ ዘቅዱስ፡ <placeName
                                         ref="INS0101MadhaneAlam">መድኃኔ፡ ዓለም፡</placeName></q>
                                 </item>
-                                
+
                                 <item xml:id="e1">
                                     <locus from="2ra" to="4va"/>
                                     <desc>Only four lines at the top and bottom of <locus from="2" to="3"/> are ruled, on which the beginnings of the Gospels of Matthew and Luke
                                     are written incompletely. <locus target="#4"/> is ruled throughout and contains the beginning of the Gospel of Luke.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e2">
                                     <desc><foreign xml:lang="gez">ማቴዎስ፡</foreign> is written in red ink in the middle of the upper margin  on
                                         <locus from="65r" to="74r"/>, <foreign xml:lang="gez">ሉቃስ፡</foreign>, with irregularities on approximately
                                         every second folio from <locus from="147r" to="214r"/>.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e3">
                                     <desc><persName ref="PRS13900WaldaD" role="scribe">ዘወልደ፡ ዳዊት፡</persName> (on <locus target="#117r #138v"/>) and
                                         <persName ref="PRS13901Zaparaqlitos" role="scribe">ዘዘጰራቅሊጦስ፡</persName> (on <locus target="#148r"/>), presumably indicating
-                                        scribes of parts of the manuscript, 
+                                        scribes of parts of the manuscript,
                                     are written in the bottom margin. On <locus target="#107r"/>, a rectangle drawn on the lower margin is visible, in which
                                     writing has been erased.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e4">
                                     <locus target="#1ra"/>
                                     <desc>An erased note in the upper part of the left column.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e5">
-                                    <desc>The manuscript contains numerous scribal corrections throughout: erasures (e.g. <locus target="#100va #230va #268vb"/>); 
-                                        corrections written above erasures (e.g. <locus target="#95rb #262ra #288vb"/>), mostly in condensed script 
+                                    <desc>The manuscript contains numerous scribal corrections throughout: erasures (e.g. <locus target="#100va #230va #268vb"/>);
+                                        corrections written above erasures (e.g. <locus target="#95rb #262ra #288vb"/>), mostly in condensed script
                                         (e.g. <locus target="#104rb #206va #291vb"/>). Rarely,  erased spaces are marked by black and red lines
                                         (e.g. <locus target="#214vb #234rb #260vb"/>).
                                         A cross and a single stroke pointing to corrections
                                         are used occasionally
                                         in the margins (e.g. <locus target="#103r #235v"/>). Rarely, omitted words have been added interlineally
-                                        (e.g. <locus target="#233rb #236rb #293ra"/>) or in the margin (e.g. <locus target="#230rb"/>, with use of 
+                                        (e.g. <locus target="#233rb #236rb #293ra"/>) or in the margin (e.g. <locus target="#230rb"/>, with use of
                                         <foreign xml:lang="am">tamallas</foreign>-sign).
                                     Superfluous words are encircled on <locus target="#235vb #275rb"/>.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e6">
                                     <locus target="#8r"/>
                                     <desc>‘<persName ref="PRS13962Lockhart">W. s. a. Lockhart</persName>’ written in red pencil the upper margin.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e8">
                                     <locus target="#1r"/>
-                                    <desc>‘473’ written in pencil in the upper margin of <locus target="#1r"/>. On <locus target="#110"/>, 
+                                    <desc>‘473’ written in pencil in the upper margin of <locus target="#1r"/>. On <locus target="#110"/>,
                                         a piece of paper with ‘3828’ printed on it either placed or glued on the parchment.</desc>
                                 </item>
                             </list>
@@ -1098,7 +1097,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
 
                     </physDesc>
-      
+
                     <history>
                         <origin>
                             <origDate notBefore="1730" notAfter="1755" evidence="reign"/>
@@ -1107,7 +1106,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             to (<locus from="96ra" to="96vb"/>), dated to <date>1743</date> as part of the original process of production or as later addition.
                         </origin>
                         <provenance>
-                            The manuscript belonged to <placeName ref="INS0101MadhaneAlam"/> (see <ref target="#a1"/>) . 
+                            The manuscript belonged to <placeName ref="INS0101MadhaneAlam"/> (see <ref target="#a1"/>) .
                             It is likely that, like most manuscripts of the <placeName ref="INS0101MadhaneAlam"/> collection, it had
                             belonged to a church in the
                             <placeName ref="LOC3577Gondar"/> area, from where it was taken by  <persName ref="PRS9430Tewodros"/>
@@ -1120,7 +1119,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             through
                             the bookseller <persName ref="PRS13559Thomas"/>, for a three-figure sum (cp. <bibl><ptr target="bm:JuelJensen1981Gospels"/></bibl>).</provenance>
                     </history>
-                    
+
                     <additional>
                         <adminInfo>
                             <recordHist>
@@ -1175,7 +1174,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <change who="DR" when="2022-09-27">Continued description</change>
             <change who="EDS" when="2023-01-29">Added description of writing support, condition and binding description</change>
 
-            
+
 
         </revisionDesc>
     </teiHeader>

--- a/OxfordBodleian/Juel-Jensen/BDLaethb4.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethb4.xml
@@ -7,16 +7,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!-- 
+                <!--
                 <title xml:lang="gez" xml:id="title1">ገድለ፡ ጊዮርጊስ፡, ተአምረ፡ ጊዮርጊስ፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Gadla Giyorgis, Taʾammǝra Giyorgis</title>
                 -->
-                <title xml:lang="en" xml:id="title1"><hi rendition="simple:italic">Vita</hi> and Miracles of St George</title>                
+                <title xml:lang="en" xml:id="title1"><hi rendition="simple:italic">Vita</hi> and Miracles of St George</title>
                 <editor key="DR"/>
                 <editor key="JG"/>
                 <editor key="MV"/>
                 <editor key="SH"/>
-                <editor key="EDS"/>                
+                <editor key="EDS"/>
                 <editor key="JK"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
@@ -1107,7 +1107,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <extent>
                                     <measure unit="leaf" quantity="164">164</measure>
                                     <measure unit="quire" quantity="22">22</measure>
-                                    <measure unit="page" type="blank" quantity="8">8</measure> 
+                                    <measure unit="page" type="blank" quantity="8">8</measure>
                                     <locus target="#ir #1rv #2rv #3v #163rv"/>
                                     <dimensions type="outer" unit="mm">
                                         <height>392</height>
@@ -1121,14 +1121,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <note corresp="#leafdim">Data on the dimensions of folios taken from
                                             <locus target="#52r"/>.</note>
                                 </extent>
-                                <foliation>Pencil foliation in the upper right corner (1–163). The first folio is not foliated. It is referred to as 
-                                    <locus target="#i"/> in this description.</foliation>   
+                                <foliation>Pencil foliation in the upper right corner (1–163). The first folio is not foliated. It is referred to as
+                                    <locus target="#i"/> in this description.</foliation>
                                 <collation>
                                     <signatures>
                                         Quire marks are written in the upper inner margin of
                                         the recto of the first folio of each quire with black ink,
-                                        with the exception of the first quire mark, which is written in red. Some quire marks are 
-                                        decorated in a simple manner, partly with red elements. 
+                                        with the exception of the first quire mark, which is written in red. Some quire marks are
+                                        decorated in a simple manner, partly with red elements.
                                     </signatures>
                                     <list>
                                         <item xml:id="q1" n="A">
@@ -1251,12 +1251,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </collation>
 
                                 <condition key="good">
-                                  The manuscript is in a good state of preservation. It has only a few losses along the margins and deformations caused by humidity.
+                                  The manuscript has a few losses along the margins of the leaves and undulations caused by humidity.
                                   Some folios have water stains (e.g. <locus
                                   from="41r" to="42v"/>, <locus from="108r" to="121r"/>). The
-                                  headband is broken, the tailband torn off. The leather cover is torn on the spine.<!--All edges were
-                                  trimmed; EDS: re-trimmed? It does not seem so to me --> <!-- a note that was written in the outer upper margin of
-                                  <locus target="#4r"/> was cut. EDS: I don't see it :( )--></condition>
+                                  headband is broken, the tailband torn off. The leather cover is torn on the spine.</condition>
                             </supportDesc>
 
                             <layoutDesc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethb5.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethb5.xml
@@ -9,10 +9,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     type="mss">
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
-            <titleStmt> 
-                <!-- 
+            <titleStmt>
+                <!--
                 <title xml:lang="gez" xml:id="title1">ስንክሳር፡</title>
-                <title xml:lang="gez" corresp="#title1" type="normalized">Sənkəssār</title> 
+                <title xml:lang="gez" corresp="#title1" type="normalized">Sənkəssār</title>
                  -->
                 <title xml:lang="en" xml:id="title1">Synaxarion (Maskaram–Yakkātit)</title>
                 <editor key="DR"/>
@@ -9026,8 +9026,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     An empty
                                     folio between <locus target="#212"/> and <locus target="#213"/>, of which two thirds are cut off, has not been foliated.</foliation>
                                 <collation>
-                                    <signatures>Decorated quire marks are written in the upper and lower margins of the recto of the first folio of all quires, except for the 
-                                        protective quires. Quire marks are also written in the upper and lower margins of the verso 
+                                    <signatures>Decorated quire marks are written in the upper and lower margins of the recto of the first folio of all quires, except for the
+                                        protective quires. Quire marks are also written in the upper and lower margins of the verso
                                         of the first folio of quires 2–4.
                                         All quire marks are written in red and black, are decorated with dots and lines and are occasionally surrounded by four nine-dot signs.
                                         Morevoer, the word <foreign xml:lang="gez">ጥራዝ፡</foreign>, i.e. ‘quire’,
@@ -9064,14 +9064,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <dim unit="leaf">10</dim>
                                             <locus from="34r" to="43v"/>
                                             3, stub after 8
-                                            8, stub after 3 
+                                            8, stub after 3
                                         </item>
                                         <item xml:id="q6" n="5">
                                             <num value="5">፭</num>
                                             <dim unit="leaf">12</dim>
                                             <locus from="44r" to="55r"/>
                                             4, stub after 8
-                                            9, stub after 3 
+                                            9, stub after 3
                                         </item>
                                         <item xml:id="q7" n="6">
                                             <num value="6">፮</num>
@@ -9123,28 +9123,28 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <dim unit="leaf">10</dim>
                                             <locus from="129r" to="138v"/>
                                             3, stub after 7
-                                            8, stub after 2 
+                                            8, stub after 2
                                         </item>
                                         <item xml:id="q16" n="15">
                                             <num value="15">፲፭</num>
                                             <dim unit="leaf">10</dim>
                                             <locus from="139r" to="146v"/>
                                             3, stub after 8
-                                            8, stub after 3 
+                                            8, stub after 3
                                         </item>
                                         <item xml:id="q17" n="16">
                                             <num value="16">፲፮</num>
                                             <dim unit="leaf">10</dim>
                                             <locus from="147r" to="156v"/>
                                             3, stub after 7
-                                            8, stub after 2 
+                                            8, stub after 2
                                         </item>
                                         <item xml:id="q18" n="17">
                                             <num value="17">፲፯</num>
                                             <dim unit="leaf">10</dim>
                                             <locus from="157r" to="166v"/>
                                             3, stub after 7
-                                            8, stub after 2 
+                                            8, stub after 2
                                         </item>
                                         <item xml:id="q19" n="18">
                                             <num value="18">፲፰</num>
@@ -9155,7 +9155,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <num value="19">፲፱</num>
                                             <dim unit="leaf">9</dim>
                                             <locus from="175r" to="183v"/>
-                                            8, stub after 1 
+                                            8, stub after 1
                                         </item>
                                         <item xml:id="q21" n="20">
                                             <num value="20">፳</num>
@@ -9167,13 +9167,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <dim unit="leaf">10</dim>
                                             <locus from="194r" to="203v"/>
                                             2, stub after 9
-                                            9, stub after 2 
+                                            9, stub after 2
                                         </item>
                                         <item xml:id="q23" n="22">
                                             <num value="22">፳፪</num>
                                             <dim unit="leaf">9</dim>
                                             <locus from="204r" to="212v"/>
-                                            1, stub after 9 
+                                            1, stub after 9
                                         </item>
                                         <item xml:id="q24" n="B">
                                             <dim unit="leaf">2</dim>
@@ -9183,9 +9183,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </collation>
 
                                 <condition key="good">
-                                  The manuscript is in a good state of preservation. The trimming of the bookblock caused minimal loss
-                                  of text on <locus target="#143v"/>. Occasionally stained by
-                                  humidity. The lower margin is slightly stained by dirt.
+                                  The trimming of the bookblock caused minimal loss
+                                  of text on <locus target="#143v"/>. The folios are occasionally stained by
+                                  humidity and their lower margin is slightly stained by dirt.
                                   The leather cover is abraded and worn. The stitching of the slip-case has become undone.
                                 </condition>
                             </supportDesc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethb6.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethb6.xml
@@ -554,8 +554,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </item>
                                     </list>
                                 </collation>
-                                <condition key="good">
-                              </condition>
+                                <!--<condition key="good">
+                              </condition>-->
                             </supportDesc>
 
                             <layoutDesc>
@@ -9287,8 +9287,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </item>
                                     </list>
                                 </collation>
-                                <condition key="good">
-                                </condition>
+                                <!--<condition key="good">
+                              </condition>-->
                             </supportDesc>
 
                             <layoutDesc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethb6.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethb6.xml
@@ -9,10 +9,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
      type="mss">
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
-            <titleStmt> 
-                <!-- 
+            <titleStmt>
+                <!--
                <title xml:lang="gez" xml:id="title1">ስንክሳር፡</title>
-                <title xml:lang="gez" corresp="#title1" type="normalized">Sənkəssār</title> 
+                <title xml:lang="gez" corresp="#title1" type="normalized">Sənkəssār</title>
                 -->
                 <title xml:lang="en" xml:id="title1">Synaxarion (Maskaram–Yakkātit)</title>
                 <editor key="DR"/>
@@ -61,14 +61,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <note>The manuscript could not be weighed due to its great size.</note>
                                 </extent>
                                 <foliation>Pencil foliation in the upper right corner (1–188).</foliation>
-                                <condition key="good">The manuscript is in a good state of preservation.
+                                <condition key="good">
+                                    The outer column of <locus target="#125"/> has been cut off. Insects droppings are occasionally present, especially where the parchment is wrinkled, e.g. <locus target="#45v #85r #169r"/>.
+                                    The tears on <locus target="#56 #133"/> occurred after parchment making, and have been repaired by sewing. The manuscript underwent conservation treatment since the lower margin of
+                                    <locus target="#1"/> has been infilled with toned paper and the folio has been mounted on a guard to link it to the bookblock.
+                                    Furthermore, a protective folio has been added at the end of the bookblock.
                                     The binding is slightly damaged, with the leather cover missing in the lower corners of the front board and all corners of the back board.
                                     The spine has been removed, like the additional leather patches on the inner side of the front board, presumably to resew the manuscript.
                                     The lower margin of the cover is darkened by use. The lower outer corner of the first folios has been damaged probably by rodents.
-                                    The outer column of <locus target="#125"/> has been cut off. Insects droppings are occasionally present, especially where the parchment is wrinkled, e.g. <locus target="#45v #85r #169r"/>.
-                                    The tears on <locus target="#56 #133"/> occurred after parchment making, and have been repaired by sewing. The manuscript underwent conservation treatment since the lower margin of
-                                    <locus target="#1"/> has been infilled with tinted paper and the folio has been mounted on a guard to link it to the bookblock.
-                                    Furthermore, a protective folio has been added at the end of the bookblock.
                                 </condition>
                             </supportDesc>
                         </objectDesc>
@@ -9157,8 +9157,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <supportDesc>
                                 <support>
                                     <material key="parchment"/>
-                                    <p>Small tears resulting from parchment making carefully amended on very few folios, e.g. 
-                                        <locus target="#21 #73 #162"/>. 
+                                    <p>Small tears resulting from parchment making carefully amended on very few folios, e.g.
+                                        <locus target="#21 #73 #162"/>.
                                         The small rounded holes from parchment making on <locus target="#41 #68 #155"/> have not been repaired.</p>
                                 </support>
                                 <extent>

--- a/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
@@ -9,10 +9,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
      type="mss">
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
-            <titleStmt> 
-                <!-- 
+            <titleStmt>
+                <!--
                 <title xml:lang="gez" xml:id="title1">አርባዑቱ፡ ወንጌል፡</title>
-                <title xml:lang="gez" corresp="#title1" type="normalized">ʾArbāʿtu wangel</title> 
+                <title xml:lang="gez" corresp="#title1" type="normalized">ʾArbāʿtu wangel</title>
                  -->
                 <title xml:lang="en" xml:id="title1">Four Gospels</title>
                 <editor key="DR"/>
@@ -55,10 +55,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <measure type="weight" unit="g">3858</measure>
                                  </extent>
                                 <foliation>Pencil foliation in the upper right corner carried out by the Bodleian Library in January 2020 (1–130).</foliation>
-                                <condition key="deficient">
-                                    The manuscript is wrapped in a modern textile embroidered with two lions and probably purchased by <persName ref="PRS5782JuelJen"/>.
-                                    The turn-ins and fragments of leather along the board edges are all that remains of the former leather cover.
-                                </condition>
                             </supportDesc>
                         </objectDesc>
 
@@ -86,6 +82,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                               uncoloured <term key="leafStringMark">leaf string marker</term> is inserted in the upper margin of <locus target="#104"/>.
                               Disjoint bifolios have been repaired with overcasting, e.g. <locus from="51" to="53"></locus> or by sewing parchment <term key="guard">guards</term> with <term key="sidestitches">side stitches</term>
                               along the <term key="spinefold">spine fold</term> of the quires, e.g. <ref target="#q18">quire 18</ref>.
+                              The manuscript is wrapped in a modern textile embroidered with two lions and probably purchased by <persName ref="PRS5782JuelJen"/>.
                           </decoNote>
                           </binding>
                       </bindingDesc>
@@ -322,7 +319,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <supportDesc>
                                     <support>
                                         <material key="parchment"/>
-                                        <p>Holes resulting from parchment making are found on e.g. <locus target="#1 #40 #85"/>. Tears on several folios have 
+                                        <p>Holes resulting from parchment making are found on e.g. <locus target="#1 #40 #85"/>. Tears on several folios have
                                             been repaired both at the moment of parchment production, e.g. on <locus target="#106 #118"/>,
                                             and at a later stage, e.g. <locus target="#2"/>.</p></support>
                                     <extent>
@@ -335,23 +332,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </dimensions>
                                         <note corresp="#leafdim1">Data on the dimensions of folios taken from <locus target="#45r"/>.</note>
                                     </extent>
-                                    
+
                                     <collation>
                                         <note>
                                             All quires have been reinforced with parchment guards at a later stage. The original quire structure cannot be reconstructed anymore (see also Condition below).
                                         </note>
                                         <signatures>
                                             Quire marks were written in the upper inner margin of the first folio and in the upper inner margin of the last folio of most of the original quires.
-                                            The position of the signatures no longer coincides with the beginning and end of the current quires.    
+                                            The position of the signatures no longer coincides with the beginning and end of the current quires.
                                             <foreign xml:lang="gez">፩</foreign> is found in the upper inner margins of <locus target="#108v"/>;
                                             <foreign xml:lang="gez">፪</foreign> is found in the upper inner margins of <locus target="#69r #76v #109r #115v"/>;
                                             <foreign xml:lang="gez">፫</foreign> is found in the upper inner margins of <locus target="#18r #25v #54r #77r #116r"/>;
                                             <foreign xml:lang="gez">፬</foreign> is found in the upper inner margins of <locus target="#26r #68v"/>;
                                             <foreign xml:lang="gez">፭</foreign> is found  in the upper inner margin of <locus target="#93r"/>;
-                                            remains of illegible quire marks are found in the upper inner margin of <locus target="#31v #85r"/>.                                 
-                                        </signatures>                                     
+                                            remains of illegible quire marks are found in the upper inner margin of <locus target="#31v #85r"/>.
+                                        </signatures>
                                         <list>
-                                            <item xml:id="q1" n="1">                                                
+                                            <item xml:id="q1" n="1">
                                                 <dim unit="leaf">2</dim>
                                                 <locus from="1r" to="2v"/>
                                             </item>
@@ -434,7 +431,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </list>
                                     </collation>
                                     <condition key="deficient">
-                                        The bookblock has been resewn together and parchment guards have been placed around all quires.                                        
+                                        The bookblock has been resewn together and parchment guards have been placed around all quires.
                                         <locus from="51r" to="62v"/> have been stitched together at a later stage.
                                         The bookblock has been damaged by humidity, especially in the outer margins, and water stains are present (e.g. on <locus target="#37 #104v"/>).
                                         Wax stains are visible on <locus target="#31v #72v"/>. The parchment is stained and crumpled on <locus target="#74"/>.

--- a/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
@@ -9,12 +9,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
      type="mss">
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
-            <titleStmt> 
+            <titleStmt>
                 <!--
                 <title xml:lang="gez" xml:id="title1">ሰቆቃወ፡ ነፍስ፡, ጠቢበ፡ ጠቢባን፡, መልክአ፡ ወለተ፡ ጴጥሮስ፡</title>
-                <title xml:lang="gez" corresp="#title1" type="normalized">Saqoqāwa nafs, Ṭabiba ṭabibān, Malkǝʾa Walatta Ṗeṭros</title> 
+                <title xml:lang="gez" corresp="#title1" type="normalized">Saqoqāwa nafs, Ṭabiba ṭabibān, Malkǝʾa Walatta Ṗeṭros</title>
                  -->
-                <title xml:lang="en" xml:id="title1">Lamentation of the Soul (<hi rendition="simple:italic">Saqoqāwa nafs</hi>), The Wisest among the Wise 
+                <title xml:lang="en" xml:id="title1">Lamentation of the Soul (<hi rendition="simple:italic">Saqoqāwa nafs</hi>), The Wisest among the Wise
                     (<hi rendition="simple:italic">Ṭabiba ṭabibān</hi>), <hi rendition="simple:italic">Malkǝʾ</hi>-hymn to Walatta Ṗeṭros</title>
                 <editor key="DR"/>
                 <editor key="JG"/>
@@ -198,7 +198,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
                                 <condition key="deficient">
-                                 The manuscript is in a poor state of preservation.
                                   The bookblock has been damaged by humidity, especially in the lower outer margins,
                                   causing the deformation of the parchment support in correspondence of the outer corners and the formation of dark spots, possibly mould (e.g. <locus target="#37 #104v"/>)
                                   Stains of various origins are present both on the leather cover and the bookblock (e.g. <locus target="#33v #34r #35v"/>).
@@ -316,7 +315,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                             </handNote>
                         </handDesc>
-                      
+
                        <decoDesc>
                     <summary>The sentence "Captions of the miniatures are added in the main hand in red
                        ink on the upper margin of each folio" might be inserted either in decoDesc or under "extra" below. (MV 09.12.2022)
@@ -453,7 +452,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <locus target="#13r"/>
                                  <desc><persName ref="PRS14010Jared">Jared</persName> and his children are shown above, while below the children of Seth descend
                                    from the Mount of the Treasures to meet the wives of Cain, one of whom is a giant.
-                                     
+
                                    <q xml:lang="gez"><persName ref="PRS14010Jared">ያሬድ።</persName></q>
                                    <q xml:lang="gez">እግዚአብሔር።</q>
                                    <q xml:lang="gez">ዘከመ፡ ወረዱ፡ ደቂቀ፡ ሴት፡ እምደብር።</q>
@@ -656,7 +655,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </item>
 
                                 <item xml:id="e1">
-                                    <desc>Several white stickers are glued on the inner side of the front cover. 
+                                    <desc>Several white stickers are glued on the inner side of the front cover.
                                         On the rightmost is printed ‘H. Kevorkian collection’, with the number ‘623’ added in pencil.
                                         On the following sticker are written in blue pen the numbers ‘1977’ and ‘18’, above a previous signature ‘MS Et 16’ in black ink.
                                         On the leftmost is printed the name of <persName ref="PRS5782JuelJen"/> (<foreign xml:lang="gez">ቤንት፡ ዩውል፡ የንሰን።</foreign>),
@@ -683,12 +682,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         of <locus target="#1va"/>. Cues for the rubricator are found on the left margin of <locus from="2ra" to="4ra"/>.
                                         Corrections are scarce. They mostly consist of interlineal additions (e.g. <locus target="#12va #12vb #14va"/>), erasures (e.g. <locus target="#11ra"/>),
                                         or are made by encircling the word (<locus target="#26rb"/>).
-                                        Pen trial in red and black ink on <locus target="#1vb"/>.                                    
+                                        Pen trial in red and black ink on <locus target="#1vb"/>.
                                     </desc>
                                 </item>
                             </list>
                         </additions>
-                        
+
                         <bindingDesc>
                             <binding contemporary="true" xml:id="binding">
                               <p>The sewing has been repaired. However, most of the binding is likely contemporary to the manuscript content.</p>

--- a/OxfordBodleian/Juel-Jensen/BDLaethd17.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd17.xml
@@ -6,10 +6,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="BDLaethd17" xml:lang="en" type="mss">
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
-            <titleStmt> 
-                <!-- 
+            <titleStmt>
+                <!--
                 <title xml:lang="gez" xml:id="title1">ውዳሴ፡ አምላክ፡</title>
-                <title xml:lang="gez" corresp="#title1" type="normalized">Wǝddāse ʾAmlāk</title> 
+                <title xml:lang="gez" corresp="#title1" type="normalized">Wǝddāse ʾAmlāk</title>
                 -->
                 <title xml:lang="en" xml:id="title1">Praise of God (<hi rendition="simple:italic">Wǝddāse ʾAmlāk</hi>)</title>
                 <editor key="DR"/>
@@ -249,7 +249,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <extent>
                                     <measure unit="leaf" quantity="139">139</measure>
                                     <measure unit="quire" quantity="18">18</measure>
-                                    <measure unit="page" type="blank" quantity="6">6</measure> 
+                                    <measure unit="page" type="blank" quantity="6">6</measure>
                                     <locus from="1r" to="3v"/>
                                     <locus target="#139rb"/>
                                     <measure type="weight" unit="g">1963</measure>
@@ -269,7 +269,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <collation>
                                     <signatures>Quire marks are written in black ink in the upper inner margin of the recto of the first folio of most quires.
                                         The first, the thirteenth and the last two quires are unmarked.
-                                        Quires 14–16 are indicated as <foreign xml:lang="gez">፪</foreign>, 
+                                        Quires 14–16 are indicated as <foreign xml:lang="gez">፪</foreign>,
                                         <foreign xml:lang="gez">፫</foreign>, and <foreign xml:lang="gez">፬</foreign>, respectively.
                                        </signatures>
                                     <list>
@@ -362,17 +362,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
                                 <condition key="good">
-                                  The manuscript is in a good state of preservation.
-                                  The leather cover is torn off from the front board
-                                  (only the outermost part is preserved) and the spine.
-                                  Tooled turn-ins are preserved for the most part. The inner
-                                  corners of the back cover are missing. The protective quire
-                                  (<locus from="1r" to="3v"/>) is reinforced with parchment
-                                  guards. Remains of tiedowns are visible on the spine folds and
-                                  in the centrefolds of the quires but the endbands are missing. <!--All edges were trimmed.-->
-                                    Many folios are damaged by humidity, especially on the upper margin <locus from="65r" to="137r"/>.
-                                  The humidity damage caused also the deformation of the parchment support.
-                                  Insect droppings on <locus from="72v" to="73r"/> and <locus from="106v" to="107r"/>.
+                                  Many folios are damaged by humidity, especially on the upper margin <locus from="65r" to="137r"/>,
+                                  resulting in undulations and stains.
+                                  Insect droppings are present on <locus from="72v" to="73r"/> and <locus from="106v" to="107r"/>.
+                                  The leather cover is torn off from
+                                  the spine and the front board but its turn-ins are preserved. The inner
+                                  corners of the back cover and the endbands are missing.
                                   The sewing is broken at the attachment with the boards.
                                 </condition>
                             </supportDesc>
@@ -504,7 +499,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 Concentric frames of double straight lines decorate the turn-ins.
                               </decoNote>
                               <decoNote xml:id="b4" type="Endbands">
-                                The endbands are missing, but their turn-ins have been preserved.
+                                The endbands are missing, but their tie-downs have been preserved.
                               </decoNote>
                               <decoNote xml:id="b5" type="SewingStations">4</decoNote>
                               <decoNote xml:id="b6">

--- a/OxfordBodleian/Juel-Jensen/BDLaethd18.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd18.xml
@@ -9,10 +9,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
      type="mss">
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
-            <titleStmt> 
-                <!-- 
+            <titleStmt>
+                <!--
                 <title xml:lang="gez" xml:id="title1">መጽሐፈ፡ ሄኖክ፡</title>
-                <title xml:lang="gez" corresp="#title1" type="normalized">Maṣḥafa Henok</title> 
+                <title xml:lang="gez" corresp="#title1" type="normalized">Maṣḥafa Henok</title>
                 -->
                 <title xml:lang="en" xml:id="title1">Book of Enoch</title>
                 <editor key="DR"/>
@@ -40,28 +40,28 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <altIdentifier>
                             <idno>Juel-Jensen 16</idno>
                         </altIdentifier>
-                    </msIdentifier>      
-                  
+                    </msIdentifier>
+
                     <history>
                         <provenance>
                             The manuscript consists of two codicological units: <ref target="#p1"/> is a codex with its own binding, while
                             <ref target="#p2"/> consists of one loose bifolio having a different origin and placed between <locus target="#2"/> and
-                            <locus target="#3"/>. 
-                            <ref target="#p1"/> was faithfully copied from another manuscript, bound together with the book of Job 
-                            and coming from <placeName ref="LOC3549Gojjam">Goǧǧām</placeName>, 
+                            <locus target="#3"/>.
+                            <ref target="#p1"/> was faithfully copied from another manuscript, bound together with the book of Job
+                            and coming from <placeName ref="LOC3549Gojjam">Goǧǧām</placeName>,
                             belonging to the deacon <persName ref="PRS12948MalakaMe">Malʿaka Mǝḥrat Yāred Gǝrmāye</persName>
-                            from <placeName ref="LOC2091Calaqo">Č̣alaqot Śǝllāse</placeName>, south of <placeName ref="LOC4545Maqala"/> 
-                            (<placeName ref="LOC6569Tegray">Tǝgray</placeName>).  
+                            from <placeName ref="LOC2091Calaqo">Č̣alaqot Śǝllāse</placeName>, south of <placeName ref="LOC4545Maqala"/>
+                            (<placeName ref="LOC6569Tegray">Tǝgray</placeName>).
                             According to <ref target="#coloph1"/> and to other information (cp. <bibl>
                                 <ptr target="bm:JuelJensen1994Bindings"/>
                                 <citedRange>189</citedRange>
                             </bibl>), <ref target="#p1"/> was commissioned in <placeName ref="LOC4545Maqala"/>
-                            by <persName ref="PRS5782JuelJen"/> and his wife <persName ref="PRS12946MaryamMary"/> in September 1974, in the house of 
-                            <persName ref="PRS12949YohannesA">ʾAbuna Yoḥannǝs</persName>, Archbishop of <placeName ref="LOC1310Aksum"/>. 
-                            <ref target="#p1"/> was copied by the deacon <persName ref="PRS12944AmhaSe">ʾAmmǝḫā Śǝllāse</persName> in his monastery of <placeName ref="LOC4505Manawe">Manāwe</placeName> 
+                            by <persName ref="PRS5782JuelJen"/> and his wife <persName ref="PRS12946MaryamMary"/> in September 1974, in the house of
+                            <persName ref="PRS12949YohannesA">ʾAbuna Yoḥannǝs</persName>, Archbishop of <placeName ref="LOC1310Aksum"/>.
+                            <ref target="#p1"/> was copied by the deacon <persName ref="PRS12944AmhaSe">ʾAmmǝḫā Śǝllāse</persName> in his monastery of <placeName ref="LOC4505Manawe">Manāwe</placeName>
                             in <placeName ref="LOC5882Tamben">Tamben</placeName>, and was completed in the month of January 1975.
-                            It costed 100 Ethiopian birr, and the binding costed 5 birr extra. 
-                            As far as <ref target="#p2"/> is concerned, a connection to <placeName ref="LOC3659GurAmb">Gʷǝrāmbā</placeName> can be established on the basis of some of the 
+                            It costed 100 Ethiopian birr, and the binding costed 5 birr extra.
+                            As far as <ref target="#p2"/> is concerned, a connection to <placeName ref="LOC3659GurAmb">Gʷǝrāmbā</placeName> can be established on the basis of some of the
                             documents contained therein.
                         </provenance>
                     </history>
@@ -265,7 +265,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </item>
                                     </list>
                                 </collation>
-                                <condition key="good"/>
+                                <condition key="good">
+                                The manuscript appears to have hardly been used and displays only slight cockling of the parchment.
+                                </condition>
                             </supportDesc>
 
                             <layoutDesc>
@@ -531,8 +533,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             </item>
                                         </list>
                                     </collation>
-                                    <condition key="deficient">The lower margin of <locus target="#ii"/> is cut.
-                                    </condition> 
+                                    <condition key="good">
+                                      A portion of the lower margin of <locus target="#ii"/> is cut out.
+                                    </condition>
                                 </supportDesc>
                                 <layoutDesc>
                                     <layout columns="1" writtenLines="36">

--- a/OxfordBodleian/Juel-Jensen/BDLaethd20.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd20.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!--
+                <!--  
                 <title xml:lang="gez" xml:id="title1">ተአምረ፡ ማርያም፡, ተአምረ፡ ኢየሱስ፡, ድርሳን፡ ቃሉ፡ ዘቅዱስ፡ ወብጹዕ፡ ያዕቆብ፡ ኤጲስ፡ ቆጶስ፡ ዘሥሩግ፡ በእንተ፡ መልአክ፡ ወፈያታዊ፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Taʾammǝra Māryām, Taʾammǝra ʾIyasus, Dǝrsān qālu za-bǝṣuʿ Yāʿqob ʾeṗis qoṗos za-Śǝrug baʾǝnta malʾak wa-fayyātāwi</title>
              -->
@@ -3530,11 +3530,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </collation>
 
                                 <condition key="good">
-                                    There are slight traces of use, such as wear along the spine. Additionally, there are dirt stains in the lower margins
-                                    up to <locus target="#105r"/>, occasional ink smudges, e.g. on <locus target="#71v"/>;
+                                    There are slight traces of use, including: wear at the spine;
+                                    dirt stains in the lower margins until <locus target="#105r"/>; occasional ink smudges, e.g. on <locus target="#71v"/>;
                                     and stains, e.g. on <locus from="109" to="117"/>.
-                                    Furthermore, there is evidence of water damage, which has caused the wrinkling of the parchment and left imprints
-                                    from the dyed leather covers on the first and last leaves.
+                                    The dye used for the leather of the covers has left an imprint on the first and last folia, which are also slightly crumpled.
+                                    All edges were trimmed.
                                 </condition>
                             </supportDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethd20.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd20.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!--  
+                <!--
                 <title xml:lang="gez" xml:id="title1">ተአምረ፡ ማርያም፡, ተአምረ፡ ኢየሱስ፡, ድርሳን፡ ቃሉ፡ ዘቅዱስ፡ ወብጹዕ፡ ያዕቆብ፡ ኤጲስ፡ ቆጶስ፡ ዘሥሩግ፡ በእንተ፡ መልአክ፡ ወፈያታዊ፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Taʾammǝra Māryām, Taʾammǝra ʾIyasus, Dǝrsān qālu za-bǝṣuʿ Yāʿqob ʾeṗis qoṗos za-Śǝrug baʾǝnta malʾak wa-fayyātāwi</title>
              -->
@@ -3530,11 +3530,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </collation>
 
                                 <condition key="good">
-                                    There are slight traces of use, including: wear at the spine;
-                                    dirt stains in the lower margins until <locus target="#105r"/>; occasional ink smudges, e.g. on <locus target="#71v"/>;
+                                    There are slight traces of use, such as wear along the spine. Additionally, there are dirt stains in the lower margins
+                                    up to <locus target="#105r"/>, occasional ink smudges, e.g. on <locus target="#71v"/>;
                                     and stains, e.g. on <locus from="109" to="117"/>.
-                                    The dye used for the leather of the covers has left an imprint on the first and last folia, which are also slightly crumpled.
-                                    All edges were trimmed.
+                                    Furthermore, there is evidence of water damage, which has caused the wrinkling of the parchment and left imprints
+                                    from the dyed leather covers on the first and last leaves.
                                 </condition>
                             </supportDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethd22.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd22.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0"
     xml:id="BDLaethd22"
@@ -36,10 +36,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <idno>Juel-Jensen 51</idno>
                         </altIdentifier>
                     </msIdentifier>
-                    
+
                     <msContents>
                         <summary/>
-                        
+
                         <msItem xml:id="ms_i1">
                             <locus target="#1r"/>
                             <!--title to be included in index manually-->
@@ -47,22 +47,22 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <textLang mainLang="am"/>
                             <note>The following is the entire text. After a greeting to <persName ref="PRS13884Bisawwer"/> and unnamed military leaders, the king informs the recipients
                                 of the arrival of a cannon in <!--or from?--> <placeName ref="LOC2449Dalant"/>. It might be related to the events leading up to the siege of
-                                <placeName ref="LOC4547Maqdal"/>, especially the cannon (<foreign xml:lang="am">ቦምባ፡</foreign>) brought there, as related in 
-                                <bibl><ptr target="bm:MondonVidailhet1904ChroniqueText"/><citedRange unit="page">46-47</citedRange></bibl>, where a 
+                                <placeName ref="LOC4547Maqdal"/>, especially the cannon (<foreign xml:lang="am">ቦምባ፡</foreign>) brought there, as related in
+                                <bibl><ptr target="bm:MondonVidailhet1904ChroniqueText"/><citedRange unit="page">46-47</citedRange></bibl>, where a
                             <foreign xml:lang="gez">Rās</foreign> Bisawwǝr is also mentioned as <foreign xml:lang="am">የመቅደላ፡ ጠባቂ፡</foreign>
                                 (<bibl><ptr target="bm:MondonVidailhet1904ChroniqueText"/><citedRange unit="page">50</citedRange></bibl>).</note>
-                            <incipit xml:lang="am">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ 
+                            <incipit xml:lang="am">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡
                                 <persName ref="PRS9430Tewodros"><roleName type="title">ንጉሠ፡ ነገሥት፡</roleName> ቴዎድሮስ፡</persName> ይድረስ፡
-                                ከ<persName ref="PRS13884Bisawwer"><roleName type="title">ራስ፡</roleName> ቢሰውር፡</persName> ከቢትወደዶች፡ ከደጃዝማቾች፡ ካምበሎች፡ ከ፻ አለቆች፡ ካ፶ አለቆች፡ ካ፲ አለቆች፡ 
+                                ከ<persName ref="PRS13884Bisawwer"><roleName type="title">ራስ፡</roleName> ቢሰውር፡</persName> ከቢትወደዶች፡ ከደጃዝማቾች፡ ካምበሎች፡ ከ፻ አለቆች፡ ካ፶ አለቆች፡ ካ፲ አለቆች፡
                                 ካ፭ አለቆች፡ እንዴት፡
                                 ሰነበታችሁ፡ እኔ፡
-                                እግዚአብሔር፡ ይመስገን፡ ደኅና፡ ነኝ። በእግዚአብሔር፡ ኃይል፡ የምስራች፡ ቡምባውም፡ መድፉም፡ ወጣልኝ፡ 
+                                እግዚአብሔር፡ ይመስገን፡ ደኅና፡ ነኝ። በእግዚአብሔር፡ ኃይል፡ የምስራች፡ ቡምባውም፡ መድፉም፡ ወጣልኝ፡
                                 <placeName ref="LOC2449Dalant">ደላንታ፡</placeName> ከሜዳው፡ ደግሞም፡ ሁለንትናውን፡ ተጫውተን፡ እልክባችሁ፡ አለሁ፡
                             ፫ ጊዜ፡ መድፍ፡ ተኩሱ። ባሩዱን፡ ተጠንቅቃችሁ።</incipit>
                         </msItem>
-                        
+
                     </msContents>
-                    
+
                     <physDesc>
                         <objectDesc form="Leaf">
                             <supportDesc>
@@ -76,12 +76,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <width>220</width>
                                     </dimensions>
                                     <measure type="weight" unit="g">2</measure>
-                                </extent> 
-                                <foliation>The leaf is not foliated. In this description, the recto is referred to as 
+                                </extent>
+                                <foliation>The leaf is not foliated. In this description, the recto is referred to as
                                     <locus target="#1r"/>, the verso as <locus target="#1v"/>.</foliation>
                                 <condition key="good">Creases show where the leaf had been folded. There are a few small tears along the border of the leaf.</condition>
                             </supportDesc>
-                            
+
                             <layoutDesc>
                                 <layout columns="1" writtenLines="8">
                                     <locus target="#1"/>
@@ -102,9 +102,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     -->
                                 </layout>
                             </layoutDesc>
-                           
+
                         </objectDesc>
-                        
+
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <date notBefore="1855" notAfter="1868"/>
@@ -112,7 +112,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            <seg type="ink">Black.</seg>
                             </handNote>
                         </handDesc>
-                        
+
                         <additions>
                             <list>
                                 <item xml:id="e1">
@@ -121,26 +121,26 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <q xml:lang="gez">ንጉሠ፡ ነገሥት፡ ቴዎድሮስ፡ ዘኢትዮጵያ፡</q>
                                     <q xml:lang="ar"><gap reason="illegible"/>تاودروس ملك الحبشة</q>
                                 </item>
-                                
+
                                 <item xml:id="e2">
                                     <locus target="#1v"/>
                                     <desc>Written on the verso, possibly by the main hand.</desc>
                                     <q xml:lang="am">ከ<persName ref="PRS13884Bisawwer"><roleName type="title">ራስ፡</roleName> ቢሰውር፡</persName></q>
                                 </item>
-                                
+
                                 <item xml:id="e3">
                                     <desc>There are no scribal corrections.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e4">
                                     <desc>Traces of printed text, maybe on the remainder of a paper sticker, are visible on the verso.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e5">
                                     <locus target="#1v"/>
                                     <desc>The shelfmark ‘Ms. Aeth. d. 21’ is written in pencil on the verso (the current shelfmark of the manuscript is Aeth. d. 22).</desc>
                                 </item>
-                                
+
                                 <item xml:id="e6">
                                     <desc>A white sticker, with the name of <persName
                                         ref="PRS5782JuelJen"/> (<foreign xml:lang="gez">ቤንት፡
@@ -151,27 +151,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </item>
                             </list>
                         </additions>
-                        
-                   <!--     <bindingDesc>
-                            <binding xml:id="binding">
-                                <decoNote xml:id="b1"></decoNote>
-                                <decoNote xml:id="b2" type="bindingMaterial">
-                           <material key="wood"/>
-                        </decoNote>
-                            </binding>
-                        </bindingDesc>-->
-                        
+
                     </physDesc>
-                    
+
                     <history>
                         <origin>
                             The letter can be dated to the reign of King <persName ref="PRS9430Tewodros"/>
                             (<origDate notBefore="1855" notAfter="1868" evidence="prosopography"/>). It seems likely that it was written towards the end of his reign, possibly in
                             <date notBefore="1867" notAfter="1868"/>, shortly before
-                            the fall of <placeName ref="LOC4547Maqdal"/>. 
+                            the fall of <placeName ref="LOC4547Maqdal"/>.
                         </origin>
                     </history>
-                    
+
                     <additional>
                         <adminInfo>
                             <recordHist>
@@ -183,7 +174,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </recordHist>
                         </adminInfo>
                     </additional>
-                    
+
                 </msDesc>
             </sourceDesc>
         </fileDesc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethe30.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe30.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!--  
+                <!--
                 <title xml:lang="gez" xml:id="title1">ዳዊት፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Dāwit</title>
                 -->
@@ -481,7 +481,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <note corresp="#leafdim">Data on the dimensions of folios taken from <locus target="#33r"/>.</note>
                                     <measure type="weight" unit="g">804</measure><!--with cloth cover-->
                                 </extent>
-                                <foliation>Pencil foliation in the upper right corner carried out by the Bodleian Library in January 2020 (i–iii+1–137).</foliation> 
+                                <foliation>Pencil foliation in the upper right corner carried out by the Bodleian Library in January 2020 (i–iii+1–137).</foliation>
                                  <collation>
                                      <signatures>
                                          Undecorated quire marks are written in the upper inner margin of the first folio of each quire. Some of them are nearly illegible.
@@ -577,7 +577,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <dim unit="leaf">1</dim>
                                             <locus from="137r" to="137v"/>
                                             1, two stubs before 1
-                                            <note>Two stubs are found between the first folio, which is cut out, and <locus target="#137r"/></note> 
+                                            <note>Two stubs are found between the first folio, which is cut out, and <locus target="#137r"/></note>
                                             <!-- It is not clear what has happened here: the previous comment said "see back of metadata", but no information is provided there.
                                                 This was perhaps originally a binion with two inner stubs (but a direct inspection might be necessary for confirmation, added to REQUESTS FOR FURTHER ACTION).
                                                 What is the formula to describe a quire in which a folio has been cut out? -->
@@ -586,12 +586,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </collation>
                                 <condition key="good">
                                   Humidity appears to have damaged the parchment, especially towards the end of the manuscript.
-                                  Some folios are slightly stained with dirt, e.g. on <locus target="#25v #36v #93v"/>, or wax, e.g. on <locus target="#108r #114r #117v"/>. 
+                                  Some folios are slightly stained with dirt, e.g. on <locus target="#25v #36v #93v"/>, or wax, e.g. on <locus target="#108r #114r #117v"/>.
                                     The text is occasionally barely legible, e.g. on <locus target="#13v #14r #96r"/>.
                                     Some letters have been washed away and poorly rewritten in a secondary hand on <locus target="#24v"/>.
-                                    Traces of intensive use. One folio after <locus target="#136"/> has been cut out at some time after the completion of the writing.
+                                    Traces of intensive use.
                                     <!-- It might be a sewing guard, that is, a strip of parchment (cut from another manuscript?) sewn through and used to give strength to the sewing.
-                                        Further photographs would be necessary (EDS 04.02.2022) -->
+                                        Further photographs would be necessary (EDS 04.02.2022) See collation and request for further actions for the stubs after f.136. (EDS 14.03.2024)-->
                                 </condition>
                             </supportDesc>
 
@@ -762,7 +762,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <locus target="#ir"/>
                                     <desc>Recent note written in pencil and barely legible, containing minimal descriptive information on the manuscript
                                             (subject of the miniatures, shelfmark, contents, age).</desc>
-                                    <q xml:lang="en">Miniatures: David with his sling. David 
+                                    <q xml:lang="en">Miniatures: David with his sling. David
                                         killing Potiphar + St. Michael. Ethiopian MS-10, Early-mid 19. Psalter</q>
                                 </item>
                                 <item xml:id="e3">

--- a/OxfordBodleian/Juel-Jensen/BDLaethe32.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe32.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!-- 
+                <!--
                 <title xml:lang="gez" xml:id="title1">ዳዊት፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Dāwit</title>
                  -->
@@ -567,7 +567,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </collation>
                                 <condition key="good">
                                   The manuscript shows traces of intensive use. It is damaged by humidity
-                                  throughout, in particular at the beginning and end, so that most folios present uneven distortions and
+                                  throughout, in particular at the beginning and end, so that most folios present uneven undulations and
                                   their bottom margin is stained. Protective strips of parchment, which were probably recycled from
                                   another manuscript and on whose inner sides letters can still be read, have been placed around the lower end of <ref target="#q8"/> and the upper part of <ref target="#q12"/> .
                                   All edges have been re-trimmed.
@@ -655,7 +655,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </list>
                             </handNote>
                         </handDesc>
-                        
+
                         <decoDesc>
                          <summary>Headbands have been executed by an untrained hand and could be contemporary or posterior to the making of the manuscript.</summary>
                         <decoNote type="ornamentation" xml:id="d1">
@@ -850,7 +850,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                       A short description of the manuscript's content and main physical features is printed on it. Written
                                       in pencil on the sticker are ‘Ge/x/-’, ‘PB 371’, ‘₤ 40’, and ‘1643’.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e4">
                                     <desc>
                                         Some writing is visible on the protective strip of parchment which was placed around the lower end of <ref target="#q8"/>.
@@ -867,7 +867,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         Below the lines of text, remains of two lines of crudely drawn ornamental bands can be seen.
                                     </desc>
                                 </item>
-                                
+
                                 <item xml:id="e5">
                                     <desc>
                                         Some writing is visible on the protective strip of parchment which was placed around the upper part of <ref target="#q12"/>.

--- a/OxfordBodleian/Juel-Jensen/BDLaethe33.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe33.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!--  
+                <!--
                 <title xml:lang="gez" xml:id="title1">ስብሐተ፡ ፍቁር፡, መዝሙረ፡ ዳዊት፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Sǝbḥata fǝqur, Mazmura Dāwit</title>
                 -->
@@ -115,7 +115,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <note corresp="#leafdim">Data on the dimensions of folios taken from <locus target="#60r"/>.</note>
                                 </extent>
                                 <foliation>
-                                    Pencil foliation in the upper right corner (1–130). Due to an omission in the numbering of one folio before <locus target="#28"/>, 
+                                    Pencil foliation in the upper right corner (1–130). Due to an omission in the numbering of one folio before <locus target="#28"/>,
                                     the two preceding folios have been foliated as <locus target="#27a"/> and <locus target="#27b"/>.
                                 </foliation>
                                 <collation>
@@ -214,15 +214,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
                                 <condition key="deficient">
-                                    Remains of glue and leather are visible on the inner side of both boards, indicating the former presence of a leather cover.
-                                    On the inner side of the lower board, a tunnel (possibly created by an insect) opens from the upper edge and crosses the board vertically.
-                                    The end of the tunnel inside the board has been closed with a dark substance.
-                                    The sewing is badly damaged and has come loose in many places. It was repaired after the misplacement of some folios, which led to severe
+                                    The sewing is badly damaged and has become loose in many places. It was repaired after the misplacement of some folios, which led to severe
                                     perturbations in the textual order (e.g. the original position of <locus from="19" to="20"/> was after <locus target="#13"/>; <locus target="#74"/> is misplaced).
                                     Some folios are most probably missing. Since the repair was carried out by stabbing the folios along the inner margin, the complete opening of the quires is prevented.
                                     Losses and tears are present; the latter have been roughly repaired on some occasions by sewing, e.g. on <locus target="#22 #36 #87 #89"/>.
                                     The parchment has been severely damaged by humidity. Most folios are stained with water, especially in the upper part, e.g. <locus target="#10rv #17rv #29rv"/>.
                                     The text is barely legible in some places due to faded ink, e.g. on <locus target="#10v #30v #74r"/>. The red ink is mostly faded out.
+                                    Remains of glue and leather are visible on the inner side of both boards, indicating the former presence of a leather cover.
+                                    On the inner side of the lower board, a tunnel (possibly created by an insect) opens from the upper edge and crosses the board vertically.
+                                    The end of the tunnel inside the board has been closed with a dark substance.
                                 </condition>
                             </supportDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethe34.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe34.xml
@@ -86,9 +86,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
                                 <condition key="good">
+                                  The manuscript is in a good state of preservation.
                                   The illuminated folios are damaged by water on the upper external corner,
                                   which has caused the parchment support to warp and turn yellow.
-                                  Insects or rodents presumably caused the losses on the lower outer corners of the leaves.
+                                  Insects or mice presumably caused the losses on the lower outer corners.
                                 </condition>
                             </supportDesc>
 
@@ -187,7 +188,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            </decoNote>
                         </decoDesc>
 
-                        <!--
+                        <!--   
                             <additions>
                             <list>
                                 <item xml:id="e1">

--- a/OxfordBodleian/Juel-Jensen/BDLaethe34.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe34.xml
@@ -86,10 +86,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
                                 <condition key="good">
-                                  The manuscript is in a good state of preservation.
                                   The illuminated folios are damaged by water on the upper external corner,
                                   which has caused the parchment support to warp and turn yellow.
-                                  Insects or mice presumably caused the losses on the lower outer corners.
+                                  Insects or rodents presumably caused the losses on the lower outer corners of the leaves.
                                 </condition>
                             </supportDesc>
 
@@ -188,7 +187,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            </decoNote>
                         </decoDesc>
 
-                        <!--   
+                        <!--
                             <additions>
                             <list>
                                 <item xml:id="e1">

--- a/OxfordBodleian/Juel-Jensen/BDLaethe36.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe36.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!--  
+                <!--
                 <title xml:lang="gez" xml:id="title1">መዝሙረ፡ ዳዊት፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Mazmura Dāwit</title>
                 -->
@@ -124,11 +124,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
                                 <condition key="deficient">
-                                    The boards are missing. The lowermost sewing station is damaged and the sewing is broken.
                                     The textblock is incomplete: an undetermined number of folios is missing with loss of text from Ps 70 onwards.
-                                    Humidity appears to have damaged the parchment, especially towards the beginning of the manuscript. Water stains are attested in the outer or inner margins of
+                                    Humidity appears to have slightly damaged the parchment, especially towards the beginning of the manuscript. Water stains are attested in the outer or inner margins of
                                     many folios, e.g. on <locus target="#1r #22r #26v"/>. Wax stains are visible on, e.g. <locus target="#1r #31v #46r"/>.
-                                    The parchment is crumpled on <locus target="#17"/>.
+                                    The parchment is crumpled on <locus target="#17"/>. The boards of the binding are missing. The lowermost sewing station is damaged and the sewing is broken.
                                 </condition>
                             </supportDesc>
 
@@ -302,6 +301,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <change who="MV" when="2020-06-17">Added handDesc, rubrication, extra, ruling.</change>
             <change who="MV" when="2020-06-18">Changes after PR.</change>
             <change who="EDS" when="2023-01-27">Updated writing support, condition, and binding description.</change>
+            <change who="EDS" when="2024-03-10">Revision condition</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">

--- a/OxfordBodleian/Juel-Jensen/BDLaethe37.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe37.xml
@@ -134,12 +134,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </item>
                                     </list>
                                 </collation>
-                                <condition key="deficient">
-                                    The sewing is broken and the quires are loose.
+                                <condition key="good">
                                     The parchment has been damaged by humidity and some folios are stained with water, e.g. <locus target="#94rv #95rv #96rv"/>.
                                     The parchment is occasionally wrinkled, e.g. <locus target="#46"/>.
                                     The margins of some folios have been damaged probably by rodents, e.g. <locus from="40" to="42"/>.
                                     Some lower outer corners are slightly stained with dirt, e.g. on <locus from="16v" to="21r"/>.
+                                    The sewing is broken and the quires are loose with the risk
+                                    of leaf displacement.
                                 </condition>
                             </supportDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethe38.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe38.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!-- 
+                <!--
                 <title xml:lang="gez" xml:id="title1">ዜና፡ ሐና፡, ተአምረ፡ ሐና፡, መልክአ፡ ሐና፡, ተአምረ፡ ሐና፡ ወኢያቄም፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Zenā Ḥannā, Taʾammǝra Ḥannā, Malkǝʾa Ḥannā, Taʾammǝra Ḥannā wa-ʾIyāqem</title>
                  -->
@@ -343,17 +343,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <measure unit="g" type="weight">785</measure>
                                 </extent>
                                 <foliation>
-                                    Pencil foliation in the upper right corner (10–79). 
+                                    Pencil foliation in the upper right corner (10–79).
                                     The first nine and last two folios are not foliated; the foliation begins with the number 10
                                     on <locus target="#10"/>. The unfoliated folios are referred to as <locus from="1" to="9"/> and <locus from="80" to="81"/>
-                                    in this description. 
+                                    in this description.
                                     A protective bifolio has been glued to the front and back cover and has not been considered in the foliation.
                                 </foliation>
-                               
+
                                 <collation>
                                     <signatures>
                                         <note>
-                                            Quire marks are written in the upper inner margin of the first folio of quires 4–8, respectively marked with 
+                                            Quire marks are written in the upper inner margin of the first folio of quires 4–8, respectively marked with
                                             Ethiopic numerals as 2–6. All quire marks are written in black and red ink and are surrounded by four nine-dot signs, also executed in red and black ink.
                                         </note>
                                     </signatures>
@@ -408,10 +408,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
                                 <condition key="good">
-                                    Traces of the former leather cover are clearly visible in the outer side of the front and back boards.
                                     Some folios, especially at the beginning of the manuscript, have been severely damaged by water, in particular in the upper outer corner (<locus from="1" to="4"/>).
                                     Stains, perhaps of wax, on <locus from="15vb" to="16ra"/>, <locus from="26va" to="27rb"/>, and <locus target="41ar"/>. <locus target="#80vb"/> is stained with dirt.
                                     <locus target="#81"/> is mutilated.
+                                    Traces of the former leather cover are clearly visible on the outer side of the front and back boards.
                                 </condition>
                             </supportDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethe39.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe39.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!--  
+                <!--
                 <title xml:lang="gez" xml:id="title1">ገድለ፡ ገብረ፡ መንፈስ፡ ቅዱስ፡, ተአምረ፡ ገብረ፡ መንፈስ፡ ቅዱስ፡, መዝገበ፡ ሃይማኖት፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Gadla Gabra Manfas Qǝddus, Taʾammǝra Gabra Manfas Qǝddus, Excerpts from Mazgaba hāymānot</title>
                -->
@@ -56,11 +56,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <depth>80</depth>
                                     </dimensions>
                                     <measure type="weight" unit="g">984</measure><!--weighted without modern documents placed inside the MS-->
-                                 </extent> 
+                                 </extent>
                                 <foliation>Pencil foliation in the upper right corner carried out by the Bodleian Library in January 2020 (1–90).</foliation>
                                 <collation>
                                     <note>The original structure of most quires is difficult to
-                                        assess because many folios did not constitute original quires: they are now detached or precariously sewn together (see also Condition below).</note>                                
+                                        assess because many folios did not constitute original quires: they are now detached or precariously sewn together (see also Condition below).</note>
                                     <list>
                                         <item xml:id="q1" n="A">
                                             <dim unit="leaf">3</dim>
@@ -142,16 +142,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
                                 <condition key="deficient">
-                                    The two codicological units forming the manuscript seem to share the same conservation history. Most folios are unevenly distorted, stained, and darkened along the margins,
+                                    The two codicological units forming the manuscript seem to share the same conservation history. Most folios are cockled, stained, and darkened along the margins,
                                     and present tears and lacunas. The sewing is broken throughout. Most bifolios became separated and the single folios are stitched to strips of parchment or textile placed
                                     around the quires. A protective strip of textile is sewn around <ref target="#q5 #q7 #q9 #q11 #q12 #q13 #q14 #q17 #q18"/>. Remains of a parchment support or two stubs are visible after <locus target="#78"/>.
                                     A parchment support has been added around <ref target="#q1"/>.
                                     <ref target="#q19"/> originates from another codex and is currently held together very precariously by means of one running stitch. One or more folios are missing after <locus target="#88"/>,
                                     with loss of text. All folios are stained with dirt and some portions of text are illegible due to faded ink.
                                 </condition>
-                            </supportDesc>                                                
+                            </supportDesc>
                         </objectDesc>
-                        
+
                         <bindingDesc>
                            <binding contemporary="Ethiopian false">
                               <p>The boards may be contemporary with the content but the sewing was certainly repaired after the strips of textile and parchment have been placed around the quires.</p>
@@ -174,15 +174,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </binding>
                         </bindingDesc>
                     </physDesc>
-                    
+
                     <history>
                         <provenance>
                             Unknown provenance. The name of a (secondary?) owner has been partially erased in all supplication formulas in <ref target="#p1">unit 1</ref>, yet the
-                            name of a certain <persName ref="PRS13934ZawaldaM"/> is still barely legible on <locus target="#13va"/>. 
+                            name of a certain <persName ref="PRS13934ZawaldaM"/> is still barely legible on <locus target="#13va"/>.
                             The manuscript was purchased by <persName ref="PRS5782JuelJen"/> under unknown circumstances.
                         </provenance>
                     </history>
-                    
+
                     <msPart xml:id="p1">
                         <msIdentifier>
                             <idno/>
@@ -195,26 +195,26 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <msItem xml:id="p1_i1.1">
                             <locus from="2ra" to="67vb"/>
                             <title type="complete" ref="LIT1451GadlaG"/>
-                            <note>The text does not correspond strictly to any of the three known recensions of the work (cp.  <bibl><ptr target="bm:Marrassini2003GabraManfasQeddusTextus"/><citedRange>viii-xi</citedRange></bibl>): 
+                            <note>The text does not correspond strictly to any of the three known recensions of the work (cp.  <bibl><ptr target="bm:Marrassini2003GabraManfasQeddusTextus"/><citedRange>viii-xi</citedRange></bibl>):
                                 it mostly follows <ref type="work" corresp="LIT4074GadlaMA">text type A</ref>, yet with some readings belonging to <ref type="work" corresp="LIT4075GadlaMB">text type B</ref>.</note>
-                               <textLang mainLang="gez"/>    
+                               <textLang mainLang="gez"/>
                             <incipit xml:lang="gez">
                                 <locus target="#2ra"/>
-                                <hi rend="rubric">በስመ፡ እግዚአብሔር፡</hi> ዘኢይትዌለጥ፡ እምህላ<hi rend="rubric">ዌሁ፡ ወበስመ፡ እግዚአብ</hi>ሔር፡ ወልድ፡ ዘኢይትፈለጥ፡  እምሕፅነ፡ 
+                                <hi rend="rubric">በስመ፡ እግዚአብሔር፡</hi> ዘኢይትዌለጥ፡ እምህላ<hi rend="rubric">ዌሁ፡ ወበስመ፡ እግዚአብ</hi>ሔር፡ ወልድ፡ ዘኢይትፈለጥ፡  እምሕፅነ፡
                                 አቡሁ። ወበስመ፡ እግዚአብሔር፡ መንፈስ፡ ቅዱስ፡ ዘአስተንፈሰ፡ ቦሙ፡ በነቢያቲሁ፡ በእስትንፋሰ፡ አፉሁ። ወተሰውጠ፡ ቦሙ፡ በሐዋርያቲሁ፡ ከመ፡ ይስብኩ፡ ወንጌለ፡
                                 ጸጋሁ። ወተፅዕነ፡ ዲቤሆሙ፡ ከመ፡ ይኩንዎ፡ ሰረገላሁ። ዝኬ፡ ውእቱ፡ አሐዱ፡ አምላክ።
-                            </incipit>                           
+                            </incipit>
                             <explicit xml:lang="gez">
                                 <locus from="67va" to="67vb"/>
-                                ወፈጺሞሙ፡ ሕገ፡ እግዚአብሔር፡ ወእሙንቱ፡ መላእክት፡ አተውዋ፡ ለነፍሱ፡ ውስተ፡ አብያተ፡ ብርሃን፡ በክብር፡ ወበስብሐት፡ ወበቃለ፡ ቀርን፡ ብዙኅ፡ ወኮነ፡ 
-                                በአርያም፡ ዐቢይ፡ ትፍሥሕት፡ በከመ፡ ዕርገተ፡ እግዚእነ፡ ወ<cb n="b"/>አኅብሮ፡ ስብሐት፡ እንዘ፡ ይብሉ፡ ሃሌ፡ ሉያ፡ ፍርቃን፡ ለአምላከነ፡ ለዓለመ፡ ዓለም፡ 
+                                ወፈጺሞሙ፡ ሕገ፡ እግዚአብሔር፡ ወእሙንቱ፡ መላእክት፡ አተውዋ፡ ለነፍሱ፡ ውስተ፡ አብያተ፡ ብርሃን፡ በክብር፡ ወበስብሐት፡ ወበቃለ፡ ቀርን፡ ብዙኅ፡ ወኮነ፡
+                                በአርያም፡ ዐቢይ፡ ትፍሥሕት፡ በከመ፡ ዕርገተ፡ እግዚእነ፡ ወ<cb n="b"/>አኅብሮ፡ ስብሐት፡ እንዘ፡ ይብሉ፡ ሃሌ፡ ሉያ፡ ፍርቃን፡ ለአምላከነ፡ ለዓለመ፡ ዓለም፡
                                 አሜን፡ ወአሜን፡ ለይኵን፡ ለይኵን።
                             </explicit>
                         </msItem>
                                 <msItem xml:id="p1_i1.2">
                             <locus from="68ra" to="85vb"/>
                             <title type="complete" ref="LIT3977Taammer"/>
-                            <textLang mainLang="gez"/> 
+                            <textLang mainLang="gez"/>
                             <note>Ten unnumbered miracles</note>
                             <incipit xml:lang="gez">
                                 <locus target="#68ra"/>
@@ -225,120 +225,120 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <msItem xml:id="p1_i1.2.1">
                                 <locus from="68ra" to="69va"/>
                                 <title type="complete" ref="LIT6765MiracleGMQ"/>
-                                <textLang mainLang="gez"/>    
+                                <textLang mainLang="gez"/>
                                 <incipit xml:lang="gez">
                                     <locus from="68ra" to="68rb"/>
                                     ወነበረ፡ ፩ መነኮስ፡ <sic resp="MV">ኃጥአ፡</sic> ወይገብር፡ ብዙኃ፡ ሥራያተ፡ ወያመልክ፡ አማልክተ። ወዓዲሰ፡ ይገብር፡ ዝሙተ፡ ወ<cb n="b"/><hi rend="rubric">አኮ፡
-                                        ሰብእ፡ ባሕቲቶ፡ አላ፡ ያወስብ፡ አክልብተ፡</hi> ወለእመ፡ ገብረ፡ አክልብተ፡ ምድረ፡ ነዲቆ፡ ያወስብ፡  <hi rend="rubric">ወአሐተ፡ ዕለተ፡ ሖረ፡ ኀበ፡ ሀለወ፡ 
+                                        ሰብእ፡ ባሕቲቶ፡ አላ፡ ያወስብ፡ አክልብተ፡</hi> ወለእመ፡ ገብረ፡ አክልብተ፡ ምድረ፡ ነዲቆ፡ ያወስብ፡  <hi rend="rubric">ወአሐተ፡ ዕለተ፡ ሖረ፡ ኀበ፡ ሀለወ፡
                                             መጽሐፈ፡ ገድሎ፡</hi> ለአቡነ፡ ገብረ፡ መንፈስ፡ ቅዱስ፡ አመ፡ ፭ ለመጋቢት፡
-                                </incipit>                           
+                                </incipit>
                                 <explicit xml:lang="gez">
                                     <locus target="#69va"/>
-                                    ወይቤ፡ እግዚእ፡ ሑሩ፡ ስድዋ፡ ለዛቲ<supplied reason="omitted">፡</supplied> ነፍስ፡ ኀበ፡ ማኅደረ፡ መሃይምናን፡ ወአዘዘ፡ እግዚአብሔር፡ ለሚካኤል፡ ከመ፡ 
+                                    ወይቤ፡ እግዚእ፡ ሑሩ፡ ስድዋ፡ ለዛቲ<supplied reason="omitted">፡</supplied> ነፍስ፡ ኀበ፡ ማኅደረ፡ መሃይምናን፡ ወአዘዘ፡ እግዚአብሔር፡ ለሚካኤል፡ ከመ፡
                                     ይደያ፡ ፍጡነ፡ ወወሰዳ፡ ወአቡነሰ፡ ብፁዓዊ፡ ተፈሥሐ፡ ወበርሃ፡ ገጹ፡ ጸሎቱ፡ ወበረከቱ፡ የሃሉ፡ ምስሌነ፡ ለዓለመ፡ ዓለም፡ አሜን።
                                 </explicit>
                             </msItem>
                                     <msItem xml:id="p1_i1.2.2">
                                 <locus from="69va" to="70vb"/>
                                 <title type="complete" ref="LIT6766MiracleGMQ"/>
-                                <textLang mainLang="gez"/>    
+                                <textLang mainLang="gez"/>
                                 <incipit xml:lang="gez" type="supplication">
                                     <locus from="69va" to="69vb"/>
                                     <hi rend="rubric">ተአምሪሁ፡ ለአቡነ፡ ገብረ፡</hi> መንፈስ፡ ቅዱስ፡ ጸሎቱ፡ ወበረከቱ፡ የሃሉ፡ ምስለ፡ <sic resp="MV">ፍቅርሩ፡</sic> <del rend="erasure"/> <add place="overstrike">ማርያም፡</add>
                                     <cb n="b"/> ለዓለመ፡ ዓለም፡ አሜን።
-                                </incipit>          
+                                </incipit>
                                 <incipit xml:lang="gez">
                                     <locus target="#69vb"/>
-                                    ወነበረት፡ አሐተ፡ ብእሲት፡ ዘአኃዛ፡ ጋኔን፡ ዘቀትር፡ ወበሣልስት፡ ዕለት፡ ይወግራ፡ ወነበረት፡ እስከ፡ ፫ ዓመት። ወእምድኅረዝ፡ ሖረት፡ ወኀበ፡ ፩ ካህን። ወውእቱሰ፡ 
+                                    ወነበረት፡ አሐተ፡ ብእሲት፡ ዘአኃዛ፡ ጋኔን፡ ዘቀትር፡ ወበሣልስት፡ ዕለት፡ ይወግራ፡ ወነበረት፡ እስከ፡ ፫ ዓመት። ወእምድኅረዝ፡ ሖረት፡ ወኀበ፡ ፩ ካህን። ወውእቱሰ፡
                                     ካህን፡ መንፈሳዊ። ወትቤሎ፡ ሀበኒ፡ መድኃኒተ፡ ለነፍስየ፡ ወአኃዘኒ፡ ጋኔን።
                                 </incipit>
                                 <explicit xml:lang="gez">
                                     <locus from="70va" to="70vb"/>
-                                    ወአሐዘት፡ ሀብለ፡ ባሕቲታ፡ ወሰሐበት፡ ወኵሉ፡ ሰብአ፡ ሀገር፡ ይተልው፡ ድኅሬሃ፡ እንዘ፡ ያን<add place="inline">ክ</add>ሩ፡ ወአብጽሐቶሙ፡ ውስተ፡ ዓቢይ፡ 
-                                    ፀድፍ፡ ወወገረቶ። ወዘንተ፡ ነበረ፡ አቡነ፡ <hi rend="rubric">ገብረ፡ መንፈስ፡ ቅ<supplied reason="omitted">ዱስ፡</supplied></hi> ጸሎቱ፡ ወበረከቱ፡ የሃሉ፡ 
+                                    ወአሐዘት፡ ሀብለ፡ ባሕቲታ፡ ወሰሐበት፡ ወኵሉ፡ ሰብአ፡ ሀገር፡ ይተልው፡ ድኅሬሃ፡ እንዘ፡ ያን<add place="inline">ክ</add>ሩ፡ ወአብጽሐቶሙ፡ ውስተ፡ ዓቢይ፡
+                                    ፀድፍ፡ ወወገረቶ። ወዘንተ፡ ነበረ፡ አቡነ፡ <hi rend="rubric">ገብረ፡ መንፈስ፡ ቅ<supplied reason="omitted">ዱስ፡</supplied></hi> ጸሎቱ፡ ወበረከቱ፡ የሃሉ፡
                                     ም<cb n="b"/>ስሌነ፡ ለዓለመ፡ ዓለም፡ አሜን።
                                 </explicit>
                             </msItem>
                                     <msItem xml:id="p1_i1.2.3">
                                 <locus from="70vb" to="71va"/>
                                 <title type="complete" ref="LIT6767MiracleGMQ"/>
-                                <textLang mainLang="gez"/>    
+                                <textLang mainLang="gez"/>
                                 <incipit xml:lang="gez" type="supplication">
                                     <locus target="#70vb"/>
-                                    <hi rend="rubric">ተአምሪሁ፡ ለአቡነ፡ <surplus>ለአቡነ፡</surplus> ገ<supplied reason="omitted">ብረ፡ መንፈስ፡</supplied></hi> ቅዱስ፡ ጸሎቱ፡ ወበረከቱ፡ 
+                                    <hi rend="rubric">ተአምሪሁ፡ ለአቡነ፡ <surplus>ለአቡነ፡</surplus> ገ<supplied reason="omitted">ብረ፡ መንፈስ፡</supplied></hi> ቅዱስ፡ ጸሎቱ፡ ወበረከቱ፡
                                     የሃሉ፡ ምስለ፡ ገብሩ፡ <del rend="erasure"/> <add place="overstrike">ማርያም፡</add> ለዓለመ፡ ዓለም፡ አሜን።
-                                </incipit>          
+                                </incipit>
                                 <incipit xml:lang="gez">
                                     <locus target="#70vb"/>
                                     ወነበረት፡ አሐቲ፡ መበለት፡ እንዘ፡ ትገብር፡ ትዝካሮ፡ ለአቡነ፡ <hi rend="rubric">ገብረ፡ መንፈስ፡ <supplied reason="omitted">ቅዱስ፡</supplied></hi> ፪ ጊዜ፡
                                     በ፩ ዓመት፡ በዕለተ፡ ልደቱ፡ ወበዕለተ፡ ሞቱ፡ ወአልቦቱ፡ ምግባረ፡ ሠናይ፡ ዘእንበ<supplied reason="omitted">ለ</supplied>፡ ገቢረ፡ በዓሉ፡
-                                </incipit>                    
+                                </incipit>
                                 <explicit xml:lang="gez">
                                     <locus from="71rb" to="71va"/>
-                                    ወሖረት፡ ወረከበት፡ እክለ፡ እሱረ፡ በሐብል፡ ዘነሥእዎ፡ ፈያት፡ ወአተወት፡ ቤታ፡ እንዘ፡ ታንክር። ወከመዝ፡ ነገረት፡ ዕበዮ፡ ለአቡነ፡ <sic resp="MV">ብፀዓዊ፡</sic> ውስተ፡ ገቢረ፡ በዐሉ፡ 
-                                    ወለነኒ፡ ይረ<pb n="71v"/><cb n="a"/>ስየነ፡ ድልዋነ፡ ውስተ፡ ሰፋኒተ፡ መንግሥቱ፡ ወብድ፡ ሥርዓቱ፡ ግብረቱ፡ ወበዝየኒ፡ ይዕቀበነ፡ እምሰይጣን፡ ተቃርኖቱ፡ 
+                                    ወሖረት፡ ወረከበት፡ እክለ፡ እሱረ፡ በሐብል፡ ዘነሥእዎ፡ ፈያት፡ ወአተወት፡ ቤታ፡ እንዘ፡ ታንክር። ወከመዝ፡ ነገረት፡ ዕበዮ፡ ለአቡነ፡ <sic resp="MV">ብፀዓዊ፡</sic> ውስተ፡ ገቢረ፡ በዐሉ፡
+                                    ወለነኒ፡ ይረ<pb n="71v"/><cb n="a"/>ስየነ፡ ድልዋነ፡ ውስተ፡ ሰፋኒተ፡ መንግሥቱ፡ ወብድ፡ ሥርዓቱ፡ ግብረቱ፡ ወበዝየኒ፡ ይዕቀበነ፡ እምሰይጣን፡ ተቃርኖቱ፡
                                     ለዓለመ፡ ዓለም፡ አሜን፡
                                 </explicit>
                             </msItem>
                                     <msItem xml:id="p1_i1.2.4">
                                 <locus from="71va" to="72vb"/>
                                 <title type="complete" ref="LIT6768MiracleGMQ"/>
-                                <textLang mainLang="gez"/>    
+                                <textLang mainLang="gez"/>
                                 <incipit xml:lang="gez" type="supplication">
                                     <locus target="#71va"/>
-                                    <hi rend="rubric">ተአምሪሁ፡ ለአቡነ፡ ገብረ፡ <supplied reason="omitted">መንፈስ፡</supplied></hi> ቅዱስ፡ ጸሎቱ፡ ወበረከቱ፡ የሃሉ፡ ምስለ፡ ፍቅርት፡ 
+                                    <hi rend="rubric">ተአምሪሁ፡ ለአቡነ፡ ገብረ፡ <supplied reason="omitted">መንፈስ፡</supplied></hi> ቅዱስ፡ ጸሎቱ፡ ወበረከቱ፡ የሃሉ፡ ምስለ፡ ፍቅርት፡
                                     <del rend="erasure"/> <add place="overstrike">ማርያም፡</add> ለዓለመ፡ ዓለም፡ አሜን።
-                                </incipit>          
+                                </incipit>
                                 <incipit xml:lang="gez">
                                     <locus from="71va" to="71vb"/>
-                                    ወሀለወት፡ አሐቲ፡ ብእሲት፡ መፍቀሪተ፡ ዝሙት፡ ወሰዓሪተ፡ ሰንበት። ወርእየ፡ እግዚአብሔር፡ እከያቲሃ፡ አዘዘ፡ ዓቢይ፡ ከይሲ፡ ከመ፡ ይባዕ፡ በዕፍረታ። ወአሐተ፡ 
-                                    ዕለተ፡ እንዘ፡ ትሰይን፡ ይእቲ፡ ብእሲት፡ ወቦአ፡ ውእቱ፡ ከይሲ፡ ወ<cb n="b"/>ቦአ፡ በ<gap reason="illegible" unit="chars" quantity="3"/> ወረሰየ፡ ምብያቶ፡ 
+                                    ወሀለወት፡ አሐቲ፡ ብእሲት፡ መፍቀሪተ፡ ዝሙት፡ ወሰዓሪተ፡ ሰንበት። ወርእየ፡ እግዚአብሔር፡ እከያቲሃ፡ አዘዘ፡ ዓቢይ፡ ከይሲ፡ ከመ፡ ይባዕ፡ በዕፍረታ። ወአሐተ፡
+                                    ዕለተ፡ እንዘ፡ ትሰይን፡ ይእቲ፡ ብእሲት፡ ወቦአ፡ ውእቱ፡ ከይሲ፡ ወ<cb n="b"/>ቦአ፡ በ<gap reason="illegible" unit="chars" quantity="3"/> ወረሰየ፡ ምብያቶ፡
                                     በህ<gap reason="illegible" unit="chars" quantity="3"/> ልዐትሂ፡ ውእቱ፡ ይትመጦሙ፡ በውስጣ።
-                                </incipit>                              
+                                </incipit>
                                 <explicit xml:lang="gez">
                                     <locus target="#72vb"/>
-                                    ወገብሩ፡ ትዝካሮ፡ ለአቡነ፡ <hi rend="rubric">ገብረ፡ መንፈስ፡ ቅ<supplied reason="omitted">ዱስ፡</supplied></hi> ወይእቲሰ፡ ተውሰበት፡ ኀበ፡ ካልዕ፡ 
-                                    ምታ፡ ወወለደት፡ ፯ ወገብረት፡ ተዝካሮ፡ ለአቡነ፡ <hi rend="rubric">ገብረ፡ መንፈስ፡ <supplied reason="omitted">ቅዱስ፡</supplied></hi> እስከ፡ ዕለተ፡ 
+                                    ወገብሩ፡ ትዝካሮ፡ ለአቡነ፡ <hi rend="rubric">ገብረ፡ መንፈስ፡ ቅ<supplied reason="omitted">ዱስ፡</supplied></hi> ወይእቲሰ፡ ተውሰበት፡ ኀበ፡ ካልዕ፡
+                                    ምታ፡ ወወለደት፡ ፯ ወገብረት፡ ተዝካሮ፡ ለአቡነ፡ <hi rend="rubric">ገብረ፡ መንፈስ፡ <supplied reason="omitted">ቅዱስ፡</supplied></hi> እስከ፡ ዕለተ፡
                                     ሞታ፡ ጸሎቱ፡ ወበረከቱ፡ የሃሉ፡ ምስሌነ፡ አሜን።
                                 </explicit>
                             </msItem>
                                     <msItem xml:id="p1_i1.2.5">
                                 <locus from="72vb" to="74va"/>
                                 <title type="complete" ref="LIT6769MiracleGMQ"/>
-                                <textLang mainLang="gez"/>    
+                                <textLang mainLang="gez"/>
                                 <incipit xml:lang="gez" type="supplication">
                                     <locus target="#72vb"/>
-                                    <hi rend="rubric">ተአምሪሁ፡ ለአቡነ፡ ገብረ፡ <supplied reason="omitted">መንፈስ፡</supplied></hi> ቅዱስ፡ ጸሎቱ፡ ወበረከቱ፡ የሃሉ፡ ምስለ፡ ገብሩ፡ 
+                                    <hi rend="rubric">ተአምሪሁ፡ ለአቡነ፡ ገብረ፡ <supplied reason="omitted">መንፈስ፡</supplied></hi> ቅዱስ፡ ጸሎቱ፡ ወበረከቱ፡ የሃሉ፡ ምስለ፡ ገብሩ፡
                                     <del rend="erasure"/> <add place="overstrike">ማርያም፡</add> ለዓለመ፡ ዓለም፡ አሜን።
-                                </incipit>          
+                                </incipit>
                                 <incipit xml:lang="gez">
                                     <locus from="72vb" to="73ra"/>
-                                    ወነበረት፡ አሐቲ፡ መበለት፡ እንዘ፡ ትገብር፡ ብዙኃ፡ ኃጢአተ፡ ከመ፡ ሰብአ፡ ዓለም። ወእምዝ፡ ፀንሰት፡ ወአእመራ፡ ሊቀ፡ አበው፡ <gap reason="illegible" unit="chars" quantity="1"/> 
-                                    <pb n="73r"/><cb n="a"/>መ፡ ፀንሰት፡ ወ<gap reason="illegible" unit="chars" quantity="1"/>ለከ፡ ኀበ፡ መምህራ። መምህራሰ፡ መዓትም፡ 
-                                    ውእቱ፡ ወሶበ፡ ሰምዓ፡ ዘንተ፡ ነገረ፡ ለአከ፡ እንዘ፡ ይብል፡ በሣልስት፡ 
+                                    ወነበረት፡ አሐቲ፡ መበለት፡ እንዘ፡ ትገብር፡ ብዙኃ፡ ኃጢአተ፡ ከመ፡ ሰብአ፡ ዓለም። ወእምዝ፡ ፀንሰት፡ ወአእመራ፡ ሊቀ፡ አበው፡ <gap reason="illegible" unit="chars" quantity="1"/>
+                                    <pb n="73r"/><cb n="a"/>መ፡ ፀንሰት፡ ወ<gap reason="illegible" unit="chars" quantity="1"/>ለከ፡ ኀበ፡ መምህራ። መምህራሰ፡ መዓትም፡
+                                    ውእቱ፡ ወሶበ፡ ሰምዓ፡ ዘንተ፡ ነገረ፡ ለአከ፡ እንዘ፡ ይብል፡ በሣልስት፡
                                     ዕለትአ፡
-                                </incipit>                              
+                                </incipit>
                                 <explicit xml:lang="gez">
                                     <locus target="#74va"/>
                                     ወእምድኅረዝ፡ ኮነት፡ ጻድቅት፡ ወነበረት፡ እንዘ፡ ትገብር፡ ተዝካሮ፡ ለአቡነ፡ <hi rend="rubric">ገብረ፡ መንፈስ፡ ቅ<supplied reason="omitted">ዱስ፡</supplied></hi>
-                                    ወይእቲሰ፡ መካን፡ ወለደት፡ ወልደ፡ ተባዕተ። ወነበረት፡ ፪ሆን፡ እንዘ፡ ይገብሩ፡ ተዝካሮ፡ ለአቡነ፡ እስከ፡ ዕለተ፡ ሞቶን፡ ጸሎቱ፡ ወበረከቱ፡ የሃሉ፡ ምስሌነ፡ አሜን። 
+                                    ወይእቲሰ፡ መካን፡ ወለደት፡ ወልደ፡ ተባዕተ። ወነበረት፡ ፪ሆን፡ እንዘ፡ ይገብሩ፡ ተዝካሮ፡ ለአቡነ፡ እስከ፡ ዕለተ፡ ሞቶን፡ ጸሎቱ፡ ወበረከቱ፡ የሃሉ፡ ምስሌነ፡ አሜን።
                                 </explicit>
                             </msItem>
                                     <msItem xml:id="p1_i1.2.6">
                                 <locus from="74va" to="75ra"/>
                                 <title type="complete" ref="LIT6770MiracleGMQ"/>
-                                <textLang mainLang="gez"/>    
+                                <textLang mainLang="gez"/>
                                 <incipit xml:lang="gez" type="supplication">
                                     <locus from="74va" to="74vb"/>
-                                    <hi rend="rubric">ተአምሪሁ፡ ለአ</hi><cb n="b"/>ቡነ፡ <hi rend="rubric">ገብረ፡ መንፈስ<supplied reason="omitted">፡ ቅዱስ፡</supplied></hi> ጸሎቱ፡ 
+                                    <hi rend="rubric">ተአምሪሁ፡ ለአ</hi><cb n="b"/>ቡነ፡ <hi rend="rubric">ገብረ፡ መንፈስ<supplied reason="omitted">፡ ቅዱስ፡</supplied></hi> ጸሎቱ፡
                                     ወበረከቱ፡ የሃሉ፡ ምስለ፡ ገብሩ፡ <del rend="erasure"/> <add place="overstrike">ማርያም፡</add> ለዓለመ፡ ዓለም፡ አሜን።
-                                </incipit>          
+                                </incipit>
                                 <incipit xml:lang="gez">
                                     <locus target="#74vb"/>
-                                    ወሀሎ፡ ፩ ወሬዛ፡ እምርኁቅ፡ ብሔር፡ ዘመጽአ፡ በዕለተ፡ ተዝካሩ፡ ለአቡነ፡ ጸዊሮ፡ ማዕተበ፡ ሐዲሰ፡ በርእሱ፡ ወእንዘ፡ ይከይድ፡ በፍኖት፡ ወነሥአ፡ ማዕተቦ፡ 
+                                    ወሀሎ፡ ፩ ወሬዛ፡ እምርኁቅ፡ ብሔር፡ ዘመጽአ፡ በዕለተ፡ ተዝካሩ፡ ለአቡነ፡ ጸዊሮ፡ ማዕተበ፡ ሐዲሰ፡ በርእሱ፡ ወእንዘ፡ ይከይድ፡ በፍኖት፡ ወነሥአ፡ ማዕተቦ፡
                                     ዖፈ፡ ጺላት፡ እምርእሱ። ወአምሐሉ፡ ውእቱ፡ ብእሲ፡ ለውእቱ፡ ዖፈ፡ ጺላት፡ እንዘ፡ ይብል፡ በጸሎቱ፡ ለአቡነ፡
                                     <hi rend="rubric">ገብረ፡ መንፈ<supplied reason="omitted">ስ፡ ቅዱስ፡</supplied></hi>
-                                </incipit>                              
+                                </incipit>
                                 <explicit xml:lang="gez">
                                     <locus target="#75ra"/>
                                     ወእንዘ፡ ይትመየጥ፡ ውስተ፡ ማኅደሩ፡ ረከበ፡ በፍኖት፡ ለውእቱ፡ ዖፈ፡ ጺላት፡ መዊቶ፡ ወማዕተቡኒ፡ ውስተ፡ ክሳዱ፡ ወነሥኦ፡ ማዕተበ፡ ወአንክረ፡
@@ -348,146 +348,146 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <msItem xml:id="p1_i1.2.7">
                                 <locus from="75ra" to="76va"/>
                                 <title type="complete" ref="LIT6771MiracleGMQ"/>
-                                <textLang mainLang="gez"/>    
+                                <textLang mainLang="gez"/>
                                 <incipit xml:lang="gez" type="supplication">
                                     <locus target="#75ra"/>
-                                    <hi rend="rubric">ተአምሪሁ፡</hi> ለአቡነ፡ <hi rend="rubric">ገብረ፡ መንፈስ፡ ቅ<supplied reason="omitted">ዱስ፡</supplied></hi> ጸሎቱ፡ የሃሉ፡ ምስሌነ፡ 
+                                    <hi rend="rubric">ተአምሪሁ፡</hi> ለአቡነ፡ <hi rend="rubric">ገብረ፡ መንፈስ፡ ቅ<supplied reason="omitted">ዱስ፡</supplied></hi> ጸሎቱ፡ የሃሉ፡ ምስሌነ፡
                                     አሜን።
-                                </incipit>          
+                                </incipit>
                                 <incipit xml:lang="gez">
                                     <locus from="75ra" to="75rb"/>
                                     ነበረት፡ እንዘ፡ ትገብር፡ ተዝካሮ፡ ለአቡነ፡ <hi rend="rubric">ገብረ፡ መንፈስ፡ ቅ<supplied reason="omitted">ዱስ፡</supplied></hi> በከመ፡ ነገራ፡
-                                    ብእሲ፡ ጻድቅ፡ ከመ፡ <cb n="b"/> ትገብር፡ ተዝካሮ፡ ወአሐተ፡ ዕለተ፡ እንዘ፡ ሀለዉ፡ ተጋቢኦሙ፡ ፸ ሕፃናት፡ በይእቲ፡ ሀገር፡ ዓይ፡ ፀድፍ፡ ወወልዳሂ፡ 
+                                    ብእሲ፡ ጻድቅ፡ ከመ፡ <cb n="b"/> ትገብር፡ ተዝካሮ፡ ወአሐተ፡ ዕለተ፡ እንዘ፡ ሀለዉ፡ ተጋቢኦሙ፡ ፸ ሕፃናት፡ በይእቲ፡ ሀገር፡ ዓይ፡ ፀድፍ፡ ወወልዳሂ፡
                                     ለገባሪተ፡ ተዝካሩ፡ ለቅዱስ፡ ነበረ፡ ምስሌሆሙ፡
-                                </incipit>                              
+                                </incipit>
                                 <explicit xml:lang="gez">
-                                    <locus from="76rb" to="76va"/>                                    
-                                    ወይእቲ፡ ጊዜ፡ ተራክቡ፡ ም<pb n="76v"/><cb n="a"/>ስለ፡ አቡሆሙ፡ ወእሞሙ፡ ወተፈሥሑ፡ ፈድፋደ፡ ወአንከሩ፡ ተአምራቲሁ፡ ለአቡነ፡ 
+                                    <locus from="76rb" to="76va"/>
+                                    ወይእቲ፡ ጊዜ፡ ተራክቡ፡ ም<pb n="76v"/><cb n="a"/>ስለ፡ አቡሆሙ፡ ወእሞሙ፡ ወተፈሥሑ፡ ፈድፋደ፡ ወአንከሩ፡ ተአምራቲሁ፡ ለአቡነ፡
                                     <hi rend="rubric">ገብረ፡ መንፈስ፡ <supplied reason="omitted">ቅዱስ፡</supplied></hi> ጸሎቱ፡ ወበረከቱ፡ የሃሉ፡ ምስሌነ፡ አሜን።
                                 </explicit>
                             </msItem>
                                     <msItem xml:id="p1_i1.2.8">
                                 <locus from="76va" to="79ra"/>
                                 <title type="complete" ref="LIT6772MiracleGMQ"/>
-                                <textLang mainLang="gez"/>    
+                                <textLang mainLang="gez"/>
                                 <incipit xml:lang="gez" type="supplication">
                                     <locus target="#76va"/>
-                                    <hi rend="rubric">ተአምሪሁ፡ ለአ</hi>ቡነ፡ <hi rend="rubric">ገብረ፡ መንፈስ፡ <supplied reason="omitted">ቅዱስ፡</supplied></hi> ጸሎቱ፡ ወበረከቱ፡ 
+                                    <hi rend="rubric">ተአምሪሁ፡ ለአ</hi>ቡነ፡ <hi rend="rubric">ገብረ፡ መንፈስ፡ <supplied reason="omitted">ቅዱስ፡</supplied></hi> ጸሎቱ፡ ወበረከቱ፡
                                     የሃሉ፡ ምስለ፡ ገብሩ፡ <del rend="erasure"/> <add place="overstrike">ማርያም፡</add> ለዓለመ፡ ዓለም፡ አሜን።
-                                </incipit>          
+                                </incipit>
                                 <incipit xml:lang="gez">
                                     <locus from="76va" to="76vb"/>
                                     ዘኮነ፡ በዘመነ፡ መንግሥቱ፡ ለናኦድ፡ ዘገብረ፡ ለአሐቲ፡ ብእሲት፡ እምድኅረ፡ ሞተ፡ ወልዳ፡ ሕፃነ፡ ወፅአት፡ ወወሰደት፡ ኀበ፡ ይሰትዩ፡ ቤተ፡ ማኅበሮሙ፡ ለአቡነ፡
                                     <hi rend="rubric">ገብረ፡ መንፈ<supplied reason="omitted">ስ፡ ቅዱስ፡</supplied></hi> ወረከበት፡ ጋነ፡ ተሰቂሎ፡ በ<cb n="b"/>ውእቱ፡ ቤት፡ ወአውረደ<surplus>፡</surplus>ት፡
                                     ወወደየት፡ በውእቱ፡ ጋን፡ ተሰቂሎ፡ ወእቱ፡ በድነ፡ ወልዳ፡
-                                </incipit>                              
+                                </incipit>
                                 <explicit xml:lang="gez">
                                     <locus from="78vb" to="79ra"/>
-                                    ወሰረረ፡ በዘባነ፡ መብረቅ፡ ወአኀዘ፡ ረምሐ፡ በመብረቅ፡ እሳት፡ ማዕከሌሆሙ፡ ወተሰጥሙ፡ ኵሎሙ፡ በድንጋፄ፡ ወኢያእምሮሙ፡ አልባሲሆሙ፡ ወነሥአ፡ ለውእቱ፡ 
-                                    ብእሲ። ወአዕረፎ፡ ሰማይ፡ ወአብኦ፡ ውስተ፡ ርስቱ፡ ወረሰዮ፡ ለባሕቲተ፡ እለ፡ <pb n="79r"/><cb n="a"/> ተመነዩ፡ ኀጉሉ፡ ኵሎሙ፡ ጸሎቱ፡ ወበረኵቱ፡ የሃሉ፡ 
-                                    ምስሌነ፡ አሜን። 
+                                    ወሰረረ፡ በዘባነ፡ መብረቅ፡ ወአኀዘ፡ ረምሐ፡ በመብረቅ፡ እሳት፡ ማዕከሌሆሙ፡ ወተሰጥሙ፡ ኵሎሙ፡ በድንጋፄ፡ ወኢያእምሮሙ፡ አልባሲሆሙ፡ ወነሥአ፡ ለውእቱ፡
+                                    ብእሲ። ወአዕረፎ፡ ሰማይ፡ ወአብኦ፡ ውስተ፡ ርስቱ፡ ወረሰዮ፡ ለባሕቲተ፡ እለ፡ <pb n="79r"/><cb n="a"/> ተመነዩ፡ ኀጉሉ፡ ኵሎሙ፡ ጸሎቱ፡ ወበረኵቱ፡ የሃሉ፡
+                                    ምስሌነ፡ አሜን።
                                 </explicit>
                             </msItem>
                                     <msItem xml:id="p1_i1.2.9">
                                 <locus from="79ra" to="81ra"/>
                                 <title type="complete" ref="LIT6774MiracleGMQ"/>
-                                <textLang mainLang="gez"/>    
+                                <textLang mainLang="gez"/>
                                 <incipit xml:lang="gez" type="supplication">
                                     <locus target="#79ra"/>
-                                    <hi rend="rubric">ተአምሪሁ፡ ለአቡነ፡ ገብረ፡ መን<supplied reason="omitted">ፈስ፡ ቅዱስ፡</supplied></hi> ጸሎቱ፡ የሃሉ፡ ምስለ፡ <add place="overstrike">ገብሩ፡</add> 
+                                    <hi rend="rubric">ተአምሪሁ፡ ለአቡነ፡ ገብረ፡ መን<supplied reason="omitted">ፈስ፡ ቅዱስ፡</supplied></hi> ጸሎቱ፡ የሃሉ፡ ምስለ፡ <add place="overstrike">ገብሩ፡</add>
                                     <del rend="erasure"/> <add place="overstrike">ማርያም፡</add> ለዓለመ፡ ዓለም፡ አሜን።
-                                </incipit>          
+                                </incipit>
                                 <incipit xml:lang="gez">
                                     <locus from="79ra" to="79rb"/>
-                                    ወነበረ፡ ፩ ብእሲ፡ ዘአኃዘ፡ ብዙኃ፡ ንዴት፡ እምብዝኃ፡ ንዴት፡ ከሀዶ፡ ለእግዚአብሔር፡ በልቡ፡ ወኃሠሠ፡ መሬተ። ወሶበ፡ የሐውር፡ በፍኖት፡ ረከበ፡ ሰይጣን፡ 
+                                    ወነበረ፡ ፩ ብእሲ፡ ዘአኃዘ፡ ብዙኃ፡ ንዴት፡ እምብዝኃ፡ ንዴት፡ ከሀዶ፡ ለእግዚአብሔር፡ በልቡ፡ ወኃሠሠ፡ መሬተ። ወሶበ፡ የሐውር፡ በፍኖት፡ ረከበ፡ ሰይጣን፡
                                     መስሐቲ፡ ወይቤሎ፡ አይቴ፡ ተሐውር፡ መኑ፡ ተኃሥሥ። ወይቤሎ፡ ውእቱ፡ ብእሲ፡ ለሰይጣን፡ አሐውር፡ ወአኃሥሥ፡ አኃዘኒ፡ ንዴት። ወይቤሎ፡ ሰይጣን፡ <cb n="b"/>
                                     ለእመ፡ ፈቀድከ፡ ትብል፡ ትክህዶኑ፡ ለእግዚአብሔር፡
-                                </incipit>                              
+                                </incipit>
                                 <explicit xml:lang="gez">
                                     <locus from="80vb" to="81ra"/>
-                                    <gap reason="illegible" unit="chars" quantity="2"/>ሎ፡ አቡነ፡ ለእግዚኡ፡ ለእመ፡ ፈቀድከ፡ ትግባዕ፡ ነፍሱ፡ ውስተ፡ ሥጋሁ፡ እምዝ፡ ኃ<gap reason="illegible" unit="chars" quantity="3"/> 
-                                    <pb n="80v"/><cb n="a"/> የዓቢ፡ ኪዳንየ፡ ወፍቁር<surplus>፡</surplus>የ፡ አኮ፡ ፍቁርየ፡ ወወሰድዎ፡ መላእክት፡ ለይእቲ፡ ነፍስ፡ ወገብአት፡ ውስተ፡ ሥጋሁ። ወገብሩ፡ ተዝካሮ፡ 
+                                    <gap reason="illegible" unit="chars" quantity="2"/>ሎ፡ አቡነ፡ ለእግዚኡ፡ ለእመ፡ ፈቀድከ፡ ትግባዕ፡ ነፍሱ፡ ውስተ፡ ሥጋሁ፡ እምዝ፡ ኃ<gap reason="illegible" unit="chars" quantity="3"/>
+                                    <pb n="80v"/><cb n="a"/> የዓቢ፡ ኪዳንየ፡ ወፍቁር<surplus>፡</surplus>የ፡ አኮ፡ ፍቁርየ፡ ወወሰድዎ፡ መላእክት፡ ለይእቲ፡ ነፍስ፡ ወገብአት፡ ውስተ፡ ሥጋሁ። ወገብሩ፡ ተዝካሮ፡
                                     ለአቡነ፡ እስከ፡ ዕለተ፡ ሞቱ። ወእምድኅረዝ፡ ሞተ፡ ወገብአት፡ ነፍሱ፡ መንግሥተ፡ ሰማያት፡ ጸሎቱ፡ ወበረከቱ፡ የሃሉ፡ ምስሌነ፡ አሜን።
                                 </explicit>
                             </msItem>
                                     <msItem xml:id="p1_i1.2.10">
                                 <locus from="81ra" to="82ra"/>
                                 <title type="complete" ref="LIT6775MiracleGMQ"/>
-                                <textLang mainLang="gez"/>    
+                                <textLang mainLang="gez"/>
                                 <incipit xml:lang="gez" type="supplication">
                                     <locus target="#81ra"/>
-                                    <hi rend="rubric">ተአም<supplied reason="omitted">ሪሁ</supplied>፡</hi> ለአቡነ፡ <hi rend="rubric">ገብረ፡ መንፈስ፡ ቅ<supplied reason="omitted">ዱስ፡</supplied></hi> 
+                                    <hi rend="rubric">ተአም<supplied reason="omitted">ሪሁ</supplied>፡</hi> ለአቡነ፡ <hi rend="rubric">ገብረ፡ መንፈስ፡ ቅ<supplied reason="omitted">ዱስ፡</supplied></hi>
                                     ጸሎቱ፡ ወበረከቱ፡ የሃሉ፡ ምስለ፡ <add place="overstrike">ገብሩ፡</add> <del rend="erasure"/> <add place="overstrike">ማርያም፡</add> ለዓለመ፡ ዓለም፡ አሜን።
-                                </incipit>          
+                                </incipit>
                                 <incipit xml:lang="gez">
                                     <locus from="81ra" to="81rb"/>
-                                    ወነበረ፡ ፩ ብእሲ፡ በ፩ ሀገር፡ ወሰምዓ፡ መጽሐፈ፡ ገድሉ፡ ለአቡነ፡ <hi rend="rubric">ገብረ፡ መንፈስ፡ <supplied reason="omitted">ቅዱስ፡</supplied></hi> አመ፡ ፭ ለመጋቢት፡ 
+                                    ወነበረ፡ ፩ ብእሲ፡ በ፩ ሀገር፡ ወሰምዓ፡ መጽሐፈ፡ ገድሉ፡ ለአቡነ፡ <hi rend="rubric">ገብረ፡ መንፈስ፡ <supplied reason="omitted">ቅዱስ፡</supplied></hi> አመ፡ ፭ ለመጋቢት፡
                                     ወጠየቀ፡ ከመ፡ ኮነ፡ ተዝካሩ፡ <cb n="b"/> በጾም፡ ወበጸሎት፡ ለእመ፡ ኮነ፡ ተስብእቱ፡ በጾም፡ ወይብል፡ ውስተ፡ ብእሲ፡ አንሰ፡ እገብር፡ ተዝካሮ፡ አመ፡ ፳ወ፱ ለታኅሣሥ፡ ወእሰውዕ፡
                                     ላሕመ፡ ወበግዓ፡
-                                </incipit>    
+                                </incipit>
                                 <explicit xml:lang="gez">
                                     <locus target="82ra"/>
-                                    ወበ<gap reason="illegible" unit="chars" quantity="1"/>ዕሂ፡ ዘተመስለ፡ ከመ፡ አድግ፡ እምብዝኃ፡ ግዝፈት፡ ወአንከ<gap reason="illegible" unit="chars" quantity="1"/>፡ 
+                                    ወበ<gap reason="illegible" unit="chars" quantity="1"/>ዕሂ፡ ዘተመስለ፡ ከመ፡ አድግ፡ እምብዝኃ፡ ግዝፈት፡ ወአንከ<gap reason="illegible" unit="chars" quantity="1"/>፡
                                     እሙንቱ፡ ሰብአ፡ ሀገር፡ ወተደሙ፡ ወበልዑ፡ እስከ፡ ፩ ሰሙን። ወገብሩ፡ <sic resp="MV">ተዝካር፡</sic> እስከ፡ ዕለተ፡ ሞቶሙ፡ ጸሎቱ፡ ወበረከቱ፡
                                     የሃሉ፡ ምስሌነ፡ አሜን።
                                 </explicit>
-                            </msItem>     
+                            </msItem>
                                     <msItem xml:id="p1_i1.2.11">
                                 <locus from="82rb" to="82vb"/>
                                 <title type="complete" ref="LIT6777MiracleGMQ"/>
-                                <textLang mainLang="gez"/>    
+                                <textLang mainLang="gez"/>
                                 <incipit xml:lang="gez" type="supplication">
                                     <locus target="#82rb"/>
-                                    <hi rend="rubric">ተአምሪሁ፡ ለአቡነ፡ ገብረ፡ መንፈስ፡ ቅዱስ፡ ጸሎቱ፡</hi> ወበረከቱ፡ የሃሉ፡ ምስለ፡ ገብሩ፡ <del rend="erasure"/> 
+                                    <hi rend="rubric">ተአምሪሁ፡ ለአቡነ፡ ገብረ፡ መንፈስ፡ ቅዱስ፡ ጸሎቱ፡</hi> ወበረከቱ፡ የሃሉ፡ ምስለ፡ ገብሩ፡ <del rend="erasure"/>
                                     <add place="overstrike">ማርያም፡</add> <hi rend="rubric">ዘጸሐፎ፡</hi> ለዓለመ፡ ዓለም፡ አሜን።
-                                </incipit>          
+                                </incipit>
                                 <incipit xml:lang="gez">
                                     <locus target="#82rb"/>
                                     ወነበረ፡ ፩ ብእሲ፡ ነዳይ፡ እምርሑቅ፡ ብሔር፡ አልቦቱ፡ ጥሪት፡ ዘእንበለ፡ ፩ ዶርሆ፡ ተባዕታይ፡ ወገደፈ፡ ዶርሆ፡ ለአቡነ፡ <hi rend="rubric">ገብረ፡
                                         መንፈስ፡ <supplied reason="omitted">ቅዱስ፡</supplied></hi> ወሠረቀ፡ ሠራቂ፡ ዶርሆ፡ ወበልዐ፡ በጊዜ፡ ፱ ሰዓት፡ ኃዘነ፡ ውእቱ፡ በዐለ፡
                                     ዶርሆ፡
-                                </incipit>    
+                                </incipit>
                                 <explicit xml:lang="gez">
                                     <locus target="82vb"/>
-                                    ወመጽኡ፡ ሰብአ፡ ሀገር፡ ኵሎሙ፡ ወርእዩ፡ ርኅወ፡ መቃብር፡ ወነጸሩ፡ ለውእቱ፡ ዶርሆ፡ በላዕለ፡ ቤተ፡ ክርስቲያን፡ ወአንከሩ፡ ወተደሙ፡ 
+                                    ወመጽኡ፡ ሰብአ፡ ሀገር፡ ኵሎሙ፡ ወርእዩ፡ ርኅወ፡ መቃብር፡ ወነጸሩ፡ ለውእቱ፡ ዶርሆ፡ በላዕለ፡ ቤተ፡ ክርስቲያን፡ ወአንከሩ፡ ወተደሙ፡
                                     ወደፈኑ፡ መሬተ፡ ወእምድኅረዝ፡ ነበረ፡ ዶርሆ፡ በላዕለ፡ ቤተ፡ ክርስቲያን፡ ፯ አመተ፡ ዘከመዝ፡ ገብረ፡ ተአምረ፡ ወመንክረ፡ አቡነ፡
                                     <hi rend="rubric">ገብረ፡ መንፈስ፡ <supplied reason="omitted">ቅዱስ፡</supplied></hi> ጸሎቱ፡ ወበረከቱ፡ የሃሉ፡ ምስሌነ፡ አሜን።
                                 </explicit>
-                            </msItem>     
+                            </msItem>
                                     <msItem xml:id="p1_i1.2.12">
                                 <locus from="82vb" to="85vb"/>
                                 <title type="complete" ref="LIT6778MiracleGMQ"/>
-                                <textLang mainLang="gez"/>    
+                                <textLang mainLang="gez"/>
                                 <incipit xml:lang="gez" type="supplication">
                                     <locus from="82vb" to="83ra"/>
                                     <hi rend="rubric">ተአምሪሁ፡ ለአቡነ፡ ገብረ፡ መንፈስ፡ ቅዱስ፡</hi> ጸሎቱ፡ ወ<pb n="83ra"/><cb n="a"/>በረከቱ፡ የሃሉ፡ ምስሌነ፡ አሜን።
-                                </incipit>          
+                                </incipit>
                                 <incipit xml:lang="gez">
                                     <locus target="#83ra"/>
-                                    ዘኮነ፡ በዕለተ፡ ሞቱ፡ ለአቡነ፡ <hi rend="rubric">ገብረ፡ መንፈስ፡ ቅ<supplied reason="omitted">ዱስ፡</supplied></hi> በከዩ፡ ፳ አናብስት፡ 
-                                    ወ፳ አናምርት፡ ወበከዩ፡ አድባር፡ ወአውግር፡ ወበከዩ፡ አዕዋፈ፡ ሰማይ፡ ወጸልመ፡ ፀሐይ፡ ወወርኅ፡ ወከዋክብት፡ ሰማይ፡ ወምድር፡ ርዕደት፡ ወአድለቅለቁ፡ 
+                                    ዘኮነ፡ በዕለተ፡ ሞቱ፡ ለአቡነ፡ <hi rend="rubric">ገብረ፡ መንፈስ፡ ቅ<supplied reason="omitted">ዱስ፡</supplied></hi> በከዩ፡ ፳ አናብስት፡
+                                    ወ፳ አናምርት፡ ወበከዩ፡ አድባር፡ ወአውግር፡ ወበከዩ፡ አዕዋፈ፡ ሰማይ፡ ወጸልመ፡ ፀሐይ፡ ወወርኅ፡ ወከዋክብት፡ ሰማይ፡ ወምድር፡ ርዕደት፡ ወአድለቅለቁ፡
                                     መቃብራት፡ ወነጐድጓድ፡ በይእቲ፡ ዕለት፡
-                                </incipit>                                    
+                                </incipit>
                                 <explicit xml:lang="gez">
                                     <locus target="#85vb"/>
-                                    በመንፈስ፡ ቅዱስ<supplied reason="omitted">፡</supplied> ይፍረይ፡ ወይሰዊ። በጸሎታ፡ ለእግዝእትነ፡ <hi rend="rubric">ማርያም፡</hi> እሙ፡ ለማኅየዊ። ወበጸሎቱ፡ ለአቡነ፡ 
-                                    <hi rend="rubric">ገብረ፡ መንፈስ፡ ቅዱስ፡</hi> ገዳማዊ። ብፁዓዊ፡ ዓዲ፡ ለዘሀሎነ፡ ህየ፡ ይኵነነ፡ መርዓዊ፡፡ እንዘ፡ ንገብር፡ ግብረ፡ መንፈስ፡ ቅዱስ፡ ማኅየዊ። ለዓለመ፡ ዓለም፡ 
+                                    በመንፈስ፡ ቅዱስ<supplied reason="omitted">፡</supplied> ይፍረይ፡ ወይሰዊ። በጸሎታ፡ ለእግዝእትነ፡ <hi rend="rubric">ማርያም፡</hi> እሙ፡ ለማኅየዊ። ወበጸሎቱ፡ ለአቡነ፡
+                                    <hi rend="rubric">ገብረ፡ መንፈስ፡ ቅዱስ፡</hi> ገዳማዊ። ብፁዓዊ፡ ዓዲ፡ ለዘሀሎነ፡ ህየ፡ ይኵነነ፡ መርዓዊ፡፡ እንዘ፡ ንገብር፡ ግብረ፡ መንፈስ፡ ቅዱስ፡ ማኅየዊ። ለዓለመ፡ ዓለም፡
                                     አሜን፡ ወአሜን፡ ለይኵን፡ ለይኵን።
                                 </explicit>
-                            </msItem>              
+                            </msItem>
                         </msItem>
                         </msItem>
-                        
+
                             <msItem xml:id="p1_i2">
                             <locus from="86ra" to="86rb"/>
                             <title type="complete" ref="LIT3975FekkareF"/>
-                      <textLang mainLang="gez"/>    
+                      <textLang mainLang="gez"/>
                             <incipit xml:lang="gez">
                                 <locus target="#86ra"/>
-                                እጽሕፍ፡ ነገረ፡ ፊደል፡ ሀ<supplied reason="omitted">፡</supplied>ብ፡ ሀሎ፡ እግዚአብሔር፡ እምቅድመ፡ ዓለም፡ በመንግሥቱ፡ ለ፡ ብ፡ ለብሰ፡ 
-                                ሥጋ፡ እምድንግል፡ ሐ፡ ብ፡ ሐመ፡ ወሞተ። መ፡ ብ፡ መንክር፡ ግብሩ፡ ለእግዚአብሔር፡ ሠ፡ ብ፡ ሠረቀ፡ በሥጋ፡ እምቅድስት፡ ድንግል፡ ረ፡ ብ፡ 
+                                እጽሕፍ፡ ነገረ፡ ፊደል፡ ሀ<supplied reason="omitted">፡</supplied>ብ፡ ሀሎ፡ እግዚአብሔር፡ እምቅድመ፡ ዓለም፡ በመንግሥቱ፡ ለ፡ ብ፡ ለብሰ፡
+                                ሥጋ፡ እምድንግል፡ ሐ፡ ብ፡ ሐመ፡ ወሞተ። መ፡ ብ፡ መንክር፡ ግብሩ፡ ለእግዚአብሔር፡ ሠ፡ ብ፡ ሠረቀ፡ በሥጋ፡ እምቅድስት፡ ድንግል፡ ረ፡ ብ፡
                                 ረግዓ፡ ሰማይ፡ ወምድር፡ በጥበቡ፡
-                            </incipit>                           
+                            </incipit>
                             <explicit xml:lang="gez">
                                 <locus target="#86rb"/>
                                 ፀ፡ ብ፡ ፀሐየ፡ ጽድቅ፡ እግዚአብሔር። ፈ፡ ብ፡ ፈጸመ፡ ዓለመ፡ በጥበቡ። ፐ፡ ብ፡ ፓፓኤል፡ ኅቡእ፡ ስሙ፡ ለእግዚአብሔር።
@@ -498,23 +498,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <locus from="86va" to="87va"/>
                                 <title type="complete" ref="LIT6780NagaraA"/>
                             <!-- The same text is also found in BLadd16211#1.33, "On the subdivision of the year", it is a part of the Sawasew -->
-                            <textLang mainLang="gez"/>    
+                            <textLang mainLang="gez"/>
                             <incipit xml:lang="gez">
                                 <locus target="#86va"/>
-                                እጽሕፍ፡ ነገረ፡ ዓመት፡ ዘይትከፈል፡ ክረምት፡ ዘመዋዕለ፡ ዘርእ፡ ፫ አውራኅ፡ መጸው፡ ብ፡ መዋዕል፡ ጽጌያት፡ ፫ አውራኅ፡ 
+                                እጽሕፍ፡ ነገረ፡ ዓመት፡ ዘይትከፈል፡ ክረምት፡ ዘመዋዕለ፡ ዘርእ፡ ፫ አውራኅ፡ መጸው፡ ብ፡ መዋዕል፡ ጽጌያት፡ ፫ አውራኅ፡
                                 ኃጋ<gap reason="illegible" unit="chars" quantity="1"/> ብ፡ መዋዕለ፡ በጋ፡ ፫ አውራኅ፡ ፀደድ፡ ብ፡ መዋዕለ፡ ጰንጠቈስጤ፡
-                            </incipit>                           
+                            </incipit>
                             <explicit xml:lang="gez">
                                 <locus from="87rb" to="87va"/>
-                                ቦዘይቤ፡ ቆስጢንጢኖስ፡ ምርቀያን፡ ኮስሪ፡ ዲዮግልጥያኖስ፡ መሐመድ፡ ዓዲ፡ በካልእ፡ አንቀጽ፡ ዲዮግልጥያኖ<cb n="b"/>ስ፡ ወምሐመድ፡ 
-                                ወመከሰምያኖስ፡ ነቡዮሙ፡ ለእ<gap reason="illegible" unit="chars" quantity="1"/>ም፡ ዕመር፡ ወልደ፡ ሐዕ፡ ጋፉር፡ ንጉሠ፡ ትንባላት፡ ቦዘረቢ፡ 
+                                ቦዘይቤ፡ ቆስጢንጢኖስ፡ ምርቀያን፡ ኮስሪ፡ ዲዮግልጥያኖስ፡ መሐመድ፡ ዓዲ፡ በካልእ፡ አንቀጽ፡ ዲዮግልጥያኖ<cb n="b"/>ስ፡ ወምሐመድ፡
+                                ወመከሰምያኖስ፡ ነቡዮሙ፡ ለእ<gap reason="illegible" unit="chars" quantity="1"/>ም፡ ዕመር፡ ወልደ፡ ሐዕ፡ ጋፉር፡ ንጉሠ፡ ትንባላት፡ ቦዘረቢ፡
                                 ሄሮድስ፡ ዳኬዎስ፡ ብስጥያን፡ ዲዮግልጥያኖስ፡ መካሰምየኖስ፡
                             </explicit>
                         </msItem>
                             <msItem xml:id="p1_i4">
                             <locus from="87va" to="87vb"/>
-                                <title type="complete">Enumeration of the Old and New Testament books</title>                        
-                            <textLang mainLang="gez"/>  
+                                <title type="complete">Enumeration of the Old and New Testament books</title>
+                            <textLang mainLang="gez"/>
                             <!--this is the complete text-->
                             <incipit xml:lang="gez">
                                 <locus target="#87va"/>
@@ -522,27 +522,27 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 ፬ሲራክ፡ መቀብያን፡ ዮዲት፡ አስቴር፡ ነገሥት፡ ኢሳይያስ፡ ኤርምያስ፡ ዳንኤል፡ ሕዝቅኤል፡ ፵ወ፮ ብሉይ። <cb n="b"/>
                                 ወሐዲስኒ፡ ፬ወንጌል፡ ፫ ሲኖዶስ፡ ፲፬ ጳውሎስ፡ ፯ ሐዋርያት፡ ግብር፡ ቀለምሲስ፡ ፴፭ ሐዲስ።
                             </incipit>
-                        </msItem>  
+                        </msItem>
                             <msItem xml:id="p1_i5">
                             <locus target="#87vb"/>
                                 <title type="complete" ref="LIT4099MashafaT">Interpretation of the seven alphabetical orders of the Ethiopic script</title>
                             <!-- A presumably longer version is found in BLadd16223#ms_i4 and BLadd16204#ms_i2-->
-                            <textLang mainLang="gez"/>    
+                            <textLang mainLang="gez"/>
                             <!--this is the complete text-->
                             <incipit xml:lang="gez">
                                 <locus target="#87va"/>
                                 ትርጓሜ፡ ቅዱስ፡ ፊደል፡ ግዕዝ፡ ወራብዕ፡ አብ፡ <sic resp="MV">ካዕበ፡</sic> ወኀምስ፡ ወልድ፡ ሣልስ፡ ወሳድስ፡ መንፈስ<supplied reason="omitted">፡</supplied> ቅዱስ፡
-                                ሳብእ፡ ፩ አምላክ። ካልእ፡ ትርጓሜ፡ ግዕዝ፡ አብ፡ ካዕበ፡ ወልድ፡ ሣልስ፡ መንፈስ<supplied reason="omitted">፡</supplied> ቅዱስ፡ ራብዕ፡ ቤተ፡ ክርስቲያን፡ 
+                                ሳብእ፡ ፩ አምላክ። ካልእ፡ ትርጓሜ፡ ግዕዝ፡ አብ፡ ካዕበ፡ ወልድ፡ ሣልስ፡ መንፈስ<supplied reason="omitted">፡</supplied> ቅዱስ፡ ራብዕ፡ ቤተ፡ ክርስቲያን፡
                                 ኃምስ፡ ጥምቀት፡ ሳድስ፡ ምስሐ፡ ደብረ፡ ጽዮን፡ ሳብእ፡ ትንሣኤ፡ ሙታን።
-                            </incipit>                           
-                        </msItem> 
+                            </incipit>
+                        </msItem>
                     </msContents>
-                    
+
                         <physDesc>
                             <objectDesc form="Codex">
                                 <supportDesc>
                                     <support>
-                                        <material key="parchment"/>                                     
+                                        <material key="parchment"/>
                                         <p>Holes resulting from parchment making are found on e.g. <locus target="#1 #52 #83"/>.
                                             A tear has been repaired on <locus target="#63"/>.
                                         </p>
@@ -557,9 +557,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <width>170</width>
                                         </dimensions>
                                         <note corresp="#leafdim">Data on the dimensions of folios taken from <locus target="#12r"/>.</note>
-                                    </extent>                                   
+                                    </extent>
                                 </supportDesc>
-                    
+
                                 <layoutDesc>
                                     <layout columns="2" writtenLines="17">
                                         <locus from="2ra" to="87v"/>
@@ -579,7 +579,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <ab type="punctuation" subtype="Dividers">
                                             A chain of red and black dots marks the end of <ref target="#p1_i1">the Vita of Gabra Manfas Qǝddus</ref>;
                                             Two chains of red and black dots mark the end of <ref target="#p1_i2">the Miracles of Gabra Manfas Qǝddus</ref>;
-                                            a chain of black dots separates <ref target="#p1_i4">the enumeration of the Old and New Testament books</ref> from 
+                                            a chain of black dots separates <ref target="#p1_i4">the enumeration of the Old and New Testament books</ref> from
                                             <ref target="#p1_i5">the interpretation of the seven alphabetical orders</ref> on <locus target="87vb"/>.
                                         </ab>
                                         <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are often visible.</ab>
@@ -589,7 +589,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </layout>
                                 </layoutDesc>
                             </objectDesc>
-                            
+
                             <handDesc>
                                 <handNote xml:id="h1" script="Ethiopic">
                                     <locus from="2ra" to="85vb"/>
@@ -603,7 +603,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         One bottom ruled line has been left unwritten on <locus from="51va" to="51vb"/>.
                                     </desc>
                                     <seg type="rubrication">
-                                        Several lines on the incipit pages of <ref target="#p1_i1">the Vita</ref> and <ref target="#p1_i2">the Miracles of Gabra Manfas Qǝddus</ref>, 
+                                        Several lines on the incipit pages of <ref target="#p1_i1">the Vita</ref> and <ref target="#p1_i2">the Miracles of Gabra Manfas Qǝddus</ref>,
                                         alternating with black lines; few words of the incipits of the miracles; holy names, the indication of the patron on <locus target="#82rb"/>;
                                         elements of the numerals and of the punctuation signs, including text dividers.
                                      </seg>
@@ -629,7 +629,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                          </list>
                                     </handNote>
                             </handDesc>
-                            
+
                               <additions>
                                 <list>
                                     <item xml:id="a1">
@@ -638,7 +638,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <locus target="#1v"/>
                                         <q xml:lang="gez">ስምዖን፡ ወአቅሌሳ፡ ዘነበሩ፡ በንኂሳ። በኃጢአ፡ ወሉድ፡ ዘይበክዩ፡ መጠነ፡ አመታት፡ በላሳ። ተወልደ፡ እምኔሆሙ፡ ተናየ፡ አናብስት፡ ስሳ። ገብረ፡ መንፈስ፡ ቅዱስ፡ ከመ፡ አምላኩ፡ ዘይሰሪ፡ አበሳ።</q>
                                     </item>
-                                   
+
                                     <item xml:id="e1">
                                         <desc>A white sticker is glued to the inner side of the front board, on the top. The name of <persName ref="PRS5782JuelJen"/> is printed on it
                                             (<foreign xml:lang="gez">ቤንት፡ ዩውል፡ የንሰን።</foreign>) and the signatures "MS. Aeth. e. 39" and "MS 17" are written in pencil.
@@ -673,7 +673,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </desc>
                                     </item>
                                     <item xml:id="e4">
-                                        <desc>Corrections throughout, in the shape of interlineal additions (e.g. on <locus target="#50va #72vb"/>), erasures (e.g. on 
+                                        <desc>Corrections throughout, in the shape of interlineal additions (e.g. on <locus target="#50va #72vb"/>), erasures (e.g. on
                                             <locus target="#51va #84rb"/>), words encircled in red and black dots (<locus target="#33ra"/>).
                                             Scribbles in pen or pencil throughout.
                                         </desc>
@@ -681,15 +681,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </list>
                               </additions>
                         </physDesc>
-                        
+
                         <history>
                             <origin>
                                 <origDate notBefore="1600" notAfter="1700" evidence="lettering">17th century</origDate>
                             </origin>
-                        </history>                        
+                        </history>
                     </msPart>
-                    
-                    
+
+
                     <msPart xml:id="p2">
                         <msIdentifier>
                             <idno/>
@@ -702,11 +702,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <!--this is the complete text-->
                                     <incipit xml:lang="gez">
                                         <locus target="88ra"/>
-                                       እምጉባኤ፡ ሐዋርያት፡ እስከ፡ መንግሥተ፡ ዲዮቅልጥያኖስ፡ ፪፻፸ወ፯ ዓመት። ወእመንግሥተ፡ ዲዮቅልጥያኖስ፡ በ፶ወ፱ ዓመት። ኮነ፡ ጉባኤ፡ ኒቅያ፡ በመዋዕለ፡ 
+                                       እምጉባኤ፡ ሐዋርያት፡ እስከ፡ መንግሥተ፡ ዲዮቅልጥያኖስ፡ ፪፻፸ወ፯ ዓመት። ወእመንግሥተ፡ ዲዮቅልጥያኖስ፡ በ፶ወ፱ ዓመት። ኮነ፡ ጉባኤ፡ ኒቅያ፡ በመዋዕለ፡
                                        ቈስጠ<supplied reason="omitted">ን</supplied>ጢኖስ፡ በእንተ፡ አ<gap reason="illegible" unit="chars" quantity="1"/>ርዮስ። አመ፡ ፻፲ወ፯ ዓመተ፡ ዲዮቅልጥያኖስ፡
-                                        ኮነ፡ ጉባኤ፡ ቈስጥንጥንያ፡ በመዋዕለ፡ ቴዎዶስዮስ፡ ዘየዐቢ፡ በእንተ፡ መቅዶንዮስ። ዓዲ፡ በ፻፸ወ፪ ዓመት፡ ዲዮቅልጥያኖስ፡ ኮነ፡ ጉባኤ፡ ኤፌሶ<gap reason="illegible" unit="chars" quantity="1"/>፡ በመዋዕለ፡ ቴዎዶስዮስ፡ 
-                                        ዘይንእስ። ዓዲ፡ አመ፡ ፻፺ወ<gap reason="illegible" unit="chars" quantity="3"/>ተ፡ ዲዮቅልጥያኖስ፡ <cb n="b"/> ኮነ፡ ጉባኤ፡ ኬልቄዶን፡ በመዋዕለ፡ ምሮቅያን፡ ዘውእቱ፡ መለካውያን። ዓዲ፡ 
-                                        <gap reason="illegible" unit="chars" quantity="2"/> ፫፻<gap reason="illegible" unit="chars" quantity="1"/>ወ፫ ዓመቱ፡ ለዲዮቅልጥያኖስ፡ ፈለ<gap reason="illegible" unit="chars" quantity="1"/>፡ 
+                                        ኮነ፡ ጉባኤ፡ ቈስጥንጥንያ፡ በመዋዕለ፡ ቴዎዶስዮስ፡ ዘየዐቢ፡ በእንተ፡ መቅዶንዮስ። ዓዲ፡ በ፻፸ወ፪ ዓመት፡ ዲዮቅልጥያኖስ፡ ኮነ፡ ጉባኤ፡ ኤፌሶ<gap reason="illegible" unit="chars" quantity="1"/>፡ በመዋዕለ፡ ቴዎዶስዮስ፡
+                                        ዘይንእስ። ዓዲ፡ አመ፡ ፻፺ወ<gap reason="illegible" unit="chars" quantity="3"/>ተ፡ ዲዮቅልጥያኖስ፡ <cb n="b"/> ኮነ፡ ጉባኤ፡ ኬልቄዶን፡ በመዋዕለ፡ ምሮቅያን፡ ዘውእቱ፡ መለካውያን። ዓዲ፡
+                                        <gap reason="illegible" unit="chars" quantity="2"/> ፫፻<gap reason="illegible" unit="chars" quantity="1"/>ወ፫ ዓመቱ፡ ለዲዮቅልጥያኖስ፡ ፈለ<gap reason="illegible" unit="chars" quantity="1"/>፡
                                         መንግሥት፡ ኀበ፡ ተን<gap reason="illegible" unit="chars" quantity="1"/>ላት።
                                     </incipit>
                                    </msItem>
@@ -716,13 +716,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <textLang mainLang="gez"/>
                                 <incipit xml:lang="gez">
                                     <locus target="88rb"/>
-                                   በእንተ፡ ክርስቶስ፡ ዘፈጸመ፡ ሕገ፡ ትስብእት፡ እንዘ፡ ውእቱ፡ መለኮታዊ፡ ወመብልዕኒ፡ ዘበልዓ፡ እምቅድመ፡ ስቅለቱ፡ ከመዝ፡ ውእቱ፡ በከመ፡ 
+                                   በእንተ፡ ክርስቶስ፡ ዘፈጸመ፡ ሕገ፡ ትስብእት፡ እንዘ፡ ውእቱ፡ መለኮታዊ፡ ወመብልዕኒ፡ ዘበልዓ፡ እምቅድመ፡ ስቅለቱ፡ ከመዝ፡ ውእቱ፡ በከመ፡
                                    በልዓ፡ አዳም፡ አመ፡ ሀለወ፡ ውስተ፡ ገነት፡ እምቅድመ፡ ይብላዕ፡ ፍሬ፡ ስሕተት። ወበከመ፡ በልዐ፡ በቤተ፡ አብርሃም፡ ወከማሁ፡ በልዓ፡ እምድኅረ፡
                                    ትንሣኤሁ፡ እሙታን፡ ዓሣ፡ ጥብስ፡
                                    </incipit>
                                 <explicit xml:lang="gez">
                                     <locus target="88vb"/>
-                                    በከመ፡ ይቤ፡ ጳውሎስ፡ እስመ፡ ደቂቅ፡ ተሳተፉ፡ ደመ፡ <add place="interlinear">ወ</add>ሥጋ። ውእቱኒ፡ ተሳተፈ፡ ምስሌሆሙ። 
+                                    በከመ፡ ይቤ፡ ጳውሎስ፡ እስመ፡ ደቂቅ፡ ተሳተፉ፡ ደመ፡ <add place="interlinear">ወ</add>ሥጋ። ውእቱኒ፡ ተሳተፈ፡ ምስሌሆሙ።
                                     በአዳም፡ ቅድመ፡ ይሰደድ፡ እምገነት። ወአመ፡ ይቤሉ፡ ባሕቱ፡ እግዚ
                                 </explicit>
                                 <note>The text ends abruptly due to loss of one or more folios.</note>
@@ -733,25 +733,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <textLang mainLang="gez"/>
                                 <incipit xml:lang="gez">
                                     <locus target="89ra"/>
-                                    ስማዕ፡ ኦብእሲ፡ በቍኤታ፡ ለነፍስከ፡ እግዚአብሔር፡ ውእቱ፡ ፈጣሪከ፡ መሀረከ፡ ወ<add place="interlinear">ኢ</add>ገብረ፡ ለከ፡ በከመ፡ እከይከ፡ 
+                                    ስማዕ፡ ኦብእሲ፡ በቍኤታ፡ ለነፍስከ፡ እግዚአብሔር፡ ውእቱ፡ ፈጣሪከ፡ መሀረከ፡ ወ<add place="interlinear">ኢ</add>ገብረ፡ ለከ፡ በከመ፡ እከይከ፡
                                     ወኢፈደየከ፡ በከመ፡ ኃጢአተከ፡ ውእቱሰ፡ ይጸንሐከ፡ እስከ፡ ትትኔሳሕ፡ እምእከይከ፡ ወትትመየጥ፡ ኀቤሁ። ስማዕ፡ ኦብእሲ፡
                                     እንግርከ፡ ውእቱሰ፡ ፈጣሪ፡ እንዘ፡ ይሬኢ፡ ኀጢአተከ፡
                                 </incipit>
                                 <explicit xml:lang="gez">
                                     <locus target="90va"/>
-                                    ለኵሉ፡ ፍኅረት፡ <gap reason="illegible" unit="chars" quantity="3"/> ወብ<gap reason="illegible" unit="chars" quantity="1"/>፡ ለኵሉ፡ ሰብእ፡ 
+                                    ለኵሉ፡ ፍኅረት፡ <gap reason="illegible" unit="chars" quantity="3"/> ወብ<gap reason="illegible" unit="chars" quantity="1"/>፡ ለኵሉ፡ ሰብእ፡
                                     ተ<gap reason="illegible" unit="chars" quantity="1"/>ሐት። ወተፍጻሜቱ፡ ለኵሉ፡ መ<gap reason="illegible" unit="chars" quantity="5"/>፡ ዓለመ፡ ለዓለመ፡ ዓለም፡ አሜን።
                                 </explicit>
                             </msItem>
-                            
+
                         </msContents>
                         <physDesc>
                             <objectDesc form="Other">
                                 <supportDesc>
                                     <support>
-                                        <material key="parchment"/>                                     
+                                        <material key="parchment"/>
                                     </support>
-                                  
+
                                     <extent>
                                         <measure unit="leaf" quantity="3">3</measure>
                                         <locus from="88" to="90"/>
@@ -762,7 +762,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <note corresp="#leafdim2">Data on leaves dimensions taken from <locus target="#89r"/>.</note>-->
                                     </extent>
                                 </supportDesc>
-                                
+
                                 <layoutDesc>
                                     <layout columns="2" writtenLines="16 20">
                                         <locus from="88r" to="90va"/>
@@ -785,7 +785,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </layout>
                                 </layoutDesc>
                             </objectDesc>
-                            
+
                             <handDesc>
                                 <handNote xml:id="h3" script="Ethiopic">
                                     <locus from="88r" to="90va"/>
@@ -796,7 +796,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </desc>
                                 </handNote>
                             </handDesc>
-                            
+
                               <additions>
                                 <list>
                                     <item xml:id="a2">
@@ -805,23 +805,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             </desc>
                                         <locus target="#88r"/>
                                         <q xml:lang="am">
-                                            <sic resp="MV">ሑልቆ፡</sic> ፀርብ፡ ፵፪ የአቤትሆይ፡ የመልካም፡ ልዛ፡ ሰ፡ አ ፵፻፡ የአዝማች፡ አብቶ፡ <add place="interlinear">፵፻</add> የአቤትሆይ፡ ፯፡ የምልካም፡ 
-                                            ልብሶ፡ ፮ የአብቶ፡ ፮<add place="below">በ</add>ድሙር፡ ፻፶፡        
+                                            <sic resp="MV">ሑልቆ፡</sic> ፀርብ፡ ፵፪ የአቤትሆይ፡ የመልካም፡ ልዛ፡ ሰ፡ አ ፵፻፡ የአዝማች፡ አብቶ፡ <add place="interlinear">፵፻</add> የአቤትሆይ፡ ፯፡ የምልካም፡
+                                            ልብሶ፡ ፮ የአብቶ፡ ፮<add place="below">በ</add>ድሙር፡ ፻፶፡
                                         </q>
                                     </item>
-                                    
+
                                     <item xml:id="a3">
                                         <desc type="Supplication">
                                             Note written in black ink at the end of <ref target="#p2_i1">the text</ref>. It is barely legible and poorly understandable due to faded ink.
                                              </desc>
                                         <locus target="#90va"/>
                                         <q xml:lang="gez">
-                                            አብ፡ ወወልድ፡ ወመን<supplied reason="omitted">ፈስ፡ ቅዱስ፡</supplied> ኦአረ፡ ረአሲ፡ ኦፈጣ<supplied reason="omitted">ሪ፡</supplied>፡ በስመ፡ <gap reason="illegible" unit="chars" quantity="1"/>አረቅ፡ 
-                                            ማዕከሌነ፡ <gap reason="illegible" unit="chars" quantity="2"/>ብ<gap reason="illegible" unit="chars" quantity="1"/>ዕ፡ 
+                                            አብ፡ ወወልድ፡ ወመን<supplied reason="omitted">ፈስ፡ ቅዱስ፡</supplied> ኦአረ፡ ረአሲ፡ ኦፈጣ<supplied reason="omitted">ሪ፡</supplied>፡ በስመ፡ <gap reason="illegible" unit="chars" quantity="1"/>አረቅ፡
+                                            ማዕከሌነ፡ <gap reason="illegible" unit="chars" quantity="2"/>ብ<gap reason="illegible" unit="chars" quantity="1"/>ዕ፡
                                             ቡ<gap reason="illegible" unit="chars" quantity="1"/>ተት፡
                                         </q>
                                     </item>
-                                    
+
                                     <item xml:id="e5">
                                         <desc>Scribbles in pen and pencil on <locus target="#90v"/>. One interlineal correction on <locus target="#89vb"/>.
                                         </desc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethf23.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf23.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!--  
+                <!--
                 <title xml:lang="gez" xml:id="title1">ፊሳልጎስ፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Fisālgos</title>
                 -->
@@ -562,11 +562,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <note corresp="#leafdim">Data on the dimensions of folios taken from <locus target="#19"/>.</note>
                                     <measure unit="g" type="weight">126</measure>
                                 </extent>
-                                <foliation>Pencil and black ink pagination in the upper outer corner (1–124). 
+                                <foliation>Pencil and black ink pagination in the upper outer corner (1–124).
                                     The first twelve and the last two pages are not paginated.
                                     They are referred to in this description as <locus from="i" to="xii"/> and <locus from="xiii" to="xiv"/>.</foliation>
-                                <condition key="good">
-                                   The manuscript is in a good state of preservation.
+                                <condition key="intact">
+                                   The manuscript hardly seems used.
                                 </condition>
                             </supportDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethf24.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf24.xml
@@ -10,11 +10,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!--  
+                <!--
                 <title xml:lang="gez" xml:id="title1">መዝሙረ፡ ዳዊት፡, መስተብቍዓን፡, ፈትሐት፡ ዘወልድ፡, እሴብሕ፡ ጸጋኪ፡ ኦምልእተ፡ ጸጋ፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Mazmura Dāwit, Mastabqʷǝʿān, Fǝtḥat za-wald, ʾƎsebbǝḥ ṣaggāki ʾo-mǝlʾǝta ṣaggā</title>
                 -->
-                <title xml:lang="en" xml:id="title1">Psalms of David, Supplications (<hi rendition="simple:italic">Mastabqʷǝʿān</hi>), Absolution of the Son, 
+                <title xml:lang="en" xml:id="title1">Psalms of David, Supplications (<hi rendition="simple:italic">Mastabqʷǝʿān</hi>), Absolution of the Son,
                     ‘I praise your grace, you, full of grace’</title>
                 <editor key="DR"/>
                 <editor key="JG"/>
@@ -100,32 +100,31 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
                                 <condition key="deficient">
-                                    The manuscript is in bad condition. The front board is broken in two halves and the outer is missing, together with the back board.
-                                    A large loss is present in the central area of <locus target="#1"/>.
+                                    A large material loss is present in <locus target="q1"/> a reused bifolio, in the central area of <locus target="#1"/>.
                                     Most folios are stained and darkened along the margins but the most severe damage is caused by insects.
                                     Apart from the presence of insect droppings, insects have eaten the upper part of the quires also damaging the sewing. Therefore, the folios became loose.
                                     The damage increases towards the end of the manuscript, with loss of text on <locus from="38" to="41"/>.
-                                    The damage also extends to the satchel.
-                                    <!-- MV 08.01.2023: Here a note should be added on the fact that q1 (n=A) is a reused bifolio -->                                    
+                                    The damage also extends to the satchel. The front board is broken in two halves and the outer is missing, together with the back board.
+                                    <!-- MV 08.01.2023: Here a note should be added on the fact that q1 (n=A) is a reused bifolio -->
                                 </condition>
                             </supportDesc>
                         </objectDesc>
-                        
+
                         <additions>
                             <list>
                                 <item xml:id="e7">
                                     <desc>Scribbles and pen trials in the margins of nearly all folios (e.g. <locus target="#12v #29r #36v"/>.)</desc>
                                 </item>
-                                
+
                                 <item xml:id="e8">
-                                    <desc>A white sticker is glued to the inner side of the front board. The name of <persName ref="PRS5782JuelJen"/> 
+                                    <desc>A white sticker is glued to the inner side of the front board. The name of <persName ref="PRS5782JuelJen"/>
                                         is printed on it
                                         (<foreign xml:lang="gez">ቤንት፡ ዩውል፡ የንሰን።</foreign>) and the signature ‘MS. Aeth. f. 24 MS Et 6’ is written in pencil.
                                         An additional sticker, with the signature ‘Ms 6’ on it, is glued below it.</desc>
                                 </item>
                             </list>
                         </additions>
-                        
+
                         <bindingDesc>
                             <binding contemporary="Ethiopian">
                                 <decoNote xml:id="b1" type="bindingMaterial">
@@ -152,25 +151,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </decoNote>
                             </binding>
                         </bindingDesc>
-                        
+
                     </physDesc>
-                    
+
                     <history>
                         <origin>
                             <origDate notBefore="1800" notAfter="1949" evidence="lettering"/>
-                            The manuscript probably consists of three distinct units of production: <ref target="#p1"/> and <ref target="#p2"/>, 
+                            The manuscript probably consists of three distinct units of production: <ref target="#p1"/> and <ref target="#p2"/>,
                             and <ref target="#p3"/>. <ref target="#p3"/>
                             consists of the addition of content on the material support of <ref target="#p1"/> and <ref target="#p2"/>
-                            and of the addition of one more quire, <ref target="#q6"/> (corresponding to the 
-                            transformation model A3 according to <bibl><ptr target="bm:Andrist2013Syntaxe"/><citedRange unit="page">65</citedRange></bibl>). 
+                            and of the addition of one more quire, <ref target="#q6"/> (corresponding to the
+                            transformation model A3 according to <bibl><ptr target="bm:Andrist2013Syntaxe"/><citedRange unit="page">65</citedRange></bibl>).
                             It is possible that <ref target="#p1"/> and <ref target="#p2"/>
-                            had been distinct units of circulation before being joined in the current unit of circulation.  <ref target="#p3"/> 
+                            had been distinct units of circulation before being joined in the current unit of circulation.  <ref target="#p3"/>
                             might have been added at the moment of joining of the two other units or at a later date.
-                            The handwriting suggests a date of production between the nineteenth and mid-twentieth century for all 
-                            units of production. 
+                            The handwriting suggests a date of production between the nineteenth and mid-twentieth century for all
+                            units of production.
                         </origin>
                     </history>
-                    
+
                     <additional>
                         <adminInfo>
                             <recordHist>
@@ -182,22 +181,22 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </recordHist>
                         </adminInfo>
                     </additional>
-                    
+
                     <msPart xml:id="p1">
                         <msIdentifier>
                         </msIdentifier>
-                        
+
                         <msContents>
                             <summary/>
-                            
+
                         <msItem xml:id="p1_i1">
                       <locus from="3r" to="26r"/>
                             <title type="incomplete" ref="LIT2000Mazmur">Psalms 1–20</title>
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez"><locus target="#3r"/><hi rend="rubric">ነዓ፡ ኀቤየ፡ ዳዊት፡ ንጉሠ፡ <sic resp="DR">ኤ፳ኤል፡</sic>
-                                በዓለ፡ መዝሙር፡ አመ፡ እወድሳ<supplied reason="omitted">፡</supplied> 
+                                በዓለ፡ መዝሙር፡ አመ፡ እወድሳ<supplied reason="omitted">፡</supplied>
                                 ለ<add place="interlinear">ማርያም፡</add></hi> ፩፡ ብፁዕ፡ ብእሲ፡ ዘኢሖረ፡ በምክረ፡ ረሲአን<hi rend="rubric" rendition="#partialRubric">፨</hi>
-                                ወዘኢቆመ፡ ውስተ፡ ፍኖተ፡ 
+                                ወዘኢቆመ፡ ውስተ፡ ፍኖተ፡
                                 ኃጥአን<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                 ወዘኢነበረ፡ ውስተ፡ መንበረ፡ መስተሣልቃን። ዘዳእሙ፡ ሕገ፡ እግዚአብሔር፡ ሥምረቱ።</incipit>
                             <explicit xml:lang="gez">
@@ -207,7 +206,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </explicit>
                         </msItem>
                     </msContents>
-                    
+
                     <physDesc>
                         <objectDesc form="Codex">
                             <supportDesc>
@@ -225,7 +224,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <note corresp="#leafdim">Data on leaves dimensions taken from <locus target="#5r"/>.</note>-->
                                 </extent>
                                  </supportDesc>
-                            
+
 
                             <layoutDesc>
                                 <layout columns="1" writtenLines="17">
@@ -252,9 +251,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </layout>
 
                             </layoutDesc>
-                            
+
                         </objectDesc>
-                        
+
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                            <locus from="3r" to="26r"/>
@@ -266,7 +265,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <ab type="punctuation" subtype="Dividers">A chain of red and black small semicircles after the first group of ten psalms
                                     (<locus target="#13r"/>). </ab>
                             </handNote>
-                            
+
                             <handNote xml:id="h2" script="Ethiopic">
                                 <locus from="26r" to="26v"/>
                                 <desc>Hand of <ref target="#a1"/>. More regular hand. Large and very round script, broadly spaced characters.</desc>
@@ -275,25 +274,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <seg type="rubrication">Incipit (double red lines); elements of numerals.</seg>
                             </handNote>
                         </handDesc>
-                        
+
                        <!-- <decoDesc>
                          <decoNote xml:id="d1" type="band">
                              <locus target="#3r"/>
                              <desc></desc>
                          </decoNote>
-                            
+
                             <decoNote xml:id="d2" type="band">
                                 <locus target="#4r"/>
                                 <desc></desc>
                             </decoNote>
                         </decoDesc>-->
-                        
+
                         <additions>
                             <list>
                                 <item xml:id="a1" corresp="#h2">
                                     <locus from="26r" to="26v"/>
                                     <desc type="CalendaricNote">Calendaric note in Gǝʿǝz and Amharic.</desc>
-                                    <q xml:lang="gez"><seg part="I"><hi rend="rubric"><sic>በዘንከር፡</sic> ሀሳበ፡ ሕጉ፡ ወትእዛዙ፡ ለእ<hi rend="ligature">ግዚ</hi>እነ፡ ወአምላክነ፡ ወመድ</hi>ኃኒነ፡ 
+                                    <q xml:lang="gez"><seg part="I"><hi rend="rubric"><sic>በዘንከር፡</sic> ሀሳበ፡ ሕጉ፡ ወትእዛዙ፡ ለእ<hi rend="ligature">ግዚ</hi>እነ፡ ወአምላክነ፡ ወመድ</hi>ኃኒነ፡
                                         ኢየሱስ፡ ክርስቶስ፡ እንዘ፡ ሀሎነ፡ በዘመነ፡ ቅዱስ፡ ዮሐንስ፡
                                         ወንጌላዊ፡ ያብጽሐነ፡ እስከ፡ ዘመነ፡ ማቴዎስ፡ ዜናዊ፡ በ<date calendar="world" when-custom="5500"><hi rend="rubric" rendition="#partialRubric">፶፻</hi>ወበ<hi rend="rubric" rendition="#partialRubric">፭፻</hi> ዓመተ፡ ዓለም፡</date>
                                         በ<date calendar="ethiopian" when-custom="1904" when="1912"><hi rend="rubric" rendition="#partialRubric">፲፻</hi>ወ<hi rend="rubric" rendition="#partialRubric">፱፻</hi>ወ<hi rend="rubric" rendition="#partialRubric">፬</hi> ኮነ፡ ዓመተ፡ ምሕረት፡</date> በዝ፡ ሠረቀ፡ ለነ፡ ወርኃ፡ ነሐሴ፡
@@ -304,37 +303,37 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         የትንሣኤ፡ ተውሳክ፡ <hi rend="rubric" rendition="#partialRubric">፱</hi> የፍሥሐ፡ ኦሪት፡ ተውሳክ፡ <hi rend="rubric" rendition="#partialRubric">፲</hi>
                                         የዕርገት፡ ተውሳክ፡
                                         <hi rend="rubric" rendition="#partialRubric">፲፰</hi> የጰራቅሊጦስ፡ ተውሳክ፡ <hi rend="rubric" rendition="#partialRubric">፳፰</hi>
-                                        የጾመ፡ ድኅነት፡ ተውሳክ፡ <hi rend="rubric" rendition="#partialRubric">፩</hi><hi rend="rubric">።</hi> 
+                                        የጾመ፡ ድኅነት፡ ተውሳክ፡ <hi rend="rubric" rendition="#partialRubric">፩</hi><hi rend="rubric">።</hi>
                                     </seg></q>
                                 </item>
-                                
+
                                 <item xml:id="a2">
                                         <locus target="#27r"/>
                                     <desc type="GuestText"><title type="incomplete" ref="LIT5690MagicPrayer"/>.
                                         The text breaks off after the beginning. The following is the entire text.</desc>
                                         <q xml:lang="gez">
                                             በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ጸሎት፡ በእንተ<supplied reason="omitted">፡</supplied>
-                                            ሕማመ፡ ዓይነ፡ ወርቅ፡ ወኵሎን፡ ሕማማት። 
-                                            ጸሎተ፡ ነድራ፡ ወእንዘ፡ የሐውር፡ እግዚአነ፡ ኢየሱስ፡ ክርስቶስ፡ ውስተ፡ ባሕረ፡ ጥብርያዶስ፡ ምስለ፡ 
+                                            ሕማመ፡ ዓይነ፡ ወርቅ፡ ወኵሎን፡ ሕማማት።
+                                            ጸሎተ፡ ነድራ፡ ወእንዘ፡ የሐውር፡ እግዚአነ፡ ኢየሱስ፡ ክርስቶስ፡ ውስተ፡ ባሕረ፡ ጥብርያዶስ፡ ምስለ፡
                                             <hi rend="rubric" rendition="#partialRubric">፲ወ፪</hi> አርዳኢሁ<hi rend="rubric" rendition="#partialRubric">፨</hi> ወርእዩ፡
                                         </q>
                                 </item>
-                                
+
                                 <item xml:id="e1">
                                     <desc>The titles of the psalms are written crudely by a secondary hand in the spaces left for them.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e2">
-                                    <desc>Scribal corrections by the main hand are relatively rare. 
+                                    <desc>Scribal corrections by the main hand are relatively rare.
                                         Occasionally, omitted words and characters are written interlineally (e.g. <locus target="#3r #20v"/>)
                                         and erroneous characters are marked for deletion with surrounding dashes (e.g. <locus target="#8v #11r #18v"/>).  </desc>
                                 </item>
-                                
+
                                 <item xml:id="e3">
                                     <locus target="#1r #2v"/>
                                     <desc>Hardly legible scribbles.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e4">
                                     <locus from="1v" to="2r"/>
                                     <desc>Outlines of ornamental bands and text, <!--is there a better formulation for this? -->
@@ -343,17 +342,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </list>
                         </additions>
                     </physDesc>
-                    
+
                     <history>
                         <origin>
                             <origDate notBefore="1800" notAfter="1949" evidence="lettering"/>
-                            The 
-                            calendaric note <ref target="#a1"/>  (<locus from="26r" to="26v"/>), an addition 
+                            The
+                            calendaric note <ref target="#a1"/>  (<locus from="26r" to="26v"/>), an addition
                             to <ref target="#p1"/>, is dated to <date>1911</date>. This date might also be close to the date of production of this
                             unit of production, and possibly of the entire manuscript.
                         </origin>
                     </history>
-                    
+
                     <additional>
                         <adminInfo>
                             <recordHist>
@@ -366,38 +365,38 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </adminInfo>
                     </additional>
                     </msPart>
-                    
+
                                     <msPart xml:id="p2">
                         <msIdentifier>
                         </msIdentifier>
-                        
+
                                         <msContents>
                                             <summary/>
-                        
+
                         <msItem xml:id="p2_i1">
                             <locus from="29r" to="37v"/>
                             <title type="incomplete" ref="LIT4711Mastabqwe"/>
                             <textLang mainLang="gez"/>
-                            
+
                             <msItem xml:id="p2_i1.1">
                                 <locus from="29r" to="30v"/>
                                 <title type="complete" ref="LIT4711Mastabqwe#SupplicationNight"/>
                                 <textLang mainLang="gez"/>
                                 <incipit xml:lang="gez">
                                     <locus target="#29r"/>
-                                    <hi rend="rubric">ወካዕበ፡ ናስተበቍዕ፡ ዘኵሎ፡ ይእኅዝ፡ እግዚአብሔር<supplied reason="omitted">፡</supplied></hi> አብ፡ 
-                                    ለእግዚእ፡ ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡ እንዘ፡ ነአኵቶ፡ በኵሉ፡ 
+                                    <hi rend="rubric">ወካዕበ፡ ናስተበቍዕ፡ ዘኵሎ፡ ይእኅዝ፡ እግዚአብሔር<supplied reason="omitted">፡</supplied></hi> አብ፡
+                                    ለእግዚእ፡ ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡ እንዘ፡ ነአኵቶ፡ በኵሉ፡
                                     ወበውስተ፡ ኵሉ፡ እስመ፡ ከደነነ፡ ወረድአነ፡ ሶቀነ፡ ወአብጽሐነ፡ እስከ<supplied reason="omitted">፡</supplied> ዛቲ፡ ሰዓት፡
                                 </incipit>
                                 <explicit xml:lang="gez">
                                     <locus from="30r" to="30v"/>
-                                    ወአምሳለ፡ ኵሉ፡ ሕዝብከ፡ ወተረፈ፡ ሌሊትኒ<supplied reason="omitted">፡</supplied> በኵሉ፡ ሰላም፡ ወዳኅና፡ 
+                                    ወአምሳለ፡ ኵሉ፡ ሕዝብከ፡ ወተረፈ፡ ሌሊትኒ<supplied reason="omitted">፡</supplied> በኵሉ፡ ሰላም፡ ወዳኅና፡
                                     ይሬስየነ፡ ነሃሉ፡
                                     በ<pb n="30v"/>ክርስቶስ፡ ዘቦቱ፡ ለከ፡ ምስሌሁ፡ ወምስለ፡ ቅዱስ<supplied reason="omitted">፡</supplied> መንፈስ፡ ስብሐት፡ ወእኂዝ፡
                                     ይእዜኒ፡ ወዘልፈኒ፡
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="p2_i1.2">
                                 <locus from="30v" to="32v"/>
                                 <title type="complete" ref="LIT4711Mastabqwe#SupplicationSick"/>
@@ -405,18 +404,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <incipit xml:lang="gez">
                                     <locus from="30v" to="31r"/>
                                     <hi rend="rubric">ወካዕበ፡ ናስተበቍዕ፡ ለዘኵሎ፡ ይእኅዝ፡ እግዚአብሔ</hi>ር፡ አብ፡ <sic>ለእሰግዚእ፡</sic> ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡ በእንተ፡
-                                    ዱያን፡ 
+                                    ዱያን፡
                                     አ<pb n="31r"/>ኃዊነ፡ ከመ፡ ኵሎ፡ ደዌ<supplied reason="omitted">፡</supplied> ወኵሎ፡ ሕማመ፡ ያሰስል፡ እምኔሆሙ፡
                                     መንፈሰ፡ ደዌ፡ ሥዒሮ፡ ሕይወተ፡ የሐቦሙ፡
                                 </incipit>
                                 <explicit xml:lang="gez">
                                     <locus from="32r" to="32v"/>
-                                    ሀብ፡ ሳሕተ፡ ወሀብ፡ ዕረፍተ፡ ኵሎ፡ ደዌ፡ ስደ<pb n="32v"/>ድ፡ እምዝንቱ፡ ቤት፡ ወእምእለ፡ ይፄውዑ፡ ቅዱሰ፡ ወቡሩከ፡ ስመከ፡ ወስእለ፡ ኈልቈ፡ ነፍሳቲነ፡ እንከ፡ 
+                                    ሀብ፡ ሳሕተ፡ ወሀብ፡ ዕረፍተ፡ ኵሎ፡ ደዌ፡ ስደ<pb n="32v"/>ድ፡ እምዝንቱ፡ ቤት፡ ወእምእለ፡ ይፄውዑ፡ ቅዱሰ፡ ወቡሩከ፡ ስመከ፡ ወስእለ፡ ኈልቈ፡ ነፍሳቲነ፡ እንከ፡
                                     ደዌ፡ ፈዊሰከ፡
                                     ፍጽመ፡ መድኃኒተ፡ ጻጕ፡ በ፩ ወልድከ፡ ዘቦቱ<supplied reason="omitted">፡</supplied>
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="p2_i1.3">
                                 <locus from="32v" to="34v"/>
                                 <title type="complete" ref="LIT4711Mastabqwe#SupplicationTraders"/>
@@ -424,58 +423,58 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <incipit xml:lang="gez">
                                     <locus from="32v" to="33r"/>
                                     <hi rend="rubric">ወካዕበ፡ ናስተበቍዕ፡</hi> በእንተ<supplied reason="omitted">፡</supplied> እለ፡ ይነግዱ፡ አኃዊነ፡
-                                    <pb n="33r"/> ወበእንተሂ፡ እለሃለው<supplied reason="omitted">፡</supplied> ይንግዱ፡ እመሂ፡ በባሕር፡ ወእመሂ፡ 
+                                    <pb n="33r"/> ወበእንተሂ፡ እለሃለው<supplied reason="omitted">፡</supplied> ይንግዱ፡ እመሂ፡ በባሕር፡ ወእመሂ፡
                                     በአፍላግ<supplied reason="omitted">፡</supplied>
-                                    ወእመሂ፡ በቀላያት፡ ወእመሂ፡ በፍኖት፡ በዘኮነ፡ መን<add place="above">ገ</add>ድ፡ ይገብሩ፡ ከመ፡ ኵሎ፡ 
+                                    ወእመሂ፡ በቀላያት፡ ወእመሂ፡ በፍኖት፡ በዘኮነ፡ መን<add place="above">ገ</add>ድ፡ ይገብሩ፡ ከመ፡ ኵሎ፡
                                     ያብጽሕ<supplied reason="omitted">፡</supplied> ውስተ፡ መርሶ፡
                                 </incipit>
                                 <explicit xml:lang="gez">
                                     <locus from="34r" to="34v"/>
                                     ፍጡነ፡ ይርከበነ፡ ሣህልከ፡ እግዚኦ። ንበል፡ ኵልነ። እግዚኦ፡ ተሣሃለነ።
-                                    አብጽሖሙ፡ ውስተ፡ ዘመድኅን፡ መርሶ፡ አውፊ፡ ለሰብኦሙ፡ በፍሥሐ፡ ወበሀሤት፡ እንዘ፡ ይትፌሥሑ፡ 
+                                    አብጽሖሙ፡ ውስተ፡ ዘመድኅን፡ መርሶ፡ አውፊ፡ ለሰብኦሙ፡ በፍሥሐ፡ ወበሀሤት፡ እንዘ፡ ይትፌሥሑ፡
                                     ወ<pb n="34v"/>ያስተፌሥሑ፡ በ፩ ወልድከ።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="p2_i1.4">
                                 <locus from="34v" to="36r"/>
                                 <title type="complete" ref="LIT4711Mastabqwe#SupplicationRain"/>
                                 <textLang mainLang="gez"/>
                                 <incipit xml:lang="gez">
                                     <locus from="34v" to="35r"/>
-                                    <hi rend="rubric">ወካዕበ፡ ናስተበቍዕ፡</hi> በእንተ፡ ዝናማት፡ ከመ<supplied reason="omitted">፡</supplied> ዝናም፡ ይፌኑ፡ 
+                                    <hi rend="rubric">ወካዕበ፡ ናስተበቍዕ፡</hi> በእንተ፡ ዝናማት፡ ከመ<supplied reason="omitted">፡</supplied> ዝናም፡ ይፌኑ፡
                                     ውስተ<supplied reason="omitted">፡</supplied>
                                     ኀበ፡ ይትፈቀድ፡ መካን<supplied reason="omitted">፡</supplied> ዘኵሎ፡ ይእኅዝ፡ እግዚአብሔር፡ አምላክነ። ጸልዩ፡ በእንተ፡
 ዝናማት። እግዚአብሔር፡ <pb n="35r"/> ዘኵሎ፡ ትእኅዝ፡ ንስእለከ፡ <sic>ወናስተበቍዓ፡ ከ፡</sic> ዝናማቲከ፡ ፈኑ፡
                                 </incipit>
                                 <explicit xml:lang="gez">
                                     <locus from="35v" to="36r"/>
-                                    እግዚኦ፡ ተሣሀለነ፡ በእንተ፡ <sic>ነዳን፡</sic> ሕዝብከ፡ ወበእንተ፡ ኵሎሙ፡ 
-                                    እለ<supplied reason="omitted">፡</supplied> ይሴፈውከ፡ ግበር፡ 
+                                    እግዚኦ፡ ተሣሀለነ፡ በእንተ፡ <sic>ነዳን፡</sic> ሕዝብከ፡ ወበእንተ፡ ኵሎሙ፡
+                                    እለ<supplied reason="omitted">፡</supplied> ይሴፈውከ፡ ግበር፡
                                     ምስሌነ፡ በከመ፡ ምሕረትከ፡ ግበር፡ ወሴሲ፡ ልበነ፡ <sic>በመለኮ፡ ተ፡</sic> ትምህርት<supplied reason="omitted">፡</supplied>
                                     <pb n="36r"/> ወበለብዎ፡ ዘእምኀከ፡ በ<hi rend="rubric" rendition="#partialRubric">፩</hi> ወልድከ፡ ዘቦቱ፡
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="p2_i1.5">
                                 <locus from="36r" to="37r"/>
                                 <title type="complete" ref="LIT4711Mastabqwe#SupplicationFruit"/>
                                 <textLang mainLang="gez"/>
                                 <incipit xml:lang="gez">
                                     <locus from="36r" to="36v"/>
-                                    <hi rend="rubric">ወካዕበ፡</hi> ናስተበቍዕ፡ በእንተ፡ ፍሬ፡ ምድር፡ ከመ፡ ፍሬሃ፡ ለምድር፡ ያልሕቅ፡ ወያሥምር፡ ያብጽሕ፡ ለዘርዕ፡ 
+                                    <hi rend="rubric">ወካዕበ፡</hi> ናስተበቍዕ፡ በእንተ፡ ፍሬ፡ ምድር፡ ከመ፡ ፍሬሃ፡ ለምድር፡ ያልሕቅ፡ ወያሥምር፡ ያብጽሕ፡ ለዘርዕ፡
                                     ወለማዕረር፡ ዘብዑለ፡
                                     ጸጋ፡ ይጸጉ፡ እግዚአብሔር፡ አምላክነ፡ <hi rend="rubric">ጸልዩ፡</hi> <sic>በእን</sic><pb n="36v"/> ፍሬ፡ ምድር።
                                 </incipit>
                                 <explicit xml:lang="gez">
                                     <locus from="36v" to="37r"/>
-                                    ፍጡነ፡ ይርከበነ፡ ሣህልከ፡ 
+                                    ፍጡነ፡ ይርከበነ፡ ሣህልከ፡
                                     እግዚኦ፡ ንበል፡ ኵልነ፡ እግዚ<pb n="37r"/>ኦ፡ ተሣሃለነ፡ በእንተ፡ ነዳያን፡ ሕዝብከ፡ ወበእንተ<supplied reason="omitted">፡</supplied>
-                                    ኵሎሙ፡ እለ፡ ይፄውዑ<supplied reason="omitted">፡</supplied> ቅዱሰ፡ ወቡሩከ፡ ስመከ፡ 
+                                    ኵሎሙ፡ እለ፡ ይፄውዑ<supplied reason="omitted">፡</supplied> ቅዱሰ፡ ወቡሩከ፡ ስመከ፡
                                     በ፩ ወልድከ፡ በል።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="p2_i1.6">
                                 <locus from="37r" to="37v"/>
                                 <title type="incomplete" ref="LIT4711Mastabqwe#SupplicationRivers"/>
@@ -484,14 +483,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <incipit xml:lang="gez">
                                     <locus from="37r" to="37v"/>
                                     <hi rend="rubric">ወካዕ</hi>በ፡ ናስተበቍዕ፡ በእንተ፡ ማያተ፡ አፍላግ፡ ከመ፡ ያዕርግ፡ እስከ፡ ምሥራርቶሙ፡ ያስተፍሥሕ፡
-                                    <pb n="37v"/> ገጻ፡ ለምድር፡ ወያርዌ<supplied reason="omitted">፡</supplied> ትላሚሃ፡ ያብጽሕ፡ 
-                                    ለ<gap reason="illegible" unit="chars" quantity="1"/>ርሶ፡ ወለመሳረር፡ 
+                                    <pb n="37v"/> ገጻ፡ ለምድር፡ ወያርዌ<supplied reason="omitted">፡</supplied> ትላሚሃ፡ ያብጽሕ፡
+                                    ለ<gap reason="illegible" unit="chars" quantity="1"/>ርሶ፡ ወለመሳረር፡
                                     ዘብ<gap reason="illegible" unit="chars" quantity="1"/>ለ
                                 </incipit>
                             </msItem>
                         </msItem>
                     </msContents>
-                    
+
                     <physDesc>
                         <objectDesc form="Codex">
                             <supportDesc>
@@ -508,9 +507,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <note corresp="#leafdim">Data on the dimensions of folios taken from <locus target="#29r"/>.</note>
                                 </extent>
                             </supportDesc>
-                            
+
                             <layoutDesc>
-                      
+
 
                                 <layout columns="1" writtenLines="9">
                                     <locus from="29r" to="37v"/>
@@ -531,15 +530,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <ab type="ruling">The upper line is written above the
                                         ruling. The bottom line is written above the
                                         ruling.</ab>
-                                    <ab type="punctuation" subtype="Dividers">Several supplications are divided by crudely drawn text dividers consisting 
+                                    <ab type="punctuation" subtype="Dividers">Several supplications are divided by crudely drawn text dividers consisting
                                         of black and red grids, lines, and dots
                                         (e.g. on <locus target="#30v #34v #37v"/>).</ab>
                                 </layout>
 
                             </layoutDesc>
-                            
+
                         </objectDesc>
-                        
+
                         <handDesc>
                             <handNote xml:id="h3" script="Ethiopic">
                                      <locus from="29r" to="37v"/>
@@ -548,29 +547,29 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 The scribe often omits the word separator at the end of a line. It is possible that the hand is identical
                                 with <ref target="#h1"/>, though the script differs.</desc>
                                 <seg type="ink">Black, red.</seg>
-                                <seg type="rubrication">Incipits (double red lines, single words or groups of words); 
+                                <seg type="rubrication">Incipits (double red lines, single words or groups of words);
                                     the word <foreign xml:lang="gez">ጸልዩ፡</foreign>;
                                     elements of numerals.</seg>
                             </handNote>
                         </handDesc>
-                        
+
                         <additions>
                             <list>
                                 <item xml:id="e5">
-                                    <desc>Scribal corrections by the main hand are relatively rare. 
+                                    <desc>Scribal corrections by the main hand are relatively rare.
                                         Occasionally, omitted words and characters are written interlineally (e.g. <locus target="#31v #33r"/>)
                                         and erroneous characters are marked for delation by means of horizontal dashes (e.g. <locus target="#32r #33v"/>).  </desc>
                                 </item>
                             </list>
                         </additions>
                     </physDesc>
-                    
+
                     <history>
                         <origin>
                             <origDate notBefore="1800" notAfter="1949" evidence="lettering"/>
                         </origin>
                     </history>
-                    
+
                     <additional>
                         <adminInfo>
                             <recordHist>
@@ -583,36 +582,36 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </adminInfo>
                     </additional>
                     </msPart>
-                    
+
                                     <msPart xml:id="p3">
                         <msIdentifier>
                         </msIdentifier>
-                                        
+
                                         <msContents>
                                             <summary/>
-               
+
                                             <msItem xml:id="p3_i1">
                             <locus target="#26v"/>
                             <locus from="27r" to="27v"/>
                             <title type="incomplete" ref="LIT4711Mastabqwe#SupplicationEntering"/>
-                            <note>Beginning of the supplication for the offerers. The text is interrupted on 
+                            <note>Beginning of the supplication for the offerers. The text is interrupted on
                             <locus target="#27r"/> by another prayer.</note>
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez">
                                 <locus target="#26v"/>
-                                <hi rend="rubric">ወእምዝ፡</hi> ጸሎተ፡ መባዓ፡ ወካዕበ፡ ናስተበቍዕ፡ ዘኵሎ፡ ይእኅዝ፡ እግዚአብሔር፡ አብ፡ ለዕግዚእ፡ 
+                                <hi rend="rubric">ወእምዝ፡</hi> ጸሎተ፡ መባዓ፡ ወካዕበ፡ ናስተበቍዕ፡ ዘኵሎ፡ ይእኅዝ፡ እግዚአብሔር፡ አብ፡ ለዕግዚእ፡
                                 ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡ በእንተ፡ እለ፡ ይበውዑ፡ መባዓ፡ በውስተ፡ ቅድስት፡ አኃቲ<supplied reason="omitted">፡</supplied> እንተ፡ ላዕለ፡ ኵሉ፡
                                 ቤተክርስቲያን፡ መሥዋዕተ፡
-                                ቀደምያተ፡ አሥራተ፡ ቀደምተ፡ አኰቴት፡ ተዝካር<supplied reason="omitted">፡</supplied> ዘብዙኅ፡ ወዘኅዳጥ፡ 
+                                ቀደምያተ፡ አሥራተ፡ ቀደምተ፡ አኰቴት፡ ተዝካር<supplied reason="omitted">፡</supplied> ዘብዙኅ፡ ወዘኅዳጥ፡
                             </incipit>
                             <explicit xml:lang="gez">
                                 <locus target="#27v"/>
-                                ምሥዋዕተ፡ ቀዳምያተ፡ አሥራተ<supplied reason="omitted">፡</supplied> ወአኰቴተ፡ ተዝካርየ፡ 
+                                ምሥዋዕተ፡ ቀዳምያተ፡ አሥራተ<supplied reason="omitted">፡</supplied> ወአኰቴተ፡ ተዝካርየ፡
                                 ዘብዙኅ<supplied reason="omitted">፡</supplied> ወዘኅዳጥ፡ ዘኅቡዕ፡ ወዘገሃድ፡ ወለዕለሂ፡ ይፈቅዱ፡ የሀቡ፡ አስቦሙ<supplied reason="omitted">፡</supplied>
                                 ዘይሁቡ፡ ተወከፍ፡ ፍትወቶሙ<supplied reason="omitted">፡</supplied> ሀብ፡ ለኵሎሙ፡ ዓስበ፡ በረከት፡ ክፍለ፡ ትኵን፡ ለዓለመ፡ ዓለም።
                             </explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="p3_i2">
                             <locus from="28r" to="28v"/>
                             <locus from="37v" to="39r"/>
@@ -622,7 +621,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez">
                                 <locus target="#28r"/>
-                                <hi rend="rubric"><gap reason="illegible"/></hi> ዘወልድ፡ እግዚእ፡ እግዚኦ፡ ኢየሱስ፡ ክርስቶስ፡ ወልድ፡ አብ፡ 
+                                <hi rend="rubric"><gap reason="illegible"/></hi> ዘወልድ፡ እግዚእ፡ እግዚኦ፡ ኢየሱስ፡ ክርስቶስ፡ ወልድ፡ አብ፡
                                 ዋህድ፡ እግዚአብሔር፡ አብ፡ ዘበተከ፡ እምኔነ፡ <sic>ኵ</sic> ማእሠረ፡ ኃጣውኢነ፡ በሕማማቲከ፡ ማኅየዊት፡ ዘነፋሕከ፡ ላዕለ<supplied reason="omitted">፡</supplied>
                                 ገጸ፡ አርዳኢከ፡ ቅዱሳን፡ ወላዕካኒከ፡
                                 ንጹሐን፡
@@ -630,43 +629,43 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <explicit xml:lang="gez">
                                 <locus target="#39r"/>
                                 <locus target="#41r"/>
-                                ወእምአፈ፡ ዚአየኒ፡ አነ፡ ገብርከ፡ ሀጥእ<supplied reason="omitted">፡</supplied> ወይኩኑ፡ ፍቱሐነ፡ ወግዑዛነ፡ ወእምአፉሀ፡ ለእግዝእትነ፡ 
-                                <hi rend="rubric">ማርያም፡</hi> 
+                                ወእምአፈ፡ ዚአየኒ፡ አነ፡ ገብርከ፡ ሀጥእ<supplied reason="omitted">፡</supplied> ወይኩኑ፡ ፍቱሐነ፡ ወግዑዛነ፡ ወእምአፉሀ፡ ለእግዝእትነ፡
+                                <hi rend="rubric">ማርያም፡</hi>
                                 ወላ<pb n="41r"/>ዲተ፡ አምላክ፡ ሐዳስ፡ ምእናም፡ ግሩም፡ ሙዳየ፡ ስእለታት። እስመ፡ ቡሩክ፡ ስብሐተ፡ ስምከ፡ <add place="top">ኦሥሉስ፡ </add>
-                                ቅዱስ፡ አብ<supplied reason="omitted">፡</supplied> ወልድ፡ ወመንፈስ፡ ቅዱስ፡ ይእዜኒ፡ ወዘልፈኒ፡ 
+                                ቅዱስ፡ አብ<supplied reason="omitted">፡</supplied> ወልድ፡ ወመንፈስ፡ ቅዱስ፡ ይእዜኒ፡ ወዘልፈኒ፡
                                 ወለአለመ<supplied reason="omitted">፡</supplied> አለም፡ አሜን።
                             </explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="p3_i3">
                             <locus from="39v" to="41r"/>
                             <title type="complete" ref="LIT3064RepCh344"/>
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez">
                                 <locus target="#39v"/>
-                                ዕሴብሕ፡ <gap reason="lost"/>ዕትጋነይ፡ ለኪ፡ ኦምልዕተ፡ ውዳሴ፡ ዘከርኩ፡ በሌሊት፡ ንጽሐ፡ 
-                                ድንግ<gap reason="lost" unit="chars" quantity="1"/>ናኪ፡ ዘኢረስሐ፡ በፀኒስ፡ ወኢማሰነ፡ 
-                                <gap reason="lost" unit="chars" quantity="1"/>ወሊድ፡ እስመ፡ ቅድስተ፡ 
+                                ዕሴብሕ፡ <gap reason="lost"/>ዕትጋነይ፡ ለኪ፡ ኦምልዕተ፡ ውዳሴ፡ ዘከርኩ፡ በሌሊት፡ ንጽሐ፡
+                                ድንግ<gap reason="lost" unit="chars" quantity="1"/>ናኪ፡ ዘኢረስሐ፡ በፀኒስ፡ ወኢማሰነ፡
+                                <gap reason="lost" unit="chars" quantity="1"/>ወሊድ፡ እስመ፡ ቅድስተ፡
                                 ቅዱሳን፡ <gap reason="lost" quantity="2" unit="chars"/>ቲ፡ እስመ፡ ናሁ፡ ይፈልሕ፡ ሞገደ፡ ፍቅ<gap reason="lost" unit="chars" quantity="1"/>ኪ፡
                                 በውስተ፡ ልብየ፡
                             </incipit>
                             <explicit xml:lang="gez">
                                 <locus from="40v" to="41r"/>
                                 ከመ፡ ታድኅንኒ<hi rend="rubric" rendition="#partialRubric">፤</hi> በዝ፡ ዓለም<hi rend="rubric" rendition="#partialRubric">፤</hi>
-                                እምእደ፡ ሰብእ<hi rend="rubric" rendition="#partialRubric">፤</hi> እኩያን፡ 
+                                እምእደ፡ ሰብእ<hi rend="rubric" rendition="#partialRubric">፤</hi> እኩያን፡
                                 ወበ<gap reason="lost" unit="chars" quantity="1"/>ይመጽእ፡ ዓለም፡ እምእደ፡ ሰይጣን<hi rend="rubric" rendition="#partialRubric">፨</hi>
-                                <pb n="41r"/><gap reason="lost"/>ክዩ፡ <gap reason="lost"/>ፍሳተ፡ ወይስሕቡ፡ ውስተ፡ 
+                                <pb n="41r"/><gap reason="lost"/>ክዩ፡ <gap reason="lost"/>ፍሳተ፡ ወይስሕቡ፡ ውስተ፡
                                 አ<gap reason="lost" quantity="1" unit="chars"/>ቀጸ<hi rend="rubric" rendition="#partialRubric">፨</hi>
-                                <gap reason="lost"/>ን፡ ሰፍሒ፡ እዴኪ<hi rend="rubric" rendition="#partialRubric">፤</hi> ወባርክኒ፡ 
+                                <gap reason="lost"/>ን፡ ሰፍሒ፡ እዴኪ<hi rend="rubric" rendition="#partialRubric">፤</hi> ወባርክኒ፡
                                 ለገብ<gap reason="lost" unit="chars" quantity="1"/>ኪ፡ በረከተ<hi rend="rubric" rendition="#partialRubric">፤</hi>
                                 ዘአኪ፡ የሀሉ፡ ወፀጋ፡ ወ<gap reason="lost" quantity="1" unit="chars"/>ድኪ፡
-                                ላዕለ<hi rend="rubric" rendition="#partialRubric">፤</hi> ኵልነ፡ አግብርትኪ<gap reason="lost"/>አዕማትኪ፡ ለዓለመ፡ 
+                                ላዕለ<hi rend="rubric" rendition="#partialRubric">፤</hi> ኵልነ፡ አግብርትኪ<gap reason="lost"/>አዕማትኪ፡ ለዓለመ፡
                                 ዓለም<hi rend="rubric" rendition="#partialRubric">፨</hi> <hi rend="rubric" rendition="#partialRubric">፨</hi> <hi rend="rubric" rendition="#partialRubric">፨</hi>
                             </explicit>
                         </msItem>
-                        
+
                     </msContents>
-                    
+
                     <physDesc>
                         <objectDesc form="Codex">
                             <supportDesc>
@@ -676,13 +675,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <extent>
                                     <measure unit="leaf">4</measure>
                                     <locus from="38r" to="41v"/>
-                                    <note>This unit of production consists of content added to the first two units on <locus target="#26v"/>, 
+                                    <note>This unit of production consists of content added to the first two units on <locus target="#26v"/>,
                                         <locus from="27r" to="27v"/>,  <locus from="28r" to="28v"/> and
                                         <locus from="37v" to="39r"/>, as well as of the quire
                                         <ref target="#q6"/> (<locus from="38r" to="41v"/>) and its content.</note>
                                 </extent>
                         </supportDesc>
-                            
+
                             <layoutDesc>
 
                                 <layout columns="1" writtenLines="14 15">
@@ -716,31 +715,31 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <seg type="rubrication">Holy names; elements of numerals and punctuation signs.</seg>
                             </handNote>
                         </handDesc>
-                        
+
                         <additions>
                             <list>
                                 <item xml:id="e6">
-                                    <desc>Scribal corrections by the main hand are very rare. 
-                                        Occasionally, erroneous characters are marked for deletion with surrounding dashes 
+                                    <desc>Scribal corrections by the main hand are very rare.
+                                        Occasionally, erroneous characters are marked for deletion with surrounding dashes
                                         (e.g. <locus target="#37v #38r"/>).  </desc>
                                 </item>
                             </list>
                         </additions>
                     </physDesc>
-                    
+
                     <history>
 
                         <origin>
                             <origDate notBefore="1800" notAfter="1949" evidence="lettering"/>
                             <ref target="#p3_i2"/> mentions <roleName type="title">liqa ṗāṗāsǝna ʾAbbā</roleName> Mārqos and
-                            <roleName type="title">ṗāṗāsǝna ʾAbbā</roleName> Yoḥannǝs in a supplication (<locus target="#39r"/>). These might refer to 
+                            <roleName type="title">ṗāṗāsǝna ʾAbbā</roleName> Yoḥannǝs in a supplication (<locus target="#39r"/>). These might refer to
                             <persName ref="PRS13830MarkVII"/> and <persName ref="PRS10393Yohanne"/>, simultaneously active in <date>1747–1761</date>.
-                            As this timespan seems early for the 
+                            As this timespan seems early for the
                             production of the manuscript, the names might have been copied from the <!--italics--> Vorlage.
                         </origin>
 
                     </history>
-                    
+
 
                     <additional>
                         <adminInfo>
@@ -800,6 +799,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <change who="SH" when="2020-04-22">Added editors</change>
             <change who="EDS" when="2022-12-06">Added binding description, condition</change>
             <change who="JG" when="2023-04-25">Added deco description</change>
+            <change who="EDS" when="2024-03-10">Revision condition</change>
           </revisionDesc>
 
     </teiHeader>

--- a/OxfordBodleian/Juel-Jensen/BDLaethf25.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf25.xml
@@ -167,7 +167,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <locus from="27ra" to="31vb"/>
                             <title type="complete" ref="LIT1110Anqasa"/>
                             <notatedMusic><desc>The text is furnished with musical notation.</desc></notatedMusic>
-                            
+
                             <incipit xml:lang="gez">
                                 <locus target="#24ra"/>
                                 <hi rend="rubric">ውዳሴ<supplied reason="undefined">፡</supplied></hi> ቅድስት፡ ወብፅዕት፡ ስብሕት፡ ወቡርክት፡ ክብርት፡ ወልዕልት፡ አንቀጸ፡ ብርሃን፡ መዓርገ፡ ሕይወት፡ ወ<cb n="b"/>ማኅደረ፡ መለኮት፡
@@ -177,12 +177,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 ስብሐት፡ ለኪ፡ ኦወላዲተ፡ እግዚአ፡ ኵሉ፡ አኰቴት፡ ወክብር፡ ለአብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ይእዜኒ፡ ወዘልፈኒ፡ ወለዓለመ፡ ዓለም፡ አሜን፡ ወልድኪ፡ ሣህሎ፡ ይክፍለነ፡ ሰአሊ፡ ለነ፡ ቅድስት።
                             </explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i1.3">
                             <locus from="32ra" to="41va"/>
                             <title type="complete" ref="LIT5646Mastagabe"></title>
                             <notatedMusic><desc>The text is furnished with musical notation.</desc></notatedMusic>
-                            
+
                             <msItem xml:id="ms_i1.3.1">
                                 <locus from="32ra" to="32va"/>
                                 <title type="complete" ref="LIT5646Mastagabe#MondayEzl"/>
@@ -195,7 +195,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     ተለዓልከ፡ እግዚኦ፡ በ<pb n="32v"/><cb n="a"/>ኃይልከ፡ ንሴብሕ፡ ወንዜምር፡ ለጽንዕከ።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.3.2">
                                 <locus from="32va" to="33va"/>
                                 <title type="complete" ref="LIT5646Mastagabe#MondayGez"/>
@@ -208,7 +208,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     እስመ፡ ኃይልየ፡ ወፀወንየ፡ አንተ፡ ወበእንተ፡ ስምከ፡ ምርሐኒ፡ ወሴስየኒ።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.3.3">
                                 <locus from="33va" to="34rb"/>
                                 <title type="complete" ref="LIT5646Mastagabe#TuesdayEzl"/>
@@ -221,7 +221,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     ሕፅበኒ፡ ወአንጽሐኒ፡ እምኃጢአትየ፡ ወእምአበሳየኒ፡ አንጽሐኒ።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.3.4">
                                 <locus from="34rb" to="35rb"/>
                                 <title type="complete" ref="LIT5646Mastagabe#TuesdayGez"/>
@@ -234,7 +234,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     ወከዓዉ፡ ልበክሙ፡ ቅድሜሁ፡ ወእግዚአብሔር፡ ውእቱ፡ ረዳኢነ።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.3.5">
                                 <locus from="35rb" to="36ra"/>
                                 <title type="complete" ref="LIT5646Mastagabe#WednesdayEzl"/>
@@ -247,7 +247,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     ምላዕ፡ አፉየ፡ ስብሐቲከ፡ ከመ፡ እሰብሕ፡ አኰቴተከ፡ ወኵሎ፡ አሚረ፡ <pb n="36r"/><cb n="a"/> ዕበየ፡ ስብሐቲከ።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.3.6">
                                 <locus from="36ra" to="36vb"/>
                                 <title type="complete" ref="LIT5646Mastagabe#WednesdayGez"/>
@@ -260,7 +260,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     ፈነወ፡ መልአ<cb n="b"/>ኮ፡ ወአድኃኖሙ፡ ሠጠቀ፡ ባሕረ፡ ወአኅለፎሙ።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.3.7">
                                 <locus from="36vb" to="37rb"/>
                                 <title type="complete" ref="LIT5646Mastagabe#ThursdayEzl"/>
@@ -273,7 +273,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     ምሕረተ፡ ወፍትሐ፡ አሐሊ፡ ለከ፡ እዜምር፡ ወእሌቡ፡ ፍኖተ፡ ንጹሐ።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.3.8">
                                 <locus from="37rb" to="38ra"/>
                                 <title type="complete" ref="LIT5646Mastagabe#ThursdayGez"/>
@@ -286,7 +286,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     ኢትሰደኒ፡ በመንፈቀ<supplied reason="undefined">፡</supplied> ዓመትየ፡ ለትውልደ፡ ትውልድ፡ ዓመቲከ።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.3.9">
                                 <locus from="38ra" to="38vb"/>
                                 <title type="complete" ref="LIT5646Mastagabe#FridayEzl"/>
@@ -299,7 +299,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     አንሣእኩ፡ አዕይንትየ፡ መንገለ፡ አድባር፡ ረድኤትየሰ፡ እምኀበ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.3.10">
                                 <locus from="38vb" to="39va"/>
                                 <title type="complete" ref="LIT5646Mastagabe#FridayGez"/>
@@ -313,7 +313,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     እስመ፡ እምኀቤከ፡ ውእቱ፡ ሣህል፡ ወበእንተ፡ ስምከ፡ ተሰፈውኩከ፡ እግዚኦ።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.3.11">
                                 <locus from="39va" to="40rb"/>
                                 <title type="complete" ref="LIT5646Mastagabe#SaturdayEzl"/>
@@ -327,7 +327,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     እግዚኦ፡ ጸ<cb n="b"/>ራኅኩ፡ ኀቤከ፡ ስምዓኒ፡ ተወክፈኒ፡ ጸሎትየ፡ ከመ፡ ዕጣን፡ በቅድሜከ።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.3.12">
                                 <locus from="40rb" to="41va"/>
                                 <title type="complete" ref="LIT5646Mastagabe#SaturdayGez"/>
@@ -340,19 +340,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     ወረሰየ፡ ሰላመ፡ ለበሐውርትኪ፡ ወሰብሒዮ፡ ለአምላክኪ፡ ጽዮን፡ አድኃነ፡ ሕዝቦ፡ በኃይለ፡ መስቀሉ፡ እስመ፡ ብርሃን፡ ሠረቀ።
                                 </explicit>
                             </msItem>
-                            
-                            
+
+
                             <msItem xml:id="ms_i1.4">
                                 <locus from="41va" to="72ra"/>
                                 <title type="complete" ref="LIT6720collections"></title>
                                 <notatedMusic><desc>The text is furnished with musical notation.</desc></notatedMusic>
-                                
+
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.4.1">
                                 <locus from="41va" to="48ra"/>
                                 <title type="complete" ref="LIT6720collections#Arbat"></title>
-                                
+
                                 <incipit xml:lang="gez">
                                     <locus from="41va" to="41vb"/>
                                     <hi rend="rubric">አርባዕት፡ ቃልየ፡</hi> አጽምዕ፡ እግዚኦ፡ ሃሌ፡ ሉያ፡ ሃሌ፡ ሉያ፡ ወለቡ፡ ጽራኅየ፡ ሃሌ፡ ሉያ፡ ሃሌ፡ ሉያ፡
@@ -360,14 +360,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </incipit>
                                 <explicit xml:lang="gez">
                                     <locus from="47va" to="48ra"/>
-                                    <hi rend="rubric">አጽምዕ<supplied reason="undefined">፡</supplied></hi> እግዚኦ፡ እዝነከ፡ ኀቤየ፡ ወስምዓኒ፡ 
-                                    ሃሌ፡<cb n="b"/> ሉያ፡ ሃሌ፡ ሉያ፡ እስመ፡ ነዳይ፡ ወምስኪን፡ አነ፡ ሃሌ፡ ሉያ፡ ዕቀባ፡ ለነፍስየ፡ እስመ፡ የዋህ፡ አነ፡ ሃሌ፡ ሉያ፡ 
-                                    አድኅኖ፡ ለገብርከ፡ አምላኪየ፡ ዘተወከለ፡ ኪያከ፡ ተሠሃለኒ፡ እግዚኦ፡ እስመ፡ ኀቤከ፡ እጸርኅ፡ ኵሎ፡ አሚረ፡ ሃሌ፡ ሉያ፡ ሃሌ፡ ሉያ፡ ሃሌ፡ ሉያ፡ 
-                                    ወአስተፍሥሓ፡ ለነፍሰ፡ ገብርከ፡ ሃሌ፡ ሃሌ፡ ሉያ፡ ለቤተ፡ ክርስቲያን፡ ልዑል፡ ሐነፃ፡ በጽድቁ፡ ሐወጻ፡ እምነ፡ ፀሐዩ፡ 
+                                    <hi rend="rubric">አጽምዕ<supplied reason="undefined">፡</supplied></hi> እግዚኦ፡ እዝነከ፡ ኀቤየ፡ ወስምዓኒ፡
+                                    ሃሌ፡<cb n="b"/> ሉያ፡ ሃሌ፡ ሉያ፡ እስመ፡ ነዳይ፡ ወምስኪን፡ አነ፡ ሃሌ፡ ሉያ፡ ዕቀባ፡ ለነፍስየ፡ እስመ፡ የዋህ፡ አነ፡ ሃሌ፡ ሉያ፡
+                                    አድኅኖ፡ ለገብርከ፡ አምላኪየ፡ ዘተወከለ፡ ኪያከ፡ ተሠሃለኒ፡ እግዚኦ፡ እስመ፡ ኀቤከ፡ እጸርኅ፡ ኵሎ፡ አሚረ፡ ሃሌ፡ ሉያ፡ ሃሌ፡ ሉያ፡ ሃሌ፡ ሉያ፡
+                                    ወአስተፍሥሓ፡ ለነፍሰ፡ ገብርከ፡ ሃሌ፡ ሃሌ፡ ሉያ፡ ለቤተ፡ ክርስቲያን፡ ልዑል፡ ሐነፃ፡ በጽድቁ፡ ሐወጻ፡ እምነ፡ ፀሐዩ፡
                                     ይበርህ፡ <pb n="48r"/><cb n="a"/> ገጻ።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.4.2">
                                 <locus from="48ra" to="62va"/>
                                 <title type="complete" ref="LIT6720collections#Salast"></title>
@@ -390,7 +390,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <add place="interlinear">ዕዝራ<supplied reason="undefined">፡</supplied></add> ይሔውጽዋ፡ በሰማይ፡ ሐራ፨
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.4.3">
                                 <locus from="62va" to="64va"/>
                                 <title type="complete" ref="LIT6720collections#TarafaSalast"></title>
@@ -405,17 +405,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <locus from="64rb" to="64va"/>
                                     <hi rend="rubric">ስምዓኒ<supplied reason="undefined">፡</supplied></hi> እግዚኦ፡ ጸሎትየ፡ ሃሌ፡ ሉያ፡ ሃሌ፡ ሉያ፡ ወይብጻሕ፡ ቅድሜከ፡ ገዓርየ፡
                                     ወኢትሚጥ፡ ገጸከ፡ እምኔየ፡ በዕለተ፡ ምንዳቤየ፡ አጽምዕ፡ እዝነከ፡ ኀቤየ፡
-                                    ሃሌ፡ ሉያ፡ ሃሌ፡ ሉያ፡ አመ፡ ዕለተ፡ እጼውዓከ፡ ፍጡነ፡ ስምዓኒ፡ ለዓለም፡ ወለዓለመ፡ ዓለም። 
+                                    ሃሌ፡ ሉያ፡ ሃሌ፡ ሉያ፡ አመ፡ ዕለተ፡ እጼውዓከ፡ ፍጡነ፡ ስምዓኒ፡ ለዓለም፡ ወለዓለመ፡ ዓለም።
                                     አዋል<pb n="64v"/><cb n="a"/>ደ፡ ንግሥት፡ ለክብርከ፡ ወትቀውም፡ ንግሥት፡ በየማንከ፡ በአልባሰ፡ ወርቅ፡ ዑፅፍት፡ ወኁብርት።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.4.4">
                                 <locus from="64va" to="72ra"/>
                                 <title type="complete" ref="LIT6720collections#Aryam"></title>
                                 <incipit xml:lang="gez">
                                     <locus target="#64va"/>
-                                    <hi rend="rubric">አርያም፡</hi> ሃሌ፡ ሉያ፡ ለአብ፡ ሃሌ፡ ሉያ፡ ለወልድ፡ ሃሌ፡ ሉያ፡ ወለመንፈስ፡ ቅዱስ፡ 
+                                    <hi rend="rubric">አርያም፡</hi> ሃሌ፡ ሉያ፡ ለአብ፡ ሃሌ፡ ሉያ፡ ለወልድ፡ ሃሌ፡ ሉያ፡ ወለመንፈስ፡ ቅዱስ፡
                                         ዮሐንስኒ፡ ሀሎ፡ ያጠምቅ፡ በሄኖን፡ በቅሩበ፡ ሳሊም፡ በማዕዶተ፡ ዮርዳኖስ፡ ወብርሃነ፡ ጽድቅሰ፡ ውእቱ፡ ኢየሱስ፡ ክርስቶስ።
                                 </incipit>
                                 <explicit xml:lang="gez">
@@ -423,13 +423,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <hi rend="rubric">ብርሃን፡</hi> ትእዛዝከ፡ ወጽድቅ፡ ስምከ፡ ዘበትእዛዝከ፡ ተሠርዓ፡ ጎህ፡ <pb n="72r"/><cb n="a"/> ወጽባሕ፡ ኮነ፡ ብርሃነ፡ ወጸብሐ።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.5">
                                 <locus from="72ra" to="74r"/>
                                 <locus from="75r" to="76r"/>
                                 <title type="complete" ref="LIT1110Anqasa"></title>
                                 <notatedMusic><desc>The text is furnished with musical notation.</desc></notatedMusic>
-                                
+
                                 <incipit xml:lang="gez">
                                     <locus target="#72ra"/>
                                     <lb/>በ<hi rend="rubric">፩</hi>ሃሌ፡ ሉያ፡ ይትፌሣ፡
@@ -443,7 +443,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <lb/>ራ፡ ወሶበ፡ ርእያ፡ ከመ፡ ብእሲተ፡
                                 </explicit>
                             </msItem>
-                            
+
                         </msItem>
 
                     </msContents>
@@ -456,7 +456,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                                     <p>Holes resulting from parchment making are found on several folios, e.g. <locus target="#13 #20 #25"/>.
                                     Tears have been repaired at the moment of parchment production by sewing, e.g. on <locus target="#1 #4 #65"/>.</p>
-                              
+
                               <!-- Eliana, I think you mean 63, not 65 -->
                                 </support>
                                 <extent>
@@ -475,9 +475,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </dimensions>
                                     <note corresp="#leafdim">Data on the dimensions of folios taken from <locus target="#33r"/>.</note>
                                 </extent>
-                                
+
                                 <foliation>Foliation in pencil in the upper right corner. The folio numbers "28" and "42" have been given twice.
-                                    The folio number "46" has been skipped. The last folio has the folio numbers "78" and "79".                         
+                                    The folio number "46" has been skipped. The last folio has the folio numbers "78" and "79".
                                 </foliation>
 
                                 <collation>
@@ -527,7 +527,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
                                 <condition key="good">
-                                  The manuscript is in good condition and it does not show evident traces of use.
+                                  The manuscript does not show evident traces of use.
                                   It is slightly damaged by humidity in the upper external corners. The ink is smudged on <locus target="#18 #26"/>
                                 </condition>
                             </supportDesc>
@@ -590,13 +590,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <seg type="ink">Black, red</seg>
                                 <date notBefore="1800" notAfter="1950">19th or 20th century</date>
                                 <desc>
-                                    Fine handwriting. Occasional use of a ligature for <foreign xml:lang="gez">ሌሉ</foreign> in 
+                                    Fine handwriting. Occasional use of a ligature for <foreign xml:lang="gez">ሌሉ</foreign> in
                                     the word <foreign xml:lang="gez">ሃሌሉያ፡</foreign> (e.g. on <locus target="#72v #75r"/>).
                                 </desc>
-                                <seg type="rubrication">                                    
+                                <seg type="rubrication">
                                     Holy names; several groups of lines on the incipit page, alternating with black lines;
-                                    metatextual elements marking weekday sections and abbreviated refrains in <ref target="ms_i1.1"/>; 
-                                    abbreviated refrains in <ref target="ms_i1.2"/>; 
+                                    metatextual elements marking weekday sections and abbreviated refrains in <ref target="ms_i1.1"/>;
+                                    abbreviated refrains in <ref target="ms_i1.2"/>;
                                     metatextual elements marking weekday sections and sections for the musical modes in <ref target="ms_i1.3"/>;
                                     metatextual elements marking antiphon types, the incipits of each model antiphon, and
                                     on a few occasions musical mode in <ref target="ms_i1.4"/>; numerals and musical modes <ref target="ms_i1.5"/>;
@@ -605,90 +605,90 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </seg>
                             </handNote>
                         </handDesc>
-                        
+
                         <additions>
                             <list>
-                                
+
                                 <item xml:id="a1" rend="guardLeaf">
                                     <locus target="#2r"/>
                                     <desc type="GuestText"><title type="complete" ref="LIT6856PPHemamaBarya"></title>
-                                        The prayer is partly in Gəʿəz and partly 
+                                        The prayer is partly in Gəʿəz and partly
                                         in Amharic. It has been written in a spiral and is surrounded by a double circle
                                         and magical letters.</desc>
                                         <q xml:lang="gez">
-                                    <seg part="I">በስመ <supplied reason="undefined">፡</supplied> አብ፡ 
-                                            ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ጸሎት፡ በእንተ፡ ሕማመ፡ ባርያ፡ 
-                                            ወለ<del rend="effaced">ያ</del>ጌዎን፡  አ<del rend="effaced">ሁ</del>ላሁ፡ 
-                                            <foreign xml:lang="am">ማቴ፡ አልመላክያው፡ ኑራተዊ፡ <del rend="effaced">ቋ</del>ቁራ፡ 
+                                    <seg part="I">በስመ <supplied reason="undefined">፡</supplied> አብ፡
+                                            ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ጸሎት፡ በእንተ፡ ሕማመ፡ ባርያ፡
+                                            ወለ<del rend="effaced">ያ</del>ጌዎን፡  አ<del rend="effaced">ሁ</del>ላሁ፡
+                                            <foreign xml:lang="am">ማቴ፡ አልመላክያው፡ ኑራተዊ፡ <del rend="effaced">ቋ</del>ቁራ፡
                                                 ስስምረጅ፡ ወመርመ፡ የፉሕሙ፡ የሽፋቴ፡</foreign>
                                     </seg>
-                                    <seg part="F">እምባርያ፡ ወላጌዎን፡ ደስክ፡ 
+                                    <seg part="F">እምባርያ፡ ወላጌዎን፡ ደስክ፡
                                         ወጉዳሌ፡ ድድቅ፡ ወጋኔነ፡ ቀትር<supplied reason="omitted">፡</supplied>ለገብርከ፡ እገሌ።
                                     </seg>
                                         </q>
                                 </item>
-                                
+
                                 <item xml:id="a2" rend="guardLeaf">
                                     <locus from="3v" to="4r"/>
                                     <desc type="GuestText">A text, originally written entirely with red ink,
                                         has been erased to illegibility.
                                     </desc>
                                 </item>
-                                
+
                                 <item xml:id="a3">
                                     <locus target="#26va"/>
                                     <desc type="GuestText"><title type="complete" ref="LIT6855Prayer"></title>
                                     </desc>
-                                        <q xml:lang="gez">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ። ፩ አምላክ፡ ያኢበያላሂሂን፡ አህቢሱ፡ 
-                                            ለአመትከ፡ እገሊት። ሃሱ፡ ለሃሱ፡ ለምሃ፡ ሸርሪ፡ ይትባረጹ፡ መባርቅት፡ ወነጐድ፡ ዘወጽአት፡ 
-                                            ትግባእ፡ ወዘርሕቀት፡ ትቅረብ፡ ሰማይኒ፡ የኢያጽልላ፡ 
+                                        <q xml:lang="gez">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ። ፩ አምላክ፡ ያኢበያላሂሂን፡ አህቢሱ፡
+                                            ለአመትከ፡ እገሊት። ሃሱ፡ ለሃሱ፡ ለምሃ፡ ሸርሪ፡ ይትባረጹ፡ መባርቅት፡ ወነጐድ፡ ዘወጽአት፡
+                                            ትግባእ፡ ወዘርሕቀት፡ ትቅረብ፡ ሰማይኒ፡ የኢያጽልላ፡
                                             አዝዊረከ፡ <del rend="overUnderlined">ነ</del>አዘዋዊረከ፡ አግብአ፡ ለአመትከ።
                                         </q>.
                                 </item>
-                                
+
                                 <item xml:id="a4">
                                     <locus target="#26vb"/>
                                     <desc type="GuestText"><title type="complete" ref="LIT6857Prayer"></title>
                                         The prayer includes abbreviations.
                                     </desc>
-                                        <q xml:lang="gez">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ 
-                                            አልሐጢን፡ አልሐጢን፡ አልሐን፡ በካዝዮን፡ ካፌር፡ ሰለባዊ፡ በዝ፡ አስማቲከ፡ 
-                                            ዘአሰርኮ፡ ለብርያል፡ በ፭፻፡ ፼፡ ሰናስለ፡ እሳት፡ ስብጉጥር፡ እሳት፡ ከማሁ፡ 
-                                            እስ፡ ለ፡ ከመ፡ ኢት፡ እም፡ ቤታ<add place="above">በ</add>፡ 
+                                        <q xml:lang="gez">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡
+                                            አልሐጢን፡ አልሐጢን፡ አልሐን፡ በካዝዮን፡ ካፌር፡ ሰለባዊ፡ በዝ፡ አስማቲከ፡
+                                            ዘአሰርኮ፡ ለብርያል፡ በ፭፻፡ ፼፡ ሰናስለ፡ እሳት፡ ስብጉጥር፡ እሳት፡ ከማሁ፡
+                                            እስ፡ ለ፡ ከመ፡ ኢት፡ እም፡ ቤታ<add place="above">በ</add>፡
                                             ሕ<add place="above">ይ</add>ወታ፡ እንዘ፡ ሐለት፡ ዘእንበለ፡ በሞት። ፯፡ ፯፡ ድግምለወሐ፡ ሎማ፡
                                         </q>.
                                 </item>
-                                
+
                                 <item xml:id="a5">
                                     <locus target="#74v"/>
                                     <desc type="GuestText"><title type="complete" ref="LIT6858PPsnakes"></title>
                                     </desc>
                                     <q xml:lang="gez">
-                                        በስመ፡ አብ፡ ወወልድ፡ ወመን<surplus>፡</surplus> ፈስ፡ ቅዱስ፡ ፩ አምላክ፨ 
-                                        አክዮስ፡ አክዮስ፡ አክየ<sic>፡</sic> ሳዊ፡ ዶል፡ መር<del rend="strikethrough">ጌዮን</del>፡<add place="above">ጌዎን፡</add> 
-                                        ለቅሌማድ፡ መልአኩ፡ ለአርዌ፡ ምድር፡ 
-                                        አኀዝኩከ፡ ቀረጽ፡ በቀረጽ፡ አግአዚ፡ አርግዘና፡ ዘምሳና፡ ሙለዱ፡ ለከይሲ፡ 
-                                        ፈውሰ፡ ኩን፡ ለተመን፡ ፈውሰ፡ ኩን፡ ለአፍኦት፡ ፈውሰ፡ ኩን፡ 
-                                        በማቴዎስ፡ ፈውሰ፡ ኩን፡ በ<del rend="strikethrough">ም</del>ማርቆስ፡ ፈውሰ፡ ኩን፡ በሉ<sic>ቂ</sic>ስ፡ 
-                                        ፈውሰ፡ ኩን፡ በዮሐንስ፡ <del rend="strikethrough">ወ</del>በ፬ወ<add place="above">ን</add>ጌላውያን፡ 
-                                        ኅድግ፡ ይቤሉከ፡ አ<sic>ቡ</sic>፡ ወወልድ<supplied reason="undefined">፡</supplied>መንፈስ፡ ቅዱስ፡ 
-                                        ከመ፡ ይፃእ፡ ሕምዙ፡ ለከይሲ፡ በሐ<add place="above">ይ</add>ለ፡ መስቀሉ፡ ለእግዚኢነ፡ 
-                                        ኢየሱስ፡ ክርስቶስ፡ በከመ፡ ኀደጉሐዋርያት። 
+                                        በስመ፡ አብ፡ ወወልድ፡ ወመን<surplus>፡</surplus> ፈስ፡ ቅዱስ፡ ፩ አምላክ፨
+                                        አክዮስ፡ አክዮስ፡ አክየ<sic>፡</sic> ሳዊ፡ ዶል፡ መር<del rend="strikethrough">ጌዮን</del>፡<add place="above">ጌዎን፡</add>
+                                        ለቅሌማድ፡ መልአኩ፡ ለአርዌ፡ ምድር፡
+                                        አኀዝኩከ፡ ቀረጽ፡ በቀረጽ፡ አግአዚ፡ አርግዘና፡ ዘምሳና፡ ሙለዱ፡ ለከይሲ፡
+                                        ፈውሰ፡ ኩን፡ ለተመን፡ ፈውሰ፡ ኩን፡ ለአፍኦት፡ ፈውሰ፡ ኩን፡
+                                        በማቴዎስ፡ ፈውሰ፡ ኩን፡ በ<del rend="strikethrough">ም</del>ማርቆስ፡ ፈውሰ፡ ኩን፡ በሉ<sic>ቂ</sic>ስ፡
+                                        ፈውሰ፡ ኩን፡ በዮሐንስ፡ <del rend="strikethrough">ወ</del>በ፬ወ<add place="above">ን</add>ጌላውያን፡
+                                        ኅድግ፡ ይቤሉከ፡ አ<sic>ቡ</sic>፡ ወወልድ<supplied reason="undefined">፡</supplied>መንፈስ፡ ቅዱስ፡
+                                        ከመ፡ ይፃእ፡ ሕምዙ፡ ለከይሲ፡ በሐ<add place="above">ይ</add>ለ፡ መስቀሉ፡ ለእግዚኢነ፡
+                                        ኢየሱስ፡ ክርስቶስ፡ በከመ፡ ኀደጉሐዋርያት።
                                         ለእመ፡ ርሁቅ፡ ኣስትዮ፡ ላክደጊመከማይ፡
                                     </q>
                                 </item>
-                                
+
                                 <item xml:id="a6">
                                     <locus target="#76v"/>
                                     <desc type="GuestText"><title type="complete" ref="LIT6859PPbirth"></title>
                                     </desc>
                                         <q xml:lang="gez">
-                                            ጸሎት፡ በእንተ፡ ወሊያ፡ በዘ፡ ቂልያስ፡ ተራትሰ፡ ዘኖምያ፡ ፍታሕ፡ 
+                                            ጸሎት፡ በእንተ፡ ወሊያ፡ በዘ፡ ቂልያስ፡ ተራትሰ፡ ዘኖምያ፡ ፍታሕ፡
                                             ማሕፀና፡ ለእመትከ፡ እገሊ፡ <del rend="overUnderlined">በማ</del>ይጻእ፡ <foreign xml:lang="am">
                                                 ልጅ፡ ወእንግህ፡ ልጅ፡ በይማ፡ ድግም፡</foreign>
                                         </q>.
                                 </item>
-                                
+
                                 <item xml:id="a7">
                                     <locus target="#76v"/>
                                     <desc type="GuestText"><title type="complete" ref="LIT6860Prayer"> (in Amharic)</title>
@@ -696,30 +696,30 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <q xml:lang="am">
                                             ቀንጠፋ፡ የቁመኛ፡ ነው፡ ምስሪች<hi rend="rubric">፤</hi> ጊንዳ<hi rend="rubric">፤</hi>
                                             የቁራ፡ ስር<hi rend="rubric">፤</hi> አንዴል<hi rend="rubric">፨</hi>
-                                            የምድር፡ ኵሂላ<hi rend="rubric">፨</hi> ሱር፡ በትሪ<hi rend="rubric">፨</hi> 
-                                            ደማይቶ<hi rend="rubric">፨</hi> ጥርጊና<add place="above">ፍን</add><hi rend="rubric">፨</hi> 
-                                            ዕ<del rend="strikethrough">ዕ</del>ፀ፡ ምናሄ<hi rend="rubric">፤</hi> 
+                                            የምድር፡ ኵሂላ<hi rend="rubric">፨</hi> ሱር፡ በትሪ<hi rend="rubric">፨</hi>
+                                            ደማይቶ<hi rend="rubric">፨</hi> ጥርጊና<add place="above">ፍን</add><hi rend="rubric">፨</hi>
+                                            ዕ<del rend="strikethrough">ዕ</del>ፀ፡ ምናሄ<hi rend="rubric">፤</hi>
                                             አጋም፡ ስር<hi rend="rubric">፨</hi> አየ፡ ስር<hi rend="rubric">፨</hi>
-                                            ኀቢጸሊም<hi rend="rubric">፤</hi> ገመሮ<hi rend="rubric">፨</hi> እንሰ፡ ላል<hi rend="rubric">፨</hi> 
+                                            ኀቢጸሊም<hi rend="rubric">፤</hi> ገመሮ<hi rend="rubric">፨</hi> እንሰ፡ ላል<hi rend="rubric">፨</hi>
                                             ሰምዛ<hi rend="rubric">፨</hi> ነጭ<hi rend="rubric">፨</hi>
-                                            ሽንጉርቲ<hi rend="rubric">፨</hi> ኦልቲት<hi rend="rubric">፨</hi> ይህነን<hi rend="rubric">፨</hi> 
+                                            ሽንጉርቲ<hi rend="rubric">፨</hi> ኦልቲት<hi rend="rubric">፨</hi> ይህነን<hi rend="rubric">፨</hi>
                                             ጨምሮ<hi rend="rubric">፨</hi> <del rend="strikethrough">ይዳ</del>ይዳ፡ በብር<hi rend="rubric">፨</hi>
                                             ቀለበት። ይምሶዋል<hi rend="rubric">፨</hi><hi rend="rubric">፨</hi>
                                         </q>.
                                 </item>
-                                
+
                                 <item xml:id="a8">
                                     <locus target="#77r"/>
                                     <desc type="GuestText"><title type="complete" ref="LIT6861Prayer"></title>
                                     </desc>
                                         <q xml:lang="gez">
-                                            ዝሀወት<hi rend="rubric">፨</hi> ዘአበረ፡ አጋዘ<hi rend="rubric">፨</hi> 
-                                            ለአበወሀ<hi rend="rubric">፨</hi> ወ<hi rend="rubric">=</hi>ሰሐበ<hi rend="rubric">፨</hi> 
-                                            ሙሐዘት<hi rend="rubric">፨</hi> አየአላፈ<hi rend="rubric">፨</hi> 
+                                            ዝሀወት<hi rend="rubric">፨</hi> ዘአበረ፡ አጋዘ<hi rend="rubric">፨</hi>
+                                            ለአበወሀ<hi rend="rubric">፨</hi> ወ<hi rend="rubric">=</hi>ሰሐበ<hi rend="rubric">፨</hi>
+                                            ሙሐዘት<hi rend="rubric">፨</hi> አየአላፈ<hi rend="rubric">፨</hi>
                                             ወፀበላነ። <add place="above">የመጦሪ<hi rend="rubric">፨</hi><hi rend="rubric">፨</hi></add>
                                         </q>.
                                 </item>
-                                                                
+
                                 <item xml:id="a9">
                                     <locus from="77v" to="78r"/>
                                     <desc type="GuestText"><title type="complete" ref="LIT6862PPscribe"></title>
@@ -727,19 +727,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </desc>
                                         <q xml:lang="gez">
                                             <hi rend="rubric">
-                                                ሰሐል፡ ሰሐል፡ ሰሐል፡ ጸጸጸጸጸጸጸጸጸጸጸጸጸጸጸጸጸጸጸጸጸጸጸጸ<del rend="strikethrough">ጸ</del>እዴየ፡ 
-                                                ሰሐል፡ ወየማንየ፡ አሕመላምል፡ ለጺሒፈ፡ ብርዕ፡ ወቀለም፡ ሊተ፡ ለገብርከ፡ አፍጌት፡ 
-                                                ወርኃ፡ ደቡብ፡ ወወርኃ፡ ደመና፡ <del rend="encircled strikethrough">አክሄል፡ ድሜሄላዊ፡</del> 
-                                                መንጥሔል፡ ድሜሄላዊ፡ በከመ፡ የሐውሩ፡ ፀሐይ፡ ወወርኅ፡ በፍጥረተ፡ 
-                                                ትእዛዝከ፡ ከማሆሙ፡ አሩፅ፡ የማነ፡ እዴየ፡ ለጋ፡ በስመ፡ 
-                                                <del rend="strikethrough">ለለ</del>ሎኤ፡ ኢላኤ፡ ኢላሄ፡ አሩፅ፡ እዴየ፡ 
-                                                ለገቢ<pb n="78r"/>ረ፡ ኵሉ፡ ተግባር፡ በሩፋኤል፡ ብርናዊ፡ 
-                                                በክሳብኤል፡ ዘ<del rend="strikethrough">ፈ</del>ያረውፃ፡ ለፀሐይ፡ 
-                                                ከማሁ፡ አሩፅ፡ እዴየ፡ ከመ፡ ይጠንቅቅ፡ ለአኂዘ፡ ብርዕ፡ ወእጽሐፍ፡ 
-                                                እበያቲከ፡ ዘእንበለ፡ ሐኬት፡ ኦእግዚእየ፡ ኢየሱስ፡ ክርስቶስ፡ 
-                                                አስተ<surplus>፡</surplus> ፋጥን<supplied reason="undefined">፡</supplied> 
-                                                ወ<add place="above">አ</add>ስተ<surplus>፡</surplus> 
-                                                ቃንዕ፡ ለገብርከ፡ በቀይ፡ ቀለም፡ <del rend="strikethrough">ወ</del>በወረቀት፡ 
+                                                ሰሐል፡ ሰሐል፡ ሰሐል፡ ጸጸጸጸጸጸጸጸጸጸጸጸጸጸጸጸጸጸጸጸጸጸጸጸ<del rend="strikethrough">ጸ</del>እዴየ፡
+                                                ሰሐል፡ ወየማንየ፡ አሕመላምል፡ ለጺሒፈ፡ ብርዕ፡ ወቀለም፡ ሊተ፡ ለገብርከ፡ አፍጌት፡
+                                                ወርኃ፡ ደቡብ፡ ወወርኃ፡ ደመና፡ <del rend="encircled strikethrough">አክሄል፡ ድሜሄላዊ፡</del>
+                                                መንጥሔል፡ ድሜሄላዊ፡ በከመ፡ የሐውሩ፡ ፀሐይ፡ ወወርኅ፡ በፍጥረተ፡
+                                                ትእዛዝከ፡ ከማሆሙ፡ አሩፅ፡ የማነ፡ እዴየ፡ ለጋ፡ በስመ፡
+                                                <del rend="strikethrough">ለለ</del>ሎኤ፡ ኢላኤ፡ ኢላሄ፡ አሩፅ፡ እዴየ፡
+                                                ለገቢ<pb n="78r"/>ረ፡ ኵሉ፡ ተግባር፡ በሩፋኤል፡ ብርናዊ፡
+                                                በክሳብኤል፡ ዘ<del rend="strikethrough">ፈ</del>ያረውፃ፡ ለፀሐይ፡
+                                                ከማሁ፡ አሩፅ፡ እዴየ፡ ከመ፡ ይጠንቅቅ፡ ለአኂዘ፡ ብርዕ፡ ወእጽሐፍ፡
+                                                እበያቲከ፡ ዘእንበለ፡ ሐኬት፡ ኦእግዚእየ፡ ኢየሱስ፡ ክርስቶስ፡
+                                                አስተ<surplus>፡</surplus> ፋጥን<supplied reason="undefined">፡</supplied>
+                                                ወ<add place="above">አ</add>ስተ<surplus>፡</surplus>
+                                                ቃንዕ፡ ለገብርከ፡ በቀይ፡ ቀለም፡ <del rend="strikethrough">ወ</del>በወረቀት፡
                                                 ጸሐፍዕስር<supplied reason="undefined">፡</supplied>
                                             </hi>
                                         </q>.
@@ -759,7 +759,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             Widassie Maryan
                                         </q>.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e3">
                                     <locus target="#1r"/>
                                     <desc><q xml:lang="la">
@@ -769,7 +769,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                                 <item xml:id="e4">
                                     <locus target="#1r"/>
-                                    <desc type="Unclear"> 
+                                    <desc type="Unclear">
                                     </desc>
                                         <q xml:lang="la">
                                             Haleca G<gap reason="lost"/><lb/>
@@ -777,7 +777,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <gap reason="lost"/>itari Adibara<lb/>
                                             <gap reason="lost"></gap>leca S G G<gap reason="lost"/>
                                         </q>.
-                                    
+
                                 </item>
 
                                 <item xml:id="e5">
@@ -788,7 +788,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <hi rend="rubric">መጸፈፈቲን፡ ብርዕ፡ ወሐልይዋ፡ እምከርሠ፡ እሙ፡</hi>
                                         </q>.
                                 </item>
-                                
+
                             </list>
                         </additions>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethf26.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf26.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!--  
+                <!--
                 <title xml:lang="gez" xml:id="title1">መልክአ፡ ቤተ፡ ክርስቲያን፡, መልክአ፡ ሩፋኤል፡, ጸሎተ፡ አኰቴት፡ ዘባስልዮስ፡, መልክአ፡ አማኑኤል፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Malkǝʾa beta krǝstiyān, Malkǝʾa Rufāʾel, Ṣalota ʾakkʷatet za-Bāsǝlyos, Malkǝʾa ʾAmānuʾel</title>
                 -->
@@ -502,6 +502,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <change who="DR" when="2022-02-09">Continued description</change>
             <change who="DR" when="2022-02-14">Corrections after review from Eliana Dal Sasso, Solomon Gebreyes, and Massimo Villa</change>
             <change who="EDS" when="2022-11-20">Added bindingDesc</change>
+            <change who="EDS" when="2024-03-10">Revision condition</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">

--- a/OxfordBodleian/Juel-Jensen/BDLaethf27.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf27.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0"
     xml:id="BDLaethf27"
@@ -15,7 +15,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <editor key="JG"/>
                 <editor key="MV"/>
                 <editor key="SH"/>
-                <editor key="EDS"/>                
+                <editor key="EDS"/>
                 <editor key="JK"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
@@ -37,37 +37,37 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <idno>Juel-Jensen 24</idno>
                         </altIdentifier>
                     </msIdentifier>
-                    
+
                     <msContents>
                         <summary/>
-                        
+
                         <msItem xml:id="ms_i1">
                       <locus from="1ra1" to="1ra53"/>
                             <title ref="LIT6781PPAynat" type="complete"/>
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ጸሎት፡ በእንተ፡
                             ሕማ</hi>መ፡ ዓይነ፡ ባርያ፡ ወሌጌዎን፡ ገሃነ፡ አርያስ፡ ስውር፡ ሰሙር፡ አግናከር፡ አግናጠር፡ አሙተዳናብኆልት፡
-                            ይሰልብ፡ ልበ፡ ሰብእ፡ ወያጸልም፡ አእይንተ፡ ወይመጽእ፡ ከመ፡ ጽላሎት፡ በመአልት፡ ወበሌሊት፡ አመሐልኩክሙ፡ ወአውገዝኩክሙ፡ 
+                            ይሰልብ፡ ልበ፡ ሰብእ፡ ወያጸልም፡ አእይንተ፡ ወይመጽእ፡ ከመ፡ ጽላሎት፡ በመአልት፡ ወበሌሊት፡ አመሐልኩክሙ፡ ወአውገዝኩክሙ፡
                             በ<hi rend="rubric" rendition="#partialRubric">፭</hi> ቅንዋተ፡ መስቀሉ፡ ለእግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡</incipit>
-                            <explicit xml:lang="gez">ወመሳነን፡ በድንጋፄ፡ ወጽጋም፡ ወተንኰል፡ በመድኀኒት፡ ወንስናሽ፡ ወሾተላይ፡ ወቆቆላይ፡ ወዓይነ፡ ወርቅ፡ ወልጅ፡ ገዳይ፡ በመጋኛ፡ 
-                                ወቍራኛ፡ በአስማተኛ፡ ወማርተኛ፡ በበደለኛ፡ ወበተንኰለኛ፡ ወቍመኛ፡ በዝ፡ ኵሉ፡ አመሐልኩክሙ፡ ወአውገዝኩክሙ፡ ከመ፡ ኢትቅረቡ፡ ኀበ፡ 
+                            <explicit xml:lang="gez">ወመሳነን፡ በድንጋፄ፡ ወጽጋም፡ ወተንኰል፡ በመድኀኒት፡ ወንስናሽ፡ ወሾተላይ፡ ወቆቆላይ፡ ወዓይነ፡ ወርቅ፡ ወልጅ፡ ገዳይ፡ በመጋኛ፡
+                                ወቍራኛ፡ በአስማተኛ፡ ወማርተኛ፡ በበደለኛ፡ ወበተንኰለኛ፡ ወቍመኛ፡ በዝ፡ ኵሉ፡ አመሐልኩክሙ፡ ወአውገዝኩክሙ፡ ከመ፡ ኢትቅረቡ፡ ኀበ፡
                                 ነፍሳ፡ ወሥጋሃ፡ ለአመትከ፡ <persName ref="PRS13863WalattaE" role="owner">ወለተ፡ <hi rend="rubric">እግዚእ፡</hi></persName></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i2">
                             <locus from="1ra53" to="1ra89"/>
                             <title ref="LIT4619Prayer" type="complete"/>
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ <hi rend="rubric" rendition="#partialRubric">፩</hi>
                             አምላክ፡ ጸሎት፡ በእንተ፡ ባርያ፡ <hi rend="rubric">ወሌጌዎን፡ ርኩስ፡ ዘይሰልብ፡ ልበ፡ ሰብእ፡ ወያጸልም፡ አዕይንተ፡ ወይመጽ</hi>እ፡ ከመ፡ ጽላሎት፡
-                                በመዓልት፡ ወሕልም፡ አምሐለከ፡ ወአውግዝከ፡ በ<hi rend="rubric" rendition="#partialRubric">፭</hi> ቅንዋተ፡ መስቀሉ፡ 
+                                በመዓልት፡ ወሕልም፡ አምሐለከ፡ ወአውግዝከ፡ በ<hi rend="rubric" rendition="#partialRubric">፭</hi> ቅንዋተ፡ መስቀሉ፡
                             ለእግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ ሳዶር፡ አላዶር፡ ዳናት፡ አዴራ፡ ሮዳስ፡</incipit>
                             <explicit xml:lang="gez">እ<hi rend="rubric">ሰሮሙ፡ ከመ፡ ኢይቀረቡ፡ ወእለሂ፡ ቀርቡ፡ ይፃዑ፡ ዘሀለው፡ እመሂ፡ በሐ</hi>ቍ፡
-                                ወእመሂ፡ በአቍያጽ፡ እመሂ፡ በአእደው፡ ወእመሂ፡ በአእጋር፡ ወበኵሉ፡ አካላት፡ ዘይቈረጥሙ፡ ወየሐምሙ፡ ወያመጽኡ፡ ንዋመ፡ በመዓልት፡ 
-                                ወበሌሊት፡ ወያንቀጠቀጡ፡ ወኢይቅረቡ፡ ኀበ፡ ነፍሳ፡ ወሥጋሃ፡ ለአመትከ፡ 
+                                ወእመሂ፡ በአቍያጽ፡ እመሂ፡ በአእደው፡ ወእመሂ፡ በአእጋር፡ ወበኵሉ፡ አካላት፡ ዘይቈረጥሙ፡ ወየሐምሙ፡ ወያመጽኡ፡ ንዋመ፡ በመዓልት፡
+                                ወበሌሊት፡ ወያንቀጠቀጡ፡ ወኢይቅረቡ፡ ኀበ፡ ነፍሳ፡ ወሥጋሃ፡ ለአመትከ፡
                                 <persName ref="PRS13863WalattaE" role="owner">ወለተ፡ <hi rend="rubric">እግዚእ፡</hi></persName></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i3">
                             <locus from="1ra90" to="1ra119"/>
                             <title ref="LIT6782PPMasaromu" type="complete"/>
@@ -79,15 +79,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 አጽራዕከ፡ ግብሮ፡ ለዲያብሎስ፡ ከመሁ፡
                             አጽርዕ፡ ሕማመ፡ ባርያ፡ ወሌጌዎን፡ ቍራኛ፡ ወተያጅ፡ መጋኛ፡ ወእሥምት፡ ዓይነት፡ ወውግዓት፡ ቍርፀት፡ ወፍልፀት፡ መትዓት፡ ወጽፍዓት፡ ምች፡ ወተላዋሽ፡ ፌራ፡ ወንዳድ፡
                             ግብጥ፡ ወዛር፡ መዋቂ፡ ወነቀኝቃኝ፡ ሾተላይ፡ ወትግርትያ፡ ወቍርጥማተ፡ እድ፡ ወእግር፡ ሓቌ፡ ወዘባን፡ ወኵሉ፡ አባለ፡ ሥጋ፡ ቡዳ፡ ወነሃብት፡ ሰብእ፡ ግብር፡ ወጠበብት፡
-                            ቸንፍር፡ ወነገርጋር፡ ድድቀ፡ ወጋኔነ፡ ቀትር፡ ይሰድዱ፡ ወይርሐ<hi rend="rubric">ቁ፡ እምላዕለ፡ ነፍሳ፡ ወሥጋሀ፡ ለአመትከ፡ 
+                            ቸንፍር፡ ወነገርጋር፡ ድድቀ፡ ወጋኔነ፡ ቀትር፡ ይሰድዱ፡ ወይርሐ<hi rend="rubric">ቁ፡ እምላዕለ፡ ነፍሳ፡ ወሥጋሀ፡ ለአመትከ፡
                                 <persName ref="PRS13863WalattaE" role="owner">ወለተ፡ እግዚእ።</persName></hi></incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i4">
                             <locus from="1ra119" to="1ra176"/>
                             <title ref="LIT6783MarkFive" type="complete"/>
                             <textLang mainLang="gez"/>
-                            <incipit xml:lang="gez"><hi rend="rubric">ወንጌል፡ ዘማርቆስ፡ ወበ</hi>ጺሆ፡ ማዕዶተ፡ ጊርጌሴኖን፡ ተቀበልዎ፡ ሶቤሃ፡ ለብእሲ፡ እመቃብር፡ 
+                            <incipit xml:lang="gez"><hi rend="rubric">ወንጌል፡ ዘማርቆስ፡ ወበ</hi>ጺሆ፡ ማዕዶተ፡ ጊርጌሴኖን፡ ተቀበልዎ፡ ሶቤሃ፡ ለብእሲ፡ እመቃብር፡
                             ዘጋኔን፡ እኩይ፡ ላዕሌሁ፡ ዘኮነ፡ ማኅደሩ፡ ማዕከለ፡ መቃብራት፡ ወዓዓቅብዎ፡ ደቅ፡ ወአልቦ፡ ዘክህለ፡ ከመ፡ ያጽንዖ፡ በሰናስል፡ ሶበ፡ ተፈትሐ፡</incipit>
                             <explicit xml:lang="gez">
                                 <hi rend="rubric">ወአብሆሙ፡ እግዚእ፡ ኢየ</hi>ሱስ፡ ወወዲሶሙ፡ ሶቤሃ፡ እሙንቱ፡ አጋንንት፡ ቦኡ፡ ላዕለ፡ አኅርው፡ ወአብዱ፡ መራእየ፡ አኅርው፡ ወመጽኡ፡
@@ -95,7 +95,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 ፀዋጋን፡ ወትግርትያ፡ እቡያን፡ ወሠብእ፡ መሠርያን፡ እምባርያ፡ ወሾተላይ፡ አድኅና፡ ለአመትከ፡
                                 <persName ref="PRS13863WalattaE" role="owner">ወለተ፡ <hi rend="rubric">እግዚእ።</hi></persName></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i5">
                             <locus from="1ra177" to="1ra"/>
                             <!--lines from here on cannot be counted because there is a gap in the images :( -->
@@ -106,11 +106,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             ሰዳዴ፡ ሰይጣናት፡ ፋኑኤል፡ ለእግዚአብሔር፡ እምጽርሁ፡ ከመ፡ ኢይስክዩ፡ ሰብእ፡ እለ፡ ይኔስሑ፡</incipit>
                                 <!--part of the scroll not photographed-->
                             <explicit xml:lang="gez">
-                                ወኵሉ፡ አባለ፡ ሥጋ፡ ቡዳ፡ ወነሃብት፡ ሰብአ፡ ግብር፡ ወጠበብት፡ ቸንፈር፡ ወነገርጋር፡ ድድቅ፡ ወጋኔነ፡ ቀትር፡ ወኵሉ፡ ደዌ፡ ወሕማመ፡ አመሐልኩክሙ፡ ወአውገዝኩክሙ፡ 
+                                ወኵሉ፡ አባለ፡ ሥጋ፡ ቡዳ፡ ወነሃብት፡ ሰብአ፡ ግብር፡ ወጠበብት፡ ቸንፈር፡ ወነገርጋር፡ ድድቅ፡ ወጋኔነ፡ ቀትር፡ ወኵሉ፡ ደዌ፡ ወሕማመ፡ አመሐልኩክሙ፡ ወአውገዝኩክሙ፡
                                 ከመ፡ ኢትቅረቡ፡ ኀበ፡ ነፍሳ፡ ወሥጋሃ፡ ለአመትከ፡ <persName ref="PRS13863WalattaE" role="owner">ወለተ፡
                                  <hi rend="rubric">እ<hi rend="ligature">ግዚ</hi>እ።</hi></persName></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i6">
                             <locus from="1ra" to="1ra"/>
                             <title ref="LIT4007Salotb" type="complete"/>
@@ -125,7 +125,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 ፍጌን፡ ደጊሞሙ፡ ፍታሐ፡ ወዝርዚር፡ ሠዓር፡ ወምንዝር፡ ኵሎ፡ ሥራያተ፡ ወአስማተ፡ ዕሙናዝር፡ ቤልናዝር፡ ፍታሕ፡ አንተ፡ አስማተ፡ ዘተደግመ፡ በእስላም፡ ወክርስቲያን፡
                                 ለአመትከ፡ <persName ref="PRS13863WalattaE" role="owner">ወለተ፡ እ<hi rend="ligature">ግዚ</hi>እ።</persName></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i7">
                             <locus from="1ra" to="1ra"/>
                             <title ref="LIT6784PPQwerdat" type="complete"/>
@@ -134,11 +134,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ጸሎት፡ በእንተ፡ ሕ</hi>ማመ፡
                                 ቍርፀት፡ በከ<gap reason="illegible" unit="chars" quantity="1"/>ኮዕ፡ ስምከ፡ በርያኖስ፡ ስምከ፡ በጸሔል፡ ስምከ፡ በአማኑኤል፡ ስምከ፡
                                 በክርስቶስ፡ ስምከ፡ በኅቡዕ፡ ስምከ፡ ወበክሱት፡ ስምከ፡ ተማኅፀንኩ፡ እልፍሉል፡ እልፍሉል፡ እልፍሉል፡ እልፍሉል፡ ጸሎተ፡ ሕማመ፡ ቍርፀት፡ ዘተፈነወ፡
-                                እምኀበ፡ አብ፡ ወወልድ፡ መንፈስ፡ ቅዱስ፡ ከመ፡ ያርዳዕ፡ ወይቤዙ፡ ውሉደ፡ ሰብእ፡ ወእንስሳ፡ እንዘ፡ ይጐጸጕጽ፡ ገበዋተ፡ ወይራነቅል፡ 
+                                እምኀበ፡ አብ፡ ወወልድ፡ መንፈስ፡ ቅዱስ፡ ከመ፡ ያርዳዕ፡ ወይቤዙ፡ ውሉደ፡ ሰብእ፡ ወእንስሳ፡ እንዘ፡ ይጐጸጕጽ፡ ገበዋተ፡ ወይራነቅል፡
                                 ቍልፈ<hi rend="rubric">ተ፡ ወይቈርፅ፡ ከማዑተ፡ ሸገር፡ ሸገር፡ ሸገር፡ ደር፡ ደር፡ ደር፡ በኃ</hi>ይለ፡ ዝንቱ፡ አስማቲከ፡ አድኅና፡ እምሕማመ፡
                                 ቍርፀት፡ ለአመትከ፡ <persName ref="PRS13863WalattaE" role="owner">ወለተ፡ <hi rend="rubric">እግዚእ፡</hi></persName></incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i8">
                             <locus from="1ra" to="1ra"/>
                             <title ref="LIT6785PPDengade" type="complete"/>
@@ -146,10 +146,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <note>The following is the entire text.</note>
                             <incipit xml:lang="gez">ጸሎት፡ በእንተ፡ ድንጋፄ፡ አጋንንት፡ ዘመዓልት፡ ወዘሌሊት፡ ባርከኒ፡ ክርስቶስ፡ አምላኪየ፡ ዕቀበኒ፡ ወአድኅነኒ፡ እምድንጋፄ፡
                                 አጋንንት፡ ወፍጹም፡ በጽልመት፡ ፈርሃ፡ ወደንገፀ፡ ዲያብሎስ፡ ርእዮ፡ ብሁተ፡ ልደት፡ በሥጋ፡ አምላክ፡ በሲኦል፡ እወግዞሙ፡ ለአጋንንት፡ እኩያን፡ በመለኮተ፡
-                                አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ዘይወጽእ፡ እምአፉሁ፡ ሰይፈ፡ እሳት፡ በአብ፡ እትዌከል፡ ወበወልድ፡ እትኬስል፡ በዘቦቱ፡ ለሰሐ፡ ሕምዙ፡ 
+                                አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ዘይወጽእ፡ እምአፉሁ፡ ሰይፈ፡ እሳት፡ በአብ፡ እትዌከል፡ ወበወልድ፡ እትኬስል፡ በዘቦቱ፡ ለሰሐ፡ ሕምዙ፡
                                 ለሞት፡ አድኅና፡ ለአመትከ፡ <persName ref="PRS13863WalattaE" role="owner">ወለተ፡ <hi rend="rubric">እግዚእ።</hi></persName></incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i9">
                             <locus from="1rb1" to="1rb107"/>
                             <title ref="LIT1763Legend" type="complete"/>
@@ -157,42 +157,42 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ጸሎት፡ በእንተ፡ ሕማመ፡ ዓይነ፡ ጋ</hi>ኔን፡
                             ወሾተላይ፡ በስመ፡ እግዚአብሔር፡ ሕያው፡ ፈጣሪ፡ ነባቢ፡ ወተናጋሪ፡ ጸሎተ፡ ቅዱስ፡ ሱስንዮስ፡ በእንተ፡ አሰስሎ፡ ደዌ፡ እምሕፃናት፡ ወአንስት፡ ወእምኵሉ፡ ደዌያት፡
                             ወይበቍዕ፡ ዓዲ፡ ለብእሲት፡ ጽንስት፡ ዘኢየሐይው፡ ላቲ፡ ታጽሐፍ፡ ወትሰቅሎ፡ ውስተ፡ ገቦሃ፡ ወይበቍዓ፡ ዓዲ፡ ለረድኤት፡ እግዚአብሔር፡ ልዑል፡ ወክቡር፡ እስከ፡ ለዓለም፡
-                            ጸሎቱ፡ ወበረከቱ፡ ወኃይለ፡ ረድኤቱ፡ ያድኅና፡ እምውርዝልያ፡ ወሾተላይ፡ ባርያ፡ ወትግርትያ፡ ወሠያጥንት፡ ወእምኵሉ፡ ደዌ፡ ወሕማም፡ ለአመትከ፡ 
+                            ጸሎቱ፡ ወበረከቱ፡ ወኃይለ፡ ረድኤቱ፡ ያድኅና፡ እምውርዝልያ፡ ወሾተላይ፡ ባርያ፡ ወትግርትያ፡ ወሠያጥንት፡ ወእምኵሉ፡ ደዌ፡ ወሕማም፡ ለአመትከ፡
                                 <persName ref="PRS13863WalattaE" role="owner">ወለተ፡ <hi rend="rubric">እግዚእ፡</hi></persName>
-                                ወሀሎ፡ <hi rend="rubric" rendition="#partialRubric">፩</hi> ብእሲ፡ ዘስሙ፡ ሱስንዮስ፡ ወአውሰበ፡ ብእሲተ፡ ወወልደ፡ ተባዕተ፡ ወአንስተ፡ 
+                                ወሀሎ፡ <hi rend="rubric" rendition="#partialRubric">፩</hi> ብእሲ፡ ዘስሙ፡ ሱስንዮስ፡ ወአውሰበ፡ ብእሲተ፡ ወወልደ፡ ተባዕተ፡ ወአንስተ፡
                                 ወበቀዳማይ፡ ወልዱ፡ ቦአት፡ ውርዝልያ። <hi rend="rubric">ወቀተለቶ፡ ለወልዱ፡ ወከልሐት፡ እሙ፡ ወበከየት፡</hi>
                             </incipit>
                             <explicit xml:lang="gez">
                                 አንሰ፡ ኢየሐውር፡ ፍኖ<hi rend="rubric">ተ፡ ኀበ፡ ሀሎ፡ ስምከ፡ ውስቴቱ፡ አው፡ ቤተ፡ ክርስቲያንከ፡ ወእንዘ፡ ይትነበብ፡ መጽሐፈ፡ ገድል</hi>ከ፡ ወእንዘ፡ ይጸውራ፡ ለዛቲ፡ ጸሎት፡
                                 እመሂ፡ ተባዕተ፡ ወእመሂ፡ አንስተ፡ አው፡ ሕፃናት፡ ኢየሐውር፡ ውስቴቱ፡ እስከ፡ ለዓለመ፡ ዓለም፡
-                                ወቅዱስ፡ ሱስንዮስ፡ ኮነ፡ ሰማዕተ፡ በእንተ፡ ስመ፡ እግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ ሎቱ፡ ስብሐት፡ እስከ፡ ለዓለመ፡ ዓለም፡ አሜን፡ 
+                                ወቅዱስ፡ ሱስንዮስ፡ ኮነ፡ ሰማዕተ፡ በእንተ፡ ስመ፡ እግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ ሎቱ፡ ስብሐት፡ እስከ፡ ለዓለመ፡ ዓለም፡ አሜን፡
                             </explicit>
                             <explicit type="supplication">ኦአምላከ፡ ቅዱስ፡ ሱስንዮስ፡ አድኅና፡ እምሕማመ፡ ሾተላይ፡ ወትግርትያ፡ ባርያ፡ ወሌጌዎን፡ ቍራጅ፡ ወተያድ፡ መጋኛ፡ ወጕሥምት፡ ዓይነት፡
-                                ወውግዓት፡ 
-                                ቍርፀት፡ ወፍልፀት፡ ዛር፡ ወንዳድ፡ ፌራ፡ ወሥራይ፡ ወቍርጥማት፡ ወሰቅሰቀት፡ ቡዳ፡ ወነሃብት፡ ቸንፈር፡ ወነገርጋር፡ ድድቅ፡ ወጋ<hi rend="rubric">ኔነ፡ ቀትር፡ ወኵሉ፡ ደዌ፡ 
+                                ወውግዓት፡
+                                ቍርፀት፡ ወፍልፀት፡ ዛር፡ ወንዳድ፡ ፌራ፡ ወሥራይ፡ ወቍርጥማት፡ ወሰቅሰቀት፡ ቡዳ፡ ወነሃብት፡ ቸንፈር፡ ወነገርጋር፡ ድድቅ፡ ወጋ<hi rend="rubric">ኔነ፡ ቀትር፡ ወኵሉ፡ ደዌ፡
                                     ወሕማም፡
-                                    አድኅና፡ ወአመትከ፡ 
+                                    አድኅና፡ ወአመትከ፡
                                     <persName ref="PRS13863WalattaE" role="owner">ወለተ፡ እግዚእ፡</persName></hi></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i10">
                             <locus from="1rb107" to="1rb151"/>
                             <title ref="LIT6786MatthewEight" type="complete"/>
                             <textLang mainLang="gez"/>
-                            <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡</hi> ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ 
+                            <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡</hi> ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡
                                 ወንጌል፡ ዘማቴዎስ፡ ወበጺሆ፡ ማዕዶተ፡ ጌርጌሴኖን፡ ተቀበልዎ፡ ፪ አጋንንት፡ ወወጺኦሙ፡ እማዕዶተ፡ እምውስተ፡ መቃብራት፡ እኩያን፡ ጥቀ፡ ወጸዋግናን፡ ወኢያበውኁ፡
                                 እስከ፡ ሶበ፡ ኢይክሉ፡ ኃሊፈ፡ መኑሂ፡ እንተ፡ ይእቲ፡ ፍኖት፡ ወሶበ፡ ርእዮ፡ ለእግዚእ፡ ኢየሱስ፡ ፀርሁ፡
                             </incipit>
                             <explicit xml:lang="gez">
                                 ወአተው፡ ውስተ፡ ሀገር፡ ወዜነው፡ ኵሎ፡ ዘከመ፡ ርእዩ፡ ወበእንተ፡ እለ፡ አጋንንት፡ ወናሁ፡ ኵሎ፡ ዘውስተ፡ ሀገር፡ ወጽኡ፡ ወተቀበልዎ፡ ለእግዚእ፡ ኢየሱስ፡ ወሶበ፡ ርእይዎ፡
-                                ለእግዚእ፡ ኢየሱስ፡ ወአስተብቍዕዎ፡ ላዕለ፡ አሕርው፡ ወአብዱ፡ መራእየ፡ አሕርው፡ ወመጽኡ፡ ኵሎሙ፡ መራእይ፡ ኀበ፡ ኀይቅ፡ ወጸድፉ፡ ውስተ፡ ባሕር፡ 
+                                ለእግዚእ፡ ኢየሱስ፡ ወአስተብቍዕዎ፡ ላዕለ፡ አሕርው፡ ወአብዱ፡ መራእየ፡ አሕርው፡ ወመጽኡ፡ ኵሎሙ፡ መራእይ፡ ኀበ፡ ኀይቅ፡ ወጸድፉ፡ ውስተ፡ ባሕር፡
                             </explicit>
                             <explicit type="supplication" xml:lang="gez">ኦእግዚእየ፡
                                 ኢየሱስ፡ ክርስቶስ፡ በዝቃለ፡ ወንጌልከ፡ ገስጾሙ፡ ወአርኅቆሙ፡ ለመናፍስተ፡ ደዌ፡ ርኩሳን፡ ወአጋንንት፡ <hi rend="rubric">ፀዋጋን፡ ወትግርትያ፡ እቡያን፡ ወሰብእ፡ መሠርያን፡
                                     እምባርያ፡
                                     ወሾተላይ፡ አድኅና፡ ለአ</hi>መትከ፡ <persName ref="PRS13863WalattaE" role="owner">ወለተ፡ እግዚእ፡</persName></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i11">
                             <locus from="1rb151" to="1rb180"/>
                             <title ref="LIT4620Prayer" type="complete"/>
@@ -200,28 +200,28 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <incipit xml:lang="gez">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ጸሎት፡ በእንተ፡ ሕማመ፡ ጋኔን፡ ወቡዳ፡ ወነሃብት፡ ሰብአ፡ ግብር፡ ወጠበብት፡
                             አላሁማ፡ ወያኑራ፡ ተዋቂራ፡ ሀድረጅ፡ ብሀቃ፡ መግኦን፡ ወግኑን፡ መበሽሽን፡ ዘረበቦሙ፡ ሰሎሞን፡ ለአጋንንት፡ ሎፍሐም፡ ሎፍሐም፡ ሎፍሐም፡</incipit>
                             <explicit xml:lang="gez">
-                                ስሙ፡ ለእግዚአብሔር፡ ሕያው፡ ወልድ፡ መፍርህ፡ ወመደንግፅ፡ ወልድ፡ ግሩም፡ ነጐድጓድ፡ መንፈስ፡ ቅዱስ፡ ነበልባል፡ ነዳዲ፡ 
-                                <hi rend="rubric">ኬኒዴን፡ ቲቲሬዴን፡ ኤፌጼራሆን፡ በኃይለ፡ ዝንቱ፡ አስማቲከ፡ አድኅና፡ እምሕማ</hi>መ፡ ቡዳ፡ ወነሃብት፡ ቸንፈር፡ ወነገርጋር፡ 
+                                ስሙ፡ ለእግዚአብሔር፡ ሕያው፡ ወልድ፡ መፍርህ፡ ወመደንግፅ፡ ወልድ፡ ግሩም፡ ነጐድጓድ፡ መንፈስ፡ ቅዱስ፡ ነበልባል፡ ነዳዲ፡
+                                <hi rend="rubric">ኬኒዴን፡ ቲቲሬዴን፡ ኤፌጼራሆን፡ በኃይለ፡ ዝንቱ፡ አስማቲከ፡ አድኅና፡ እምሕማ</hi>መ፡ ቡዳ፡ ወነሃብት፡ ቸንፈር፡ ወነገርጋር፡
                                 ሰብአ፡ ግብር፡ ወጠበብት፡ ወሠውራ፡ እምኵሉ፡ ደዌ፡ ወሕማም፡ ለአመትከ፡
                                 <persName ref="PRS13863WalattaE" role="owner">ወለተ፡ <hi rend="rubric">እግዚእ፡</hi></persName></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i12">
                             <locus from="1rb181" to="1rb226"/>
                             <title ref="LIT5186PrayerAsmatAbayt" type="complete"/>
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ <hi rend="rubric" rendition="#partialRubric">፩</hi>
-                                አምላክ፡ ጸሎት፡ በእንተ፡ ሕማመ፡ ዛር፡ ወንዳድ፡ ወትብል፡ በትሁት፡ ቃል፡ እሎንተ፡ አስማተ፡ አቢያተ፡ አኮሰ፡ አሜዕሌኬ፡ ኤንካ፡ ካዜዕ፡ ኤርናኪም፡ 
+                                አምላክ፡ ጸሎት፡ በእንተ፡ ሕማመ፡ ዛር፡ ወንዳድ፡ ወትብል፡ በትሁት፡ ቃል፡ እሎንተ፡ አስማተ፡ አቢያተ፡ አኮሰ፡ አሜዕሌኬ፡ ኤንካ፡ ካዜዕ፡ ኤርናኪም፡
                                 ከምኬዎንኬዎን፡
                             ፒካ፡ ጊሎ፡ ኤሉቅ፡ አሶኤለኝ፡ አሰሰሙ፡ ኤሬም፡ ያብሲተ፡ ፒሰካር፡</incipit>
                             <explicit xml:lang="gez">
                                 <hi rend="rubric">ወበስእለቶሙ፡ ለ፬ እንስሳ፡ ለ፳ወ፬ ካህናተ፡ ሰማይ፡ በጸሎታ፡ ወበስእለታ፡ ለእግ</hi>ዝእትነ፡
-                                <hi rend="rubric">ማርያም፡</hi> ወላዲተ፡ አምላክ፡ እመ፡ ብርሃን፡ ወእግዝእተ፡ ኵሉ፡ ፍጥረት፡ ይሰደዱ፡ ኵሎሙ፡ አጋንንት፡ ፀዋጋን፡ 
-                                ወኵሎሙ፡ 
+                                <hi rend="rubric">ማርያም፡</hi> ወላዲተ፡ አምላክ፡ እመ፡ ብርሃን፡ ወእግዝእተ፡ ኵሉ፡ ፍጥረት፡ ይሰደዱ፡ ኵሎሙ፡ አጋንንት፡ ፀዋጋን፡
+                                ወኵሎሙ፡
                                 ሠራዊተ፡ አጋንንት፡ እኩያን፡ ወሠራዊተ፡ መስቴማ፡ ጽልሙታን፡ ይሰደዱ፡ ወይርሐቁ፡ እምላዕለ፡ ነፍሳ፡ ወሥጋሃ፡ ለአመትከ፡
                                 <persName ref="PRS13863WalattaE" role="owner">ወለተ፡ እግዚእ፡</persName></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i13">
                             <locus from="1rb226" to="1rb"/>
                             <!--lines cannot be counted from here-->
@@ -233,23 +233,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             አርዳኢሁ፡</incipit>
                             <!--part of the text not photographed, must be checked whether this is only one prayer-->
                             <explicit xml:lang="gez">
-                                ሰሜነ፡ ወደቡበ፡ ከመ፡ ትፃእ፡ ወትሰሰል፡ ዛቲ፡ ሕማመ፡ ዓይነት፡ እምላዕለ፡ አመትከ፡ 
+                                ሰሜነ፡ ወደቡበ፡ ከመ፡ ትፃእ፡ ወትሰሰል፡ ዛቲ፡ ሕማመ፡ ዓይነት፡ እምላዕለ፡ አመትከ፡
                                 <persName ref="PRS13863WalattaE" role="owner"> ወለተ፡ <hi rend="rubric">እግዚእ፡</hi></persName></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i14">
                             <locus from="1rb" to="1rb"/>
                             <title ref="LIT6787PPAyn" type="complete"/>
                             <textLang mainLang="gez"/>
                             <note>The following is the entire text.</note>
                             <incipit xml:lang="gez">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩
-                                አምላክ፡ ጸሎት፡ በእንተ፡ ሕማመ፡ ዓይን፡ ወፍልፀተ፡ <sic>ርእሰ፡</sic> ክርስቶስ፡ ብርሃን፡ ወምእመን፡ ዝበምራቅከ፡ ከሠትከ፡ አዕይንተ፡ እውራን፡ ወበቃልከ፡ ይትፌውሱ፡ ድውያን፡ ዛቲ፡ 
-                            <hi rend="rubric">ነፍስ፡ ሕምምት፡ ወጥውቂት፡ ትርክብ፡ ፈውሶ፡ ዘይቀጠቀጥ፡ ርእሰ፡ ወየለ፡ ወ</hi>ይሰቀሰቀ፡ አዕይንተ፡ ወይሐቂ፡ አስናን፡ ወይጐጸጉጽ፡ 
-                            ገበዋተ፡ ወይፈነቅል፡ ቍልፊተ፡ ወይቈርፅ፡ አማዑተ፡ ወያደቅቅ፡ አእፅምተ፡ በስመ፡ እግዚአብሔር፡ ሕያው፡ ዘጸሐፈ፡ ኤርምያስ፡ ነቢይ፡ ዲበ፡ ኰኵሕ፡ ኀበ፡ ታቦት፡ ማይ፡ 
+                                አምላክ፡ ጸሎት፡ በእንተ፡ ሕማመ፡ ዓይን፡ ወፍልፀተ፡ <sic>ርእሰ፡</sic> ክርስቶስ፡ ብርሃን፡ ወምእመን፡ ዝበምራቅከ፡ ከሠትከ፡ አዕይንተ፡ እውራን፡ ወበቃልከ፡ ይትፌውሱ፡ ድውያን፡ ዛቲ፡
+                            <hi rend="rubric">ነፍስ፡ ሕምምት፡ ወጥውቂት፡ ትርክብ፡ ፈውሶ፡ ዘይቀጠቀጥ፡ ርእሰ፡ ወየለ፡ ወ</hi>ይሰቀሰቀ፡ አዕይንተ፡ ወይሐቂ፡ አስናን፡ ወይጐጸጉጽ፡
+                            ገበዋተ፡ ወይፈነቅል፡ ቍልፊተ፡ ወይቈርፅ፡ አማዑተ፡ ወያደቅቅ፡ አእፅምተ፡ በስመ፡ እግዚአብሔር፡ ሕያው፡ ዘጸሐፈ፡ ኤርምያስ፡ ነቢይ፡ ዲበ፡ ኰኵሕ፡ ኀበ፡ ታቦት፡ ማይ፡
                             እንተ፡ ተከድነት፡ በደመና፡ ሰማይ፡ በይእቲ፡ ስም፡ ይሕልፍ፡ ወይሰስል፡ ዝንቱ፡ ሕማመ፡ ዓይነት፡ እምላዕ<gap reason="illegible"/>
                                 <hi rend="rubric">አመትከ፡ <persName ref="PRS13863WalattaE" role="owner">ወለተ፡ እግዚእ፡</persName></hi></incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i15">
                             <locus from="1rb" to="1rb"/>
                             <title ref="LIT6788PPDrowning" type="complete"/>
@@ -261,27 +261,27 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 ይሠዓር፡ ሥራይክሙ፡ ወይልሣሕ፡ ሕምዝክሙ። ወይድክም፡ ኃይልክሙ፡ ወይስበር፡ ርእሰክሙ፡ ወይትቀጥቀጥ፡ አዕፅምቲክሙ፡ በዝ፡ ጠልሰም፡ ወበዝ፡ አስማት፡ ኩኑ፡
                                 ርኡዳነ፡ ወድንጉፃነ፡ ኢትቀረቡ፡ ኀበ፡ ነፍሳ፡ ወሥጋሃ፡ ለአመትከ፡ <persName ref="PRS13863WalattaE" role="owner">ወለተ፡ እግዚእ፡</persName></explicit>
                         </msItem>
-                      
+
                         <msItem xml:id="ms_i16">
                             <locus from="1rb" to="1rb"/>
                             <title ref="LIT6789HymnRaguel" type="complete"/>
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez">ሰላም፡ ለከ፡ ራጉኤል፡ ሊቀ፡ ሊቃናት፡ <hi rend="rubric" rendition="#partialRubric">፯</hi>ቱ፡ በገጸ፡ አምላክ፡ ትቀውም፡ ለለዕለቱ፡ ሰዓል፡ ለለሰዓቱ፡
-                            ሰላም፡ ለከ፡ መልአከ፡ ቅዳሴ፡ <hi rend="rubric">ራጉኤል፡ ዘውገ፡ ቅዳስያን፡ እንስሳ፡ ሰዓል፡ ሊተ፡ ሰሬቀ፡ አበሲ፡ ኀበ፡ ወልድ፡ ለምሕረት፡ 
+                            ሰላም፡ ለከ፡ መልአከ፡ ቅዳሴ፡ <hi rend="rubric">ራጉኤል፡ ዘውገ፡ ቅዳስያን፡ እንስሳ፡ ሰዓል፡ ሊተ፡ ሰሬቀ፡ አበሲ፡ ኀበ፡ ወልድ፡ ለምሕረት፡
                             ዘሰብሳ።</hi></incipit>
                             <explicit xml:lang="gez">
-                                ሰላም፡ ለከ፡ ምክንያተ፡ ጽሂን፡ ራጉኤል፡ አምጣነ፡ ተሐሥ<hi rend="rubric">ሥ፡ አንተ፡ ከመ፡ አምላክከ፡ በሥጋ፡ ዘሞተ፡ ተወኪሊከ፡ 
+                                ሰላም፡ ለከ፡ ምክንያተ፡ ጽሂን፡ ራጉኤል፡ አምጣነ፡ ተሐሥ<hi rend="rubric">ሥ፡ አንተ፡ ከመ፡ አምላክከ፡ በሥጋ፡ ዘሞተ፡ ተወኪሊከ፡
                                     ማኅሌ</hi><surplus>ሌ</surplus>ትየ፡ ዘንተ፡ ጸግወኒ፡ ሠናየ፡ ዕሤተ፡ ሰላም፡ ለከ፡
                                 ዘኃይስተ፡ ሰማይ፡ ልዑል፡ ራጉኤል፡ ሊቅ፡  መልአከ፡ ኃይል፡ እስመ፡ አንተ፡ መልአከ፡ ሣህል፡ ሰላም፡ ለከ፡ እግዚኦ፡ አድኅና፡ እምሕማመ፡ ዓይነ፡  ወርቅ፡
                                 ለአመትከ፡  <persName ref="PRS13863WalattaE" role="owner">ወለተ፡ እግዚእ፡</persName>
                             </explicit>
-                            <explicit type="supplication" xml:lang="gez">ወገፁ፡ ዘፍጹም፡ በጽልመት፡ ፈርሃ፡ ወደንገፀ፡ ዲያብሎስ፡ ርእዮ፡ ብሁተ፡ ልደት፡ በሥጋ፡ አምላክ፡ 
+                            <explicit type="supplication" xml:lang="gez">ወገፁ፡ ዘፍጹም፡ በጽልመት፡ ፈርሃ፡ ወደንገፀ፡ ዲያብሎስ፡ ርእዮ፡ ብሁተ፡ ልደት፡ በሥጋ፡ አምላክ፡
                             በሲኦል፡ ወሪዶ፡ ዘበመስቀልከ፡ አጽራዕከ፡ ግብሮ፡ ለዲያብሎስ፡ ከማሁ፡ አጽርዕ፡ ሕማመ፡ ዓይነ፡ ባርያ፡ ወፍልፀተ፡ ርእስ፡ ለአመትከ፡
                                 <persName ref="PRS13863WalattaE" role="owner">ወለተ፡ <hi rend="rubric">እግዚእ።</hi></persName>
                             </explicit>
                         </msItem>
                     </msContents>
-                    
+
                     <physDesc>
                         <objectDesc form="Scroll">
                             <supportDesc>
@@ -308,7 +308,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </dimensions>
                                     <measure unit="g" type="weight">66</measure>
                                 </extent>
-                                <condition key="good">There are a few holes, particularly along the right side of the scroll, possibly caused by insects.
+                                <condition key="good">There are a few losses, particularly along the right side of the scroll, possibly caused by insects.
                                 In a few places, the ink is smudged.</condition>
                             </supportDesc>
                             <layoutDesc>
@@ -347,7 +347,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </layout>
                             </layoutDesc>
                         </objectDesc>
-                        
+
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <date notBefore="1800" notAfter="2006"/>
@@ -355,11 +355,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                Depending on nib, the script alternates between more cursive and bulky shapes.
                            </desc>
                                 <seg type="ink">Black, red.</seg>
-                                <seg type="rubrication">The first three lines of each panel regardless of the beginning of textual units; holy names; 
+                                <seg type="rubrication">The first three lines of each panel regardless of the beginning of textual units; holy names;
                                 elements of numerals.</seg> <!--is panel the best word? section?-->
                             </handNote>
                         </handDesc>
-                        
+
               <!--          <decoDesc>
                             <decoNote xml:id="d1" type="miniature" corresp="#pic1">
                                 <desc></desc>
@@ -368,7 +368,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <width>101</width>
                                 </dimensions>
                             </decoNote>
-                            
+
                             <decoNote xml:id="d2" type="miniature" corresp="#pic2">
                                 <desc></desc>
                                 <dimensions unit="mm">
@@ -377,7 +377,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </dimensions>
                                 one or two miniatures? Now two for ease of encoding below
                             </decoNote>
-                            
+
                                 <decoNote xml:id="d3" type="miniature" corresp="#pic3">
                                 <desc></desc>
                                 <dimensions unit="mm">
@@ -386,7 +386,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </dimensions>
                                 one or two miniatures? Now two for ease of encoding below
                             </decoNote>
-                            
+
                             <decoNote xml:id="d4" type="miniature" corresp="#pic4">
                                 <desc></desc>
                                 <dimensions unit="mm">
@@ -395,39 +395,39 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </dimensions>
                             </decoNote>
                         </decoDesc>-->
-                        
+
                         <additions>
                             <list>
                                 <item xml:id="e1">
                                     <desc>The name of the owner, mentioned in supplications throughout, was
                                         <persName ref="PRS13863WalattaE" role="owner"/>.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e2">
                                     <desc>The manuscript contains no scribal corrections.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e3">
                                     <desc>The verso is empty.</desc>
                                 </item>
                             </list>
                         </additions>
-                        
+
                         <bindingDesc>
                             <binding xml:id="binding">
                                 <decoNote xml:id="b1">The three parchment strips are slightly overlapping and sewn together with a running stitch using a narrow parchment strip each.</decoNote>
                                 <decoNote xml:id="b2">A textile strip is attached to a hole in the right corner of the lower edge of the scroll.</decoNote>
                             </binding>
                         </bindingDesc>
-                        
+
                     </physDesc>
-                    
+
                     <history>
                         <origin>
                             <origDate notBefore="1800" notAfter="2006" evidence="lettering"/>
                         </origin>
                     </history>
-                    
+
                     <additional>
                         <adminInfo>
                             <recordHist>
@@ -439,7 +439,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </recordHist>
                         </adminInfo>
                     </additional>
-                    
+
                 </msDesc>
             </sourceDesc>
         </fileDesc>
@@ -485,12 +485,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <body>
                 <div type="edition">
                     <div type="textpart" subtype="recto">
-                       
-                        
+
+
                         <div type="textpart" subtype="section" n="1" xml:id="sec1">
                             <div type="textpart" subtype="picture" n="1" xml:id="pic1" corresp="#d1"/>
                         </div>
-                        
+
                         <div type="textpart" subtype="section" n="2" xml:id="sec2">
                             <cb n="a"/>
                             <div type="textpart" subtype="text" n="1" corresp="#ms_i1" xml:id="text1">
@@ -507,7 +507,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     አጽራዕከ፡ ግብሮ፡ ለዲያብሎስ፡ ከመሁ፡
                                     አጽርዕ፡ ሕማመ፡ ባርያ፡ ወሌጌዎን፡ ቍራኛ፡ ወተያጅ፡ መጋኛ፡ ወእሥምት፡ ዓይነት፡ ወውግዓት፡ ቍርፀት፡ ወፍልፀት፡ መትዓት፡ ወጽፍዓት፡ ምች፡ ወተላዋሽ፡ ፌራ፡ ወንዳድ፡
                                     ግብጥ፡ ወዛር፡ መዋቂ፡ ወነቀኝቃኝ፡ ሾተላይ፡ ወትግርትያ፡ ወቍርጥማተ፡ እድ፡ ወእግር፡ ሓቌ፡ ወዘባን፡ ወኵሉ፡ አባለ፡ ሥጋ፡ ቡዳ፡ ወነሃብት፡ ሰብእ፡ ግብር፡ ወጠበብት፡
-                                    ቸንፍር፡ ወነገርጋር፡ ድድቀ፡ ወጋኔነ፡ ቀትር፡ ይሰድዱ፡ ወይርሐ<hi rend="rubric">ቁ፡ እምላዕለ፡ ነፍሳ፡ ወሥጋሀ፡ ለአመትከ፡ 
+                                    ቸንፍር፡ ወነገርጋር፡ ድድቀ፡ ወጋኔነ፡ ቀትር፡ ይሰድዱ፡ ወይርሐ<hi rend="rubric">ቁ፡ እምላዕለ፡ ነፍሳ፡ ወሥጋሀ፡ ለአመትከ፡
                                         <persName ref="PRS13863WalattaE" role="owner">ወለተ፡ እግዚእ።</persName></hi>
                                 </ab>
                             </div>
@@ -518,103 +518,103 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <ab/>
                             </div>
                         </div>
-                        
+
                         <div type="textpart" subtype="section" n="3" xml:id="sec3">
                             <div type="textpart" subtype="picture" n="2" xml:id="pic2" corresp="#d2"/>
                             <!--not sure whether these should be counted as one or two miniatures!! Two makes my encoding easier-->
                         </div>
-                        
+
                         <div type="textpart" subtype="section" n="4" xml:id="sec4">
                             <div type="textpart" subtype="text" n="5" corresp="#ms_i5" xml:id="text5part2">
                                 <ab/>
                             </div>
-                            
+
                             <div type="textpart" subtype="text" n="6" corresp="#ms_i6" xml:id="text6">
                                 <ab><milestone unit="parchmentStrip" n="3"/></ab>
                             </div>
-                            
+
                             <div type="textpart" subtype="text" n="7" corresp="#ms_i7" xml:id="text7">
                                 <ab>
                                     <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ጸሎት፡ በእንተ፡ ሕ</hi>ማመ፡
                                     ቍርፀት፡ በከ<gap reason="illegible" unit="chars" quantity="1"/>ኮዕ፡ ስምከ፡ በርያኖስ፡ ስምከ፡ በጸሔል፡ ስምከ፡ በአማኑኤል፡ ስምከ፡
                                     በክርስቶስ፡ ስምከ፡ በኅቡዕ፡ ስምከ፡ ወበክሱት፡ ስምከ፡ ተማኅፀንኩ፡ እልፍሉል፡ እልፍሉል፡ እልፍሉል፡ እልፍሉል፡ ጸሎተ፡ ሕማመ፡ ቍርፀት፡ ዘተፈነወ፡
-                                    እምኀበ፡ አብ፡ ወወልድ፡ መንፈስ፡ ቅዱስ፡ ከመ፡ ያርዳዕ፡ ወይቤዙ፡ ውሉደ፡ ሰብእ፡ ወእንስሳ፡ እንዘ፡ ይጐጸጕጽ፡ ገበዋተ፡ ወይራነቅል፡ 
+                                    እምኀበ፡ አብ፡ ወወልድ፡ መንፈስ፡ ቅዱስ፡ ከመ፡ ያርዳዕ፡ ወይቤዙ፡ ውሉደ፡ ሰብእ፡ ወእንስሳ፡ እንዘ፡ ይጐጸጕጽ፡ ገበዋተ፡ ወይራነቅል፡
                                     ቍልፈ<hi rend="rubric">ተ፡ ወይቈርፅ፡ ከማዑተ፡ ሸገር፡ ሸገር፡ ሸገር፡ ደር፡ ደር፡ ደር፡ በኃ</hi>ይለ፡ ዝንቱ፡ አስማቲከ፡ አድኅና፡ እምሕማመ፡
                                     ቍርፀት፡ ለአመትከ፡ <persName ref="PRS13863WalattaE" role="owner">ወለተ፡ <hi rend="rubric">እግዚእ፡</hi></persName>
                                 </ab>
                             </div>
-                            
+
                             <div type="textpart" subtype="text" n="8" corresp="#ms_i8" xml:id="text8">
                                 <ab>
                                     ጸሎት፡ በእንተ፡ ድንጋፄ፡ አጋንንት፡ ዘመዓልት፡ ወዘሌሊት፡ ባርከኒ፡ ክርስቶስ፡ አምላኪየ፡ ዕቀበኒ፡ ወአድኅነኒ፡ እምድንጋፄ፡
                                     አጋንንት፡ ወፍጹም፡ በጽልመት፡ ፈርሃ፡ ወደንገፀ፡ ዲያብሎስ፡ ርእዮ፡ ብሁተ፡ ልደት፡ በሥጋ፡ አምላክ፡ በሲኦል፡ እወግዞሙ፡ ለአጋንንት፡ እኩያን፡ በመለኮተ፡
-                                    አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ዘይወጽእ፡ እምአፉሁ፡ ሰይፈ፡ እሳት፡ በአብ፡ እትዌከል፡ ወበወልድ፡ እትኬስል፡ በዘቦቱ፡ ለሰሐ፡ ሕምዙ፡ 
+                                    አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ዘይወጽእ፡ እምአፉሁ፡ ሰይፈ፡ እሳት፡ በአብ፡ እትዌከል፡ ወበወልድ፡ እትኬስል፡ በዘቦቱ፡ ለሰሐ፡ ሕምዙ፡
                                     ለሞት፡ አድኅና፡ ለአመትከ፡ <persName ref="PRS13863WalattaE" role="owner">ወለተ፡ <hi rend="rubric">እግዚእ።</hi></persName>
                                 </ab>
                             </div>
                     </div>
-                        
+
                         <div type="textpart" subtype="section" n="5" xml:id="sec5">
                             <cb n="b"/>
                             <div type="textpart" subtype="text" n="9" corresp="#ms_i9" xml:id="text9">
                                 <ab/>
                             </div>
-                            
+
                             <div type="textpart" subtype="text" n="10" corresp="#ms_i10" xml:id="text10">
                                 <ab><milestone unit="parchmentStrip" n="2"/></ab>
                             </div>
-                            
+
                             <div type="textpart" subtype="text" n="11" corresp="#ms_i11" xml:id="text11">
                                 <ab/>
                             </div>
-                            
+
                             <div type="textpart" subtype="text" n="12" corresp="#ms_i12" xml:id="text12part1">
                                 <ab/>
                             </div>
                         </div>
-                        
+
                         <div type="textpart" subtype="section" n="6" xml:id="sec6">
                             <div type="textpart" subtype="picture" n="3" xml:id="pic3" corresp="#d3"/>
                             <!--not sure whether these should be counted as one or two miniatures!! Two makes my encoding easier-->
                         </div>
-                        
+
                         <div type="textpart" subtype="section" n="7" xml:id="sec7">
                             <div type="textpart" subtype="text" n="12" corresp="#ms_i12" xml:id="text12part2">
                                 <ab/>
                             </div>
-                            
+
                             <div type="textpart" subtype="text" n="13" corresp="#ms_i13" xml:id="text13">
                                 <ab/>
                             </div>
-                            
+
                             <div type="textpart" subtype="text" n="14" corresp="#ms_i14" xml:id="text14">
                                 <ab>
                                     በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩
-                                    አምላክ፡ ጸሎት፡ በእንተ፡ ሕማመ፡ ዓይን፡ ወፍልፀተ፡ <sic>ርእሰ፡</sic> ክርስቶስ፡ ብርሃን፡ ወምእመን፡ ዝበምራቅከ፡ ከሠትከ፡ አዕይንተ፡ እውራን፡ ወበቃልከ፡ ይትፌውሱ፡ ድውያን፡ ዛቲ፡ 
-                                    <hi rend="rubric">ነፍስ፡ ሕምምት፡ ወጥውቂት፡ ትርክብ፡ ፈውሶ፡ ዘይቀጠቀጥ፡ ርእሰ፡ ወየለ፡ ወ</hi>ይሰቀሰቀ፡ አዕይንተ፡ ወይሐቂ፡ አስናን፡ ወይጐጸጉጽ፡ 
-                                    ገበዋተ፡ ወይፈነቅል፡ ቍልፊተ፡ ወይቈርፅ፡ አማዑተ፡ ወያደቅቅ፡ አእፅምተ፡ በስመ፡ እግዚአብሔር፡ ሕያው፡ ዘጸሐፈ፡ ኤርምያስ፡ ነቢይ፡ ዲበ፡ ኰኵሕ፡ ኀበ፡ ታቦት፡ ማይ፡ 
+                                    አምላክ፡ ጸሎት፡ በእንተ፡ ሕማመ፡ ዓይን፡ ወፍልፀተ፡ <sic>ርእሰ፡</sic> ክርስቶስ፡ ብርሃን፡ ወምእመን፡ ዝበምራቅከ፡ ከሠትከ፡ አዕይንተ፡ እውራን፡ ወበቃልከ፡ ይትፌውሱ፡ ድውያን፡ ዛቲ፡
+                                    <hi rend="rubric">ነፍስ፡ ሕምምት፡ ወጥውቂት፡ ትርክብ፡ ፈውሶ፡ ዘይቀጠቀጥ፡ ርእሰ፡ ወየለ፡ ወ</hi>ይሰቀሰቀ፡ አዕይንተ፡ ወይሐቂ፡ አስናን፡ ወይጐጸጉጽ፡
+                                    ገበዋተ፡ ወይፈነቅል፡ ቍልፊተ፡ ወይቈርፅ፡ አማዑተ፡ ወያደቅቅ፡ አእፅምተ፡ በስመ፡ እግዚአብሔር፡ ሕያው፡ ዘጸሐፈ፡ ኤርምያስ፡ ነቢይ፡ ዲበ፡ ኰኵሕ፡ ኀበ፡ ታቦት፡ ማይ፡
                                     እንተ፡ ተከድነት፡ በደመና፡ ሰማይ፡ በይእቲ፡ ስም፡ ይሕልፍ፡ ወይሰስል፡ ዝንቱ፡ ሕማመ፡ ዓይነት፡ እምላዕ<gap reason="illegible"/>
                                     <milestone unit="parchmentStrip" n="3"/>
                                     <hi rend="rubric">አመትከ፡ <persName ref="PRS13863WalattaE" role="owner">ወለተ፡ እግዚእ፡</persName></hi></ab>
                             </div>
-                            
+
                             <div type="textpart" subtype="text" n="15" corresp="#ms_i15" xml:id="text15">
                                 <ab/>
                             </div>
-                            
+
                             <div type="textpart" subtype="text" n="16" corresp="#ms_i16" xml:id="text16">
                                 <ab/>
                             </div>
-                        
+
                     </div>
-                        
+
                         <div type="textpart" subtype="section" n="8" xml:id="sec8">
                             <div type="textpart" subtype="picture" n="4" xml:id="pic4" corresp="#d4"/>
                         </div>
                     </div>
-                    
+
                 </div>
-            
+
         </body>
     </text>
 </TEI>

--- a/OxfordBodleian/Juel-Jensen/BDLaethf28.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf28.xml
@@ -103,9 +103,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </collation>
                                 <condition key="good">
                                  The bookblock has been damaged by humidity, especially in the outer margins.
-                                 Hairs are still attached to <locus target="#49"/>.
+                                 <!--Hairs are still attached to <locus target="#49"/>.-->
                                  Insect droppings are present on <locus target="#31 #32"/>. The blunt edge used for ruling has perforated on <locus target="#22"/>.
-                                    Creases and losses are present, especially on the first and last folios.
+                                 Creases and losses are present, especially on the first and last folios.
                                  New boards replace the original ones and a new thread attaches the bookblock to the boards.
                                </condition>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethf29.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf29.xml
@@ -6,19 +6,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="BDLaethf29" xml:lang="en" type="mss">
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
-            <titleStmt> 
-                <!--  
+            <titleStmt>
+                <!--
                 <title xml:lang="gez" xml:id="title1">ሰይፈ፡ ሥላሴ፡, መልክአ፡ ሥላሴ፡, ሰቆቃወ፡ ድንግል፡, ነዓ፡ ኀቤየ፡ ኦእግዚእየ፡ ኢየሱስ፡ ክርስቶስ፡, መልክአ፡ ሥላሴ፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Sayfa Śǝllāse, Malkǝʾa Śǝllāse, Saqoqāwa dǝngǝl, Naʿā ḫabeya ʾo-ʾǝgziʾǝya ʾIyasus Krǝstos, Malkǝʾa Śǝllāse</title>
               -->
-                <title xml:lang="en" xml:id="title1">Sword of the Trinity (<hi rendition="simple:italic">Sayfa Śǝllāse</hi>), <hi rendition="simple:italic">Malkǝʾ</hi>-hymns 
+                <title xml:lang="en" xml:id="title1">Sword of the Trinity (<hi rendition="simple:italic">Sayfa Śǝllāse</hi>), <hi rendition="simple:italic">Malkǝʾ</hi>-hymns
                     to the Trinity, Lament on the Virgin (<hi rendition="simple:italic">Saqoqāwa dǝngǝl</hi>), ‘Come to me, o my Lord Jesus Christ’, Prayer to the Three Names</title>
                 <editor key="DR"/>
                 <editor key="JG"/>
                 <editor key="MV"/>
                 <editor key="SH"/>
                 <editor key="EDS"/>
-                <editor key="JK"/> 
+                <editor key="JK"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
             <publicationStmt>
@@ -373,7 +373,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                                 <collation>
                                     <signatures>
-                                        Undecorated quire marks are written in the upper inner margin of the first folio of most quires, with the exception of 
+                                        Undecorated quire marks are written in the upper inner margin of the first folio of most quires, with the exception of
                                         the first two and last three quires.
                                         The quire mark on <locus target="#72"/> (<foreign xml:lang="gez">፰</foreign>) was added later, still by the main hand.
                                     </signatures>
@@ -381,7 +381,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <item xml:id="q1" n="A">
                                             <dim unit="leaf">3</dim>
                                             <locus from="1r" to="3v"/>
-                                            3, stub before 3 
+                                            3, stub before 3
                                             <note>The quire currently consists of a loose bifolio and a loose folio preceded by a stub.</note>
                                         </item>
                                         <item xml:id="q2" n="1">
@@ -450,13 +450,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
 
-                                <condition key="good">Head and tailband are missing (tiedowns are
-                                    visible in the centrefolds of all quires). A rectangular piece
+                                <condition key="good">A rectangular piece
                                     of parchment has been cut out from <locus target="#121"/> at the
                                     bottom. All edges were re-trimmed.
                                     Occasionally smudged ink, e.g. on <locus target="#19r #69v #80v"/>.
                                     The sewing broke at the connection with the upper board.
                                     As a result, the <locus target="#1 #2 #3"/> are detached from the textblock.
+                                    Head and tailband are missing (tiedowns are
+                                        visible in the centrefolds of all quires). 
                                 </condition>
 
                             </supportDesc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethf30.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf30.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!--  
+                <!--
                 <title xml:lang="gez" xml:id="title1">ዳዊት፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Dāwit</title>
                 -->
@@ -144,8 +144,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
                                 <condition key="deficient">
-                                  The manuscript is in a poor state of preservation.
-                                    <locus target="#i"/> is much less broad than the other folios, but this might be its original state.
+                                  <locus target="#i"/> is much less broad than the other folios, but this might be its original state.
                                   The manuscript is damaged by humidity, in particular at the beginning
                                   and at the end. The lower margin is darkened by use. The ink is occasionally smudged, e.g. <locus target="#41v #104v"/>.
                                     The folios present stains of various origins, uneven deformations, tears, and losses,
@@ -1035,6 +1034,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <change who="SH" when="2020-04-22">Added editors</change>
             <change who="DR" when="2022-02-11">Continued description</change>
             <change who="EDS" when="2023-02-06">Updated conditions and binding description</change>
+            <change who="EDS" when="2024-03-10">Revision condition</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">

--- a/OxfordBodleian/Juel-Jensen/BDLaethf31.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf31.xml
@@ -213,8 +213,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     There are insect holes on the inner side of the upper board, the first and the last folios (<locus target="#1 #82"/>). Insect droppings are also present.
                                     A small loss, possibly a burn, is found on <locus target="#54"/>. The original sewing on four sewing stations is lost and the manuscript has been resewn by stitching each quire through the inner margin
                                     in correspondence of the uppermost and the lowermost sewing stations.
-                                    <!--The leather cover has been cut off, most probably to facilitate the resewing, and later applied again on the spine and part of the boards.-->
-                                    The parchment is crumpled on <locus target="#12"/> and torn on <locus target="#26"/>.
+                                    The parchment is cockled on <locus target="#12"/> and torn on <locus target="#26"/>.
 
                                 </condition>
                             </supportDesc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethf31.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf31.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!--  
+                <!--
                 <title xml:lang="gez" xml:id="title1">ብስራተ፡ ዮሐንስ፡, ተፈሥሒ፡ ማርያም፡ ለአዳም፡ ፋሲካሁ፡, መልክአ፡ ኤዶም፡, ኦፍጡነ፡ ረድኤት፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Bǝsrāta Yoḥannǝs, Tafaśśəḥi Māryām la-ʾAddām fāsikāhu, Malkǝʾa ʾEdom, ʾO-fəṭuna radʾet</title>
                 -->
@@ -207,15 +207,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
                                 <condition key="deficient">
-                                    The original sewing on four sewing stations is lost and the manuscript has been resewn by stitching each quire through the inner margin
-                                    in correspondence of the uppermost and the lowermost sewing stations.
-                                    <!--The leather cover has been cut off, most probably to facilitate the resewing, and later applied again on the spine and part of the boards.-->
-                                    Some folios have been damaged by humidity and water stains, especially towards the end of the manuscript. More generally, the conditions of the
+                                    The manuscript shows traces of intensive use.
+                                    Some folios have been damaged by humidity and present water stains, especially towards the end of the manuscript. More generally, the conditions of the
                                     manuscript and the readability of the text deteriorate towards the end. The ink is occasionaly smudged (e.g.<locus target="#36 #68 #77"/>).
                                     There are insect holes on the inner side of the upper board, the first and the last folios (<locus target="#1 #82"/>). Insect droppings are also present.
-                                    A small loss, possibly a burn, is found on <locus target="#54"/>.
+                                    A small loss, possibly a burn, is found on <locus target="#54"/>. The original sewing on four sewing stations is lost and the manuscript has been resewn by stitching each quire through the inner margin
+                                    in correspondence of the uppermost and the lowermost sewing stations.
+                                    <!--The leather cover has been cut off, most probably to facilitate the resewing, and later applied again on the spine and part of the boards.-->
                                     The parchment is crumpled on <locus target="#12"/> and torn on <locus target="#26"/>.
-                                    The manuscript shows traces of intensive use.
+
                                 </condition>
                             </supportDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethf32.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf32.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!-- 
+                <!--
                 <title xml:lang="gez" xml:id="title1">አኰቴተ፡ ቍርባን፡ ዘቅዱስ፡ ህርያቆስ፡ ዘሀገረ፡ ብህንሳ፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">ʾAkkʷateta qʷǝrbān za-qǝddus Hǝryāqos za-hagara Bǝhnǝsā</title>
                  -->
@@ -123,7 +123,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <dim unit="leaf">10</dim>
                                             <locus from="47r" to="56v"/>
                                             3, stub after 7
-                                            8, stub after 2                                            
+                                            8, stub after 2
                                         </item>
                                         <item xml:id="q7" n="6">
                                             <dim unit="leaf">10</dim>
@@ -140,9 +140,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </list>
                                 </collation>
                                 <condition key="good">
-                                    The entire manuscript is slightly damaged by humidity and dirt, especially at the upper and outer corners of the folios.
-                                    Stains <!-- of wax EDS: I am not sure it is wax -->are found on <locus target="#76v #77r"/>.
+                                    The entire manuscript is slightly damaged by humidity.  Dirt is present especially in the upper and outer corners of the folios.
+                                    Stains are found on <locus target="#76v #77r"/>.
                                     The readability of text deteriorates towards the end of the book: the text is barely legible due to faded ink (<locus target="#81r #81v"/>).
+                                    The sewing, despite having been repaired over time, is broken in many points.
                                 </condition>
                             </supportDesc>
 
@@ -301,8 +302,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <origin>
                             <origDate from="1700" to="1799" evidence="lettering"/>
                         </origin>
-                        <provenance>Unknown provenance. 
-                            The manuscript is listed in an auction catalogue dated to <date>9 July 1979</date>. It can be assumed that it was purchased 
+                        <provenance>Unknown provenance.
+                            The manuscript is listed in an auction catalogue dated to <date>9 July 1979</date>. It can be assumed that it was purchased
                             at that date by <persName ref="PRS5782JuelJen"/>.</provenance>
                         <!--catalogue page copy in ms BDLaethb3-->
                     </history>

--- a/OxfordBodleian/Juel-Jensen/BDLaethf33.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf33.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!--  
+                <!--
                 <title xml:lang="gez" xml:id="title1">መጽሐፈ፡ ግንዘት፡ መጽሐፈ፡ ክርስትና፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Maṣḥafa gǝnzat, Maṣḥafa krǝstǝnnā</title>
                 -->
@@ -44,31 +44,31 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                     <msContents>
                         <summary/>
-                        
+
                         <msItem xml:id="ms_i1">
                             <locus from="2ra" to="71vb"/>
                             <title type="complete" ref="LIT1931Mashaf"/>
                             <incipit xml:lang="gez">
                                 <locus target="#2ra"/>
-                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡</hi> ወ<gap reason="illegible" unit="chars" quantity="1"/>ንፈስ፡ ቅዱስ፡ 
-                                <hi rend="rubric"><gap reason="illegible" unit="chars" quantity="2"/>ዱ፡ አምላክ።</hi> አ<gap reason="illegible" unit="chars" quantity="1"/>እስተ፡ 
-                                ምንባብ፡ ዘያትነበብ፡ ላዕለ፡ ምዉታን፡ በሰላመ፡ እግዚአብሔር፡ አሜን። መጽሐፈ፡ ግንዘት፡ በእንተ፡ እለ፡ ኖሙ። ወሶበ፡ ትወጽእ፡ መንፈሱ፡ በኀበ፡ ማኅደሩ፡ 
+                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡</hi> ወ<gap reason="illegible" unit="chars" quantity="1"/>ንፈስ፡ ቅዱስ፡
+                                <hi rend="rubric"><gap reason="illegible" unit="chars" quantity="2"/>ዱ፡ አምላክ።</hi> አ<gap reason="illegible" unit="chars" quantity="1"/>እስተ፡
+                                ምንባብ፡ ዘያትነበብ፡ ላዕለ፡ ምዉታን፡ በሰላመ፡ እግዚአብሔር፡ አሜን። መጽሐፈ፡ ግንዘት፡ በእንተ፡ እለ፡ ኖሙ። ወሶበ፡ ትወጽእ፡ መንፈሱ፡ በኀበ፡ ማኅደሩ፡
                                 ወይትበሀል፡ ጸሎተ፡ አኰቴት፡ ወጸሎተ፡ ዕጣን።
                             </incipit>
-                            
+
                             <msItem xml:id="ms_i1.1">
                                 <locus from="3rb" to="18va"/>
                                 <title>Biblical readings and supplications</title>
                                 <incipit xml:lang="gez">
                                     <locus from="3rb" to="3va"/>
-                                    <hi rend="rubric">ወእምዝ፡ ትብል፡ አሌፍ፡ እስከ፡ ላማድ፡ ወፈጺመከ፡</hi> ትብል፡ ሶበ፡ ታወፅእ፡ ግኑዝ፡ እማኅደሩል ሜሞ፡ እስከ፡ ሳምኬት፡ ወተአርፍ፡ 
-                                    በፍ<pb n="3v"/><cb n="a"/>ኖት፡ ፩ ምዕራፍ፡ ወትብል፡ ቅድመ፡ ወንጌል፡ ዘ፶፬። ወመጽአኒ፡ ድንጋፄ፡ ሞት፡ ሃሌ፡ ሉያ፡ ፍርሃት፡ ወረዓድ፡ አኃዘኒ፡ 
+                                    <hi rend="rubric">ወእምዝ፡ ትብል፡ አሌፍ፡ እስከ፡ ላማድ፡ ወፈጺመከ፡</hi> ትብል፡ ሶበ፡ ታወፅእ፡ ግኑዝ፡ እማኅደሩል ሜሞ፡ እስከ፡ ሳምኬት፡ ወተአርፍ፡
+                                    በፍ<pb n="3v"/><cb n="a"/>ኖት፡ ፩ ምዕራፍ፡ ወትብል፡ ቅድመ፡ ወንጌል፡ ዘ፶፬። ወመጽአኒ፡ ድንጋፄ፡ ሞት፡ ሃሌ፡ ሉያ፡ ፍርሃት፡ ወረዓድ፡ አኃዘኒ፡
                                     ወደፈነኒ፡ ጽልመት።
                                 </incipit>
                                 <explicit xml:lang="gez">
                                     <locus target="#18va"/>
-                                    ዘያፈቅራ፡ ለነፍሱ፡ ለይግድፉ፡ በእንቲአየ፡ ይረክባ።  <hi rend="rubric">ጸሎተ፡</hi> ምናሴ፡ ወይእዜኒ፡ እግዚአ፡ አምላኮሙ፡ ለአበዊነ፡ ያስተርኢ፡ 
-                                    ኂሩትከ፡ በላዕሌየ፡ አምኮሙ፡ ለጻድቃን። <hi rend="rubric">ወእምድኅሬሁ፡</hi> ታነብብ፡ ድርሳነ፡ ካህናት፡ ለእመ፡ ኮነ፡ 
+                                    ዘያፈቅራ፡ ለነፍሱ፡ ለይግድፉ፡ በእንቲአየ፡ ይረክባ።  <hi rend="rubric">ጸሎተ፡</hi> ምናሴ፡ ወይእዜኒ፡ እግዚአ፡ አምላኮሙ፡ ለአበዊነ፡ ያስተርኢ፡
+                                    ኂሩትከ፡ በላዕሌየ፡ አምኮሙ፡ ለጻድቃን። <hi rend="rubric">ወእምድኅሬሁ፡</hi> ታነብብ፡ ድርሳነ፡ ካህናት፡ ለእመ፡ ኮነ፡
                                     <surplus>ኮነ፡</surplus> ቀሲስ፡ አው፡ ዲአቆን፡ ወትብል።
                                 </explicit>
                                 <note>
@@ -82,10 +82,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <ref cRef="betmas:LIT2709Matthew.22.23-32">Gospel of Matthew 22:23-32</ref> (<locus from="9vb" to="10va"/>),
                                     Prayer for the dead (<foreign xml:lang="gez">ጸሎት፡ በእንተ፡ እለ፡ ኖሙ፡</foreign>, <locus from="10va" to="11ra"/>),
                                     <ref cRef="betmas:LIT2713Luke.16.19-31">Gospel of Luke 16:19-31</ref> (<locus from="12ra" to="13va"/>),
-                                    then follow another prayer for the dead (<foreign xml:lang="gez">ጸሎት፡ በእንተ፡ እለ፡ ኖሙ፡</foreign>), supplications and exhortations (<locus from="13va" to="18va"/>). 
+                                    then follow another prayer for the dead (<foreign xml:lang="gez">ጸሎት፡ በእንተ፡ እለ፡ ኖሙ፡</foreign>), supplications and exhortations (<locus from="13va" to="18va"/>).
                                 </note>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.2">
                                 <locus from="18va" to="25vb"/>
                                 <title type="complete" ref="LIT1629Homily"/>
@@ -97,17 +97,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <incipit xml:lang="gez">
                                         <locus from="18vb" to="19ra"/>
                                     ስምዑ፡ ኦፍቁራንየ፡ ከመ፡ እግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ አምላከ፡ ምዉታን፡ ወሕያዋን፡ ውእቱ፡ ወኵሉ፡ ውስተ፡ እዴሁ፡ ንስእለከ፡ እግዚኦ፡ አምላክነ፡
-                                    ኢየሱስ፡ ክርስቶስ፡ ከመ፡ ትጸውዖሙ፡ ለአግብርቲከ፡ ካህናት፡ እሙስና፡ ውስተ፡ ዘኢ<pb n="19r"/><cb n="a"/>ይማስን፡ ወታወሥኦሙ፡ ወለዲያቆናት፡ እምነ፡ 
+                                    ኢየሱስ፡ ክርስቶስ፡ ከመ፡ ትጸውዖሙ፡ ለአግብርቲከ፡ ካህናት፡ እሙስና፡ ውስተ፡ ዘኢ<pb n="19r"/><cb n="a"/>ይማስን፡ ወታወሥኦሙ፡ ወለዲያቆናት፡ እምነ፡
                                         መቃብር፡ እስመ፡ ጸለሎሙ፡ ጽላሎተ፡ ሞት።
                                 </incipit>
                                 <explicit xml:lang="gez">
                                     <locus from="25va" to="25vb"/>
                                     አኰቴት፡ ወክብር፡ ለመንፈስ፡ ቅዱስ፡ ዘረሰዮሙ፡ ማኅደረ፡ ለመ<add place="inline">ለ</add>ኮተ፡ ዚአሁ፡ አሐዱ፡ አምላክ፡ ዕሪና፡ ሥላሴ፡ ሎቱ፡ <cb n="b"/>
-                                    ይደሉ፡ ክብር፡ ወስብሐት፡ ወኃይል፡ ወመንግሥት፡ ወሰጊድ፡ ለአብ፡ <add place="overstrike">ወወ</add>ልድ፡ ወመንፈስ፡ ቅዱስ፡ ኵሎ፡ ይእዜኒ፡ 
+                                    ይደሉ፡ ክብር፡ ወስብሐት፡ ወኃይል፡ ወመንግሥት፡ ወሰጊድ፡ ለአብ፡ <add place="overstrike">ወወ</add>ልድ፡ ወመንፈስ፡ ቅዱስ፡ ኵሎ፡ ይእዜኒ፡
                                     ወዘልፈኒ፡ ወለዓለመ፡ ዓለም፡ አሜን፡ ወአሜን። ለይኩን፡ ለይኩን።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.3">
                                 <locus from="25vb" to="34rb"/>
                                 <title type="complete" ref="LIT1931Mashaf#Exhortation"/>
@@ -118,18 +118,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </incipit>
                                 <incipit xml:lang="gez">
                                     <locus from="25vb" to="26ra"/>
-                                    ስብሐት፡ ለ<pb n="26r"/><cb n="a"/>እግዚአብሔር፡ ፈጣሪ፡ ወመንሥኢ፡ ኃያል፡ መሐሪ፡ ዘውእቱ፡ ዘውስተ፡ እዴሁ፡ ሥልጣነ፡ ሞት፡ ወሕይወት፡ 
-                                    ወትፍሥሕት፡ ወገሀናም። ዘይብል፡ ኀበ፡ ተጋብኡ፡ አው፡ በስምየ፡ እሄሉ፡ አነ፡ ውስተ፡ ማእከሎሙ፡ ወኵሎ፡ ዘሰአልክምዎ፡ በስምየ፡ በእንቲአሁ፡ 
-                                    እገብር፡ ለክሙ፡ 
+                                    ስብሐት፡ ለ<pb n="26r"/><cb n="a"/>እግዚአብሔር፡ ፈጣሪ፡ ወመንሥኢ፡ ኃያል፡ መሐሪ፡ ዘውእቱ፡ ዘውስተ፡ እዴሁ፡ ሥልጣነ፡ ሞት፡ ወሕይወት፡
+                                    ወትፍሥሕት፡ ወገሀናም። ዘይብል፡ ኀበ፡ ተጋብኡ፡ አው፡ በስምየ፡ እሄሉ፡ አነ፡ ውስተ፡ ማእከሎሙ፡ ወኵሎ፡ ዘሰአልክምዎ፡ በስምየ፡ በእንቲአሁ፡
+                                    እገብር፡ ለክሙ፡
                                 </incipit>
                                 <explicit xml:lang="gez">
                                     <locus from="34ra" to="34rb"/>
-                                    እምድኅሬሁ፡ በአስተብቍዖተ፡ እግዝእትነ፡ ድንግል፡ ንጽሕት፡ ወበረከታተ፡ <cb n="b"/> እለ፡ ምግባራት፡ ወሥምረታት፡ ወአስተብቍዖታተ፡ 
-                                    ለዘተወክፈት። ወአስተብቍዖቶሙ፡ እምሰማዕት፡ ወቅዱሳን፡ ወዘአሥመሮ፡ ወዘያሠምሮ፡ አሜን። ወስብሐት፡ ለእግዚአብሔር፡ ወላዕሌነ፡ ይኩን፡ 
+                                    እምድኅሬሁ፡ በአስተብቍዖተ፡ እግዝእትነ፡ ድንግል፡ ንጽሕት፡ ወበረከታተ፡ <cb n="b"/> እለ፡ ምግባራት፡ ወሥምረታት፡ ወአስተብቍዖታተ፡
+                                    ለዘተወክፈት። ወአስተብቍዖቶሙ፡ እምሰማዕት፡ ወቅዱሳን፡ ወዘአሥመሮ፡ ወዘያሠምሮ፡ አሜን። ወስብሐት፡ ለእግዚአብሔር፡ ወላዕሌነ፡ ይኩን፡
                                     ምሕረቱ፡ እስከ፡ ለዓለመ፡ ዓለም፡ አሜን።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.4">
                                 <locus from="34va" to="38va"/>
                                 <title type="complete" ref="LIT1931Mashaf#Order"/>
@@ -139,57 +139,57 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </incipit>
                                 <incipit xml:lang="gez">
                                     <locus from="34va" to="34vb"/>
-                                     ስብሐት፡ ለእግዚአብሔር፡ ስፉሐ፡ ሀብት፡ ውዱስ፡ አምላክ፡ በእንተ፡ ጸጋቲሁ፡ ዘአስማቲሁ። ስን፡ ዘአዘዘ፡ ወፈትሐ፡ ወፈጠረ፡ ወአስተዳለወ፡ 
-                                     ወሥሉሠ፡ በህላዌሁ፡ ማኅየዊት፡ ብሑት፡ ርእሱ፡ ባሕራዊት፡ ዘአጸገወ፡ ኵሎ፡ ዓለመ፡ በእንተ፡ አምልኮቱ፡ ወአገበሮሙ፡ <cb n="b"/> 
+                                     ስብሐት፡ ለእግዚአብሔር፡ ስፉሐ፡ ሀብት፡ ውዱስ፡ አምላክ፡ በእንተ፡ ጸጋቲሁ፡ ዘአስማቲሁ። ስን፡ ዘአዘዘ፡ ወፈትሐ፡ ወፈጠረ፡ ወአስተዳለወ፡
+                                     ወሥሉሠ፡ በህላዌሁ፡ ማኅየዊት፡ ብሑት፡ ርእሱ፡ ባሕራዊት፡ ዘአጸገወ፡ ኵሎ፡ ዓለመ፡ በእንተ፡ አምልኮቱ፡ ወአገበሮሙ፡ <cb n="b"/>
                                     በእንተ፡ ስብሐቱ፡ ወረሰዮሙ፡ ታቦተ፡ መንፈሳዊት፡
                                 </incipit>
                                 <explicit xml:lang="gez">
                                     <locus from="38rb" to="38va"/>
-                                    ይፈትዉ፡ ለተመይጦትከ፡ ወአኃዊከ፡ ወአግብርቲከ፡ ይጸንሕ፡ በጽሕትከ። ኮኑ፡ ኵሎሙ፡ እምድኅሬከ፡ እጓለ፡ ማውታ፡ ወረቦሙ፡ ሕማመ፡ 
-                                    ወምንዳቤ<supplied reason="omitted">፡</supplied> <pb n="38v"/><cb n="a"/> ወኀሳር፡ አይቴ፡ ስንከ፡ መዓድም፡ ወልብከ፡ ብሩህ፡ ወራእይከ፡ 
+                                    ይፈትዉ፡ ለተመይጦትከ፡ ወአኃዊከ፡ ወአግብርቲከ፡ ይጸንሕ፡ በጽሕትከ። ኮኑ፡ ኵሎሙ፡ እምድኅሬከ፡ እጓለ፡ ማውታ፡ ወረቦሙ፡ ሕማመ፡
+                                    ወምንዳቤ<supplied reason="omitted">፡</supplied> <pb n="38v"/><cb n="a"/> ወኀሳር፡ አይቴ፡ ስንከ፡ መዓድም፡ ወልብከ፡ ብሩህ፡ ወራእይከ፡
                                     መፍርህ።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.5">
                                 <locus from="43ra" to="47ra"/>
                                 <title type="complete" ref="LIT1644Homily"/>
                                 <incipit xml:lang="gez" type="inscription">
                                     <locus target="#43ra"/>
-                                    <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡</hi> ወመንፈስ፡ ቅዱስ፡ ፩፡ <hi rend="rubric">አምላክ፡ ድርሳን፡ ዘአ</hi>ባ፡ ሰላማ፡ ጳጳስ፡ 
+                                    <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡</hi> ወመንፈስ፡ ቅዱስ፡ ፩፡ <hi rend="rubric">አምላክ፡ ድርሳን፡ ዘአ</hi>ባ፡ ሰላማ፡ ጳጳስ፡
                                     ዘኢት<add place="interlinear">ዮ</add>ጵያ፡ ሀገር፡ ዘይትነበብ፡ ላዕለ፡ ሙታን፡ እምድኅረ፡ ጸሎት፡ ላዕሌሆሙ፡
                                 </incipit>
                                 <incipit xml:lang="gez">
                                     <locus from="43ra" to="43rb"/>
                                     ስብሐት፡ ለእግዚአብሔር፡ ዘለዓለም፡ እምቅድመ፡ ዓለም፡ ወአዝማን፡ ዘየአምር፡ ኵሎ፡ ወኢያገምሮ፡ መካን። ዓቢየ፡ ምልክና፡ ወብሑተ፡
-                                    ህሉና፡ ፈጣሬ፡ ሰማይ፡ ወምድር፡ ዘእንበለ፡ ጻማ፡ <cb n="b"/> ዘየአምር፡ ኑኃ፡ ወግድማ፡ እምኀበ፡ መላእክት፡ ስቡሕ፡ ዘይሰግዱ፡ ሎቱ፡ 
+                                    ህሉና፡ ፈጣሬ፡ ሰማይ፡ ወምድር፡ ዘእንበለ፡ ጻማ፡ <cb n="b"/> ዘየአምር፡ ኑኃ፡ ወግድማ፡ እምኀበ፡ መላእክት፡ ስቡሕ፡ ዘይሰግዱ፡ ሎቱ፡
                                     መላእክት፡ ሱራፌል፡ ወኪሩቤል፡
                                 </incipit>
                                 <explicit xml:lang="gez">
                                     <locus from="46vb" to="47ra"/>
-                                     ወያስምዐነ፡ ለኵልነ፡ ቃለ፡ ዘምሉእ፡ ፍሥሐ፡ ዘይብል፡ ንዑ፡ ኀቤየ፡ ቡሩካኑ፡ ለአቡየ፡ ትረሱ፡ መንግሥተ፡ ሰ<pb n="47r"/><cb n="a"/>ማያት፡ 
-                                    ዘድልው፡ ለክሙ፡ እምቅድመ፡ ይትፈጠር፡ ዓለም፡ ወንበል፡ እግዚኦ፡ መሐሪነ፡ ወይበል፡ ሕዝብ፡ እግዚኦ፡ መሐረነ፡ ወእምድኅሬሁ፡ ይሁብ፡ ካህን፡ 
+                                     ወያስምዐነ፡ ለኵልነ፡ ቃለ፡ ዘምሉእ፡ ፍሥሐ፡ ዘይብል፡ ንዑ፡ ኀቤየ፡ ቡሩካኑ፡ ለአቡየ፡ ትረሱ፡ መንግሥተ፡ ሰ<pb n="47r"/><cb n="a"/>ማያት፡
+                                    ዘድልው፡ ለክሙ፡ እምቅድመ፡ ይትፈጠር፡ ዓለም፡ ወንበል፡ እግዚኦ፡ መሐሪነ፡ ወይበል፡ ሕዝብ፡ እግዚኦ፡ መሐረነ፡ ወእምድኅሬሁ፡ ይሁብ፡ ካህን፡
                                     ቡራኬ።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.6">
                                 <locus from="47ra" to="48vb"/>
                                 <title>This section begins with a free quotation from <ref cRef="betmas:LIT1320Eccles.12.6">Ecclesiastes 12:6-7</ref> and follows with other unidentified quotations</title>
                                 <incipit xml:lang="gez">
                                     <locus from="47ra" to="47rb"/>
-                                    <hi rend="rubric">በከመ፡ ይቤ፡ ሰሎሞን፡ </hi> ተቀጥቀጠ፡ መሶብ<hi rend="rubric">ከ፡ ውስተ፡ ዐዘቅት፡</hi> ወተወለጠ፡ ኅብሩ፡ ለብሩር፡ 
+                                    <hi rend="rubric">በከመ፡ ይቤ፡ ሰሎሞን፡ </hi> ተቀጥቀጠ፡ መሶብ<hi rend="rubric">ከ፡ ውስተ፡ ዐዘቅት፡</hi> ወተወለጠ፡ ኅብሩ፡ ለብሩር፡
                                     ወተገፍዓ፡ ርእየቱ፡ ለወርቅ፡ ወ<cb n="b"/>ተጸርዓ፡ ማኅሌተ፡ አዋልድ፡ ወኦደ፡ ጹጐ፡ እለ፡ የሐብሉ። ወተጸርዓ፡ እለ፡ የሐርፃ፡ መሬተ፡ ወገብአ፡
                                     ወስተ፡ መሬት፡
                                 </incipit>
                                 <explicit xml:lang="gez">
                                     <locus from="48va" to="48vb"/>
-                                    ከመ፡ ትፍድዮሙ፡ ለኵሉ፡ ፍጥረት፡ በከመ፡ ምግባሮሙ፡ ወአስተርእዮተ፡ መሲሕከ፡ እግዚእነ፡ ወአምላከነ፡ ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡ ዘቦቱ፡ 
+                                    ከመ፡ ትፍድዮሙ፡ ለኵሉ፡ ፍጥረት፡ በከመ፡ ምግባሮሙ፡ ወአስተርእዮተ፡ መሲሕከ፡ እግዚእነ፡ ወአምላከነ፡ ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡ ዘቦቱ፡
                                     ለከ፡ ምስሌሁ፡ ወምስለ፡ መንፈስ፡ ቅዱስ፡ ስብሐት፡ ወእኂዝ፡ ይእዜኒ፡ ወዘልፈኒ፡ ወ<cb n="b"/>ለዓለመ፡ ዓለም፡ አሜን።
                                 </explicit>
                                 <note></note>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.7">
                                 <locus from="48vb" to="52va"/>
                                 <title type="complete" ref="LIT1931Mashaf#Penance3"/>
@@ -199,17 +199,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </incipit>
                                 <incipit xml:lang="gez">
                                     <locus target="#48vb"/>
-                                    እግዚእ፡ እግዚአብሔር፡ አኃዜ፡ ዓለም፡ ብሑተ፡ ሥልጣን፡ ወስም፡ ቀዳማዊ፡ ዘእንበለ፡ ጥንት፡ ወዳኅራዊ፡ ዘእንበለ፡ ፍጽም፡ 
+                                    እግዚእ፡ እግዚአብሔር፡ አኃዜ፡ ዓለም፡ ብሑተ፡ ሥልጣን፡ ወስም፡ ቀዳማዊ፡ ዘእንበለ፡ ጥንት፡ ወዳኅራዊ፡ ዘእንበለ፡ ፍጽም፡
                                     ዘት<supplied reason="omitted">ነ</supplied>ብር፡ ውስተ፡ አርያም፡ መንበረ፡ ስብሐቲከ፡ ዘኢይተረጐም፡ ዘልብሰትከ፡ አፍሐም፡
                                 </incipit>
                                 <explicit xml:lang="gez">
                                     <locus target="#52va"/>
-                                    ወአናሕሲ፡ እስመ፡ ሰብእ፡ ዘእንበለ፡ ኃጢአት፡ አልቦ፡ ዘሞተ፡ ዘእንበለ፡ አንተ፡ ባሕቲትከ፡ ልዑል፡ እምሰማያት፡ ወንጹሕ፡ 
+                                    ወአናሕሲ፡ እስመ፡ ሰብእ፡ ዘእንበለ፡ ኃጢአት፡ አልቦ፡ ዘሞተ፡ ዘእንበለ፡ አንተ፡ ባሕቲትከ፡ ልዑል፡ እምሰማያት፡ ወንጹሕ፡
                                     እምኃጢአት፡ ወለከ፡ ይደሉ፡ ስብሐት፡ ወከብር፡ ኦሥሉስ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ እስከ፡ ነፍስ፡ ደኃሪት፡ ወላዕሌነ፡
                                     ይኩን፡ ሣህል፡ ወምሕረት፡ ይእዜኒ፡ ወዘልፈኒ፡ ወለዓለመ፡ ዓለም፡ አሜን።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.8">
                                 <locus from="52vb" to="54rb"/>
                                 <title type="complete" ref="LIT1931Mashaf#Penance2"/>
@@ -219,17 +219,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </incipit>
                                 <incipit xml:lang="gez">
                                     <locus target="#52vb"/>
-                                 እግዚአ፡ አኃዜ፡ ኵሉ፡ ዓለም፡ አንተ፡ ውእቱ፡ ዘትፌውስ፡ ቍስለ፡ ነፍስነ፡ ወሥጋነ፡ ወመንፈስነ፡ እስመ፡ አንተ፡ ውእቱ፡ ዘትቤ፡ በአፈ፡ 
+                                 እግዚአ፡ አኃዜ፡ ኵሉ፡ ዓለም፡ አንተ፡ ውእቱ፡ ዘትፌውስ፡ ቍስለ፡ ነፍስነ፡ ወሥጋነ፡ ወመንፈስነ፡ እስመ፡ አንተ፡ ውእቱ፡ ዘትቤ፡ በአፈ፡
                                  ወልድከ፡ ዋሕድ፡ እግዚእነ፡ ወአምላክነ፡ ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡ ዘይቤሎ፡ ለአቡነ፡ ጴጥሮስ፡ አንተ፡ ኰኵሕ፡ ወዲበ፡ <add place="interlinear">ዛቲ፡</add>
                                  ኵኵሕ፡ አሐንጻ፡ ለቤተ፡ ክርስቲያን፡
                                 </incipit>
                                 <explicit xml:lang="gez">
                                     <locus target="#54rb"/>
-                                    ሀበነ፡ ንግበር፡ ሥምረትከ፡ በኵሉ፡ ጊዜ፡ ወጸሐፍ፡ አስማቲነ፡ በመንግሥተ፡ ሰማያት፡ ምስለ፡ ኵሎሙ፡ ቅዱሳን፡ ወሰማዕት፡ በኢየሱስ፡ 
+                                    ሀበነ፡ ንግበር፡ ሥምረትከ፡ በኵሉ፡ ጊዜ፡ ወጸሐፍ፡ አስማቲነ፡ በመንግሥተ፡ ሰማያት፡ ምስለ፡ ኵሎሙ፡ ቅዱሳን፡ ወሰማዕት፡ በኢየሱስ፡
                                     ክርስቶስ፡ እግዚእነ፡ ዘቦቱ፡ ለከ፡ ምስሌሁ፡ ወምስለ፡ ቅዱስ፡ መንፈስ፡ ስብሐት፡ ወእኂዝ፡ ይእዜኒ፡ ወዘልፈኒ፡ ወለዓለመ፡ ዓለም፡ አሜን።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.9">
                                 <locus from="54va" to="57va"/>
                                 <title type="complete" ref="LIT1931Mashaf#Tazkar"/>
@@ -239,39 +239,39 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </incipit>
                                 <incipit xml:lang="gez">
                                     <locus target="#54va"/>
-                                    በዕጣን፡ ወ<hi rend="rubric">በቍርባን፡ እስመ፡ ይ</hi>በቍዖሙ፡ ወይከውን፡ ዕረፍተ፡ ለነፍሳቲሆሙ። በከመ፡ ትቤሎ፡ እግዝእትነ፡ 
-                                    <hi rend="rubric">ማርያም፡</hi> ለብፁዕ፡ ጴጥሮስ፡ ሊቀ፡ ሐዋርያት፡ ወሶበ፡ ተስእለቶ። እንዘ፡ ይብላ፡ መሥዋዕተ፡ ወቍርባን፡ ዘይትገበር፡ 
+                                    በዕጣን፡ ወ<hi rend="rubric">በቍርባን፡ እስመ፡ ይ</hi>በቍዖሙ፡ ወይከውን፡ ዕረፍተ፡ ለነፍሳቲሆሙ። በከመ፡ ትቤሎ፡ እግዝእትነ፡
+                                    <hi rend="rubric">ማርያም፡</hi> ለብፁዕ፡ ጴጥሮስ፡ ሊቀ፡ ሐዋርያት፡ ወሶበ፡ ተስእለቶ። እንዘ፡ ይብላ፡ መሥዋዕተ፡ ወቍርባን፡ ዘይትገበር፡
                                     በቤተ፡ ክርስቲያን፡ ምንተ፡ ይበቍዖሙ፡ ለሙታን፡ ወአውሥአት፡ ወትቤሎ፡ እምጼና፡ ገነት።
                                 </incipit>
                                 <explicit xml:lang="gez">
                                     <locus from="57rb" to="57va"/>
-                                     ሐየውነ፡ ላዕለ፡ ምድር፡ ከመ፡ ማቱሳላ፡ ዘሐይወ፡ ዘ፻ወ፰፡ ዓመት፡ አው፡ ከመ፡ ኖኃ፡ ዘሐየወ፡ ፺፡ ፻፡ ፶፡ ዓመት፡ አልብነ፡ ኀበ፡ ናመስጥ፡ 
+                                     ሐየውነ፡ ላዕለ፡ ምድር፡ ከመ፡ ማቱሳላ፡ ዘሐይወ፡ ዘ፻ወ፰፡ ዓመት፡ አው፡ ከመ፡ ኖኃ፡ ዘሐየወ፡ ፺፡ ፻፡ ፶፡ ዓመት፡ አልብነ፡ ኀበ፡ ናመስጥ፡
                                      እምኔሁ፡ ወንስአሎ፡ ለእግዚአብሔር፡ ኢየሱስ፡ ክርስቶስ፡ ያድኅብ፡ እምኃጢአት፡ ዘሎቱ፡ ስብሐት፡ ወዕበይ፡ ወአኰቴት፡ ምስለ፡ <pb n="57v"/><cb n="a"/>
                                     ኄር፡ አቡሁ፡ ወመንፈስ፡ ቅዱሳን፡ ይእዜኒ፡ ወዘልፈኒ፡ ለዓለመ፡ ዓለም፡ አሜን።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.10">
                                 <locus from="57va" to="59rb"/>
                                 <title type="complete" ref="LIT1931Mashaf#FirstBlessing"/>
                                 <incipit xml:lang="gez" type="inscription">
                                     <locus target="#57va"/>
-                                    <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡</hi> ወመንፈስ፡ ቅዱስ፡ ፩፡ አምላክ። ቡራኬ፡ ዘአቡነ፡ አባ፡ ሳሙኤል፡ ዘአዕረፈ፡ ይምሐሮ፡ 
-                                    እግዚአብሔር፡ አሜን። 
+                                    <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡</hi> ወመንፈስ፡ ቅዱስ፡ ፩፡ አምላክ። ቡራኬ፡ ዘአቡነ፡ አባ፡ ሳሙኤል፡ ዘአዕረፈ፡ ይምሐሮ፡
+                                    እግዚአብሔር፡ አሜን።
                                 </incipit>
                                 <incipit xml:lang="gez">
                                     <locus from="57va" to="57vb"/>
                                     ይሠሃሎ፡ እግዚአብሔር፡ በብሩህ፡ ገጽ፡ ይትቀበሎ፡ በቃለ፡ ፍሥሐ፡ ወኀሤት፡ ያሰምዖ፡ እግዚአብሔር፡ በጸሎታ፡ ለ<cb n="b"/>እግዝእትነ፡
-                                    <hi rend="rubric">ማርያም፡</hi> ይምሐሮ፡ እግዚአብሔር፡ ማኅፀንትየ። ወምዕቅብናየ፡ ውእቱ፡ ነዳይ፡ ዘዓቀበኒ፡ <sic>ዘንዘ፡</sic> 
+                                    <hi rend="rubric">ማርያም፡</hi> ይምሐሮ፡ እግዚአብሔር፡ ማኅፀንትየ። ወምዕቅብናየ፡ ውእቱ፡ ነዳይ፡ ዘዓቀበኒ፡ <sic>ዘንዘ፡</sic>
                                     ብሂል፡ ውስተ፡ ሕይወት፡
                                 </incipit>
                                 <explicit xml:lang="gez">
                                     <locus from="59ra" to="59rb"/>
-                                    በጸሎቶሙ፡ ለ፬ ወንጌላውያን፡ ማኅበረ፡ በኵር፡ ፍሡሐን፡ ይምሐሮ፡ አሜን። በምንግሥተ፡ ደብረ፡ ጽዮን፡ በመንግሥተ፡ ሰማያት፡ 
+                                    በጸሎቶሙ፡ ለ፬ ወንጌላውያን፡ ማኅበረ፡ በኵር፡ ፍሡሐን፡ ይምሐሮ፡ አሜን። በምንግሥተ፡ ደብረ፡ ጽዮን፡ በመንግሥተ፡ ሰማያት፡
                                     ምስለ፡ እለ፡ ይትፌሥሁ፡ ምስሌሆሙ፡ ያብኦ፡ <cb n="b"/> እግዚአብሔር፡ አሜን፡ በብዝኀ፡ ሣህሉ፡ ወምሕረቱ፡ ለዓለመ፡ ዓለም፡ አሜን።
                                 </explicit>
-                            </msItem>   
-                            
+                            </msItem>
+
                                 <msItem xml:id="ms_i1.11">
                                     <locus from="59rb" to="61va"/>
                                     <title type="complete" ref="LIT1931Mashaf#Matthew"/>
@@ -281,17 +281,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </incipit>
                                     <incipit xml:lang="gez">
                                         <locus target="#59rb"/>
-                                       እባርከከ፡ እግዚእየ፡ በኵሉ፡ ጊዜ፡ ዘኢይበሊ፡ ማኅደሩ፡ ልዑል፡ ላዕለ፡ ኵሉ፡ መልዕል፡ እሴብሕ። ወኢየኀብእ፡ ርእሰ፡ ዳእሙ፡ አግብአ፡ 
+                                       እባርከከ፡ እግዚእየ፡ በኵሉ፡ ጊዜ፡ ዘኢይበሊ፡ ማኅደሩ፡ ልዑል፡ ላዕለ፡ ኵሉ፡ መልዕል፡ እሴብሕ። ወኢየኀብእ፡ ርእሰ፡ ዳእሙ፡ አግብአ፡
                                        በእንተ፡ ኃጣውኢነ፡ ከመ፡ ያውፅአነ፡ እምስሐተት።
                                     </incipit>
                                     <explicit xml:lang="gez">
                                         <locus from="61rb" to="61va"/>
-                                        ወእምብድብድ፡ ዘኢይትከሀል፡ ለግንዘት፡ ወታተሉ፡ ላዕሌነ። ሞት፡ ወመቅሠፍት፡ ዘያስተፋጥን፡ ለለ፡ ዕለት፡ ወቍርባን፡ በርትዕት፡ ሃይማኖት። 
-                                        እስከ፡ ነፍስ፡ ደኃሪት፡ እስመ፡ ለከ፡ ስብሐት፡ ወሰጊድ፡ ስሉስ፡ ቅዱስ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ይእዜኒ፡ ወዘልፈኒ፡ ለዓለመ፡  
+                                        ወእምብድብድ፡ ዘኢይትከሀል፡ ለግንዘት፡ ወታተሉ፡ ላዕሌነ። ሞት፡ ወመቅሠፍት፡ ዘያስተፋጥን፡ ለለ፡ ዕለት፡ ወቍርባን፡ በርትዕት፡ ሃይማኖት።
+                                        እስከ፡ ነፍስ፡ ደኃሪት፡ እስመ፡ ለከ፡ ስብሐት፡ ወሰጊድ፡ ስሉስ፡ ቅዱስ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ይእዜኒ፡ ወዘልፈኒ፡ ለዓለመ፡
                                         <pb n="61v"/><cb n="a"/> ዓለም፡ አሜን።
                                     </explicit>
                                 </msItem>
-                            
+
                                     <msItem xml:id="ms_i1.12">
                                         <locus from="61va" to="62vb"/>
                                         <title type="complete" ref="LIT4346Prayer"/>
@@ -301,34 +301,34 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </incipit>
                                         <incipit xml:lang="gez">
                                             <locus target="#61va"/>
-                                            <sic>ወከዕበ፡</sic> ናስተ<surplus>፡</surplus>በቍዕ፡ ዘኵሎ፡ ይእኅዝ፡ እግዚአብሔር፡ አብ፡ ለእግዚእ፡ ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ። 
-                                            እግዚአ፡ ሕያዋ<surplus>ያ</surplus>ን፡ ሕይወተ፡ ሙታን፡ ተስፋ፡ ቅቡጻን፡ ረዳኤ፡ ምንዱባን፡ ወመንጽኤ፡ ኃጥአን፡ ዘሞተ፡ አፅራእከ፡ 
-                                            ወማእሰረ፡ ሰይጣን፡ በቲከከ፡ ሕይወተ፡ ለትዝምደ፡ ሰብእ፡                                                
+                                            <sic>ወከዕበ፡</sic> ናስተ<surplus>፡</surplus>በቍዕ፡ ዘኵሎ፡ ይእኅዝ፡ እግዚአብሔር፡ አብ፡ ለእግዚእ፡ ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ።
+                                            እግዚአ፡ ሕያዋ<surplus>ያ</surplus>ን፡ ሕይወተ፡ ሙታን፡ ተስፋ፡ ቅቡጻን፡ ረዳኤ፡ ምንዱባን፡ ወመንጽኤ፡ ኃጥአን፡ ዘሞተ፡ አፅራእከ፡
+                                            ወማእሰረ፡ ሰይጣን፡ በቲከከ፡ ሕይወተ፡ ለትዝምደ፡ ሰብእ፡
                                         </incipit>
                                         <explicit xml:lang="gez">
                                             <locus from="62va" to="62vb"/>
-                                            አንተ፡ እግዚአብሔር፡ እስመ፡ አልቦ፡ ንጹሕ፡ እምኃጢአት፡ በቅድሜከ፡ ወ፩እመኒ፡ አሐተ፡ ሰዓት፡ ሐይወ፡ በዲበ፡ ምድር፡ ማኅለፍታተ፡ 
-                                            <cb n="b"/> ነፍሶሙ፡ ግዑዘ፡ ዘእንበለ፡ ከልአት፡ አንተ፡ ጸጉ። መንፈሰ፡ ናዛዜ፡ ወመናህየ፡ ለሰብኦሙ፡ ፈኑ፡ ናዝዞሙ፡ ወአስተፍሥሖሙ፡ 
-                                            በክርስቶስ። በ፩፡ ወልድከ፡ ዘቦቱ፡ ለከ። 
+                                            አንተ፡ እግዚአብሔር፡ እስመ፡ አልቦ፡ ንጹሕ፡ እምኃጢአት፡ በቅድሜከ፡ ወ፩እመኒ፡ አሐተ፡ ሰዓት፡ ሐይወ፡ በዲበ፡ ምድር፡ ማኅለፍታተ፡
+                                            <cb n="b"/> ነፍሶሙ፡ ግዑዘ፡ ዘእንበለ፡ ከልአት፡ አንተ፡ ጸጉ። መንፈሰ፡ ናዛዜ፡ ወመናህየ፡ ለሰብኦሙ፡ ፈኑ፡ ናዝዞሙ፡ ወአስተፍሥሖሙ፡
+                                            በክርስቶስ። በ፩፡ ወልድከ፡ ዘቦቱ፡ ለከ።
                                         </explicit>
                                     </msItem>
-                            
+
                                     <msItem xml:id="ms_i1.13">
                                         <locus from="62vb" to="63rb"/>
                                         <title type="complete">Untitled prayer</title>
                                         <incipit xml:lang="gez">
                                             <locus from="62vb" to="63ra"/>
-                                            <hi rend="rubric">እግዚአ፡ መናፍስት፡</hi> ወለኵሉ፡ ዘሥጋ፡ ዘኬድኮ፡ ለሞት፡ ወረገምኮ፡ ለዲያብሎስ፡ ወወሀብከነ፡ ሕይወተ፡ ዘለዓለም። 
+                                            <hi rend="rubric">እግዚአ፡ መናፍስት፡</hi> ወለኵሉ፡ ዘሥጋ፡ ዘኬድኮ፡ ለሞት፡ ወረገምኮ፡ ለዲያብሎስ፡ ወወሀብከነ፡ ሕይወተ፡ ዘለዓለም።
                                             አዕርፍ፡ ነፍሶሙ፡ በመካን፡ ዘአልቦ፡ ጻማ፡ ወአል<pb n="63r"/><cb n="a"/>ቦ፡ ኀዘን፡ ለእመ፡ አበሳ።
                                         </incipit>
                                 <explicit xml:lang="gez">
                                     <locus from="63ra" to="63rb"/>
-                                    እስመ፡ አልቦ፡ ሰብእ፡ ዘሐይወ፡ ዘእንበለ፡ ኃጢአት፡ ባሕቲትከ፡ ዘአልቦ፡ ኃጢአት፡ ወጻድቅ፡ ስምዕከ፡ እስከ፡ ለዓለም፡ ወሥርዓትከ፡ እሙን፡ ውእቱ፡ 
-                                    እስመ፡ ሕያው፡ ወተአርፎሙ፡ ለእለ፡ ኖሙ፡ አግብርቲከ፡ በክርስቶስ፡ አም<cb n="b"/>ላክነ፡ ለከ፡ ናቄርብ፡ ለከ፡ ስብሐት፡ ለአብ፡ ወወልድ፡ 
+                                    እስመ፡ አልቦ፡ ሰብእ፡ ዘሐይወ፡ ዘእንበለ፡ ኃጢአት፡ ባሕቲትከ፡ ዘአልቦ፡ ኃጢአት፡ ወጻድቅ፡ ስምዕከ፡ እስከ፡ ለዓለም፡ ወሥርዓትከ፡ እሙን፡ ውእቱ፡
+                                    እስመ፡ ሕያው፡ ወተአርፎሙ፡ ለእለ፡ ኖሙ፡ አግብርቲከ፡ በክርስቶስ፡ አም<cb n="b"/>ላክነ፡ ለከ፡ ናቄርብ፡ ለከ፡ ስብሐት፡ ለአብ፡ ወወልድ፡
                                     ወመንፈስ፡ ቅዱስ፡ ይእዜኒ፡ ወዘልፈኒ፡ ወለዓለመ፡ ዓለም፡ አሜን።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.14">
                                 <locus from="63rb" to="68rb"/>
                                 <title type="complete" ref="LIT1931Mashaf#Blessings"/>
@@ -338,8 +338,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title type="complete" ref="LIT1931Mashaf#FirstBlessing"/>
                                     <incipit xml:lang="gez" type="inscription">
                                         <locus target="#63rb"/>
-                                        <hi rend="rubric">ቡራኬ፡ ዘአቡነ፡ አባ፡ ሳሙኤል። በስመ፡ አብ፡ ወወልድ፡ ወ</hi>መንፈስ፡ ቅዱስ፡ ፩፡ አምላክ፡ ለዘ፡ አዕረፈ፡ ይምሐሮ፡ 
-                                        እግዚአብሔር፡ አሜን። 
+                                        <hi rend="rubric">ቡራኬ፡ ዘአቡነ፡ አባ፡ ሳሙኤል። በስመ፡ አብ፡ ወወልድ፡ ወ</hi>መንፈስ፡ ቅዱስ፡ ፩፡ አምላክ፡ ለዘ፡ አዕረፈ፡ ይምሐሮ፡
+                                        እግዚአብሔር፡ አሜን።
                                     </incipit>
                                     <incipit xml:lang="gez">
                                         <locus from="63rb" to="63va"/>
@@ -348,7 +348,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </incipit>
                                     <explicit xml:lang="gez">
                                         <locus target="#65ra"/>
-                                        በምንግሥተ፡ ደብረ፡ ጽዮን፡ ወበመንግሥተ፡ ሰማያት፡ 
+                                        በምንግሥተ፡ ደብረ፡ ጽዮን፡ ወበመንግሥተ፡ ሰማያት፡
                                         ምስለ፡ እለ፡ ይትፌሥሑ፡ ወይትኃሠዩ፡ ምስሌሆሙ፡ ያብኦ፡ እግዚአብሔር፡ አሜን። በብዝኃ፡ ሣህሉ፡ ወምሕረቱ፡ ለዓለመ፡ ዓለም። አሜን፡
                                         </explicit>
                                 </msItem>
@@ -361,14 +361,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </incipit>
                                     <incipit xml:lang="gez">
                                         <locus from="65ra" to="65rb"/>
-                                        <sic>ወለከሙኒ፡</sic> ኦአበውየ፡ ወአኃውየ፡ ያክህልክሙ፡ እግዚአብሔር፡ <del rend="erasure" unit="chars" quantity="7"/> ለገቢረ፡ ፈቃዱ፡ 
+                                        <sic>ወለከሙኒ፡</sic> ኦአበውየ፡ ወአኃውየ፡ ያክህልክሙ፡ እግዚአብሔር፡ <del rend="erasure" unit="chars" quantity="7"/> ለገቢረ፡ ፈቃዱ፡
                                         <sic>ወሥመረቱ።</sic> ወያኅድር፡ መንፈሰ፡ ጸጋሁ፡ ላዕሌክሙ። አ፡ ወይ<add place="interlinear">ኅ</add>ጽርክሙ፡ በኃጹረ፡ መስቀሉ። ወይሰውርክሙ፡
                                         በጽላሎተ፡ ክነፊሁ።
                                     </incipit>
                                     <explicit xml:lang="gez">
                                         <locus from="66ra" to="66rb"/>
-                                        አ፡ ወይእቲ፡ ትዕ<cb n="b"/>ቀብክሙ፡ ወይ<add place="interlinear">ት</add>ስአል፡ ኀበ፡ እግዚአብሔር፡ በእንቲአክሙ። አ። ከመ፡ 
-                                        ይዕቀብክሙ፡ በዲበ፡ ምድር፡ እምኵሉ፡ መከራት፡ ዘአጋንንት፡ መስኅታን። አ፡ ወበሰማያትኒ፡ እምበላዒ፡ እሳት፡ ታድኅንኮሙ፡ ስኢላ፡ ኀበ፡ 
+                                        አ፡ ወይእቲ፡ ትዕ<cb n="b"/>ቀብክሙ፡ ወይ<add place="interlinear">ት</add>ስአል፡ ኀበ፡ እግዚአብሔር፡ በእንቲአክሙ። አ። ከመ፡
+                                        ይዕቀብክሙ፡ በዲበ፡ ምድር፡ እምኵሉ፡ መከራት፡ ዘአጋንንት፡ መስኅታን። አ፡ ወበሰማያትኒ፡ እምበላዒ፡ እሳት፡ ታድኅንኮሙ፡ ስኢላ፡ ኀበ፡
                                         ወልዳ። መሐሪ።
                                     </explicit>
                                 </msItem>
@@ -377,7 +377,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title type="complete" ref="LIT1931Mashaf#ThirdBlessing"/>
                                     <incipit xml:lang="gez">
                                         <locus from="66rb" to="66va"/>
-                                       ኦአበውየ፡ ወአኃውየ፡ ወደቂቅየ፡ ቡሩካን፡ ወጽዉዓን፡ ዘጸውዓክሙ፡ እግዚአብሔር፡ ውስተዝ፡ ብሔረ፡ በድቅ፡ ወያክህልክሙ፡ እግዚብሔር፡ 
+                                       ኦአበውየ፡ ወአኃውየ፡ ወደቂቅየ፡ ቡሩካን፡ ወጽዉዓን፡ ዘጸውዓክሙ፡ እግዚአብሔር፡ ውስተዝ፡ ብሔረ፡ በድቅ፡ ወያክህልክሙ፡ እግዚብሔር፡
                                        ለገቢረ፡ ፈቃዱ፡ ወለሥምረተ፡ ዚአሁ። አ፡ ወያኅድር፡ መንፈሰ፡ ጸጋሁ፡ <pb n="66v"/><cb n="a"/> ላዕሌክሙ፡ አ፡ ወይቀድስክሙ፡ እንተ፡
                                         ውስጥ፡ ወአፍአክሙ፡
                                     </incipit>
@@ -392,45 +392,45 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title type="complete" ref="LIT1931Mashaf#FourthBlessing"/>
                                     <incipit xml:lang="gez">
                                         <locus from="67va" to="67vb"/>
-                                       ቡራኬ፡ ለእለ፡ ተልእኩ፡ ወአልዐሉ። ወለክሙኒ፡ ያልዕክሙ፡ እግዚአብሔር፡ በመንግሥተ፡ ሰማያት። በከመ፡ ቃሉ፡ ለእግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ 
+                                       ቡራኬ፡ ለእለ፡ ተልእኩ፡ ወአልዐሉ። ወለክሙኒ፡ ያልዕክሙ፡ እግዚአብሔር፡ በመንግሥተ፡ ሰማያት። በከመ፡ ቃሉ፡ ለእግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡
                                        ዘኢ<cb n="b"/>ይሔሱ፡ ዘይቤ፡ በወንጌል፡ ቅዱስ።
                                     </incipit>
                                 <explicit xml:lang="gez">
                                     <locus from="68ra" to="68rb"/>
-                                    በወለዘቲኒ፡ ቅድስት፡ ቤተ፡ ክርስቲያን፡ ያጽንዓ፡ እግዚአብሔር፡ እስከ፡ ዳግም፡ ምጽአቱ። 
-                                    እንዘ፡ ይትገበር፡ በውስቴታ፡ ሕግ፡ ወሥርዓት። አሜን፡ በከመ፡ <cb n="b"/> መፍትው፡ አሜን። ወለኵሉ፡ ዓለም፡ ሣህል፡ ወምሕረት፡ ያውርድ፡ 
+                                    በወለዘቲኒ፡ ቅድስት፡ ቤተ፡ ክርስቲያን፡ ያጽንዓ፡ እግዚአብሔር፡ እስከ፡ ዳግም፡ ምጽአቱ።
+                                    እንዘ፡ ይትገበር፡ በውስቴታ፡ ሕግ፡ ወሥርዓት። አሜን፡ በከመ፡ <cb n="b"/> መፍትው፡ አሜን። ወለኵሉ፡ ዓለም፡ ሣህል፡ ወምሕረት፡ ያውርድ፡
                                     እግዚአብሔር፡ አሜን፡ ወአሜን።
                                 </explicit>
                                 <explicit xml:lang="gez" type="subscription">
                                     <locus target="#68rb"/>
                                     ስረዩ፡ ወባርኩኒ፡ ለጸሐፊሃ፡ <del rend="erasure" unit="chars" quantity="8"/> አቡነ፡ ዘበሰማያት፡ ወሰላመ፡ ገርበኤል፡፡ <del rend="erasure" unit="chars" quantity="10"/>
                                     ዘወሀብኩ፡ ለመቅድሰ፡ <del rend="erasure" unit="chars" quantity="9"/> ወቀይሰ፡ ገበዝሂ፡ ዘተግሃ፡ ለአጽሕፎታ፡ <del rend="erasure" unit="chars" quantity="7"/>።
-                                    ተሰፊዎሙ፡ <del rend="erasure" unit="chars" quantity="3"/> መንግሥተ፡ ሰማያት፡ ለዓለመ፡ ዓለም፡ አሜን። ኢትርስዑነ፡ አቡነ፡ ዘበሰማያት። 
+                                    ተሰፊዎሙ፡ <del rend="erasure" unit="chars" quantity="3"/> መንግሥተ፡ ሰማያት፡ ለዓለመ፡ ዓለም፡ አሜን። ኢትርስዑነ፡ አቡነ፡ ዘበሰማያት።
                                 </explicit>
                             </msItem>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.15">
                                 <locus from="68va" to="70vb"/>
                                 <title type="complete">Fǝtḥat za-wald</title>
                                 <incipit xml:lang="gez" type="inscription">
                                     <locus target="#68va"/>
-                                    <hi rend="rubric">ፍትሐት፡ ዘወልድ፡</hi> 
+                                    <hi rend="rubric">ፍትሐት፡ ዘወልድ፡</hi>
                                 </incipit>
                                 <incipit xml:lang="gez">
                                     <locus target="#68va"/>
-                                    እግዚእ፡ እግዚኦ፡ ኢየሱስ፡ ክርስቶስ፡ ወልድ፡ ዋሕድ፡ ቃለ፡ እግዚአብሔር፡ አብ፡ ዘበተከ፡ እምኔነ፡ ኵሎ፡ ማእሰረ፡ ኃጣውኢነ። በሕማማቲከ፡ 
+                                    እግዚእ፡ እግዚኦ፡ ኢየሱስ፡ ክርስቶስ፡ ወልድ፡ ዋሕድ፡ ቃለ፡ እግዚአብሔር፡ አብ፡ ዘበተከ፡ እምኔነ፡ ኵሎ፡ ማእሰረ፡ ኃጣውኢነ። በሕማማቲከ፡
                                     ማሕየዊት፡ ወመድ<supplied reason="omitted">ኀ</supplied>ኒት፡ ዘነፋከ፡ ላዕለ፡ ገጸ፡ አርዳኢከ፡ ንጹሐን፡ ወላእካኒከ፡ ቅዱሳን።
                                 </incipit>
                                 <note>The incipit corresponds to the seventh prayer of penance contained in <ref type="mss" corresp="BAVet115#i1.12.7"/>.</note>
                                 <explicit xml:lang="gez">
                                     <locus target="#70vb"/>
                                     ጽኑዕ፡ ወቅዱስ፡ አባ፡ ሙሴ፡ ወ፵ወ፱፡ ሰማዕታት፡ ወኵሎሙ፡ ለባስያነ፡ መስቀል፡ ጻድቃን፡ ወኄራን፡ ወመአልከ፡ ዛቲ፡ ዕለት፡ ቅድስት፡
-                                    ወቡርክት፡ በረከቶሙ፡ ወጸጋ፡ ረድኤቶሙ፡ ወፍቅረ፡ አምላኮሙ፡ ወገድለ፡ ጻማሆሙ፡ ወትንብልና፡ ሣህሎሙ፡ የሀሉ፡ ምስለ፡ ገብሮሙ፡ 
+                                    ወቡርክት፡ በረከቶሙ፡ ወጸጋ፡ ረድኤቶሙ፡ ወፍቅረ፡ አምላኮሙ፡ ወገድለ፡ ጻማሆሙ፡ ወትንብልና፡ ሣህሎሙ፡ የሀሉ፡ ምስለ፡ ገብሮሙ፡
                                     <del rend="erasure" unit="chars" quantity="7"/>  ዘወልደ፡ ለዓለመ፡ ዓለም፡ አሜን።
                                 </explicit>
                             </msItem>
-                            
+
                             <msItem xml:id="ms_i1.16">
                                 <locus from="70vb" to="71vb"/>
                                 <title type="complete" ref="LIT1931Mashaf#PrayerBlessing"/>
@@ -446,12 +446,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <explicit xml:lang="gez">
                                     <locus target="#71vb"/>
                                     ኢየሱስ፡ ክርስቶስ፡ ወለኵሎሙ፡ እለ፡ <gap reason="illegible" unit="chars" quantity="2"/>ዙነ፡ ከመ፡ ንዘክሮሙ፡ በምሕረትከ፡ በውስተ፡ ምንግሥትከ፡ ሰማያዊት፡
-                                    ወሊተኒ፡ ለ<gap reason="illegible" unit="chars" quantity="2"/>እ፡ ገብርከ፡ ተዘ<gap reason="illegible" unit="chars" quantity="2"/> ኦእግዚኦ፡ አድኅ<gap reason="illegible" unit="chars" quantity="2"/>ዝበከ፡ 
+                                    ወሊተኒ፡ ለ<gap reason="illegible" unit="chars" quantity="2"/>እ፡ ገብርከ፡ ተዘ<gap reason="illegible" unit="chars" quantity="2"/> ኦእግዚኦ፡ አድኅ<gap reason="illegible" unit="chars" quantity="2"/>ዝበከ፡
                                     ወባረክ፡ ር<gap reason="illegible" unit="chars" quantity="2"/>ከ፡ ረአዮሙ፡ ወ<gap reason="illegible" unit="chars" quantity="3"/>ሎሙ፡ እስከ፡ ለዓለመ፡ ዓለም፡ አሜን።
                                 </explicit>
                             </msItem>
                         </msItem>
-                       
+
                         <msItem xml:id="ms_i2">
                             <locus from="72ra" to="91vb"/>
                             <title type="complete" ref="LIT1940Mashaf"/>
@@ -460,16 +460,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             It is not LIT3948MashafaKrS (the short version) -->
                             <incipit xml:lang="gez" type="inscription">
                                 <locus target="#72ra"/>
-                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩፡</hi> አምላክ። መጽሐፈ፡ ጥ<hi rend="rubric">ምቀት።</hi> 
+                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩፡</hi> አምላክ። መጽሐፈ፡ ጥ<hi rend="rubric">ምቀት።</hi>
                             </incipit>
                             <incipit xml:lang="gez">
-                                <hi rend="rubric">ዝንቱ፡ ጸሎት፡</hi> ንብረተ፡ እድ፡ ላዕለ፡ እሙ፡ ለሕፃን። ወእምድኅረ፡ ነጽሐት፡ በ፵፡ ዕለት፡ ተባዕት፡ ወበ፹፡ ዕለት፡ አንስት፡ 
+                                <hi rend="rubric">ዝንቱ፡ ጸሎት፡</hi> ንብረተ፡ እድ፡ ላዕለ፡ እሙ፡ ለሕፃን። ወእምድኅረ፡ ነጽሐት፡ በ፵፡ ዕለት፡ ተባዕት፡ ወበ፹፡ ዕለት፡ አንስት፡
                                 ትበውእ፡ ቤተ፡ ክርስቲያን፡ ወያንብቡ፡ ካህናት፡ ጸሎተ፡ አኰቴት፡ ወጸሎተ፡ ዕጣን፡ ወእምድኅሬሁ፡ ዘንተ፡ ጸሎተ። እግዚአብሔር፡ አምላክነ፡ አኃዜ፡
                                 ኵሉ፡ አቡሁ፡ ለእግዚእነ፡ ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡
                             </incipit>
                             <explicit xml:lang="gez">
                                 <locus target="#91vb"/>
-                                አለብዎሙ፡ ፈ<gap reason="illegible" unit="chars" quantity="1"/>ሆተከ፡ አብጽሖሙ፡ መጠነ፡ አካል፡ ጸግዎሙ፡ አእምሮ፡ አምላካዊ፡ ዕቀቦሙ፡ በሃይማኖት፡ 
+                                አለብዎሙ፡ ፈ<gap reason="illegible" unit="chars" quantity="1"/>ሆተከ፡ አብጽሖሙ፡ መጠነ፡ አካል፡ ጸግዎሙ፡ አእምሮ፡ አምላካዊ፡ ዕቀቦሙ፡ በሃይማኖት፡
                                 ዘእንበለ፡ ነውር። በትንብልናሃ፡ ለእግዝእተ፡ ኵልነ፡ ወላዲተ፡ አምላክ፡ ቅድስት፡ ወንጽሕት፡ <hi rend="rubric">ማርያም፡</hi> ወቃለ፡ አዋዲ፡ ዮሐንስ፡
                                 መጥምቅ፡ ወኵሎሙ፡ ጉባኤ፡ ቅዱሳን፡ ለዓለመ፡ ዓለም፡ አሜን፡ ወአሜን።
                             </explicit>
@@ -505,7 +505,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </dimensions>
                                     <note corresp="#leafdim">Data on the dimensions of folios taken from <locus target="#18r"/>.</note>
                                     <measure type="weight" unit="g">803</measure>
-                                </extent> 
+                                </extent>
                                 <foliation>Pencil foliation in the upper right corner carried out by the Bodleian Library in January 2020 (1–92).
                                 </foliation>
                                 <collation>
@@ -518,7 +518,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </item>
                                         <item xml:id="q2" n="1">
                                             <dim unit="leaf">8</dim>
-                                            <locus from="2r" to="9v"/>                  
+                                            <locus from="2r" to="9v"/>
                                          </item>
                                         <item xml:id="q3" n="2">
                                             <dim unit="leaf">8</dim>
@@ -582,26 +582,26 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </list>
                                 </collation>
                                 <condition key="deficient">
-                                    The manuscript is in bad condition. The front board is fractured vertically in two halves kept together by means of a thread 
-                                    passing through two pairs of holes made along the inner edges of the two pieces. A third pair of holes close to the upper 
-                                    margin of the wooden pieces has not been used. The board also shows signs of damage by insects. The back board displays 
-                                    fractures and a large hole close to the upper margin. In both boards the wood is worn along the outer edges.
-                                    The manuscript has been resewn and an additional pair of holes have been made close to the original sewing stations (e.g. 
-                                    <locus from="63v" to="64r"/>); nevertheless, the new sewing is broken at the third and fourth sewing stations, between the 
-                                    third and the fifth quires. Many bifolios are torn along the fold and some are completely separated. Most of the disjoint 
-                                    bifolios have been stitched together, even if out of their original place.                                    
-                                    The structure of the <ref target="#q2">second quire</ref> is reconstructed and cannot anymore be observed in the manuscript, 
+                                    The manuscript has been resewn and an additional pair of holes have been made close to the original sewing stations (e.g.
+                                    <locus from="63v" to="64r"/>); nevertheless, the new sewing is broken at the third and fourth sewing stations, between the
+                                    third and the fifth quires. Many bifolios are torn along the fold and some are completely separated. Most of the disjoint
+                                    bifolios have been stitched together, even if out of their original place.
+                                    The structure of the <ref target="#q2">second quire</ref> is reconstructed and cannot anymore be observed in the manuscript,
                                     as many folios have become loose and
-                                    been placed out of their original place. In particular, <locus from="2" to="4"/> are single folios which have been detached and were partly sewn 
+                                    been placed out of their original place. In particular, <locus from="2" to="4"/> are single folios which have been detached and were partly sewn
                                     together at a later point; <locus target="#5"/> and <locus target="#10"/> are loose single folios.
                                     The original sequence was the following:
                                     <locus target="#2"/>, <locus target="#4"/>, <locus target="#6"/>, <locus target="#7"/>, <locus target="#8"/>,
-                                    <locus target="#9"/>, <locus target="#5"/>, <locus target="#3"/>.                                                                      
+                                    <locus target="#9"/>, <locus target="#5"/>, <locus target="#3"/>.
                                     <locus target="#92"/> is hastly attached to the board. <locus target="#15"/> is cut diagonally along the upper outer margin.
                                     The text is occasionally barely legible, e.g. on <locus target="#2vb #59vb #73rb"/>.
-                                    Traces of intensive use: the parchment is darker in the lower margin and in correspondence of the lower outer corners of 
+                                    Traces of intensive use: the parchment is darker in the lower margin and in correspondence of the lower outer corners of
                                     several folios (<locus from="6r" to="9r"/>). Stains of unknown origin and wax stains are visible on many folios, e.g. on
                                     <locus target="#2r #59r #62vb"/>.
+                                    The front board is fractured vertically in two halves kept together by means of a thread
+                                    passing through two pairs of holes made along the inner edges of the two pieces. A third pair of holes close to the upper
+                                    margin of the wooden pieces has not been used. The board also shows signs of damage by insects. The back board displays
+                                    fractures and a large hole close to the upper margin.
                                 </condition>
                             </supportDesc>
 
@@ -624,7 +624,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <ab type="punctuation" subtype="Dividers">
                                         Single chains of red and black dots are e.g. on <locus target="#15vb #39va #54rb"/>.
                                         Double chains of red and black dots, often interspersed with sequences of red and black nine-dot asterisks, are e.g on <locus target="#25vb #34rb #44vb"/>.
-                                        Single lines are sometimes used as dividers, either in black ink (<locus target="#4ra #17va"/>) or in red ink (<locus target="#11ra"/>), or both (<locus target="#40rb"/>). 
+                                        Single lines are sometimes used as dividers, either in black ink (<locus target="#4ra #17va"/>) or in red ink (<locus target="#11ra"/>), or both (<locus target="#40rb"/>).
                                     </ab>
                                     <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are visible.</ab>
                                     <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A-1A1A/0-0/0-0/C.</ab>
@@ -649,7 +649,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <note> The characters per line are 9-11.</note>
                                     <ab type="punctuation" subtype="Dividers">
                                         Single chains of red and black dots are e.g. on <locus target="#68rb #74ra #81vb"/>.
-                                        Single lines in red and black ink are on <locus target="#68rb #76vb #85ra"/>. 
+                                        Single lines in red and black ink are on <locus target="#68rb #76vb #85ra"/>.
                                     </ab>
                                     <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are visible.</ab>
                                     <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A-1A1A/0-0/0-0/C.</ab>
@@ -668,13 +668,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <seg type="ink">Black, red</seg>
                                 <date notBefore="1750" notAfter="1850">18th-19th century handwriting</date>
                                <desc>
-                                 Decent and mostly uniform handwriting. 
+                                 Decent and mostly uniform handwriting.
                                  Characters are broadly spaced. Sometimes the lower part of the characters are written below the ruled line.
                                  The scribe wrote the last line of <locus target="#63va"/> under the last ruled line.
                                 </desc>
                                 <seg type="rubrication">
                                     Two lines on the incipit pages, alternating with black lines; first lines and incipit formulas of the individual sections (sometimes alternating with a black line);
-                                    the titles of the biblical passages and of the prayers; liturgical exhortations (e.g. <foreign xml:lang="gez">ንስእለከ፡</foreign>, <foreign xml:lang="gez">ጸልዩ፡</foreign>) 
+                                    the titles of the biblical passages and of the prayers; liturgical exhortations (e.g. <foreign xml:lang="gez">ንስእለከ፡</foreign>, <foreign xml:lang="gez">ጸልዩ፡</foreign>)
                                     and directives (e.g. <foreign xml:lang="gez">ይበል፡ ዲያቆን</foreign>); the name of Mary and of the Archangels; the word <foreign xml:lang="gez">እገሌ፡</foreign> ;
                                     elements of the punctuation signs, text dividers, and numerals (in full or in part).
                                     The rubrication has not been executed on the last lines of <locus target="#34rb"/>.
@@ -691,17 +691,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <seg type="ink">Black, red</seg>
                                 <date notBefore="1750" notAfter="1850">18th-19th century handwriting</date>
                                 <desc>
-                                   Mediocre handwriting. 
+                                   Mediocre handwriting.
                                    Characters are relatively thick, perhaps due to a change of nib
                                     The last ruled line has not been written on <locus target="#86ra"/>.
                                 </desc>
                                 <note>
-                                    The grapheme <foreign xml:lang="gez">ጵ</foreign> has the ancient shape, with the vowel marker of the sixth order placed on the top of the letter, towards the left 
+                                    The grapheme <foreign xml:lang="gez">ጵ</foreign> has the ancient shape, with the vowel marker of the sixth order placed on the top of the letter, towards the left
                                     (e.g. on <locus target="#80va"/>).
                                 </note>
                               <seg type="rubrication">
                                    First lines and incipit formulas of the individual sections, sometimes alternating with a black line;
-                                    the titles of the single prayers; liturgical directives in full or in abbreviation (e.g. <foreign xml:lang="gez">ይካ</foreign>, <foreign xml:lang="gez">ይዲ</foreign>); 
+                                    the titles of the single prayers; liturgical directives in full or in abbreviation (e.g. <foreign xml:lang="gez">ይካ</foreign>, <foreign xml:lang="gez">ይዲ</foreign>);
                                     the name of Mary; elements of the punctuation signs, text dividers, and numerals.
                                 </seg>
                                 <list type="abbreviations">
@@ -723,7 +723,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </list>
                             </handNote>
                         </handDesc>
-                        
+
                         <additions>
                             <list>
                                 <item xml:id="e1">
@@ -733,9 +733,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         Above the stickers is written the shelfmark ‘MS. Aeth. J.J. 43’ in pencil</desc>
                                 </item>
                                 <item xml:id="e2">
-                                    <desc>Cues for the rubricator have been added in the main hand in black ink or pale black ink on the upper margin of several folios: 
-                                        <foreign xml:lang="gez">ጸሎት፡</foreign> (<locus target="#73vb #74r"/>), ጸሎ (<locus target="#83vb"/>), 
-                                        ወእ (e.g. <locus target="#75r #77ra #79ra"/>), ወይጼሊ፡ (<locus target="#84vb"/>), ወይነሥእ፡ (<locus target="#88rb"/>), 
+                                    <desc>Cues for the rubricator have been added in the main hand in black ink or pale black ink on the upper margin of several folios:
+                                        <foreign xml:lang="gez">ጸሎት፡</foreign> (<locus target="#73vb #74r"/>), ጸሎ (<locus target="#83vb"/>),
+                                        ወእ (e.g. <locus target="#75r #77ra #79ra"/>), ወይጼሊ፡ (<locus target="#84vb"/>), ወይነሥእ፡ (<locus target="#88rb"/>),
                                         ወይብል፡ (<locus target="#89va"/>), እምድኅረ፡ (<locus target="#91ra"/>).
                                     </desc>
                                 </item>
@@ -748,8 +748,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </item>
                             </list>
                         </additions>
-                        
-  
+
+
 
                         <bindingDesc>
                             <binding contemporary="Ethiopian false">
@@ -788,8 +788,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <origDate notBefore="1750" notAfter="1850" evidence="lettering"/>
                         </origin>
 
-                        <provenance>Unknown provenance. Part of the end note on <locus target="#68rb"/>, containing information on the scribe, the patron, and the owning 
-                            institution of the book, has been carefully erased. The manuscript was purchased by <persName ref="PRS5782JuelJen"/> at auction on <date>24 June 
+                        <provenance>Unknown provenance. Part of the end note on <locus target="#68rb"/>, containing information on the scribe, the patron, and the owning
+                            institution of the book, has been carefully erased. The manuscript was purchased by <persName ref="PRS5782JuelJen"/> at auction on <date>24 June
                                 1974</date>, according to the Sotheby's sale receipt (lot 146), through the bookseller <persName ref="PRS13559Thomas"/>.
                         </provenance>
                     </history>

--- a/OxfordBodleian/Juel-Jensen/BDLaethf34.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf34.xml
@@ -10,10 +10,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-              <!-- 
+              <!--
                   <title xml:lang="gez" xml:id="title1">መዝሙር፡ ዘሌሊት፡</title>
                   <title xml:lang="gez" corresp="#title1" type="normalized">Mazmur za-lelit</title>
-              -->  
+              -->
                 <title xml:lang="en" xml:id="title1">Psalms of the Night</title>
                 <editor key="DR"/>
                 <editor key="JG"/>
@@ -661,10 +661,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
                                 <condition key="good">
-                                    The back board has two cracks along the vertical axis. The cracks are repaired with threads passing through pairs of holes.
-                                    The leather cover is damaged, lacking at the head and tail of the spine. The headband is missing and the tail band is fragmentary.
+                                    <locus from="14v" to="19r"/> are stained with dirt at the lower outer corners.
+                                    The back board has two cracks along the vertical axis which have been repaired with threads passing through pairs of holes.
+                                    The leather cover lacks of the spine at the head and tail. The headband is missing and the tail band is fragmentary.
                                     The sewing is broken at the uppermost sewing station between the first and second quires.
-                                    Some folios are slightly stained with dirt (e.g. <locus target="#12r #13r #48r"/>), sometimes at the lower corners (e.g. <locus from="14v" to="19r"/>).
                                 </condition>
                             </supportDesc>
                             <layoutDesc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg28.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg28.xml
@@ -7,10 +7,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-               <!-- 
+               <!--
                <title xml:lang="gez" xml:id="title1">መልክአ፡ ሚካኤል፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Malkǝʾa Mikāʾel</title>
-               --> 
+               -->
                 <title xml:lang="en" xml:id="title1"><hi rendition="simple:italic">Malkǝʾ</hi>-hymn to St Michael</title>
                 <editor key="DR"/>
                 <editor key="JG"/>
@@ -104,11 +104,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <list>
                                         <item xml:id="q1" n="A">
                                             <dim unit="leaf">1</dim>
-                                            <locus from="1r" to="1v"/> 1, stub before 1 
+                                            <locus from="1r" to="1v"/> 1, stub before 1
                                         </item>
                                         <item xml:id="q2" n="1">
                                             <dim unit="leaf">7</dim>
-                                            <locus from="2r" to="8v"/> 6, stub after 1 
+                                            <locus from="2r" to="8v"/> 6, stub after 1
                                         </item>
                                         <item xml:id="q3" n="2">
                                             <dim unit="leaf">8</dim>
@@ -117,13 +117,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
 
-                                <condition key="deficient">The original sewing is broken and it has been repaired by using a different kind of thread. <!--A brown liquid
+                                <condition key="deficient"><!--A brown liquid
                                      was spilled on the manuscript, see especially on <locus
                                         from="15r" to="16v"/> I think that a different kind of ink, a brownish one, has been used to draw
                                       the figures on f. 15v and f. 16v later damaged by humidity. The same ink is on f. 1v, 2r, 9r, 9v, 10r, 10v, 11r, 11v.-->
-                                        Smudged ink on many folios see especially on <locus
-                                           from="15r" to="16v"/>.</condition>
-
+                                        Smudged ink on many folios, see especially on <locus from="15r" to="16v"/>. Insect droppings and humidity stains
+                                        on most leaves. The original sewing is broken with the risk
+                                        of leaf displacement. </condition>
                             </supportDesc>
                             <layoutDesc>
                                 <layout columns="1" writtenLines="13">
@@ -294,6 +294,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <change who="DR" when="2020-03-09">Added incipit and explicit</change>
             <change who="SH" when="2020-04-22">Added editors</change>
             <change who="SH" when="2020-11-16">Full textual and preliminary physical description of the Ms</change>
+            <change who="EDS" when="2024-03-10">Revision condition</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">

--- a/OxfordBodleian/Juel-Jensen/BDLaethg29.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg29.xml
@@ -10,10 +10,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-              <!-- 
+              <!--
               <title xml:lang="gez" xml:id="t1">ልፋፈ፡ ጽድቅ፡</title>
                 <title xml:lang="gez" corresp="#t1" type="normalized">Lǝfāfa ṣǝdq</title>
-              --> 
+              -->
                 <title xml:lang="en" xml:id="t1">Bandlet of Righteousness</title>
                 <editor key="DR"/>
                 <editor key="JG"/>
@@ -141,10 +141,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </item>
                                     </list>
                                 </collation>
-                                <condition key="good">The manuscript is in very good condition and hardly seems used.
+                                <condition key="intact">The manuscript is in very good condition and hardly seems used.
                                     Ink is smudged on <locus target="#7v"/>. <!--The outer margins of
                                     <locus target="#13 #15"/> are darkened. EDS (21.11.2022): it does not seem a damage, but a consequence
-                                    of an inaccurate parchement making process, see lower external corner of f. 20 --> The sewing thread is not tensioned in <locus target="q3"/>.</condition>
+                                    of an inaccurate parchement making process, see lower external corner of f. 20 --> The sewing is a little bit loose in <locus target="q3"/>.</condition>
                             </supportDesc>
 
                             <layoutDesc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg30.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg30.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-             <!-- 
+             <!--
              <title xml:lang="gez" xml:id="title1">ጸሎት፡ በእንተ፡ ልሳነ፡ ሰብእ፡, ጸሎት፡ በእንተ፡ ሕማመ፡ ዓይነት፡, መልክአ፡ ፋኑኤል፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Ṣalot baʾǝnta lǝssāna sabʾ, Ṣalot baʾǝnta ḥǝmāma ʿaynat, Malkǝʾa Fānuʾel</title>
              -->
@@ -123,9 +123,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
                                 <condition key="deficient">
-                                    The manuscript is in bad condition. The entire manuscript is severely damaged by humidity, which has led to a general browning and stiffening of the parchment.
+                                    The entire manuscript is severely damaged by humidity, which has led to a general browning and stiffening of the parchment.
                                     Most of folios are wrinkled and stained with water.
                                     The text is for the most part illegible due to faded ink and stains of unclear origin (e.g. on <locus target="#6v #7r #10v"/>). The red ink is mostly faded out.
+                                    The binding is in good conditions.
                                 </condition>
                             </supportDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethg31.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg31.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-            <!--  
+            <!--
                 <title xml:lang="gez" xml:id="title1">ጸሎት፡ ዘእግዝእትነ፡ ማርያም፡ በደብረ፡ ጎልጎታ፡, ተስእልዎ፡ ፲ወ፩ አርዳኢሁ፡ ለኢየሱስ፡ ክርስቶስ፡, ጸሎተ፡ ፍትሐተ፡ ማይ፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Ṣalot za-ʾǝgzǝʾǝtǝna Māryām ba-Dabra Golgotā, Tasǝʾlǝwwo 10wa2 ʾardāʾihu la-ʾIyasus Krǝstos, Ṣalota fǝtḥata māy</title>
              -->
@@ -138,7 +138,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </dimensions>
                                     <note corresp="#leafdim">Data on the dimensions of folios taken from <locus target="#1r"/>.</note>
                                 </extent>
-                                <foliation>Pencil foliation in the upper right corner (1–48). 
+                                <foliation>Pencil foliation in the upper right corner (1–48).
                                     Two guard folios each at the beginning and end of the manuscript
                                 are not foliated. They are referred to respectively as <locus from="i" to="ii"/> and <locus from="iii" to="iv"/> in this description.</foliation>
                                 <collation>
@@ -182,10 +182,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
                                 <condition key="good">
-                                  The manuscript is in a good state of preservation. The leather cover is slightly damaged at the edges and presents a superficial abrasion
-                                  on the outer surface of the upper board. The edges of the textblock have been re-trimmed, with loss of text on the upper margin of <locus target="#26r"/>.
+                                  The edges of the textblock have been re-trimmed, with loss of text on the upper margin of <locus target="#26r"/>.
                                     Some folios have stains of unspecified origin, e.g. on <locus target="#5v #25r #26v"/>.
-                                    <locus target="#ir #ivv"/> are glued to the binding.
+                                    <locus target="#ir #ivv"/> are glued to the binding. The leather cover is slightly damaged at the edges and presents a superficial abrasion
+                                    on the outer surface of the upper board.
                                 </condition>
                             </supportDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethg32.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg32.xml
@@ -223,8 +223,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
                                 <condition key="good">
-                                  The first and last folio, and the lower margins are stained by dirt.
-                                  The upper margins, the openings <locus from="1v" to="2r"/>, and <locus from="7v" to="8r"/>
+                                  The first, the last, and the lower margins of the folios are stained by dirt.
+                                  The upper margins of the folios, the openings <locus from="1v" to="2r"/>, and <locus from="7v" to="8r"/>
                                   are stained by pink ink.
                                 </condition>
                             </supportDesc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg33.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg33.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!--
+                <!-- 
                   <title xml:lang="gez" xml:id="title1">አኰቴተ፡ ቍርባን፡ ዘቅዱስ፡ ህርያቆስ፡ ዘሀገረ፡ ብህንሳ፡, አኰቴተ፡ ቍርባን፡ ዘእግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡, አኰቴተ፡ ቍርባን፡
                     ዘሐዋርያት፡, አኰቴተ፡ ቍርባን፡ ዘቅዱስ፡ ዲዮስቆሮስ፡, ተፈሥሒ፡ ኦዘንስእለኪ፡ ዳኅና፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">ʾAkkʷateta qʷǝrbān za-qǝddus Hǝryāqos za-hagara Bǝhnǝsā, ʾAkkʷateta qʷǝrbān za-ʾǝgziʾǝna ʾIyasus Krǝstos,
@@ -355,12 +355,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
                                 <condition key="deficient">
-                                    The outer margin of the textblock has been damaged probably by rodents, with loss of text on <locus from="1r" to="4r"/> and <locus target="#29v"/>.
-                                    The lower margins of many folios are stained with dirt, e.g. on <locus from="4v" to="12r"/> and <locus target="#36r"/>.
-                                    The text is occasionally barely legible due to faded ink, e.g. on <locus target="#4r #18r"/>.
-                                    The sewing has been repaired but the textblock is still unstable and the single quires are somewhat loose.
+                                    The manuscript is in a poor state of preservation. The sewing has been repaired but the textblock is still unstable and the single quires are somewhat loose.
                                     The textile chemise has been crudely sewn to the boards
-                                    and to the board attachments.
+                                    and to the board attachments. The outer margin of the textblock has been damaged probably by rodents, with loss of text on <locus from="1r" to="4r"/> and <locus target="#29v"/>.
+                                    The lower margins of many folios are slightly stained with dirt, e.g. on <locus from="4v" to="12r"/> and <locus target="#36r"/>.
+                                    The parchment is wrinkled on <locus target="#17"/> and folded on <locus target="#34"/>.
+                                    The text is occasionally barely legible due to faded ink, e.g. on <locus target="#4r #18r"/>.
                                 </condition>
                             </supportDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethg33.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg33.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!-- 
+                <!--
                   <title xml:lang="gez" xml:id="title1">አኰቴተ፡ ቍርባን፡ ዘቅዱስ፡ ህርያቆስ፡ ዘሀገረ፡ ብህንሳ፡, አኰቴተ፡ ቍርባን፡ ዘእግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡, አኰቴተ፡ ቍርባን፡
                     ዘሐዋርያት፡, አኰቴተ፡ ቍርባን፡ ዘቅዱስ፡ ዲዮስቆሮስ፡, ተፈሥሒ፡ ኦዘንስእለኪ፡ ዳኅና፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">ʾAkkʷateta qʷǝrbān za-qǝddus Hǝryāqos za-hagara Bǝhnǝsā, ʾAkkʷateta qʷǝrbān za-ʾǝgziʾǝna ʾIyasus Krǝstos,
@@ -355,12 +355,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
                                 <condition key="deficient">
-                                    The manuscript is in a poor state of preservation. The sewing has been repaired but the textblock is still unstable and the single quires are somewhat loose.
-                                    The textile chemise has been crudely sewn to the boards
-                                    and to the board attachments. The outer margin of the textblock has been damaged probably by rodents, with loss of text on <locus from="1r" to="4r"/> and <locus target="#29v"/>.
-                                    The lower margins of many folios are slightly stained with dirt, e.g. on <locus from="4v" to="12r"/> and <locus target="#36r"/>.
-                                    The parchment is wrinkled on <locus target="#17"/> and folded on <locus target="#34"/>.
+                                    The outer margin of the textblock has been damaged probably by rodents, with loss of text on <locus from="1r" to="4r"/> and <locus target="#29v"/>.
+                                    The lower margins of many folios are stained with dirt, e.g. on <locus from="4v" to="12r"/> and <locus target="#36r"/>.
                                     The text is occasionally barely legible due to faded ink, e.g. on <locus target="#4r #18r"/>.
+                                    The sewing has been repaired but the textblock is still unstable and the single quires are somewhat loose.
+                                    The textile chemise has been crudely sewn to the boards
+                                    and to the board attachments.
                                 </condition>
                             </supportDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethg34.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg34.xml
@@ -10,11 +10,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!-- 
+                <!--
                 <title xml:lang="gez" xml:id="title1">ፍትሐተ፡ ሥራይ፡, ነገረ፡ ስሕተቶሙ፡ ለመናፍቃን፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Fǝtḥata śǝrāy, Nagara sǝḥtatomu la-manāfǝqān</title>
                 -->
-                <title xml:lang="en" xml:id="title1">Dissolution of the Spell (<hi rendition="simple:italic">Fǝtḥata śǝrāy</hi>), Amharic theological treatise, Discourse 
+                <title xml:lang="en" xml:id="title1">Dissolution of the Spell (<hi rendition="simple:italic">Fǝtḥata śǝrāy</hi>), Amharic theological treatise, Discourse
                     on the Errors of the Heretics, List of commemorations of saints, <hi rendition="simple:italic">Malkǝʾ</hi>-hymns</title>
                 <editor key="DR"/>
                 <editor key="JG"/>
@@ -60,7 +60,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <depth>46</depth>
                                     </dimensions>
                                 </extent>
-                                
+
                                 <foliation>Pencil foliation in the upper right corner (1–74).</foliation>
 
                                 <collation>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg34.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg34.xml
@@ -10,11 +10,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!--
+                <!-- 
                 <title xml:lang="gez" xml:id="title1">ፍትሐተ፡ ሥራይ፡, ነገረ፡ ስሕተቶሙ፡ ለመናፍቃን፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Fǝtḥata śǝrāy, Nagara sǝḥtatomu la-manāfǝqān</title>
                 -->
-                <title xml:lang="en" xml:id="title1">Dissolution of the Spell (<hi rendition="simple:italic">Fǝtḥata śǝrāy</hi>), Amharic theological treatise, Discourse
+                <title xml:lang="en" xml:id="title1">Dissolution of the Spell (<hi rendition="simple:italic">Fǝtḥata śǝrāy</hi>), Amharic theological treatise, Discourse 
                     on the Errors of the Heretics, List of commemorations of saints, <hi rendition="simple:italic">Malkǝʾ</hi>-hymns</title>
                 <editor key="DR"/>
                 <editor key="JG"/>
@@ -60,7 +60,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <depth>46</depth>
                                     </dimensions>
                                 </extent>
-
+                                
                                 <foliation>Pencil foliation in the upper right corner (1–74).</foliation>
 
                                 <collation>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg35.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg35.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-               <!-- 
+               <!--
                 <title xml:lang="gez" xml:id="title1">መልክአ፡ ጊዮርጊስ፡, መልክአ፡ ጊዮርጊስ፡, መልክአ፡ ኪዳነ፡ ምሕረት፡, መልክአ፡ ማርያም፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Malkǝʾa Giyorgis, Malkǝʾa Giyorgis, Malkǝʾa Kidāna mǝḥrat, Malkǝʾa Māryām</title>
                  -->
@@ -213,8 +213,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </item>
                                         </list>
                                 </collation>
-                                <condition key="good">The manuscript folios are in good condition and show only slight traces of use.
-                                  The sewing has become undone since the sewing thread broke in many points. Both boards are detached from the bookblock, together with <ref target="#q1"/>.</condition>
+                                <condition key="good">The manuscript folios show only slight traces of use.
+                                  However, the sewing has become undone since the thread broke in many points with the risk of leaves displacemnent.
+                                  Both boards are detached from the bookblock, together with <ref target="#q1"/>.</condition>
                             </supportDesc>
 
                             <layoutDesc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg37.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg37.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!-- 
+                <!--
                <title xml:lang="gez" xml:id="title1">መሓልየ፡ ነቢያት፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Maḥālǝya nabiyāt</title>
                 -->
@@ -410,7 +410,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </collation>
 
                                 <condition key="good">The first folio and the outer margins of many pages are stained by dirt, e.g.
-                                    <locus target="#25 #30v #31r"/>. Insect droppings on some folios, e.g. <locus target="#1r #12v #13r"/>.</condition>
+                                    <locus target="#25 #30v #31r"/>. Insect droppings are present on some folios, e.g. <locus target="#1r #12v #13r"/>.</condition>
                             </supportDesc>
 
                             <layoutDesc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg38.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg38.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0"
     xml:id="BDLaethg38"
@@ -37,19 +37,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <idno>Juel-Jensen 9</idno>
                         </altIdentifier>
                     </msIdentifier>
-                    
+
                     <msContents>
                         <summary/>
-                        
+
                         <msItem xml:id="ms_i1">
                             <locus from="1r1" to="1r15"/>
                             <title type="incomplete" ref="LIT6810Protect"/>
                             <textLang mainLang="gez"/>
                             <note>The incipit is missing due to material damage.</note>
-                            <incipit xml:lang="gez"><gap reason="lost"/>ተ፡ ጸዋጋን፡ ወሰ<gap reason="lost"/>ርያን፡ ወባርያ፡ <gap reason="lost"/>ማን፡ ወመናፍስት፡ 
-                                ርኩሳ<gap reason="lost"/> ደሰክ፡ ወጉዳሊ፡ ዓይነ፡ ባርጨዛ፡ አልጉም፡ ሸርጋታ፡ ወ<gap reason="lost"/>በሽታ፡ ሸውታ፡ 
+                            <incipit xml:lang="gez"><gap reason="lost"/>ተ፡ ጸዋጋን፡ ወሰ<gap reason="lost"/>ርያን፡ ወባርያ፡ <gap reason="lost"/>ማን፡ ወመናፍስት፡
+                                ርኩሳ<gap reason="lost"/> ደሰክ፡ ወጉዳሊ፡ ዓይነ፡ ባርጨዛ፡ አልጉም፡ ሸርጋታ፡ ወ<gap reason="lost"/>በሽታ፡ ሸውታ፡
                                 ሽውታ፡ ወትንትን፡ ወቃታ፡ ዘያጸልሙ፡ አ<gap reason="lost"/>ተ፡ ወይቀጠቅጡ፡ አእጽም<gap reason="lost"/>፡ ወይመጽኡ፡</incipit>
-                            <explicit xml:lang="gez">አመሐልኩከ፡ ወ<gap reason="lost"/>ውገዝኩከ፡ በ፭ ቅንዋት፡ መስቀሉ፡ ለእግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ ዕቀባ፡ ወአድኅ<gap reason="lost"/> 
+                            <explicit xml:lang="gez">አመሐልኩከ፡ ወ<gap reason="lost"/>ውገዝኩከ፡ በ፭ ቅንዋት፡ መስቀሉ፡ ለእግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ ዕቀባ፡ ወአድኅ<gap reason="lost"/>
                                 እምሕማመ፡ መጋኛ፡ ወ<gap reason="lost"/>ኛ፡ ለአመትከ፡ ወለ<gap reason="illegible" unit="chars" quantity="2"/></explicit>
                         </msItem>
                         <msItem xml:id="ms_i2">
@@ -60,11 +60,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez">
                                 <gap reason="lost"/>ም፡ ዘየሐዩ፡ በታሕተ፡ ሰማ<gap reason="lost" unit="chars" quantity="1"/>፡ ዘእንበለ፡ ስሙ፡ ለእግዚእ<gap reason="lost" unit="chars" quantity="1"/>
-                                ኢየሱስ፡ ክርስቶስ፡ ጋኔን፡ ዘ<gap reason="lost" unit="chars" quantity="1"/>ሬዒ፡ በዓይነ፡ ጠባይዕ፡ እሳታዊ፡ ተዓሠር፡ ይቤላከ፡ ቃለ፡ እግዚአብሔር፡ 
+                                ኢየሱስ፡ ክርስቶስ፡ ጋኔን፡ ዘ<gap reason="lost" unit="chars" quantity="1"/>ሬዒ፡ በዓይነ፡ ጠባይዕ፡ እሳታዊ፡ ተዓሠር፡ ይቤላከ፡ ቃለ፡ እግዚአብሔር፡
                                 ዘአሠሮ፡ ልብርያል፡ በ፭፻፼ ሰናስለ፡ እሳት፡
                             </incipit>
-                            <explicit xml:lang="gez">አቃንን፡ አብሮብርዮን፡ አቶታኤል፡ መትርማይ፡ በዝ፡ አስማት፡ አድኅና፡ እምሕማመ፡ ባርያ<supplied reason="omitted">፡</supplied> 
-                                ወሌጌዎን፡ ዘይጥህል፡ ወያሰለስል፡ ወያመነሞ፡ ወእምኵሎሙ፡ መናፍስት፡ እኩያን፡ ለአመትከ፡ <persName ref="PRS13973WalattaMa">ወለተ፡ ማርያም፡</persName></explicit>  
+                            <explicit xml:lang="gez">አቃንን፡ አብሮብርዮን፡ አቶታኤል፡ መትርማይ፡ በዝ፡ አስማት፡ አድኅና፡ እምሕማመ፡ ባርያ<supplied reason="omitted">፡</supplied>
+                                ወሌጌዎን፡ ዘይጥህል፡ ወያሰለስል፡ ወያመነሞ፡ ወእምኵሎሙ፡ መናፍስት፡ እኩያን፡ ለአመትከ፡ <persName ref="PRS13973WalattaMa">ወለተ፡ ማርያም፡</persName></explicit>
                         </msItem>
                         <msItem xml:id="ms_i3">
                             <locus from="1r125" to="1r186"/>
@@ -76,19 +76,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 አህያ፡ ሸራህያ፡ አልሻዳይ፡ ፀባኦት፡ ቢዛ፡ ባሃ፡ ጻሃ፡ ዱጳሃ፡ ረሃ፡ መልረጹዳንያ፡ ፎያ፡ አክሰሜና፡ ባባፊማርት፡ ወአመበሎ፡ ወማርት፡ አርግዕ፡ ጾማ፡ ለአመትከ፡ <persName ref="PRS13973WalattaMa">ወለተ፡
                                     <hi rend="rubric">ማር<supplied reason="omitted">ያም፡</supplied></hi></persName>
                             </incipit>
-                            <explicit xml:lang="gez"> ወይፃዕ፡ መንፈስ፡ ርኩስ፡ ዘአኃዘ፡ እደ፡ ሰብእ፡ ወተግባረ፡ ሰብእ፡ ይደምሰስ፡ ወዘርአ፡ ጸሎት፡ ከማሁ፡ አርግዕ፡ ውኅዘተ፡ 
-                                ደማ፡ ወአቁም፡ ፍሬ፡ ማኅፀና፡ ለአመትከ፡ <persName ref="PRS13973WalattaMa">ወለተ፡ <hi rend="rubric">ማርያም፡</hi></persName> 
+                            <explicit xml:lang="gez"> ወይፃዕ፡ መንፈስ፡ ርኩስ፡ ዘአኃዘ፡ እደ፡ ሰብእ፡ ወተግባረ፡ ሰብእ፡ ይደምሰስ፡ ወዘርአ፡ ጸሎት፡ ከማሁ፡ አርግዕ፡ ውኅዘተ፡
+                                ደማ፡ ወአቁም፡ ፍሬ፡ ማኅፀና፡ ለአመትከ፡ <persName ref="PRS13973WalattaMa">ወለተ፡ <hi rend="rubric">ማርያም፡</hi></persName>
                                 እስመ፡ አልቦ፡ ነገር፡ ዘይሰዓኖ፡ ለእግዚአብሔር<supplied reason="omitted">።</supplied></explicit>
                         </msItem>
                         <msItem xml:id="ms_i4">
                             <locus from="1r186" to="1r290"/>
                             <title type="complete" ref="LIT6813Seqyael"/>
                             <textLang mainLang="gez"/>
-                            <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወምንፈስ፡ ቅዱስ፡ ፩ አምላክ። ስቅያኤልኤል፡ ስቅያኤልኤል፡ ስቅያኤልኤል፡ 
+                            <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወምንፈስ፡ ቅዱስ፡ ፩ አምላክ። ስቅያኤልኤል፡ ስቅያኤልኤል፡ ስቅያኤልኤል፡
                                 ስቅያኤልኤል፡ ስቅያኤልኤል፡ ስቅያኤልኤል፡ ስቅያኤልኤል፡ በ<gap reason="illegible" unit="chars" quantity="1"/></hi>ይለ፡ ዝንቱ፡ አስማቲከ፡
                                 ዘአርዕከ፡ <gap reason="illegible" unit="chars" quantity="1"/>ይለ፡ በረድ፡  ወነፋስ፡ ከማሁ፡ አርግዕ፡ ደም፡ ትክቶሃ፡ ለአመትከ፡ <persName ref="PRS13973WalattaMa">ወለተ፡
                                     <hi rend="rubric">ማር<supplied reason="omitted">ያም፡</supplied></hi></persName></incipit>
-                            <explicit xml:lang="gez">ኦ<hi rend="rubric">አምላከ፡ ቅዱስ፡ ፋኑኤል፡ ዕቀባ፡ ወአድኅና፡ እምሕማመ፡ መጋኛ፡ ወቁራኛ፡ <sic>ጻም፡</sic> ወሸተላይ፡ ዓይነ፡ ወርቅ፡ ወዓይነ፡ 
+                            <explicit xml:lang="gez">ኦ<hi rend="rubric">አምላከ፡ ቅዱስ፡ ፋኑኤል፡ ዕቀባ፡ ወአድኅና፡ እምሕማመ፡ መጋኛ፡ ወቁራኛ፡ <sic>ጻም፡</sic> ወሸተላይ፡ ዓይነ፡ ወርቅ፡ ወዓይነ፡
                                 ጥላ፡ አይነት፡ ቡዳ፡ ወቁመኛ፡ ለአመትከ፡ <persName ref="PRS13973WalattaMa">ወለተ፡ ማርያም፡</persName> </hi></explicit>
                         </msItem>
                         <msItem xml:id="ms_i5">
@@ -96,13 +96,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <title type="complete" ref="LIT6814MagicPr"/>
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ በእንተ፡ ጽንስ፡ ወስደተ፡ አጋንንት፡ ገቢረከ፡ በእንተ፡ ጽንሰታ፡
-                                ለ<hi rend="rubric">ማርያም፡</hi> ዘብሩድስክኤል፡ ኢያርማናኤል፡ በዝንቱ፡ ማኅፀነ፡ ክትረት፡ በስመ፡ ሥሉስ፡ ቅዱስ፡ ሜልዮስ፡ መላልዮስ፡ ሊስ፡ 
+                                ለ<hi rend="rubric">ማርያም፡</hi> ዘብሩድስክኤል፡ ኢያርማናኤል፡ በዝንቱ፡ ማኅፀነ፡ ክትረት፡ በስመ፡ ሥሉስ፡ ቅዱስ፡ ሜልዮስ፡ መላልዮስ፡ ሊስ፡
                                 አፍሊስ፡ በክሜሎስ፡ ዘአርጋዕከ፡ ኃይለ፡ በረድ፡ ወነፋስ፡ ከማሁ፡ አርግዕ፡ ደማ፡ ለእግዚአብሔር፡</incipit>
-                            <explicit xml:lang="gez">በዝንቱ፡ አስማት፡ ዘከተሮ፡ ለዲያብሎስ፡ ሳዶር፡ አላዶር፡ ዳናት፡ አዴራ፡ ሮዳስ፡ ሴቃ፡ ሌቃ፡ ጼቃ፡ በእሉ፡ አስማት፡ ዘከተሮ፡ 
+                            <explicit xml:lang="gez">በዝንቱ፡ አስማት፡ ዘከተሮ፡ ለዲያብሎስ፡ ሳዶር፡ አላዶር፡ ዳናት፡ አዴራ፡ ሮዳስ፡ ሴቃ፡ ሌቃ፡ ጼቃ፡ በእሉ፡ አስማት፡ ዘከተሮ፡
                                 ለሰይጣን፡ ከማሁ፡ ክትር፡ ደማ፡ ለአመትከ፡ <persName ref="PRS13973WalattaMa">ወለ<hi rend="rubric">ተ፡ ማርያም፡</hi></persName> <hi rend="rubric">ሰገዱ፡</hi></explicit>
                         </msItem>
                     </msContents>
-                    
+
                     <physDesc>
                         <objectDesc form="Scroll">
                             <supportDesc>
@@ -130,13 +130,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <!-- <measure type="weight" unit="g">28</measure><!-\-with case-\->-->
                                     <measure type="weight" unit="g">17</measure><!--without case-->
                                 </extent>
-                                <condition key="good">The manuscript is in a mediocre state of preservation. The upper part of the scroll is missing, with subsequent loss of text;
+                                <condition key="good">The upper part of the scroll is missing, with subsequent loss of text;
                                     the right margin in the upper border and the left margin in the lower border are also damaged.
                                     The parchment is crumpled due to rolling and displays stains of unspecified nature.
                                     The red ink is mostly faded away, leading to textual lacunas in several places.
                                 </condition>
                             </supportDesc>
-                            
+
                             <layoutDesc>
                                 <layout columns="1" writtenLines="88">
                                     <note>Number of characters per line: 10–13</note>
@@ -185,23 +185,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </layout>
                             </layoutDesc>
                         </objectDesc>
-                        
+
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <date notBefore="1800" notAfter="2006"/>
                                 <desc>Fine handwriting. Characters are uniformly spaced.
-                                    The scribe has used modified letters which are not usually found in the fidal syllabary, like 
+                                    The scribe has used modified letters which are not usually found in the fidal syllabary, like
                                     <foreign xml:lang="gez">ሐ</foreign> or <foreign xml:lang="gez">ሑ</foreign> with a horizontal stroke on the top of the letter (e.g. <locus target="#1r56 #1r57"/>).
                                     Some letters are provided with loops at their ends, like <foreign xml:lang="gez">ፓ</foreign>
-                                        (<locus target="#1r30"/>), 
-                                        <foreign xml:lang="gez">ሐ</foreign>/<foreign xml:lang="gez">ሑ</foreign> (e.g. <locus target="#1r56 #1r57"/>), and 
+                                        (<locus target="#1r30"/>),
+                                        <foreign xml:lang="gez">ሐ</foreign>/<foreign xml:lang="gez">ሑ</foreign> (e.g. <locus target="#1r56 #1r57"/>), and
                                             <foreign xml:lang="gez">ዎ</foreign> (<locus target="#2r4"/>).
                                     These letters resemble Brillenbuchstaben <!--italics-->, but they are used within words in the body of the text.</desc>
                                 <seg type="ink">Black, red.</seg>
                                 <seg type="rubrication">Few lines of the incipits and other lines within the text, the name of Mary, some of the Brillenbuchstaben <!--italics-->.</seg>
                             </handNote>
                         </handDesc>
-                        
+
                         <additions>
                             <list>
                                 <item xml:id="e1">
@@ -212,7 +212,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </item>
                                 <item xml:id="e3">
                                     <desc>The name of the owner, mentioned in supplications throughout and introduced by the epithet <foreign xml:lang="gez">አመትከ፡</foreign> "your maid", was <persName ref="PRS13973WalattaMa"/>.
-                                        The name is partially illegible due to faded ink. Also, some of the letters of the name are very often crossed out and replaced with those of 
+                                        The name is partially illegible due to faded ink. Also, some of the letters of the name are very often crossed out and replaced with those of
                                         another poorly decipherable name.</desc>
                                 </item>
                                 <item xml:id="e4">
@@ -221,7 +221,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </item>
                             </list>
                         </additions>
-                        
+
                         <bindingDesc>
                             <binding>
                                 <decoNote xml:id="b1">The three parchment strips that compose the scroll are sewn together with a running stitch.</decoNote>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg39.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg39.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0"
     xml:id="BDLaethg39"
@@ -15,7 +15,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <editor key="JG"/>
                 <editor key="MV"/>
                 <editor key="SH"/>
-                <editor key="EDS"/>                
+                <editor key="EDS"/>
                  <editor key="JK"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
@@ -41,33 +41,33 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <!-- What is this identifier? An inventory number? -->
                         </altIdentifier>
                     </msIdentifier>
-                    
+
                     <msContents>
                         <summary/>
-                        
+
                         <msItem xml:id="ms_i1">
                             <locus from="1r1" to="1r28"/>
                             <title ref="LIT6791PPAsmat" type="complete"/>
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላልክ፡ ተሰደ፡ አጋን</hi>ንት፡ ሺማዳን፡ ሺማዳን፡
-                            ሺማዳናኤል፡ ጉጉስን፡ ተክለ፡ ሺርታን፡ ያሆን፡ ያሼሺን፡ በ<add place="above">ዝ</add>ንቱ፡ አስማቲከ፡ ምስለ፡ ኖባ፡ ንጉሥክሙ፡ 
+                            ሺማዳናኤል፡ ጉጉስን፡ ተክለ፡ ሺርታን፡ ያሆን፡ ያሼሺን፡ በ<add place="above">ዝ</add>ንቱ፡ አስማቲከ፡ ምስለ፡ ኖባ፡ ንጉሥክሙ፡
                                 ወምስለ፡ ወለ<hi rend="rubric">ተ፡ ወርቅ፡ ንግሥትክሙ፡</hi></incipit>
-                            <explicit xml:lang="gez">በከመ፡ አሰሮ፡ ለብርያል፡ ከማሁ፡ እሰሮሙ፡ <sic>ለመናፍስተ፡</sic> ርኩሳን፡ በስመ፡ ድማሔር፡ አብርሮ፡ ፈሮኪ፡ ሰራሒ፡ 
+                            <explicit xml:lang="gez">በከመ፡ አሰሮ፡ ለብርያል፡ ከማሁ፡ እሰሮሙ፡ <sic>ለመናፍስተ፡</sic> ርኩሳን፡ በስመ፡ ድማሔር፡ አብርሮ፡ ፈሮኪ፡ ሰራሒ፡
                             ሰጥርናሃ፡ መስፍኑ፡ አድክም፡ ሃይሎሙ፡ ለመናፍስት፡ ርኩሳን፡ በኃይለ፡ ዝንቱ፡ አስማቲከ፡ ረሰዮሙ፡ ቅጥቁጣኒ፡ ለአጋንንት፡ ርኩሳን፡ በኀይለ፡ ዝንቱ፡
                             አስማቲከ፡ አድኅኖ፡ ለገብርከ። <persName ref="PRS13862GabraY" role="owner"><hi rend="rubric">ገብረ፡ ዮናስ፡</hi></persName></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i2">
                             <locus from="1r29" to="1r41"/>
                             <title ref="LIT6792PPBinding" type="complete"/>
                             <textLang mainLang="gez"/>
                             <note>The following is the entire text.</note>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡</hi> ቅዱስ፡ ፩ አምላክ፡ ንጉሠ፡ አጋንንት፡ ኢተዮጵያ፡
-                            ባኖ፡ በኖባ፡ ንጉሥክሙ፡ አጋንንት፡ ፈርስ፡ ማእስሮሙ፡ ለአጋንንት፡ ፋርስ፡ በሹማዳን፡ በሹማዳን፡ በሹማዳኤል፡ በጉላጅን፡ በተክለ፡ ሺርታን፡ እለ፡ ሰማያውያን፡ 
+                            ባኖ፡ በኖባ፡ ንጉሥክሙ፡ አጋንንት፡ ፈርስ፡ ማእስሮሙ፡ ለአጋንንት፡ ፋርስ፡ በሹማዳን፡ በሹማዳን፡ በሹማዳኤል፡ በጉላጅን፡ በተክለ፡ ሺርታን፡ እለ፡ ሰማያውያን፡
                             ቃሹን፡ ጥቅማሹን፡ አቅማሀሹን፡ ዘነበረ፡ ውስተ፡ ህልቀቱ፡ ለሰሎሞን፡ ሰሎሞናዊ፡ ከማሁ፡ እሰሮሙ፡ እግዚእ፡ ለአጋንንት፡ ሰሎሞ፡ ፎሐ፡ ሰሎሞ፡ ከሀማ፡ ሰሎሞናዊ፡
                             አድኅኖ፡ ለገብርከ፡ <persName ref="PRS13862GabraY" role="owner"><hi rend="rubric">ገብረ፡ ዮናስ፡</hi></persName></incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i3">
                             <locus from="1r42" to="1r53"/>
                             <title ref="LIT5920JohnBeg" type="complete"/>
@@ -76,11 +76,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <incipit xml:lang="gez">ቀዳሚሁ፡ ቃል፡ ውእቱ፡ ቃል፡ ኀበ፡ እግዚአብሔር፡ ውእቱ፡ ቃል፡ ወከማሁ፡ ቀዳሚሁ፡ እምቀዲሙ፡ ኀበ፡
                                 እግዚአብሔር፡ ውእቱ፡ ወቦቱ፡ ኵሉ<supplied reason="omitted">፡</supplied> ኮነ፡ ወዘእንበሌሆሰ፡ አልቦ፡ ዘኮነ፡ ወኢምንትኒ፡ ወዘሂ፡
                                 ኮነ፡ በእንቲአሁ፡ ቦቱ፡ ሕይወትሰ፡ ብርሃኑ፡ ለእጓለ፡ እመህያው፡ ወብርሃኑሰ፡ ለዘ<gap reason="illegible" unit="chars" quantity="1"/>ስተ፡
-                                ጽልመት፡ ያበርህ፡ ወያርኢ፡ ወጽልመትኒ፡ ኢይቅረቦ፡ ከማሁ፡ ኢይቅረቡኒ፡ ደስክ፡ ወጉዳሌ፡ 
+                                ጽልመት፡ ያበርህ፡ ወያርኢ፡ ወጽልመትኒ፡ ኢይቅረቦ፡ ከማሁ፡ ኢይቅረቡኒ፡ ደስክ፡ ወጉዳሌ፡
                                 ለገብርከ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                 <persName ref="PRS13862GabraY" role="owner"><hi rend="rubric">ገብረ፡ ዮናስ፡</hi></persName></incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i4">
                             <locus from="1r54" to="1r66"/>
                             <title ref="LIT6793PPAsmat" type="complete"/>
@@ -92,7 +92,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 ህድግ፡ አስተህድ፡ ወሰዊትከ፡ ይቤለከ፡ ወለዘቦቱ፡ ትእዛዝየ፡ የአቅቦ፡ ወዘያፈቅረኑ፡ አፈቅር፡ ወአርዕዮ፡ ርዕሶ፡ ለገብርከ፡
                                 <persName ref="PRS13862GabraY" role="owner"><hi rend="rubric">ገብረ፡ ዮናስ፡</hi></persName></incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i5">
                             <locus from="1r67" to="1r80"/>
                             <title ref="LIT6794PPBarya" type="complete"/>
@@ -104,13 +104,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 ክርስትና፡ በ<hi rend="rubric" rendition="#partialRubric">፯</hi> ንጉሠ፡ ትብልና፡ በ<hi rend="rubric" rendition="#partialRubric">፯</hi>
                                 ጵጵስና፡ በ<hi rend="rubric" rendition="#partialRubric">፯</hi> ንጉሠ፡ ቅስስና፡ በ<hi rend="rubric" rendition="#partialRubric">፯</hi> ብህርይ፡
                                 በገጸር፡ በ<hi rend="rubric" rendition="#partialRubric">፯</hi> ዘፈር፡ በ<hi rend="rubric" rendition="#partialRubric">፯</hi> ነገሥት፡
-                                በ<hi rend="rubric" rendition="#partialRubric">፯</hi> አፈ፡ ነገሥት፡ በ<hi rend="rubric" rendition="#partialRubric">፯</hi> ጳጳሳት፡ 
-                                በ<hi rend="rubric" rendition="#partialRubric">፯</hi> ሊቃነ፡ ጳጳሳት፡ በ<hi rend="rubric" rendition="#partialRubric">፯</hi> 
-                                አስማተ፡ ክርስቶስ፡ ዘተውህበ፡ አርድዕት፡ ወአርድዕት፡ ከዕትኩ፡ ለውሉደ፡ ጥምቀት፡ በዘተአስሩ፡ አጋንንት፡ ከማሁ፡ እስሮሙ፡ ከመ፡ ኢይቅረቡ፡ ሀበ፡ ነፍሱ፡ ወሥጋሁ፡ 
+                                በ<hi rend="rubric" rendition="#partialRubric">፯</hi> አፈ፡ ነገሥት፡ በ<hi rend="rubric" rendition="#partialRubric">፯</hi> ጳጳሳት፡
+                                በ<hi rend="rubric" rendition="#partialRubric">፯</hi> ሊቃነ፡ ጳጳሳት፡ በ<hi rend="rubric" rendition="#partialRubric">፯</hi>
+                                አስማተ፡ ክርስቶስ፡ ዘተውህበ፡ አርድዕት፡ ወአርድዕት፡ ከዕትኩ፡ ለውሉደ፡ ጥምቀት፡ በዘተአስሩ፡ አጋንንት፡ ከማሁ፡ እስሮሙ፡ ከመ፡ ኢይቅረቡ፡ ሀበ፡ ነፍሱ፡ ወሥጋሁ፡
                                 ለገብርከ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                 <persName ref="PRS13862GabraY" role="owner"><hi rend="rubric">ገብረ፡ ዮናስ፡</hi></persName></incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i6">
                             <locus from="1r81" to="1r100"/>
                             <title ref="LIT6795PPApellon" type="complete"/>
@@ -118,29 +118,29 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <incipit xml:lang="gez">
                                 <hi rend="rubric"><gap reason="illegible"/>አጵሎን፡ በገነውተ፡ ባርያ፡ በአብ፡ <gap reason="illegible"/></hi>በጸሎቱ፡ በጸሎቱ፡ በበለው፡ ለአቂቦታቱ፡
                                 አወግዘከ፡ በእንተ፡ ባርያ፡ በእ<gap reason="illegible"/> ንግሥት፡ በ<hi rend="rubric" rendition="#partialRubric">፲</hi>ወ<hi rend="rubric" rendition="#partialRubric">፪</hi>
-                                ሐዋርያት፡ ወበ<hi rend="rubric" rendition="#partialRubric">፲</hi>ወ<hi rend="rubric" rendition="#partialRubric">፭</hi> ነቢያት፡ 
+                                ሐዋርያት፡ ወበ<hi rend="rubric" rendition="#partialRubric">፲</hi>ወ<hi rend="rubric" rendition="#partialRubric">፭</hi> ነቢያት፡
                                 በ<hi rend="rubric" rendition="#partialRubric">፸</hi>ወ<hi rend="rubric" rendition="#partialRubric">፪</hi> አርድዕት፡
                                 በ<hi rend="rubric" rendition="#partialRubric">፫፻</hi>፡ <hi rend="rubric" rendition="#partialRubric">፲</hi>ወ<hi rend="rubric" rendition="#partialRubric">፰</hi>
                                 ርቱአነ፡ ሃይማኖት፡</incipit>
-                            <explicit xml:lang="gez">አወግዘከ፡ አንተ፡ አንተ፡ ባርያ፡ ዘትነብር፡ ሀበ፡ ጸላዕት፡ አወግዘከ፡ አንተ፡ ባርያ፡ ዘትነብር፡ ታህተ፡ እብነ፡ መሰህት፡ ባርያ፡ 
-                                ዘትትሜሰል፡ በኵሉ፡ አምሳል፡ አወግዘከ፡ አንተ፡ ባርያ፡ ከመ፡ ትባዕ፡ ውስተ፡ ዱዱር፡ ወከመ፡ ትባዕ፡ ውስተ፡ ባሕር፡ ወከመ፡ <gap reason="illegible"/>ጸዕ፡ ከመ፡ ጢስ፡ ወነፋስ፡ ወነፋስ፡ 
+                            <explicit xml:lang="gez">አወግዘከ፡ አንተ፡ አንተ፡ ባርያ፡ ዘትነብር፡ ሀበ፡ ጸላዕት፡ አወግዘከ፡ አንተ፡ ባርያ፡ ዘትነብር፡ ታህተ፡ እብነ፡ መሰህት፡ ባርያ፡
+                                ዘትትሜሰል፡ በኵሉ፡ አምሳል፡ አወግዘከ፡ አንተ፡ ባርያ፡ ከመ፡ ትባዕ፡ ውስተ፡ ዱዱር፡ ወከመ፡ ትባዕ፡ ውስተ፡ ባሕር፡ ወከመ፡ <gap reason="illegible"/>ጸዕ፡ ከመ፡ ጢስ፡ ወነፋስ፡ ወነፋስ፡
                             <gap reason="illegible" unit="lines" quantity="1"/></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i7">
                             <locus from="1r101" to="1r118"/>
                             <title ref="LIT6796PPIllnesses" type="complete"/>
                             <textLang mainLang="gez"/>
                             <note>The following is the entire text.</note>
                             <incipit xml:lang="gez">
-                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅ</hi>ዱስ፡ <hi rend="rubric" rendition="#partialRubric">፩</hi> አምላክ፡ 
-                                ጸሎት፡ በእንተ፡ ለጌዎን፡ ርኩስ፡ ዘይሰልብ፡ ልበ፡ ሰብእ፡ ወያደቅቅ፡ 
+                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅ</hi>ዱስ፡ <hi rend="rubric" rendition="#partialRubric">፩</hi> አምላክ፡
+                                ጸሎት፡ በእንተ፡ ለጌዎን፡ ርኩስ፡ ዘይሰልብ፡ ልበ፡ ሰብእ፡ ወያደቅቅ፡
                                 አዕጽምት፡ ወያጸልም፡ አ<hi rend="rubric">ዕይን<sic>ት</sic>፡ ወይመጽዕ፡ ከመ፡ ጽላ</hi>ሎት፡ ወህልም፡ አምሕለከ፡ ወአወግዘከ፡ በ፭ ቅንዋተ፡ መስቀሉ፡ ለእግዚነ፡ ኢየሱስ፡ ክርስቶስ፡ በስመ፡
-                            ሳዶር፡ አላዶር፡ ዳናት፡ አዴራ፡ ሮዳስ፡ በሃይለ፡ ዝንቱ፡ አስማቲከ፡ አድኅነኒ፡ እምሕማመ፡ ባርያ፡ ወለጌዎን፡ ደስከ፡ ወገዳሌ፡ ለውግአት፡ ወለቈርጥማት፡ ለዓይነት፡ ወለመጋኛ፡ ለውግአት፡ ወለቍርጥማት፡ 
+                            ሳዶር፡ አላዶር፡ ዳናት፡ አዴራ፡ ሮዳስ፡ በሃይለ፡ ዝንቱ፡ አስማቲከ፡ አድኅነኒ፡ እምሕማመ፡ ባርያ፡ ወለጌዎን፡ ደስከ፡ ወገዳሌ፡ ለውግአት፡ ወለቈርጥማት፡ ለዓይነት፡ ወለመጋኛ፡ ለውግአት፡ ወለቍርጥማት፡
                             ለቍርፀት፡ ወለፍልፀት፡ ለፌራ፡ ወለትንር፡ ርኩሳን፡ ከመ፡ ኢይቅረቡ፡ ኀበ፡ ነፍሱ፡ ወሥጋሁ፡ ለገብርከ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                 <persName ref="PRS13862GabraY" role="owner"><hi rend="rubric">ገብረ፡ ዮናስ፡</hi></persName></incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i8">
                       <locus from="1r119" to="1r133"/>
                             <title ref="LIT6797PPStomachache" type="complete"/>
@@ -153,7 +153,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             ጽዮን፡ ሰማያዊት፡ <hi rend="rubric">ማርያም፡</hi> ወላዲተ፡ አምላክ፡ ሰንበተ፡ ክርስቲያን፡ ቅድስት፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ አድኅኖ፡ እምሕማመ፡ ውግአት፡
                                 ለገብርከ<hi rend="rubric" rendition="#partialRubric">፨</hi> <persName ref="PRS13862GabraY" role="owner"><hi rend="rubric">ገብረ፡ ዮናስ፡</hi></persName></incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i9">
                             <locus from="1r134" to="1r144"/>
                             <title ref="LIT5133MagicFormula" type="complete"/>
@@ -161,19 +161,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <note>The following is the entire text.</note>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡</hi> ቅዱስ፡ <hi rend="rubric" rendition="#partialRubric">፩</hi>
                                 አምላክ፡ ጸሎት፡ በእንተ፡ <hi rend="rubric">ሕማመ፡ ቍርፀት፡ ቄፄቤ፡ ቄፄ</hi>ቤ፡ ቄፄቤ፡ ቄፌኩ፡ ቡያክ፡ ቄፌኑ፡ ቡያክ፡ ሞሌ፡ ሞሌ፡ አርጋዔ፡ በረድ፡
-                                ከማሁ፡ አርግዕ፡ ሕማመ፡ ቍርፀት<hi rend="rubric" rendition="#partialRubric">፤</hi> ዘይጠዊ፡ 
+                                ከማሁ፡ አርግዕ፡ ሕማመ፡ ቍርፀት<hi rend="rubric" rendition="#partialRubric">፤</hi> ዘይጠዊ፡
                                 አንዥ<!--?-->ተ<hi rend="rubric" rendition="#partialRubric">፤</hi> ወዓማዑተ<hi rend="rubric" rendition="#partialRubric">፤</hi>
                                 ወያደቅቅ<hi rend="rubric" rendition="#partialRubric">፤</hi> አዕጽምተ<hi rend="rubric" rendition="#partialRubric">፤</hi>
                                 ወይፈነቅል፡ ገበዋተ፡ አድኅኖ፡ እምሕማመ፡ ቍርፀት፡ ለገብርከ፡ <persName ref="PRS13862GabraY" role="owner"><hi rend="rubric">ገብረ፡ ዮናስ፡</hi></persName></incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i10">
                             <locus from="1r145" to="1r172"/>
                             <title ref="LIT4704MagicPr" type="complete"/>
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡</hi> ቅዱስ፡ <hi rend="rubric" rendition="#partialRubric">፩</hi>
                                 አምላክ፡ አህያ፡ ሺራህያ፡ አልሸዳይ፡ እልመክኑን፡ አልፋ፡ ወአ፡ ኢየሱስ፡ ክርስቶስ፡ ወልደ፡ እግዚአብሕዌ፡ ህያው፡ ወልደ<hi rend="rubric" rendition="#partialRubric">፨</hi>
-                                <hi rend="rubric">ማርያም፡</hi>  ሥግው፡ ዘበመስቀልከ፡ አጽራዕከ፡ ግብሮ፡ ለዲያብሎስ፡ ከማሁ፡ አጽርእ፡ ሕማመ፡ ባርያ፡ 
+                                <hi rend="rubric">ማርያም፡</hi>  ሥግው፡ ዘበመስቀልከ፡ አጽራዕከ፡ ግብሮ፡ ለዲያብሎስ፡ ከማሁ፡ አጽርእ፡ ሕማመ፡ ባርያ፡
                             </incipit>
                             <explicit xml:lang="gez">በመስቀልከ፡ አድኀነኒ፡ እምፀር፡ መስቀል፡ ኀይልነ፡ መስቀል፡ ጽንእነ፡ መስቀል፡ ቤዛነ፡ አይሁድ፡ ክህዱ፡ ንሕነ፡ ንህነ፡ አመነ፡ በመስቀልከ፡
                                 ርድአነ፡ በመስቀልከ፡ ቤዝወኒ፡ ለገብርከ<hi rend="rubric" rendition="#partialRubric">፨</hi>
@@ -181,26 +181,26 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <gap reason="illegible"/>በፍፁም፡ ጽልመት፡ ፈ<gap reason="illegible" unit="lines" quantity="3"/>
                             </explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i11">
                             <locus from="1r173" to="1r207"/>
                             <title ref="LIT6798PPAsmat" type="complete"/>
                             <textLang mainLang="gez"/>
                           <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱ</hi>ስ፡ ፩ አምላክ፡ አብ፡ እሳት፡ ወወልድ፡ ወልድ፡ እሳት፡ መንፈስ፡ ቅዱስ፡
-                              እሳት፡ <hi rend="rubric" rendition="#partialRubric">፩</hi> ውእቱ፡ እሳት፡ መለኮት፡ በዝንቱ፡ አስማት፡ አ፡ ይሰደዱ፡ አጋንንት፡ 
+                              እሳት፡ <hi rend="rubric" rendition="#partialRubric">፩</hi> ውእቱ፡ እሳት፡ መለኮት፡ በዝንቱ፡ አስማት፡ አ፡ ይሰደዱ፡ አጋንንት፡
                               <gap reason="illegible"/>ወይጸኡ፡ ሰይጣናት፡ እለ፡ ያጸር<seg rend="below">ይ</seg>፡</incipit>
                             <explicit xml:lang="gez">እሰሮሙ፡ ለመናፍስት፡ ርኩሳን፡ ለ<del rend="expunctuated">ደ</del>ባርያ፡ ቀይሐን፡ ወለባርያ፡
                             ጸሊማን፡ ወለአጋንንት፡ እኩያን፡ ወእደ፡ ሰብእ፡ መሠርያን፡ ወኵሎሙ፡ መናፍስት፡ ርኵሳን፡ ከመ፡ ኢይቅረቡ፡ ኀበ፡ ነፍሱ፡
                             ወሥጋሁ<hi rend="rubric" rendition="#partialRubric">፨</hi> ለገብርከ <gap reason="illegible"/></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i12">
                             <locus target="#1r"/>
                             <title type="complete">Unidentified texts</title>
                             <note>Traces of erased writing are visible between <ref target="#d3"/> and the bottom of the recto.</note>
                         </msItem>
                     </msContents>
-                    
+
                     <physDesc>
                         <objectDesc form="Scroll">
                             <supportDesc>
@@ -227,9 +227,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <width>80–93</width>
                                     </dimensions>
                                 </extent>
-                                <condition key="good">The scroll is in a good state of preservation. The parchment has become very stiff, 
-                                    and the content of the recto shows through on the verso. The bottom of the scroll
-                                has been damaged by humidity.</condition>
+                                <condition key="good">The parchment has been damaged by humity becoming very stiff.
+                                    Consequently, the content on the recto is visible through the verso.</condition>
                             </supportDesc>
                             <layoutDesc>
                                 <layout columns="1" writtenLines="118" corresp="#sec2">
@@ -293,7 +292,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </layout>
                             </layoutDesc>
                         </objectDesc>
-                        
+
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <date notBefore="1800" notAfter="2006"/>
@@ -304,7 +303,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     elements of numerals and punctuation marks. Traces of rubrication are also visible on the verso.</seg>
                             </handNote>
                         </handDesc>
-                        
+
                      <!--   <decoDesc>
                             <decoNote xml:id="d1" type="miniature" corresp="#pic1">
                                 <locus target="#1r"/>
@@ -314,7 +313,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <width>89</width>
                                 </dimensions>
                             </decoNote>
-                            
+
                             <decoNote xml:id="d2" type="miniature" corresp="#pic2">
                                 <locus target="#1r"/>
                                 <desc></desc>
@@ -323,7 +322,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <width>90</width>
                                 </dimensions>
                             </decoNote>
-                            
+
                             <decoNote xml:id="d3" type="miniature" corresp="#pic3">
                                 <locus target="#1r"/>
                                 <desc></desc>
@@ -333,48 +332,48 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </dimensions>
                             </decoNote>
                         </decoDesc>-->
-                        
+
                         <additions>
                             <list>
                                 <item xml:id="e1">
                                     <desc>The verso of the scroll is empty.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e2">
                                     <desc>An omitted character has been added interlineally (<locus target="#1r4"/>)
                                         and a few erroneous characters have been under- and overlined and then erased (e.g. <locus target="#1r16"/>).</desc>
                                 </item>
-                                
+
                                 <item xml:id="e3">
                                     <desc>The name of the owner <persName ref="PRS13862GabraY" role="owner"/> has been inserted in space left empty at
-                                        the end of each prayer, 
+                                        the end of each prayer,
                                         written with a different nib and different red ink than the other rubrications, but
                                         possibly by the main hand.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e4">
-                                    <desc> A white sticker, with the number ‘22401’ printed on it, is glued onto the 
+                                    <desc> A white sticker, with the number ‘22401’ printed on it, is glued onto the
                                         upper part of the verso.</desc>
                                 </item>
                             </list>
                         </additions>
-                        
+
                         <bindingDesc>
                             <binding>
                                 <decoNote xml:id="b1">The three strips are slightly overlapped and sewn together with a
                                     running stitch using two narrow parchment strips and, in the first joining, white thread.</decoNote>
                             </binding>
                         </bindingDesc>
-                        
+
                     </physDesc>
-                    
+
                 <!--    <history>
                         <origin>
                             <origDate when="" evidence=""/>
                         </origin>
                         <provenance>  </provenance>
                     </history>-->
-                    
+
                     <additional>
                         <adminInfo>
                             <recordHist>
@@ -386,7 +385,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </recordHist>
                         </adminInfo>
                     </additional>
-                    
+
                 </msDesc>
             </sourceDesc>
         </fileDesc>
@@ -435,7 +434,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <div type="textpart" subtype="section" n="1" xml:id="sec1">
                         <div type="textpart" subtype="picture" n="1" xml:id="pic1" corresp="#d1"/>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="2" xml:id="sec2">
                         <div type="textpart" subtype="text" n="1" corresp="#ms_i1" xml:id="text1">
                             <ab/>
@@ -443,7 +442,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <div type="textpart" subtype="text" n="2" corresp="#ms_i2" xml:id="text2">
                             <ab>
                                 <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡</hi> ቅዱስ፡ ፩ አምላክ፡ ንጉሠ፡ አጋንንት፡ ኢተዮጵያ፡
-                                ባኖ፡ በኖባ፡ ንጉሥክሙ፡ አጋንንት፡ ፈርስ፡ ማእስሮሙ፡ ለአጋንንት፡ ፋርስ፡ በሹማዳን፡ በሹማዳን፡ በሹማዳኤል፡ በጉላጅን፡ በተክለ፡ ሺርታን፡ እለ፡ ሰማያውያን፡ 
+                                ባኖ፡ በኖባ፡ ንጉሥክሙ፡ አጋንንት፡ ፈርስ፡ ማእስሮሙ፡ ለአጋንንት፡ ፋርስ፡ በሹማዳን፡ በሹማዳን፡ በሹማዳኤል፡ በጉላጅን፡ በተክለ፡ ሺርታን፡ እለ፡ ሰማያውያን፡
                                 ቃሹን፡ ጥቅማሹን፡ አቅማሀሹን፡ ዘነበረ፡ ውስተ፡ ህልቀቱ፡ ለሰሎሞን፡ ሰሎሞናዊ፡ ከማሁ፡ እሰሮሙ፡ እግዚእ፡ ለአጋንንት፡ ሰሎሞ፡ ፎሐ፡ ሰሎሞ፡ ከሀማ፡ ሰሎሞናዊ፡
                                 አድኅኖ፡ ለገብርከ፡ <persName ref="PRS13862GabraY" role="owner"><hi rend="rubric">ገብረ፡ ዮናስ፡</hi></persName>
                             </ab>
@@ -453,7 +452,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 ቀዳሚሁ፡ ቃል፡ ውእቱ፡ ቃል፡ ኀበ፡ እግዚአብሔር፡ ውእቱ፡ ቃል፡ ወከማሁ፡ ቀዳሚሁ፡ እምቀዲሙ፡ ኀበ፡
                                 እግዚአብሔር፡ ውእቱ፡ ወቦቱ፡ ኵሉ<supplied reason="omitted">፡</supplied> ኮነ፡ ወዘእንበሌሆሰ፡ አልቦ፡ ዘኮነ፡ ወኢምንትኒ፡ ወዘሂ፡
                                 ኮነ፡ በእንቲአሁ፡ ቦቱ፡ ሕይወትሰ፡ ብርሃኑ፡ ለእጓለ፡ እመህያው፡ ወብርሃኑሰ፡ ለዘ<gap reason="illegible" unit="chars" quantity="1"/>ስተ፡
-                                ጽልመት፡ ያበርህ፡ ወያርኢ፡ ወጽልመትኒ፡ ኢይቅረቦ፡ ከማሁ፡ ኢይቅረቡኒ፡ ደስክ፡ ወጉዳሌ፡ 
+                                ጽልመት፡ ያበርህ፡ ወያርኢ፡ ወጽልመትኒ፡ ኢይቅረቦ፡ ከማሁ፡ ኢይቅረቡኒ፡ ደስክ፡ ወጉዳሌ፡
                                 ለገብርከ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                 <persName ref="PRS13862GabraY" role="owner"><hi rend="rubric">ገብረ፡ ዮናስ፡</hi></persName>
                             </ab>
@@ -473,9 +472,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 ክርስትና፡ በ<hi rend="rubric" rendition="#partialRubric">፯</hi> ንጉሠ፡ ትብልና፡ በ<hi rend="rubric" rendition="#partialRubric">፯</hi>
                                 ጵጵስና፡ በ<hi rend="rubric" rendition="#partialRubric">፯</hi> ንጉሠ፡ ቅስስና፡ በ<hi rend="rubric" rendition="#partialRubric">፯</hi> ብህርይ፡
                                 በገጸር፡ በ<hi rend="rubric" rendition="#partialRubric">፯</hi> ዘፈር፡ በ<hi rend="rubric" rendition="#partialRubric">፯</hi> ነገሥት፡
-                                በ<hi rend="rubric" rendition="#partialRubric">፯</hi> አፈ፡ ነገሥት፡ በ<hi rend="rubric" rendition="#partialRubric">፯</hi> ጳጳሳት፡ 
-                                በ<hi rend="rubric" rendition="#partialRubric">፯</hi> ሊቃነ፡ ጳጳሳት፡ በ<hi rend="rubric" rendition="#partialRubric">፯</hi> 
-                                አስማተ፡ ክርስቶስ፡ ዘተውህበ፡ አርድዕት፡ ወአርድዕት፡ ከዕትኩ፡ ለውሉደ፡ ጥምቀት፡ በዘተአስሩ፡ አጋንንት፡ ከማሁ፡ እስሮሙ፡ ከመ፡ ኢይቅረቡ፡ ሀበ፡ ነፍሱ፡ ወሥጋሁ፡ 
+                                በ<hi rend="rubric" rendition="#partialRubric">፯</hi> አፈ፡ ነገሥት፡ በ<hi rend="rubric" rendition="#partialRubric">፯</hi> ጳጳሳት፡
+                                በ<hi rend="rubric" rendition="#partialRubric">፯</hi> ሊቃነ፡ ጳጳሳት፡ በ<hi rend="rubric" rendition="#partialRubric">፯</hi>
+                                አስማተ፡ ክርስቶስ፡ ዘተውህበ፡ አርድዕት፡ ወአርድዕት፡ ከዕትኩ፡ ለውሉደ፡ ጥምቀት፡ በዘተአስሩ፡ አጋንንት፡ ከማሁ፡ እስሮሙ፡ ከመ፡ ኢይቅረቡ፡ ሀበ፡ ነፍሱ፡ ወሥጋሁ፡
                                 ለገብርከ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                 <persName ref="PRS13862GabraY" role="owner"><hi rend="rubric">ገብረ፡ ዮናስ፡</hi></persName>
                             </ab>
@@ -487,19 +486,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </div>
                         <div type="textpart" subtype="text" n="7" corresp="#ms_i7" xml:id="text7">
                             <ab>
-                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅ</hi>ዱስ፡ <hi rend="rubric" rendition="#partialRubric">፩</hi> አምላክ፡ ጸሎት፡ በእንተ፡ ለጌዎን፡ ርኩስ፡ ዘይሰልብ፡ ልበ፡ ሰብእ፡ ወያደቅቅ፡ 
+                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅ</hi>ዱስ፡ <hi rend="rubric" rendition="#partialRubric">፩</hi> አምላክ፡ ጸሎት፡ በእንተ፡ ለጌዎን፡ ርኩስ፡ ዘይሰልብ፡ ልበ፡ ሰብእ፡ ወያደቅቅ፡
                                 አዕፍምት፡ ወያጸልም፡ አ<hi rend="rubric">ዕይንት፡ ወይመጽዕ፡ ከመ፡ ጽላ</hi>ሎት፡ ወህልም፡ አምሕለከ፡ ወአወግዘከ፡ በ፭ ቅንዋተ፡ መስቀሉ፡ ለእግዚነ፡ ኢየሱስ፡ ክርስቶስ፡ በስመ፡
-                                ሳዶር፡ አላዶር፡ ዳናት፡ አዴራ፡ ሮዳስ፡ በሃይለ፡ ዝንቱ፡ አስማቲከ፡ አድኅነኒ፡ እምሕማመ፡ ባርያ፡ ወለጌዎን፡ ደስከ፡ ወገዳሌ፡ ለውግአት፡ ወለቈርጥማት፡ ለዓይነት፡ ወለመጋኛ፡ ለውግአት፡ ወለቍርጥማት፡ 
+                                ሳዶር፡ አላዶር፡ ዳናት፡ አዴራ፡ ሮዳስ፡ በሃይለ፡ ዝንቱ፡ አስማቲከ፡ አድኅነኒ፡ እምሕማመ፡ ባርያ፡ ወለጌዎን፡ ደስከ፡ ወገዳሌ፡ ለውግአት፡ ወለቈርጥማት፡ ለዓይነት፡ ወለመጋኛ፡ ለውግአት፡ ወለቍርጥማት፡
                                 ለቍርፀት፡ ወለፍልፀት፡ ለፌራ፡ ወለትንር፡ ርኩሳን፡ ከመ፡ ኢይቅረቡ፡ ኀበ፡ ነፍሱ፡ ወሥጋሁ፡ ለገብርከ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                 <persName ref="PRS13862GabraY" role="owner"><hi rend="rubric">ገብረ፡ ዮናስ፡</hi></persName>
                             </ab>
                         </div>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="3" xml:id="sec3">
                         <div type="textpart" subtype="picture" n="2" xml:id="pic2" corresp="#d2"/>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="4" xml:id="sec4">
                         <div type="textpart" subtype="text" n="8" corresp="#ms_i8" xml:id="text8">
                             <ab>
@@ -516,10 +515,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <ab>
                                 <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡</hi> ቅዱስ፡ <hi rend="rubric" rendition="#partialRubric">፩</hi>
                                 አምላክ፡ ጸሎት፡ በእንተ፡ <hi rend="rubric">ሕማመ፡ ቍርፀት፡ ቄፄቤ፡ ቄፄ</hi>ቤ፡ ቄፄቤ፡ ቄፌኩ፡ ቡያክ፡ ቄፌኑ፡ ቡያክ፡ ሞሌ፡ ሞሌ፡ አርጋዔ፡ በረድ፡
-                                ከማሁ፡ አርግዕ፡ ሕማመ፡ ቍርፀት<hi rend="rubric" rendition="#partialRubric">፤</hi> ዘይጠዊ፡ 
+                                ከማሁ፡ አርግዕ፡ ሕማመ፡ ቍርፀት<hi rend="rubric" rendition="#partialRubric">፤</hi> ዘይጠዊ፡
                                 አንዥ<!--?-->ተ<hi rend="rubric" rendition="#partialRubric">፤</hi> ወዓማዑተ<hi rend="rubric" rendition="#partialRubric">፤</hi>
                                 ወያደቅቅ<hi rend="rubric" rendition="#partialRubric">፤</hi> አዕጽምተ<hi rend="rubric" rendition="#partialRubric">፤</hi>
-                                ወይፈነቅል፡ ገበዋተ፡ አድኅኖ፡ እምሕማመ፡ ቍርፀት፡ ለገብርከ፡ 
+                                ወይፈነቅል፡ ገበዋተ፡ አድኅኖ፡ እምሕማመ፡ ቍርፀት፡ ለገብርከ፡
                                 <persName ref="PRS13862GabraY" role="owner"><hi rend="rubric">ገብረ፡ ዮናስ፡</hi></persName>
                             </ab>
                         </div>
@@ -530,18 +529,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <ab><milestone unit="parchmentStip" n="3"/></ab>
                         </div>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="5" xml:id="sec5">
                         <div type="textpart" subtype="picture" n="3" xml:id="pic3" corresp="#d3"/>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="6" xml:id="sec6">
                         <div type="textpart" subtype="text" xml:id="text12">
                             <note>The writing is faded and the text not legible.</note>
                             <ab/>
                         </div>
                     </div>
-                    
+
                 </div>
             </div>
         </body>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg40.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg40.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0"
     xml:id="BDLaethg40"
@@ -15,7 +15,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <editor key="JG"/>
                 <editor key="MV"/>
                 <editor key="SH"/>
-                <editor key="EDS"/>                
+                <editor key="EDS"/>
                  <editor key="JK"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
@@ -37,10 +37,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <idno>Juel-Jensen 37</idno>
                         </altIdentifier>
                     </msIdentifier>
-                    
+
                     <msContents>
                         <summary/>
-                        
+
                         <msItem xml:id="ms_i1">
                       <locus from="1r1" to="1r121"/>
                             <title type="complete" ref="LIT1763Legend"/>
@@ -48,29 +48,29 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <note>The legend of Susǝnyos proper is framed by lengthy protective
                             supplications.</note>
                             <incipit xml:lang="gez" type="inscriptio"><hi rend="rubric">በስመ፡ እግዚአብሔር፡ ሕያው፡ ነባቢ፡ ወተናጋሪ፡ ጸሎቱ፡ ለቅዱስ፡ ሱስንዮስ፡ በ</hi>እንተ፡
-                            አሰስሎ፡ ደዌ፡ እምሕፃናት፡ እለ፡ ይጠብው፡ ጥበ<supplied reason="omitted">፡</supplied> እሞሙ፡ እምኵሉ፡ 
-                                ደዊያ<hi rend="rubric"><gap reason="illegible" unit="chars" quantity="1"/>፡ ዓዲ፡ ጸሐፍኩ፡ ለብእሲ<surplus>ሲ</surplus>ት፡ ሐሐዋ፡ ዘየሐዩ፡ 
+                            አሰስሎ፡ ደዌ፡ እምሕፃናት፡ እለ፡ ይጠብው፡ ጥበ<supplied reason="omitted">፡</supplied> እሞሙ፡ እምኵሉ፡
+                                ደዊያ<hi rend="rubric"><gap reason="illegible" unit="chars" quantity="1"/>፡ ዓዲ፡ ጸሐፍኩ፡ ለብእሲ<surplus>ሲ</surplus>ት፡ ሐሐዋ፡ ዘየሐዩ፡
                                 ደዌ</hi><gap reason="illegible"/> ወትስቅሎ፡ ላዕሌሃ፡ <sic>ወይበቁዕ፡</sic> በረድኤተ፡ እግዚአብሔር፡ ልዑል፡ ወክቡር፡
                             እስከ፡ ለዓለመ፡ ዓለም፡ አሜን፡</incipit>
                             <incipit xml:lang="gez" type="supplication"><sic>ቱ፡</sic> ወበረከቱ፡ ለቅዱስ፡ ሱስንዮስ፡ ያድኅና፡ እምሕማመ፡ ዓይነጥላ፡ ወዓይነናስ<supplied reason="omitted">፡</supplied>
                                 ዓይነናስ፡ ዓይነ፡ ዛር፡ ወዓይነ፡ ጠቢብ፡ ወቡዳ፡ ዓይነ፡ ባርያ<supplied reason="omitted">፡</supplied> ወሌጌዎን፡ ድድቅ፡ ወጋኔነ፡ ቀትር፡ ምች፡ ወተላዋሽ፡
                                 ቁራኛ፡ ወተያያዥ፡ ዕጀ፡ ሰብእ፡ ወጽላወጊ፡ ደም፡ ወሽተላይ<supplied reason="omitted">፡</supplied>
-                                ለዓመትከ<hi rend="rubric" rendition="#partialRubric">፨</hi> 
+                                ለዓመትከ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                 <persName ref="PRS13860HawituA" role="owner"><hi rend="rubric">ሐዊቱ አሊ፡</hi></persName>
                                 <persName ref="PRS13861WalattaH" role="owner"><hi rend="rubric"><add place="interlinear">ወለተ፡ ሕይወት</add></hi></persName></incipit>
                             <incipit xml:lang="gez">ወሀሎ<supplied reason="omitted">፡</supplied> <hi rend="rubric" rendition="#partialRubric">፩</hi>
-                            ብእሲ፡ ዘስሙ፡ ሱስንዮስ፡ ወአውሰበ፡ ብእሲተ፡ ወወለደ፡ ወልደ፡ ትባዕተ፡ ወአንስተ፡ ወበቀዳማይ፡ ወልዳ፡ ቦዓት፡ ውርዝልያ፡ ጋኔን፡ 
+                            ብእሲ፡ ዘስሙ፡ ሱስንዮስ፡ ወአውሰበ፡ ብእሲተ፡ ወወለደ፡ ወልደ፡ ትባዕተ፡ ወአንስተ፡ ወበቀዳማይ፡ ወልዳ፡ ቦዓት፡ ውርዝልያ፡ ጋኔን፡
                                 <del rend="expunctuated">ወ</del>ወቀተለቶ፡ ለወልዳ፡ ወበከየት፡ እሙ፡ ወይቤላ፡ ኦብእሲቶ፡ ምንት፡ <sic>ያበከየኪ፡</sic></incipit>
                             <explicit xml:lang="gez">ወትቤ፡ ይእቲ፡ አንሰ፡ ኢየኃውር፡ ኀበ፡ ሀሎ፡ ስምከ፡ ፍኖተ፡ ውስቴታ፡ ወኢይቀርብ፡ ኀበ፡ ሀሎ፡ ስምከ፡ ፍኖተ፡ ወኀበ፡ ይፀውራ፡ ለዛቲ፡ ጸሎት፡ እመሂ፡
                             አንስት፡ ወእመሂ፡ <sic>አንስት፡</sic> ወወተባዕት፡ ወእመሂ፡ አዕሩግ፡ ወሕፃናት፡ ወወሬዛ፡ ልሂቅ፡ ኢይበጽሕ፡ እስከ፡ ለአለም፡ ወእምድኅረዝ፡ ሶበ፡ ኮነ፡ ሰማዕተ፡ ቅዱስ፡ ሱስንዮስ፡ በስመ፡
                                 እግዚእነ፡ ኢየሱስ<supplied reason="omitted">፡</supplied> <surplus>ኢየሱስ፡</surplus> ክርስቶስ፡ ሎቱ፡ ስብሐት፡ እስከ፡ ለዓለመ፡ አለም፡ አሜን።</explicit>
                             <explicit xml:lang="gez" type="supplication">ኦአምላከ፡ ቅዱስ፡ ሱስንዮስ፡ አድኅና፡ እምሕማመ፡ ዓይነጥላ፡ ወዓይነናስ፡ ወዓይነናስ፡ ዓይነ፡ ዘር፡ ወውላጅ፡ ዓይነጠቢብ፡ ወቡዳ፡
-                                ዓይነ፡ ባርያ<surplus>ያ</surplus>፡ ወሌጌዎን፡ ድድቅ፡ ወጋኔነ፡ ቀትር፡ ምች፡ ወተላዋሽ፡ ቁራኛ፡ ወተያያዥ፡ ደም፡ 
-                                ወሸተላይ፡ መገኛ፡ ወጕሥምት፡ ውጋት፡ ወቁርጥማት፡ ፍልጸት፡ ሥራይ፡ ወድግምት፡ ወቁርጸት፡ ፌራ፡ ዘደጋ፡ ንዳድ፡ ዘቆላ፡ ወእምኵሉ፡ ደዌያት፡ 
+                                ዓይነ፡ ባርያ<surplus>ያ</surplus>፡ ወሌጌዎን፡ ድድቅ፡ ወጋኔነ፡ ቀትር፡ ምች፡ ወተላዋሽ፡ ቁራኛ፡ ወተያያዥ፡ ደም፡
+                                ወሸተላይ፡ መገኛ፡ ወጕሥምት፡ ውጋት፡ ወቁርጥማት፡ ፍልጸት፡ ሥራይ፡ ወድግምት፡ ወቁርጸት፡ ፌራ፡ ዘደጋ፡ ንዳድ፡ ዘቆላ፡ ወእምኵሉ፡ ደዌያት፡
                             ከመ፡ ኢይቅረቡ፡ እምላዕለ፡ ዓመትከ<hi rend="rubric" rendition="#partialRubric">፨</hi> <persName ref="PRS13860HawituA" role="owner"><hi rend="rubric">ወይዘሮ ሃዋ</hi></persName>
                                 <persName ref="PRS13861WalattaH" role="owner"><hi rend="rubric"><add place="below">ወለተ፡ ሕይወት</add></hi></persName></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i2">
                             <locus from="1r122" to="1r219"/>
                             <title type="complete" ref="LIT4703MagicPr"/>
@@ -79,28 +79,28 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 ዓይነት፡ እኪት፡ ወእንዘ፡ የኃውር፡ እግዚእነ፡ ውስተ<supplied reason="omitted">፡</supplied> ባሕረ፡ ጥብርያዶስ፡
                                 ወምስ<hi rend="rubric">ሌሁ፡ ፲ወ፪ አርዳኢሁ፡
                             ወሶበ፡ ርዕዩ፡ መልክዓ፡ ብእሲት፡ <sic>ኀራጊት፡</sic> እንተ፡ ትነብ</hi>ር፡ በማዕዶተ፡ ፈለግ፡</incipit>
-                            <explicit xml:lang="gez">አድኅና፡ እምሕማመ<supplied reason="omitted">፡</supplied> ደም፡ ወሾተላይ፡ ለዓመተ፡ እግዚአብሔር<supplied reason="omitted">፡</supplied> 
+                            <explicit xml:lang="gez">አድኅና፡ እምሕማመ<supplied reason="omitted">፡</supplied> ደም፡ ወሾተላይ፡ ለዓመተ፡ እግዚአብሔር<supplied reason="omitted">፡</supplied>
                                 <persName ref="PRS13860HawituA"><hi rend="rubric">ሐዊቱ አሊ</hi></persName>
                                 <persName ref="PRS13861WalattaH"><hi rend="rubric"><add place="interlinear">ወለተ፡ ሕይወት፡</add></hi></persName>
-                                ሊስ፡ አፍሊስ<supplied reason="omitted">፡</supplied> መሊስ፡ ማላሊስ፡ መላልዮስ፡ በኃይለ፡ ዝንቱ፡ አስማቲከ፡ ዘአርጋዕከ፡ ኀይለ፡ በረድ፡ ወነፋስ፡ ከማሁ፡ አርግዕ፡ ደማ፡ 
-                                ወአፅገዕ፡ ፍሬ፡ ማኅፀና፡ 
+                                ሊስ፡ አፍሊስ<supplied reason="omitted">፡</supplied> መሊስ፡ ማላሊስ፡ መላልዮስ፡ በኃይለ፡ ዝንቱ፡ አስማቲከ፡ ዘአርጋዕከ፡ ኀይለ፡ በረድ፡ ወነፋስ፡ ከማሁ፡ አርግዕ፡ ደማ፡
+                                ወአፅገዕ፡ ፍሬ፡ ማኅፀና፡
                                 እስከ<supplied reason="omitted">፡</supplied> ትወልድ፡ ወልደ፡ በጊዜሃ፡ ለዓመትከ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                 <persName ref="PRS13860HawituA" role="owner"><hi rend="rubric">ሐዋ</hi></persName>
                                 <persName ref="PRS13861WalattaH" role="owner"><hi rend="rubric"><add place="interlinear">ወለተ፡ ሕይወት</add></hi></persName></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i3">
                             <locus from="1r219" to="1r230"/>
                             <title type="complete" ref="LIT6739PPDam"/>
                             <textLang mainLang="gez"/>
                             <note>The following is the entire text.</note>
                             <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡ በእንተ፡ ሕማመ፡ ደም፡ <gap reason="illegible"/></hi>
-                                ተላይ፡ ማሎክ፡ ሉሎክ፡ አፍላሎክ፡ በእ<gap reason="illegible" unit="chars" quantity="1"/> አስማቲከ፡ ዘአንሳእከ፡ ለዓልአዛር፡ እም<gap reason="illegible"/>ሰ፡ መቃብር፡ ከማሁ፡ 
+                                ተላይ፡ ማሎክ፡ ሉሎክ፡ አፍላሎክ፡ በእ<gap reason="illegible" unit="chars" quantity="1"/> አስማቲከ፡ ዘአንሳእከ፡ ለዓልአዛር፡ እም<gap reason="illegible"/>ሰ፡ መቃብር፡ ከማሁ፡
                                 አንሥዓ፡ እምሕማመ፡ ደም፡ ወወሊድ፡ ወዕግዲሕልጅ፡ ለዓመተ፡ እግዚአብሔር<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                 <persName ref="PRS13860HawituA" role="owner"><hi rend="rubric">ሓዊቱ</hi></persName>
                                 <persName ref="PRS13861WalattaH" role="owner"><hi rend="rubric"><add place="interlinear">ወለተ፡ ሕይወት</add></hi></persName></incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i4">
                             <locus from="1r230" to="1r240"/>
                             <title type="incomplete" ref="LIT6740PPWegat"/>
@@ -108,19 +108,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <note>The text breaks off at the end due to material damage.</note>
                             <note>The following is the entire text.</note>
                             <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡ በእንተ፡ ሕማመ፡ ውጋት፡</hi> ወቁርጸት፡ ድሜጥርስ፡ ድሜጥርስ፡ ድሜጥርስ፡
-                                ጋይስጦስ፡ <gap reason="illegible"/>ስጦስ፡ ጋይስጦስ፡ <gap reason="illegible"/>ታው፡ ሰቈታው፡ ሰቆ<gap reason="illegible"/>ው፡ 
+                                ጋይስጦስ፡ <gap reason="illegible"/>ስጦስ፡ ጋይስጦስ፡ <gap reason="illegible"/>ታው፡ ሰቈታው፡ ሰቆ<gap reason="illegible"/>ው፡
                                 <foreign xml:lang="am">የልብ፡
                                 ውጋት፡ የሆድ፡ ቁርጸጥ፡ ሸገር፡ <gap reason="illegible"/>ሸገር፡ ጪጪ<gap reason="illegible"/></foreign></incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i5">
                             <locus target="#1v"/>
                             <title>Largely illegible text on the verso of the scroll</title>
                             <textLang mainLang="gez"/>
                         </msItem>
-                        
+
                     </msContents>
-                    
+
                     <physDesc>
                         <objectDesc form="Scroll">
                             <supportDesc>
@@ -147,13 +147,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </dimensions>
                                     <measure unit="g" type="weight">24</measure>
                                 </extent>
-                                <condition key="good">The state of preservation is good. Small holes in the upper part, maybe from insects.
-                                The parchment is very stiff, and at the lowest part of the scroll, part of the parchment has apparently broken off, 
-                                with loss of text. As the text has been written without leaving a margin, many characters at the beginning and end 
+                                <condition key="good">Small losses are present in the upper part of the parchment support, likely caused by insects.
+                                The parchment is very stiff, and at the lowest part of the scroll, it has apparently broken off,
+                                with loss of text. As the text has been written without leaving a margin, many characters at the beginning and end
                                 of a line are not legible anymore. Only traces remain of a drawing and text on the verso of the scroll. It is not
-                                clear whether this has been intentionally erased or has worn out due to its location on the exterior of the 
+                                clear whether this has been intentionally erased or has worn out due to its location on the exterior of the
                                 rolled up scroll.
-                                The sewing that joins <ref target="#strip2">strip 2</ref> and <ref target="#strip3">strip 3</ref> has become 
+                                The sewing that joins <ref target="#strip2">strip 2</ref> and <ref target="#strip3">strip 3</ref> has become
                                 partly undone.</condition>
                             </supportDesc>
                             <layoutDesc>
@@ -171,7 +171,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <note>There are no side margins.</note>
                                     <ab type="pricking">Pricking and ruling are not visible.</ab>
                                 </layout>
-                                
+
                                 <layout columns="1" writtenLines="119" corresp="#sec4">
                                     <note>Number of characters per line: 11–12.</note>
                                     <note>The left margin is delimited by a black line.</note>
@@ -187,18 +187,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </layout>
                             </layoutDesc>
                         </objectDesc>
-                        
+
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <date notBefore="1650" notAfter="1849"/>
                            <desc>Probably a trained hand, but slightly irregular. Broad and cursive script. The characters are widely spaced.</desc>
                                 <seg type="ink">Black, red.</seg>
-                                <seg type="rubrication">Incipits (groups of rubricated lines alterating with groups of black lines or 
-                                    pairs of rubricated lines); several groups of lines within the main body of 
+                                <seg type="rubrication">Incipits (groups of rubricated lines alterating with groups of black lines or
+                                    pairs of rubricated lines); several groups of lines within the main body of
                                     <ref target="#ms_i1"/> and <ref target="#ms_i2"/>; holy name; names of owners; elements of numerals and punctuation signs.</seg>
                             </handNote>
                         </handDesc>
-                        
+
                  <!--        <decoDesc>
                          <decoNote xml:id="d1" type="miniature" corresp="#pic1">
                              <desc></desc>
@@ -207,7 +207,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                  <width>72–74</width>
                              </dimensions>
                          </decoNote>
-                            
+
                             <decoNote xml:id="d2" type="miniature" corresp="#pic2">
                                 <desc></desc>
                                 <dimensions unit="mm">
@@ -216,24 +216,24 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </dimensions>
                             </decoNote>
                             </decoDesc>-->
-                            
-                        
+
+
                         <additions>
                             <list>
                                 <item xml:id="e1">
                                     <desc>The name of the owner, mentioned in supplications throughout, was <persName ref="PRS13860HawituA" role="owner"/>.
                                         The name <persName ref="PRS13861WalattaH" role="owner"/>, possibly a later owner, has been added in different ink interlineally.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e2">
                                     <desc>There are few scribal corrections. Rarely, characters are marked for deletion with strokes above and below
                                         or are striked through.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e3">
                                     <desc>The last visible line contains <!--cursive--> Brillenbuchstaben.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e4">
                                     <desc>Remains of writing and a drawing are visible on the upper part of the verso. Only single characters are still legible.
                                     The drawing and rubrication of the incipit mirror the drawing and rubrication of the incipit on the top of the recto exactly.
@@ -241,7 +241,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </item>
                             </list>
                         </additions>
-                        
+
                         <bindingDesc>
                             <binding xml:id="binding">
                                 <decoNote xml:id="b1">The three parchment strips are sewn together with narrow parchment strips.</decoNote>
@@ -249,15 +249,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 to a thread that once was attached there.</decoNote> <!--or should this be in extras?-->
                             </binding>
                         </bindingDesc>
-                        
+
                     </physDesc>
-                    
+
                     <history>
                         <origin>
                             <origDate notBefore="1650" notAfter="1849" evidence="lettering"/>
                         </origin>
                     </history>
-                    
+
                     <additional>
                         <adminInfo>
                             <recordHist>
@@ -269,7 +269,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </recordHist>
                         </adminInfo>
                     </additional>
-                    
+
                 </msDesc>
             </sourceDesc>
         </fileDesc>
@@ -315,11 +315,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <body>
             <div type="edition" xml:lang="gez">
             <div type="textpart" subtype="recto">
-                
+
                 <div type="textpart" subtype="section" n="1" xml:id="sec1">
                     <div type="textpart" subtype="picture" n="1" xml:id="pic1" corresp="#d1"/>
                 </div>
-                
+
                 <div type="textpart" subtype="section" n="2" xml:id="sec2">
                     <div type="textpart" subtype="text" n="1" corresp="#ms_i1" xml:id="text1">
                         <ab>
@@ -327,45 +327,45 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </ab>
                     </div>
                 </div>
-                
+
                 <div type="textpart" subtype="section" n="3" xml:id="sec3">
                     <div type="textpart" subtype="picture" n="2" xml:id="pic2" corresp="#d2"/>
                 </div>
-                
+
                 <div type="textpart" subtype="section" n="4" xml:id="sec4">
                     <div type="textpart" subtype="text" n="2" corresp="#ms_i2" xml:id="text2">
                         <ab>
                             <milestone unit="parchmentStrip" n="3"/>
                         </ab>
                     </div>
-                    
+
                     <div type="textpart" subtype="text" n="3" corresp="#ms_i3" xml:id="text3">
                         <ab>
                             <hi rend="rubric">ጸሎት፡ በእንተ፡ ሕማመ፡ ደም፡ <gap reason="illegible"/></hi>
-                            ተላይ፡ ማሎክ፡ ሉሎክ፡ አፍላሎክ፡ በእለ፡ አስማቲከ፡ ዘአንሳእከ፡ ለዓልአዛር፡ እም<gap reason="illegible"/>ሰ፡ መቃብር፡ ከማሁ፡ 
+                            ተላይ፡ ማሎክ፡ ሉሎክ፡ አፍላሎክ፡ በእለ፡ አስማቲከ፡ ዘአንሳእከ፡ ለዓልአዛር፡ እም<gap reason="illegible"/>ሰ፡ መቃብር፡ ከማሁ፡
                             አንሥዓ፡ እምሕማመ፡ ደም፡ ወወሊድ፡ ወዕግዲሕልጅ፡ ለዓመተ፡ እግዚአብሔር<hi rend="rubric" rendition="#partialRubric">፨</hi>
                             <persName ref="PRS13860HawituA" role="owner"><hi rend="rubric">ሓዊቱ</hi></persName>
                             <persName ref="PRS13861WalattaH" role="owner"><hi rend="rubric"><add place="interlinear">ወለተ፡ ሕይወት</add></hi></persName>
                         </ab>
                     </div>
-                    
+
                     <div type="textpart" subtype="text" n="4" corresp="#ms_i4" xml:id="text4">
                         <ab>
                             <hi rend="rubric">ጸሎት፡ በእንተ፡ ሕማመ፡ ውጋት፡</hi> ወቁርጸት፡ ድሜጥርስ፡ ድሜጥርስ፡ ድሜጥርስ፡
-                            ጋይስጦስ፡ <gap reason="illegible"/>ስጦስ፡ ጋይስጦስ፡ <gap reason="illegible"/>ተው፡ ሰቁታው፡ ሰቅ<gap reason="illegible"/>ው፡ 
+                            ጋይስጦስ፡ <gap reason="illegible"/>ስጦስ፡ ጋይስጦስ፡ <gap reason="illegible"/>ተው፡ ሰቁታው፡ ሰቅ<gap reason="illegible"/>ው፡
                             <foreign xml:lang="am">የልብ፡
                                 ውጋት፡ የሆድ፡ ቁርጸጥ፡ ሸገር፡ <gap reason="illegible"/>ሸገር፡ ጪጪ<gap reason="illegible"/></foreign>
                         </ab>
                     </div>
                 </div>
-                
+
             </div>
-                
+
                 <div type="textpart" subtype="verso">
                     <div type="textpart" subtype="section" n="5" xml:id="sec5">
                         <div type="textpart" subtype="picture" n="1" xml:id="pic3" corresp="#d3"/>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="6" xml:id="sec6">
                         <div type="textpart" subtype="text" n="1" corresp="#ms_i4" xml:id="text5">
                             <ab/>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg41.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg41.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0"
     xml:id="BDLaethg41"
@@ -10,12 +10,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-               <title xml:lang="en" xml:id="title1">Protective prayers</title> 
+               <title xml:lang="en" xml:id="title1">Protective prayers</title>
                 <editor key="DR"/>
                 <editor key="JG"/>
                 <editor key="MV"/>
                 <editor key="SH"/>
-                <editor key="EDS"/>                
+                <editor key="EDS"/>
                 <editor key="JK"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
@@ -37,25 +37,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <idno>Juel-Jensen 49</idno>
                         </altIdentifier>
                     </msIdentifier>
-                    
+
                     <msContents>
                         <summary/>
-                        
+
                         <msItem xml:id="ms_i1">
                       <locus from="1r1" to="1r23"/>
                             <title type="complete" ref="LIT5920JohnBeg"/>
                            <textLang mainLang="gez"/>
-                            <incipit xml:lang="gez"><hi rend="rubric">ወንጌል፡ ዘዮሐንስ፡ ቀዳሚሁ፡ ቃል፡ ውእቱ፡ ቃል፡</hi> ወውእቱ፡ ቃል፡ ኀበ፡ 
+                            <incipit xml:lang="gez"><hi rend="rubric">ወንጌል፡ ዘዮሐንስ፡ ቀዳሚሁ፡ ቃል፡ ውእቱ፡ ቃል፡</hi> ወውእቱ፡ ቃል፡ ኀበ፡
                             እግዚአብሔር፡ ውእቱ፡ ወእግዚአብሔር፡ ውእቱ፡ ቃል፡ ወከማሁ፡ ቀዳሚሁ፡ እምቀዲሙ፡ ኀበ፡ እግዚአብሔር፡ ውእቱ፡</incipit>
                             <explicit xml:lang="gez">ወብርሃኑሰ፡ ዘውስተ፡ ጽልመት፡ ያበርህ፡ ወያርኢ፡ ወጽልመትኒ<supplied reason="omitted">፡</supplied>
-                                ኢይረክቦ፡ ወኢይቅርቦ፡ ወከማሁ፡ ኢይርከብዎ፡ 
+                                ኢይረክቦ፡ ወኢይቅርቦ፡ ወከማሁ፡ ኢይርከብዎ፡
                             ወኢይቅረብ<hi rend="rubric">ዎ</hi>፡ ባርያ፡ ወለጌዎን፡ ወባርያ፡ ጸሊማን፡ ወባርያ፡ ቀይሐን፡ ወባርያ፡ ጥቁር፡ ከመ፡ ኢይቅረቡ፡ ኀበ፡
-                            ነፍ<choice><orig>ሳ</orig><corr>ሱ</corr></choice>፡ 
-                                ወሥጋ<choice><orig>ሀ</orig><corr>ሁ</corr></choice>፡ ለ<hi rend="rubric">ገብርከ፡ 
+                            ነፍ<choice><orig>ሳ</orig><corr>ሱ</corr></choice>፡
+                                ወሥጋ<choice><orig>ሀ</orig><corr>ሁ</corr></choice>፡ ለ<hi rend="rubric">ገብርከ፡
                                     <persName ref="PRS13856Elyas">ኤልያስ፡</persName>
                                 <persName ref="PRS13857Baselyos"><sic>ባስዮስ፡</sic></persName> <persName ref="PRS13858MaryamS">ማርያም፡ ስና፡</persName></hi></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i2">
                             <locus from="1r24" to="1r43"/>
                             <title type="complete" ref="LIT6756PPQwerdat"/>
@@ -64,66 +64,66 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡ በእንተ፡ ሕማመ፡ ቍርፀት፡ ወቅርጥማት፡</hi> ዝራድም፡ ምኩር፡ ኤዳሴ፡ ፍላኤል፡
                             ግጣግላኤል፡ ኑዱኤል፡ ሱኑኤል፡ እምላብኤል፡ እሉ፡ እሙንቱ፡ አስማት፡ ማእሰሮሙ፡ ለአጋንንት፡ ወለትግርትያ፡ ለዓይነት፡ ወለባርያ፡ ለቍርፀት፡ ወለቅርጥማት፡
                             ለምኙ፡ ወለጕሰመት፡ ለፌራ፡ ወለነዳድ፡ ለማሪ፡ ወለማሪት፡ ለዘሪ፡ ወለዘሪት፡ ለዶቢ፡ ወለዶቢት፡ ለጋፍ፡ ወለጋፋት፡ ወእምድንጋፄ፡ ዘሌሊት፡ ወዘመዓልት፡ ድድቅ፡
-                            ወጋኔነ፡ ቀትር፡ ወዘኵሎሙ፡ መናፍስተ፡ ርኩሳን፡ አድኅ<choice><orig>ና</orig><corr>ኖ</corr></choice>፡ 
+                            ወጋኔነ፡ ቀትር፡ ወዘኵሎሙ፡ መናፍስተ፡ ርኩሳን፡ አድኅ<choice><orig>ና</orig><corr>ኖ</corr></choice>፡
                                 ለ<hi rend="rubric">ገብርከ፡</hi> <persName ref="PRS13856Elyas">ኤልያስ፡</persName> <persName ref="PRS13857Baselyos"><sic>ባስዮስ፡</sic></persName>
                                 <hi rend="rubric"><persName ref="PRS13858MaryamS">ማርያም፡</persName> <persName ref="PRS13859Nesebbeyo">ንጽበዮ፡</persName></hi></incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i3">
                             <locus from="1r44" to="1r80"/>
                             <title type="complete" ref="LIT4007Salotb"/>
                             <textLang mainLang="gez"/>
-                            <note>The beginning and further elements of the prayer are close to the one attested in <ref type="mss" corresp="BLorient566">MS London, 
+                            <note>The beginning and further elements of the prayer are close to the one attested in <ref type="mss" corresp="BLorient566">MS London,
                             British Library, Or. 566</ref> (<locus from="1r" to="5v"/>).</note>
-                            <incipit xml:lang="gez"><hi rend="rubric">በስመ<supplied reason="omitted">፡</supplied> አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ 
-                                ፩ አምላክ፡ ጸሎት፡</hi> በእንተ፡ ፍትሐተ፡ ሥራይ፡ 
+                            <incipit xml:lang="gez"><hi rend="rubric">በስመ<supplied reason="omitted">፡</supplied> አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡
+                                ፩ አምላክ፡ ጸሎት፡</hi> በእንተ፡ ፍትሐተ፡ ሥራይ፡
                             ዘተቀድሐ፡ እም፹ወ፩ መጻሕፍት፡ በዝንቱ፡ ጠልሠም፡ ተፈትሁ፡ መሠርያን፡ ብዙኃን፡ ወነባብያነ፡ ሐሰት፡ እለ፡ ይገብሩ፡ ዕፀ፡ ሥራይ፡ ወአስማተ፡ ዕፀ፡ ሰቢሮሙ።</incipit>
-                            <explicit xml:lang="gez">ፍታሕ፡ ተፈታሕ፡ ዘተገብረ<supplied reason="omitted">፡</supplied> ቅድመ፡ ወድኅረ፡ ዘገብረ፡ ፍታሕ፡ 
-                                በስመ፡ ቀንተው፡ ሰንተው፡ ቀርነለው፡ በከመ፡ አጊገዎኮሙ፡ 
-                            ለአዳም፡ ወለሄዋን፡ ወከማሁ፡ አንግሣ፡ ለዛቲ፡ መጽሐፍ፡ እምላዕለ፡ ነፍ<choice><orig>ሳ</orig><corr>ሱ</corr></choice>፡ ወሥጋሁ፡ ለገብርከ፡ 
-                                <hi rend="rubric"><persName ref="PRS13856Elyas"><sic>ኤል፡</sic></persName></hi> 
+                            <explicit xml:lang="gez">ፍታሕ፡ ተፈታሕ፡ ዘተገብረ<supplied reason="omitted">፡</supplied> ቅድመ፡ ወድኅረ፡ ዘገብረ፡ ፍታሕ፡
+                                በስመ፡ ቀንተው፡ ሰንተው፡ ቀርነለው፡ በከመ፡ አጊገዎኮሙ፡
+                            ለአዳም፡ ወለሄዋን፡ ወከማሁ፡ አንግሣ፡ ለዛቲ፡ መጽሐፍ፡ እምላዕለ፡ ነፍ<choice><orig>ሳ</orig><corr>ሱ</corr></choice>፡ ወሥጋሁ፡ ለገብርከ፡
+                                <hi rend="rubric"><persName ref="PRS13856Elyas"><sic>ኤል፡</sic></persName></hi>
                                 <persName ref="PRS13857Baselyos">ባስልዮስ፡</persName> <hi rend="rubric"><persName ref="PRS13859Nesebbeyo">ንጽብዮ፡</persName></hi></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i4">
                             <locus from="1r81" to="1r122"/>
                             <title type="complete" ref="LIT6757PPUndoing"/>
                             <textLang mainLang="gez"/>
-                            <incipit xml:lang="gez"><hi rend="rubric">ጸሎተ፡ አስማተ፡ ሥራይ፡ ጅር፡ ጅር፡ ጅር፡ አቅዦር፡</hi> ፍታሕ፡ ሥራየ፡ ግብጽ፡ ወአረብ፡ 
+                            <incipit xml:lang="gez"><hi rend="rubric">ጸሎተ፡ አስማተ፡ ሥራይ፡ ጅር፡ ጅር፡ ጅር፡ አቅዦር፡</hi> ፍታሕ፡ ሥራየ፡ ግብጽ፡ ወአረብ፡
                                 ወኢትዮጵያ፡
-                                ወአንጾኪያ፡ ወሶርያ፡ ወሮምያ፡ ወቢታንያ፡ ፍታሕ፡ ሥራየ<supplied reason="omitted">፡</supplied> በቅላ፡ ወሐማሴን፡ ሶሬ፡ ወሰራዌ፡ ጋላ፡ 
+                                ወአንጾኪያ፡ ወሶርያ፡ ወሮምያ፡ ወቢታንያ፡ ፍታሕ፡ ሥራየ<supplied reason="omitted">፡</supplied> በቅላ፡ ወሐማሴን፡ ሶሬ፡ ወሰራዌ፡ ጋላ፡
                                 ወሸንቅላ፡ በለው፡ ወአገው፡ ወልቃይት፡ ወጸገዴ፡</incipit>
                             <explicit xml:lang="gez">ይግባእ፡ ሥራዮሙ፡ ኅድግ፡ ይቤሉከ፡ በቃለ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፍታሕ፡ በንጉሥነ፡ <persName ref="PRS9142TaklaGi">ተክለ፡ ጊዮርጊስ፡</persName>
-                                በጳጳስነ፡ <persName ref="PRS10450YosabI">አባ፡ ኢዮሳብ፡</persName> ፍታሕ፡ በአፈ፡ ጴጥሮስ፡ ወጳውሎስ፡ በታቦተ፡ ቅዱስ፡ ዮሐንስ፡ ሰማዕት፡ 
-                                ፍታሕ፡ 
+                                በጳጳስነ፡ <persName ref="PRS10450YosabI">አባ፡ ኢዮሳብ፡</persName> ፍታሕ፡ በአፈ፡ ጴጥሮስ፡ ወጳውሎስ፡ በታቦተ፡ ቅዱስ፡ ዮሐንስ፡ ሰማዕት፡
+                                ፍታሕ፡
                                 ዘንተ፡ ሥራዩ፡ ወአስማቱ፡ ለገብርከ፡ <persName ref="PRS13856Elyas"><hi rend="rubric">ኤልያስ፡</hi></persName></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i5">
                             <locus from="1r123" to="1r136"/>
                             <title type="complete" ref="LIT6758PPSupplications"/>
                             <textLang mainLang="gez"/>
                             <note>The following is the entire text.</note>
-                            <incipit xml:lang="gez">ጸሎተ፡ አስማተ፡ ሥራይ፡ ድኅድጋሰኒ፡ አግማኒ፡ አግማኒ፡ አቅማኒ፡ አግማጅን፡ አቅማጅን፡ ፍታሕ፡ በቃለ፡ አ፫፻፲፰ ርቱአነ፡ ሃይማኖት፡ 
+                            <incipit xml:lang="gez">ጸሎተ፡ አስማተ፡ ሥራይ፡ ድኅድጋሰኒ፡ አግማኒ፡ አግማኒ፡ አቅማኒ፡ አግማጅን፡ አቅማጅን፡ ፍታሕ፡ በቃለ፡ አ፫፻፲፰ ርቱአነ፡ ሃይማኖት፡
                                 በ፲ወ፭ ነቢያት፡ በ፲፪ ሐዋርያት፡ በ፸፪ አርድእት፡ ፍታሕ<supplied reason="omitted">፡</supplied> በ፺፱ ነገደ፡ መላእክት፡ ወ፬ <sic>እስሳ፡</sic>
-                                ወበ፳ወ፬ ካህናተ፡ ሰማይ፡ ፍታሕ፡ በአፈ፡ ኵሎሙ፡ ቅዱሳን፡ 
+                                ወበ፳ወ፬ ካህናተ፡ ሰማይ፡ ፍታሕ፡ በአፈ፡ ኵሎሙ፡ ቅዱሳን፡
                                 ወሰማዕት፡ አድኅኖ፡ ለገብርከ፡ <persName ref="PRS13856Elyas">ኤልያስ፡</persName> </incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i6">
                             <locus from="1r137" to="1r184"/>
                             <title type="complete" ref="LIT6759PPGod"/>
                             <textLang mainLang="gez"/>
-                            <incipit xml:lang="gez"><hi rend="rubric">አንተ፡ በሰማይ፡ ወአንተ፡ በምድር፡ ሕራስ፡ ንዋም</hi>፡ ዘኢይመጽአከ፡ ወአንተ፡ ንጉሠ፡ ሰማይ፡ 
-                            ወአንተ፡ ንጉሠ፡ ምድር፡ ወአንተ፡ ዘሀሎ፡ ውስተ፡ ሕሊና፡ ወዘሀሎ፡ ውስተ፡ ልብ፡ ወዘሀሎ፡ ውስተ፡ እድ፡ ወዘሀሎ፡ ውስተ፡ ኵሉ፡ በሐውርተ፡ መለኮቱ፡ 
+                            <incipit xml:lang="gez"><hi rend="rubric">አንተ፡ በሰማይ፡ ወአንተ፡ በምድር፡ ሕራስ፡ ንዋም</hi>፡ ዘኢይመጽአከ፡ ወአንተ፡ ንጉሠ፡ ሰማይ፡
+                            ወአንተ፡ ንጉሠ፡ ምድር፡ ወአንተ፡ ዘሀሎ፡ ውስተ፡ ሕሊና፡ ወዘሀሎ፡ ውስተ፡ ልብ፡ ወዘሀሎ፡ ውስተ፡ እድ፡ ወዘሀሎ፡ ውስተ፡ ኵሉ፡ በሐውርተ፡ መለኮቱ፡
                             ለእግዚአብሔር፡</incipit>
                             <explicit xml:lang="gez">ፍታሕ፡ ሥራዩ፡ መሠርያን፡ ይግባእ፡ ዲበ፡ ርእሶሙ፡ ከመ፡ ኢይቅረቡ፡ ኵሎሙ፡ መናፍስተ፡ ርኩሳን፡ አርኅቅ፡ ወአሰስል፡
                                 እምላዕለ፡ ነፍሱ፡
-                                ወሥጋሁ፡ ለገብርከ፡ <persName ref="PRS13856Elyas"><hi rend="rubric">ኤልያስ፡</hi></persName> 
-                                ወለዓመትከ፡ <persName ref="PRS13858MaryamS"><hi rend="rubric">ማርያም፡</hi> ስና፡</persName> 
+                                ወሥጋሁ፡ ለገብርከ፡ <persName ref="PRS13856Elyas"><hi rend="rubric">ኤልያስ፡</hi></persName>
+                                ወለዓመትከ፡ <persName ref="PRS13858MaryamS"><hi rend="rubric">ማርያም፡</hi> ስና፡</persName>
                                 <persName ref="PRS13857Baselyos">ባስልዮስ፡</persName> <persName ref="PRS13856Elyas"><hi rend="rubric">ኤልያስ፡</hi></persName></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i7">
                             <locus from="1r185" to="1r196"/>
                             <title type="complete" ref="LIT4506Salam"/>
@@ -131,24 +131,24 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <note>The following is the entire text.</note>
                             <incipit xml:lang="gez"><hi rend="rubric">ሰላም፡</hi> ለገጽኪ፡ ዘጥቀ፡ ይልይ፡ እምሥነ፡ ከዋክብት፡ ወወርኅ፡ ወእምሥነ፡ ፀሐይ፡ መብርሂ፡
                                 <hi rend="rubric">ማርያም፡</hi> ድንግል፡ ፍናዋትየ፡ ሠርሂ፡ በመዓልት፡ ወበሌሊት፡ ኢይርከበኒ፡ ጸናሂ፡ መሥገርተ፡ አበሳ፡ ዘይጽፍር፡
-                                ወግበ፡ ዘይድኂ፡ አድኅኖ፡ ለገብርከ፡ <persName ref="PRS13856Elyas"><hi rend="rubric">ኤልያስ፡</hi></persName> 
+                                ወግበ፡ ዘይድኂ፡ አድኅኖ፡ ለገብርከ፡ <persName ref="PRS13856Elyas"><hi rend="rubric">ኤልያስ፡</hi></persName>
                                 <persName ref="PRS13858MaryamS"><hi rend="rubric">ማርያም፡</hi> ስና፡</persName>
                                 <persName ref="PRS13857Baselyos"><hi rend="rubric">ባስልዮስ፡</hi></persName></incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i8">
                             <locus from="1r196" to="1r224"/>
                             <title type="complete" ref="LIT6761PPUndoing"/>
                             <textLang mainLang="gez"/>
-                            <incipit xml:lang="gez"><hi rend="rubric">ፍታሕ፡ ሥራየ፡ ሴዋ፡</hi> ወአምሐራ፡ በጌ፡ 
+                            <incipit xml:lang="gez"><hi rend="rubric">ፍታሕ፡ ሥራየ፡ ሴዋ፡</hi> ወአምሐራ፡ በጌ፡
                                 ምድር<supplied reason="omitted">፡</supplied> ወዳሞት፡ ወላስታ፡ ወጐንደር፡ ሥራየ፡ ወሰራዌ፡
                             ወሥራየ፡ ደጕዓ፡ ወበለው፡ ወአገው፡ ፍታሕ፡ ሥራዮሙ፡ ወአስማቶሙ፡ እመሂ፡ በውሉዱ፡ ወበንብርታ፡ ዘገብሩ፡ ዘገዘቱ፡ ወዘደገሙ፡ ወዘአስተኃደሩ፡ መሠርያን፡</incipit>
-                            <explicit xml:lang="gez">አድኅኖ፡ እምፀር፡ ሳዶር፡ አላዶር፡ ዳናት፡ አዴራ፡ ሮዳስ፡ ኢየሱስ፡ ክርስቶስ፡ ሊቀ፡ ካህናት፡ ዘላዕለ፡ ኵሉ፡ አዴራ፡ ይጸሐፍ፡ 
+                            <explicit xml:lang="gez">አድኅኖ፡ እምፀር፡ ሳዶር፡ አላዶር፡ ዳናት፡ አዴራ፡ ሮዳስ፡ ኢየሱስ፡ ክርስቶስ፡ ሊቀ፡ ካህናት፡ ዘላዕለ፡ ኵሉ፡ አዴራ፡ ይጸሐፍ፡
                             በመሰንየ፡ በውዳሴከ፡ ፊደሉ፡ ዳናት፡ ይትኃደግ፡ ዲበ፡ ምድር፡ ንባቡ፡ ወቃሉ፡ በዝንቱ፡ በቃልከ፡ አድኅኖ፡ ለገብርከ፡ <gap reason="illegible"/></explicit>
                         </msItem>
-                        
+
                     </msContents>
-                    
+
                     <physDesc>
                         <objectDesc form="Scroll">
                             <supportDesc>
@@ -171,7 +171,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </dimensions>
                                     <measure type="weight" unit="g">28</measure>
                                 </extent>
-                                <condition key="good">The state of preservation is good. Small areas of loss in the upper part of the scroll. The lower part of the scroll has been crumpled by rolling,
+                                <condition key="good">Small areas of loss are present in the upper part of the scroll. The lower has been crumpled by rolling,
                                 the last line is not legible anymore.</condition>
                             </supportDesc>
                             <layoutDesc>
@@ -238,7 +238,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </layout>
                             </layoutDesc>
                         </objectDesc>
-                        
+
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <date notBefore="1777" notAfter="1800"/>
@@ -248,7 +248,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <seg type="rubrication">Beginnings of texts and sections, holy name, some of the names of the owners.</seg>
                             </handNote>
                         </handDesc>
-                        
+
            <!--             <decoDesc>
                          <decoNote xml:id="d1" type="miniature" corresp="#pic1">
                              <desc></desc>
@@ -257,7 +257,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                  <width>68</width>
                              </dimensions>
                          </decoNote>
-                            
+
                             <decoNote xml:id="d2" type="miniature" corresp="#pic2">
                                 <desc></desc>
                                 <dimensions unit="mm">
@@ -265,7 +265,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <width>68</width>
                                 </dimensions>
                             </decoNote>
-                            
+
                             <decoNote xml:id="d3" type="miniature" corresp="#pic3">
                                 <desc></desc>
                                 <dimensions unit="mm">
@@ -273,7 +273,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <width>70–74</width>
                                 </dimensions>
                             </decoNote>
-                            
+
                             <decoNote xml:id="d4" type="miniature" corresp="#pic4">
                                 <desc></desc>
                                 <dimensions unit="mm">
@@ -282,11 +282,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </dimensions>
                             </decoNote>
                         </decoDesc>-->
-                        
+
                         <additions>
                             <list>
                                 <item xml:id="e1">
-                                   <desc>The names of the owners, mentioned in supplications throughout, were 
+                                   <desc>The names of the owners, mentioned in supplications throughout, were
                                        <persName ref="PRS13856Elyas"/>, <persName ref="PRS13857Baselyos"/>, <persName ref="PRS13858MaryamS"/>,
                                        and <persName ref="PRS13859Nesebbeyo"/>.
                                    Spaces for the name or the owner(s) had been left empty by the scribe and were filled subsequently. In the upper
@@ -296,38 +296,38 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    then corrected to the masculine form.
                                    </desc>
                                 </item>
-                                
+
                                 <item xml:id="e2">
                                     <desc>The manuscript contains no scribal corrections other than the adaptation of the supplications
                                         to the gender of the owner.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e3">
                                     <desc>The verso is empty.</desc>
                                 </item>
                             </list>
                         </additions>
-                        
+
                         <bindingDesc>
                             <binding xml:id="binding">
                                 <decoNote xml:id="b1">The two strips are slightly overlapping and are
                                     sewn together with a running stitch using two narrow parchment strips.</decoNote>
                             </binding>
                         </bindingDesc>
-                        
+
                     </physDesc>
-                    
+
                     <history>
                         <origin>
                             <origDate notBefore="1777" notAfter="1800" evidence="prosopography"/>
                             <persName ref="PRS9142TaklaGi"/> and <persName ref="PRS10450YosabI"/>, who were
-                            active simultaneously in 1777–1800 (with interruptions), 
+                            active simultaneously in 1777–1800 (with interruptions),
                             are mentioned in <ref target="#ms_i4">.</ref>
                         </origin>
-                        <provenance>One of the names mentioned in the supplications, <persName ref="PRS13859Nesebbeyo"/>, 
+                        <provenance>One of the names mentioned in the supplications, <persName ref="PRS13859Nesebbeyo"/>,
                         points to a Tigrinya-speaking area as place of production.</provenance>
                     </history>
-                    
+
                     <additional>
                         <adminInfo>
                             <recordHist>
@@ -339,7 +339,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </recordHist>
                         </adminInfo>
                     </additional>
-                    
+
                 </msDesc>
             </sourceDesc>
         </fileDesc>
@@ -380,75 +380,75 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <body>
             <div type="edition">
                 <div type="textpart" subtype="recto">
-                    
+
                     <div type="textpart" subtype="section" n="1" xml:id="sec1">
                         <div type="textpart" subtype="picture" n="1" xml:id="pic1" corresp="#d1"/>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="2" xml:id="sec2">
                         <div type="textpart" subtype="text" n="1" corresp="#ms_i1" xml:id="text1">
                             <ab/>
                         </div>
-                        
+
                         <div type="textpart" subtype="text" n="2" corresp="#ms_i2" xml:id="text2">
                             <ab>
                                 <hi rend="rubric">ጸሎት፡ በእንተ፡ ሕማመ፡ ቍርፀት፡ ወቅርጥማት፡</hi> ዝራድም፡ ምኩር፡ ኤዳሴ፡ ፍላኤል፡
                                 ግጣግላኤል፡ ኑዱኤል፡ ሱኑኤል፡ እምላብኤል፡ እሉ፡ እሙንቱ፡ አስማት፡ ማእሰሮሙ፡ ለአጋንንት፡ ወለትግርትያ፡ ለዓይነት፡ ወለባርያ፡ ለቍርፀት፡ ወለቅርጥማት፡
                                 ለምኙ፡ ወለጕሰመት፡ ለፌራ፡ ወለነዳድ፡ ለማሪ፡ ወለማሪት፡ ለዘሪ፡ ወለዘሪት፡ ለዶቢ፡ ወለዶቢት፡ ለጋፍ፡ ወለጋፋት፡ ወእምድንጋፄ፡ ዘሌሊት፡ ወዘመዓልት፡ ድድቅ፡
-                                ወጋኔነ፡ ቀትር፡ ወዘኵሎሙ፡ መናፍስተ፡ ርኩሳን፡ አድኅ<choice><orig>ና</orig><corr>ኖ</corr></choice>፡ 
+                                ወጋኔነ፡ ቀትር፡ ወዘኵሎሙ፡ መናፍስተ፡ ርኩሳን፡ አድኅ<choice><orig>ና</orig><corr>ኖ</corr></choice>፡
                                 ለ<hi rend="rubric">ገብርከ፡</hi> <persName ref="PRS13856Elyas">ኤልያስ፡</persName> <persName ref="PRS13857Baselyos">ባስዮስ፡</persName>
                                 <hi rend="rubric"><persName ref="PRS13858MaryamS">ማርያም፡</persName> <persName ref="PRS13859Nesebbeyo">ንጽበዮ፡</persName></hi>
                             </ab>
                         </div>
-                        
+
                         <div type="textpart" subtype="text" n="3" corresp="#ms_i3" xml:id="text3">
                             <ab/>
                         </div>
-                        
+
                         <div type="textpart" subtype="text" n="4" corresp="#ms_i4" xml:id="text4part1">
                             <ab/>
                         </div>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="3" xml:id="sec3">
                         <div type="textpart" subtype="picture" n="2" xml:id="pic2" corresp="#d2"/>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="4" xml:id="sec4">
                     <div type="textpart" subtype="text" n="4" corresp="#ms_i4" xml:id="text4part2">
                         <ab><milestone unit="parchmentStrip" n="2"/></ab>
                     </div>
-                    
+
                     <div type="textpart" subtype="text" n="5" corresp="#ms_i5" xml:id="text5">
                         <ab>
-                            ጸሎተ፡ አስማተ፡ ሥራይ፡ ድኅድጋሰኒ፡ አግማኒ፡ አግማኒ፡ አቅማኒ፡ አግማጅን፡ አቅማጅን፡ ፍታሕ፡ በቃለ፡ አ፫፻፲፰ ርቱአነ፡ ሃይማኖት፡ 
+                            ጸሎተ፡ አስማተ፡ ሥራይ፡ ድኅድጋሰኒ፡ አግማኒ፡ አግማኒ፡ አቅማኒ፡ አግማጅን፡ አቅማጅን፡ ፍታሕ፡ በቃለ፡ አ፫፻፲፰ ርቱአነ፡ ሃይማኖት፡
                             በ፲ወ፭ ነቢያት፡ በ፲፪ ሐዋርያት፡ በ፸፪ አርድእት፡ ፍታሕ<supplied reason="omitted">፡</supplied> በ፺፱ ነገደ፡ መላእክት፡ ወ፬ <sic>እስሳ፡</sic>
-                            ወበ፳ወ፬ ካህናተ፡ ሰማይ፡ ፍታሕ፡ በአፈ፡ ኵሎሙ፡ ቅዱሳን፡ 
-                            ወሰማዕት፡ አድኅኖ፡ ለገብርከ፡ <persName ref="PRS13856Elyas">ኤልያስ፡</persName> 
+                            ወበ፳ወ፬ ካህናተ፡ ሰማይ፡ ፍታሕ፡ በአፈ፡ ኵሎሙ፡ ቅዱሳን፡
+                            ወሰማዕት፡ አድኅኖ፡ ለገብርከ፡ <persName ref="PRS13856Elyas">ኤልያስ፡</persName>
                         </ab>
                     </div>
                 </div>
-                    
+
                     <div type="textpart" subtype="section" n="5" xml:id="sec5">
                         <div type="textpart" subtype="picture" n="3" xml:id="pic3" corresp="#d3"/>
                     </div>
-                
+
                     <div type="textpart" subtype="section" n="6" xml:id="sec6">
                         <div type="textpart" subtype="text" n="6" corresp="#ms_i6" xml:id="text6">
                             <ab/>
                         </div>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="7" xml:id="sec7">
                         <div type="textpart" subtype="picture" n="4" xml:id="pic4" corresp="#d4"/>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="8" xml:id="sec8">
                         <div type="textpart" subtype="text" n="7" corresp="#ms_i7" xml:id="text7">
                             <ab>
                                 <hi rend="rubric">ሰላም፡</hi> ለገጽኪ፡ ዘጥቀ፡ ይልይ፡ እምሥነ፡ ከዋክብት፡ ወወርኅ፡ ወእምሥነ፡ ፀሐይ፡ መብርሂ፡
                                 <hi rend="rubric">ማርያም፡</hi> ድንግል፡ ፍናዋትየ፡ ሠርሂ፡ በመዓልት፡ ወበሌሊት፡ ኢይርከበኒ፡ ጸናሂ፡ መሥገርተ፡ አበሳ፡ ዘይጽፍር፡
-                                ወግበ፡ ዘይድኂ፡ አድኅኖ፡ ለገብርከ፡ <persName ref="PRS13856Elyas"><hi rend="rubric">ኤልያስ፡</hi></persName> 
+                                ወግበ፡ ዘይድኂ፡ አድኅኖ፡ ለገብርከ፡ <persName ref="PRS13856Elyas"><hi rend="rubric">ኤልያስ፡</hi></persName>
                                 <persName ref="PRS13858MaryamS"><hi rend="rubric">ማርያም፡</hi> ስና፡</persName>
                                 <persName ref="PRS13857Baselyos"><hi rend="rubric">ባስልዮስ፡</hi></persName>
                             </ab>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg43.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg43.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0"
     xml:id="BDLaethg43"
@@ -15,7 +15,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <editor key="JG"/>
                 <editor key="MV"/>
                 <editor key="SH"/>
-                <editor key="EDS"/>                
+                <editor key="EDS"/>
                  <editor key="JK"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
@@ -37,38 +37,38 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <idno>Juel-Jensen 38</idno>
                         </altIdentifier>
                     </msIdentifier>
-                    
+
                     <msContents>
                         <summary/>
-                        
+
                         <msItem xml:id="ms_i1">
                       <locus from="1r1" to="1r32"/>
                             <title type="complete" ref="LIT6749PPBinding"/>
                             <textLang mainLang="gez"/>
-                            <incipit xml:lang="gez"><hi rend="rubric">በስ፡ መ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አም</hi>ላክ፡ ጸሎት፡ በእንተ፡ ማእሰሮሙ፡ 
+                            <incipit xml:lang="gez"><hi rend="rubric">በስ፡ መ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አም</hi>ላክ፡ ጸሎት፡ በእንተ፡ ማእሰሮሙ፡
                             ለአጋንንት፡ በስሙ፡ ለእግዚአብሔር፡ አብ፡ ምናቴር፡ በስሙ፡ ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ ወልድ፡ አብያቴር፡ በስሙ፡ ለእግዚአብሔር<supplied reason="omitted">፡</supplied>
                             መንፈስ፡ ቅዱስ፡ አቅያቴቴር፡ ኢየሱስ፡ ክርስቶስ፡ ወልደ፡ እግዚአብሔር፡ ሕያው፡</incipit>
                             <explicit xml:lang="gez">ቡዳ፡ ወነሃብት፡ ሰብአ፡ ግብር፡ ወጠበብት፡ ፍጌን፡ ወሥራይ፡ ቸነፈር፡ ወነገርጋር፡ ድድቅ፡ ወጋኔነ፡ ቀትር፡ ይስደዱ፡ ወይርኃቁ፡
                                 እምላዕለ፡ ገብርከ፡ <persName ref="PRS13851TaklaM"><hi rend="rubric">ተክለ፡ ማርያም፡</hi></persName></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i2">
                             <locus from="1r32" to="1r68"/>
                             <title type="complete" ref="LIT6750PPFera"/>
                             <textLang mainLang="gez"/>
-                            <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ<supplied reason="omitted">፡</supplied> ወወልድ፡ ወመንፈስ፡ 
+                            <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ<supplied reason="omitted">፡</supplied> ወወልድ፡ ወመንፈስ፡
                                 ቅዱስ፡ ፩</hi> ጸሎት፡ በእንተ፡ <surplus>በእንተ፡</surplus> ሕማመ፡ ፌራ፡ ወአ<gap reason="illegible" unit="chars" quantity="2"/>
                             ይቤለከ፡ እግዚአብ<milestone unit="parchmentStrip" n="2"/>ሔር፡ እሎፍ፡ በሸጫን፡ ንጉሠ፡ አጋንንት፡ ወበሸጫን፡ ቀጨር፡ ንጉሠ፡ ባርያ፡ ጀሊፍ፡ ጅርኤል፡ ንጉሠ፡ ቸነፈር፡ ቀሲጥ፡ ፈሊጥ፡ ወዘባርያ፡ ንጉሥክሙ፡
                             <sic>ለነጋንት፡</sic></incipit>
                             <explicit xml:lang="gez">
-                                ተማኅፀንኩ፡ በቅዱስ፡ ጊዮርጊስ፡ ወበቅዱስ፡ ቂርቆስ<supplied reason="omitted">፡</supplied> ተማኅፀንኩ፡ በሥላሴ፡ ዋሕድ፡ ተማኅፀንኩ፡ 
+                                ተማኅፀንኩ፡ በቅዱስ፡ ጊዮርጊስ፡ ወበቅዱስ፡ ቂርቆስ<supplied reason="omitted">፡</supplied> ተማኅፀንኩ፡ በሥላሴ፡ ዋሕድ፡ ተማኅፀንኩ፡
                                 በትሥልስቱ<supplied reason="omitted">፡</supplied>
                                 ወበትስብእቱ፡ ተማኅፀንኩ፡ <hi rend="rubric">በ፲ወ፪</hi> ሐዋርያት፡ ተማኅፀንኩ፡ በ፲ወ፭ ነቢያት፡ ተማኅፀንኩ፡ በ፸ወ፪ አርድእት፡
-                            ተማኅፀንኩ፡ በእግዚእነ፡ <sic>ወአምላነ፡</sic> ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡ አድኅነኒ፡ 
+                            ተማኅፀንኩ፡ በእግዚእነ፡ <sic>ወአምላነ፡</sic> ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡ አድኅነኒ፡
                                 እምሕማመ፡ ፌ<seg rend="above">ራ<supplied reason="omitted">፡</supplied></seg>
                                 ለገብርከ፡ <persName ref="PRS13851TaklaM"><hi rend="rubric">ተክለ፡ ማርያም።</hi></persName></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i3">
                             <locus from="1r69" to="1r97"/>
                             <title type="complete" ref="LIT6751PPAynat"/>
@@ -79,40 +79,40 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ</hi>፡ ጸሎት፡
                             በእንተ፡ ሕማመ፡ ዓይነት፡ ይስድድከ፡ እግዚአብሔር፡ አንተ፡ ሰይጣን፡ ርጉም፡ ዓይነተ፡ ዓይን፡ ውፃእ፡ በቀይሕ፡ ወጸሊም፡ ዮሴፍ፡ በከመ፡ ወፅአ፡ እምሕሱም፡ ፈአንት፡
                             አበሹን፡ ቀበሹን፡ ሰሐብን፡ ይጐድርን፡ የብሹን፡ ርየቶ፡ አንተ፡ ዓይን፡ ውፃእ፡</incipit>
-                            <explicit xml:lang="gez">ውፃእ፡ አንተ፡ ዓይን፡ እም፡ ሥራየ<supplied reason="omitted">፡</supplied> ብእሲ፡ ወብእሲት፡ 
+                            <explicit xml:lang="gez">ውፃእ፡ አንተ፡ ዓይን፡ እም፡ ሥራየ<supplied reason="omitted">፡</supplied> ብእሲ፡ ወብእሲት፡
                             ዓይነ፡ እስላም፡ ወክርስቲያን፡ ዓይነ፡ አይሁድ፡ ወዓይነ፡ አረማውያን፡ በኃይልከ፡ ኃይለ፡ እግዚአብሔር፡ ወበፅንዕከ፡ ፅንዓ፡ እግዚአብሔር፡ ፃእ፡ እምላዕለ፡
                             ገብርከ። <persName ref="PRS13851TaklaM"><hi rend="rubric">ተክለ፡ ማርያም፡</hi></persName></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i4">
                             <locus from="1r98" to="1r119"/>
                             <title type="complete" ref="LIT1878Marbab"/>
                             <textLang mainLang="gez"/>
                             <note>The following is the entire text.</note>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመን</hi>ፈስ፡ ቅዱስ፡ ፩ አምላክ፡
-                                ጸሎት<supplied reason="omitted">፡</supplied> በእንተ፡ መርበብተ፡ ሰሎሞን፡ 
+                                ጸሎት<supplied reason="omitted">፡</supplied> በእንተ፡ መርበብተ፡ ሰሎሞን፡
                             በከመ፡ ረበቦሙ፡ ወቀነዮሙ፡ ሰሎሞን፡ ለአጋንንት፡ ሰሎሞን፡ ሰሎሞ፡ ሰሎሞን፡ ለአጋንንት፡ ሰሎሞን፡ ሰሎሞን፡ ሎፍሐም፡ ሎፍሐም፡ ሎፍሐም፡ ንምሎስ፡ ንምሎስ፡ ንምሎስ፡
                             ዮፍታሔ፡ ዮፍታሔ፡ ዮፍታሔ፡ ዮፍታሔ፡ አምላከ፡ <sic>ጴሮስ፡</sic> ወጳውሎስ፡ ብርስባሔል፡ ብርሃናኤል፡ አዌን፡ ቆጶንዮስ፡ ፓፒሮስ፡ ዕብኖዲ፡ ማስያስ፡ ድስቡጠ፡
-                            ሳዶር፡ አላዶር፡ ዳናት፡ አዴራ፡ ሮዳስ፡ በ፭ ቅንዋተ፡ መስቀሉ፡ ለእግዚእነ፡ ወአምላክነ፡ ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡ ከመ፡ ኢይቅረቡ፡ 
+                            ሳዶር፡ አላዶር፡ ዳናት፡ አዴራ፡ ሮዳስ፡ በ፭ ቅንዋተ፡ መስቀሉ፡ ለእግዚእነ፡ ወአምላክነ፡ ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡ ከመ፡ ኢይቅረቡ፡
                                 <hi rend="rubric">ወይርኃቁ፡</hi> እምላዕለ፡ ነፍሱ፡ ወሥጋሁ፡ ለገብርከ። <persName ref="PRS13851TaklaM"><hi rend="rubric">ተክለ፡ ማርያም።</hi></persName></incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i5">
                             <locus from="1r119" to="1r165"/>
                             <title type="complete" ref="LIT4697MagicPr"/>
                             <textLang mainLang="gez"/>
-                            <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡</hi> 
+                            <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡</hi>
                                 <surplus>ቅዱስ፡</surplus> ፩ አምላክ፡ ጸሎ<milestone unit="parchmentStrip" n="3"/>ት፡
                                 በእንተ፡ ማዕሰሮሙ፡ ለአጋንንት፡ <hi rend="rubric">ሰላም፡ ለከ፡</hi> ሰዳዴ፡ አጋንንት፡ ፋኑኤል፡ ለእግዚአብሔር፡ እምጽርሑ፡
                                 ከመ፡ ኢይስክዩ፡ ሰብአ፡ እለ፡ ይኔስሑ፡ ኃጣውአ፡ ሰብእ፡ ዘዘዚአሁ፡ <hi rend="rubric">ሰላም፡ ለከ፡</hi> ሰዳዴ፡ ሰይጣናት፡
                             ፋኑኤል፡ እምገጸ፡ ፈጣሪ፡ ልዑል፡</incipit>
-                            <explicit xml:lang="gez">ንሣእ፡ ዘማኅሌ<add place="above">ት</add>የ፡ ቡዓዴ፡ እለ፡ ይሌቅሁ፡ ወርቆሙ፡ በርዴ፡ መቅደሰ፡ 
+                            <explicit xml:lang="gez">ንሣእ፡ ዘማኅሌ<add place="above">ት</add>የ፡ ቡዓዴ፡ እለ፡ ይሌቅሁ፡ ወርቆሙ፡ በርዴ፡ መቅደሰ፡
                                 ኦሪት፡ ዘቦእኪ፡
-                                ማርያም፡ እምነ፡ ወእሙ፡ ለእ<hi rend="ligature">ግዚ</hi>እነ፡ በሕፅነ፡ ሐና፡ እምኪ፡ ተማፀነ፡ <add place="above">አዝዝዮ፡ ለፋኑኤል፡ ይዕ<gap reason="illegible" unit="chars" quantity="1"/>ብ፡ <sic>ኪየ</sic>።</add> 
+                                ማርያም፡ እምነ፡ ወእሙ፡ ለእ<hi rend="ligature">ግዚ</hi>እነ፡ በሕፅነ፡ ሐና፡ እምኪ፡ ተማፀነ፡ <add place="above">አዝዝዮ፡ ለፋኑኤል፡ ይዕ<gap reason="illegible" unit="chars" quantity="1"/>ብ፡ <sic>ኪየ</sic>።</add>
                                 በረምኃ፡ በረሞ፡ መስቀል፡ ረጊዞ፡ ሰይጣን፡ ኦአምላከ፡
                                 ፋኑኤል፡ ዕቀበኒ፡ ወሰውረኒ፡ እመከራ፡ ሥጋ፡ ወነፍስ፡ ወእም<surplus>ሕም</surplus>ሕማመ፡ ፌራ፡ ወንዳድ<supplied reason="omitted">፡</supplied> ለገብርከ፡ <persName ref="PRS13851TaklaM"><hi rend="rubric">ተክለ፡ ማርያም፡</hi></persName></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i6">
                             <locus from="1r166" to="1r176"/>
                             <title type="complete" ref="LIT6752PPSmiths"/>
@@ -122,30 +122,30 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             ሐረፓሮስ፡ አልዩድ፡ ኢልህምዩድ፡ አርክህምዩድ፡ ሴር፡ ሴር፡ ቈቍነስኩክሙ፡ በአብ፡ አወግዘክሙ፡ ወበወልድ፡ እከልክሙ፡ በመንፈስ፡ ቅዱስ፡ ከመ፡ ኢታሕምሙ፡
                             ኀበ፡ ነፍሱ፡ ወሥጋሁ፡ ለገብርከ። <persName ref="PRS13851TaklaM"><hi rend="rubric">ተክለ፡ ማርያም፡</hi></persName></incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i7">
                             <locus from="1r177" to="1r190"/>
                             <title type="complete" ref="LIT4622Prayer"/>
                             <textLang mainLang="gez"/>
                             <note>The following is the entire text.</note>
-                            <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡</hi> ቅዱስ፡ ፩ አምላክ፡ ጸሎት፡ በእንተ፡ ሕማመ፡ ቍርፀት፡ ዘተፈነወ፡ 
+                            <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡</hi> ቅዱስ፡ ፩ አምላክ፡ ጸሎት፡ በእንተ፡ ሕማመ፡ ቍርፀት፡ ዘተፈነወ፡
                                 እምኀበ፡
                                 <sic>ወወል፡</sic> ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ይርዳዕ፡ ወይዕ፡ ወይቤ<unclear>ዙ</unclear>፡ ለውሉደ፡ እጓለ፡ እመሕያው፡ እንዘ<supplied reason="omitted">፡</supplied>
-                            ይበ<gap reason="illegible" unit="chars" quantity="1"/>ብዕ፡ ከርሥ፡ ወያጠዊ፡ ዓማዑት፡ ወያደቅቅ፡ አዕፅምት፡ ሸገር፡ ሸገር፡ በኃይለ፡ ዝንቱ፡ 
+                            ይበ<gap reason="illegible" unit="chars" quantity="1"/>ብዕ፡ ከርሥ፡ ወያጠዊ፡ ዓማዑት፡ ወያደቅቅ፡ አዕፅምት፡ ሸገር፡ ሸገር፡ በኃይለ፡ ዝንቱ፡
                                 አስማቲከ፡
                                 አድኅኖ፡ እምሕማመ፡ ቍርፀት፡ <sic>ለገብከ።</sic> <persName ref="PRS13851TaklaM"><hi rend="rubric">ተክለ፡ ማርያም።</hi></persName></incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i8">
                             <locus from="1r190" to="1r198"/>
                             <title type="complete" ref="LIT6753PPWegat"/>
                             <textLang mainLang="gez"/>
                           <note>The following is the entire text.</note>
-                            <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ<supplied reason="omitted">፡</supplied> ወመንፈስ፡ ቅዱስ፡</hi> ፩ አምላክ፡ ጸሎት፡ በእንተ፡ ሕማመ፡ ውግአት፡ አላህ፡ 
-                                ባላህ፡ ማላህ፡ አድራት፡ ወባራት፡ ወበኤድራት፡ ክንቅሮን፡ በስመ፡ ኮን፡ ሕትም፡ ሕማመ፡ ዕቃሁ፡ ለውግአት፡ እምላ<surplus>ዕላ</surplus>ዕለ፡ 
+                            <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ<supplied reason="omitted">፡</supplied> ወመንፈስ፡ ቅዱስ፡</hi> ፩ አምላክ፡ ጸሎት፡ በእንተ፡ ሕማመ፡ ውግአት፡ አላህ፡
+                                ባላህ፡ ማላህ፡ አድራት፡ ወባራት፡ ወበኤድራት፡ ክንቅሮን፡ በስመ፡ ኮን፡ ሕትም፡ ሕማመ፡ ዕቃሁ፡ ለውግአት፡ እምላ<surplus>ዕላ</surplus>ዕለ፡
                                 ገብርከ። <persName ref="PRS13851TaklaM"><hi rend="rubric">ተክለ፡ ማርያም፡</hi></persName></incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i9">
                             <locus from="1r199" to="1r204"/>
                             <title type="complete" ref="LIT6754PPQwertmat"/>
@@ -155,9 +155,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 አማኑኤል፡ ሰዳዲሆሙ፡ <sic>ለአጋን</sic>
                                 ወይእዜኒ፡ ለቍርጥማት፡ እምላዕለ፡ ገብርከ፡ <persName ref="PRS13851TaklaM"><hi rend="rubric">ተክለ፡ ማርያም<supplied reason="omitted">፡</supplied></hi></persName></incipit>
                         </msItem>
-                    
+
                     </msContents>
-                    
+
                     <physDesc>
                         <objectDesc form="Scroll">
                             <supportDesc>
@@ -184,9 +184,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </dimensions>
                                     <measure type="weight" unit="g">49</measure>
                                 </extent>
-                                <condition key="good">The state of preservation is good. The upper part of the scroll is crumpled due to rolling.</condition>
+                                <condition key="good">The upper part of the scroll is crumpled due to rolling.</condition>
                             </supportDesc>
-                            
+
                             <layoutDesc>
                                 <layout columns="1" writtenLines="61" corresp="#">
                                     <note>Number of characters per line: 16–17.</note>
@@ -235,21 +235,21 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </layout>
                             </layoutDesc>
                         </objectDesc>
-                        
+
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <date notBefore="1800" notAfter="2006"/>
-                                <desc>Relatively regular hand. Broad and slightly cursive characters. The word separator at the end of a line is 
+                                <desc>Relatively regular hand. Broad and slightly cursive characters. The word separator at the end of a line is
                                 occasionally omitted or placed at the beginning of the next line. The ligature
                                 <foreign xml:lang="gez"><hi rend="ligature">ግዚ</hi></foreign> is used.</desc>
                                 <seg type="ink">Black, red.</seg>
-                                <seg type="rubrication">Incipits (one or two rubricated lines), name of the owner, one numeral, 
+                                <seg type="rubrication">Incipits (one or two rubricated lines), name of the owner, one numeral,
                                     the words <foreign xml:lang="gez">ወይርኃቁ፡</foreign>
                                     in <ref target="#ms_i4">textual unit IV</ref> and
                                     <foreign xml:lang="gez">ሰላም፡ ለከ፡</foreign> in <ref target="#ms_i5">textual unit V</ref>.</seg>
                             </handNote>
                         </handDesc>
-                        
+
                        <!-- <decoDesc>
                             <decoNote xml:id="d1" type="miniature" corresp="#pic1">
                                 <desc></desc>
@@ -280,25 +280,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </dimensions>
                             </decoNote>
                         </decoDesc>-->
-                        
+
                         <additions>
                             <list>
                                 <item xml:id="e1">
                                     <desc>The verso is empty.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e2">
                                     <desc>The manuscript contains nearly no scribal corrections. In <ref target="#ms_i5">textual unit V</ref>,
-                                        a correction is written 
+                                        a correction is written
                                     above an erasure and omitted characters are written interlineally.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e3">
                                     <desc>The name of the owner, mentioned in supplications throughout, was <persName ref="PRS13851TaklaM"/>.</desc>
                                 </item>
                             </list>
                         </additions>
-                        
+
                         <bindingDesc>
                             <binding>
                                 <decoNote xml:id="b1">The three parchment strips of which the scroll is composed are sewn together with narrow parchment
@@ -307,13 +307,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </binding>
                         </bindingDesc>
                     </physDesc>
-                    
+
                     <history>
                         <origin>
                             <origDate notBefore="1800" notAfter="2006" evidence="lettering"/>
                         </origin>
                     </history>
-                    
+
                     <additional>
                         <adminInfo>
                             <recordHist>
@@ -325,7 +325,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </recordHist>
                         </adminInfo>
                     </additional>
-                    
+
                 </msDesc>
             </sourceDesc>
         </fileDesc>
@@ -366,62 +366,62 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <body>
             <div type="edition">
                 <div type="textpart" subtype="recto">
-                    
+
                     <div type="textpart" subtype="section" n="1" xml:id="sec1">
                         <div type="textpart" subtype="picture" n="1" xml:id="pic1" corresp="#d1"/>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="2" xml:id="sec2">
                         <div type="textpart" subtype="text" n="1" corresp="#ms_i1" xml:id="text1">
                             <ab/>
                         </div>
-                        
+
                         <div type="textpart" subtype="text" n="2" corresp="#ms_i2" xml:id="text2part1">
                             <ab>
                                 <milestone unit="parchmentStrip" n="2"/>
                             </ab>
                         </div>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="3" xml:id="sec3">
                         <div type="textpart" subtype="picture" n="1" xml:id="pic2" corresp="#d2"/>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="4" xml:id="sec4">
                         <div type="textpart" subtype="text" n="2" corresp="#ms_i2" xml:id="text2part2">
                             <ab/>
                         </div>
-                        
+
                         <div type="textpart" subtype="text" n="3" corresp="#ms_i3" xml:id="text3">
                             <ab/>
                         </div>
-                        
+
                         <div type="textpart" subtype="text" n="4" corresp="#ms_i4" xml:id="text4">
                             <ab>
                                 <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመን</hi>ፈስ፡ ቅዱስ፡ ፩ አምላክ፡
-                                ጸሎት<supplied reason="omitted">፡</supplied> በእንተ፡ መርበብተ፡ ሰሎሞን፡ 
+                                ጸሎት<supplied reason="omitted">፡</supplied> በእንተ፡ መርበብተ፡ ሰሎሞን፡
                                 በከመ፡ ረበቦሙ፡ ወቀነዮሙ፡ ሰሎሞን፡ ለአጋንንት፡ ሰሎሞን፡ ሰሎሞ፡ ሰሎሞን፡ ለአጋንንት፡ ሰሎሞን፡ ሰሎሞን፡ ሎፍሐም፡ ሎፍሐም፡ ሎፍሐም፡ ንምሎስ፡ ንምሎስ፡ ንምሎስ፡
                                 ዮፍታሔ፡ ዮፍታሔ፡ ዮፍታሔ፡ ዮፍታሔ፡ አምላከ፡ <sic>ጴሮስ፡</sic> ወጳውሎስ፡ ብርስባሔል፡ ብርሃናኤል፡ አዌን፡ ቆጶንዮስ፡ ፓፒሮስ፡ ዕብኖዲ፡ ማስያስ፡ ድስቡጠ፡
-                                ሳዶር፡ አላዶር፡ ዳናት፡ አዴራ፡ ሮዳስ፡ በ፭ ቅንዋተ፡ መስቀሉ፡ ለእግዚእነ፡ ወአምላክነ፡ ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡ ከመ፡ ኢይቅረቡ፡ 
+                                ሳዶር፡ አላዶር፡ ዳናት፡ አዴራ፡ ሮዳስ፡ በ፭ ቅንዋተ፡ መስቀሉ፡ ለእግዚእነ፡ ወአምላክነ፡ ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡ ከመ፡ ኢይቅረቡ፡
                                 <hi rend="rubric">ወይርኃቁ፡</hi> እምላዕለ፡ ነፍሱ፡ ወሥጋሁ፡ ለገብርከ። <persName ref="PRS13851TaklaM"><hi rend="rubric">ተክለ፡ ማርያም።</hi></persName>        </ab>
                         </div>
-                        
+
                         <div type="textpart" subtype="text" n="5" corresp="#ms_i5" xml:id="text5part1">
                             <ab>
                                 <milestone unit="parchmentStrip" n="3"/>
                             </ab>
                         </div>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="5" xml:id="sec5">
                         <div type="textpart" subtype="picture" n="3" xml:id="pic3" corresp="#d3"/>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="6" xml:id="sec6">
                     <div type="textpart" subtype="text" n="5" corresp="#ms_i5" xml:id="text5part2">
                         <ab/>
                     </div>
-                        
+
                         <div type="textpart" subtype="text" n="6" corresp="#ms_i6" xml:id="text6">
                             <ab>
                                 <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ አ፩ አምላክ፡ ጸሎ</hi>ት፡ በእንተ፡ ሕማመ፡ ነሃብት፡
@@ -429,26 +429,26 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 ኀበ፡ ነፍሱ፡ ወሥጋሁ፡ ለገብርከ። <persName ref="PRS13851TaklaM"><hi rend="rubric">ተክለ፡ ማርያም፡</hi></persName>
                             </ab>
                         </div>
-                        
+
                         <div type="textpart" subtype="text" n="7" corresp="#ms_i7" xml:id="text7">
                             <ab>
-                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡</hi> ቅዱስ፡ ፩ አምላክ፡ ጸሎት፡ በእንተ፡ ሕማመ፡ ቍርፀት፡ ዘተፈነወ፡ 
+                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡</hi> ቅዱስ፡ ፩ አምላክ፡ ጸሎት፡ በእንተ፡ ሕማመ፡ ቍርፀት፡ ዘተፈነወ፡
                                 እምኀበ፡
                                 <sic>ወወል፡</sic> ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ይርዳዕ፡ ወይዕ፡ ወይቤዘ፡ ለውሉደ፡ እጓለ፡ እምሕያው፡ እንዘ<supplied reason="omitted">፡</supplied>
-                                ይበ<gap reason="illegible" unit="chars" quantity="1"/>ብዕ፡ ከርሥ፡ ወያጠዊ፡ ዓማዑት፡ ወያደቅቅ፡ አዕፅምት፡ ሸገር፡ ሸገር፡ በኃይለ፡ ዝንቱ፡ 
+                                ይበ<gap reason="illegible" unit="chars" quantity="1"/>ብዕ፡ ከርሥ፡ ወያጠዊ፡ ዓማዑት፡ ወያደቅቅ፡ አዕፅምት፡ ሸገር፡ ሸገር፡ በኃይለ፡ ዝንቱ፡
                                 አስማቲከ፡
                                 አድኅኖ፡ እምሕማመ፡ ቍርፀት፡ ለገብርከ። <persName ref="PRS13851TaklaM"><hi rend="rubric">ተክለ፡ ማርያም።</hi></persName>
                             </ab>
                         </div>
-                        
+
                         <div type="textpart" subtype="text" n="8" corresp="#ms_i8" xml:id="text8">
                             <ab>
-                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡</hi> ፩ አምላክ፡ ጸሎት፡ በእንተ፡ ሕማመ፡ ውግአት፡ አላህ፡ 
-                                ባላህ፡ ማላህ፡ አድራት፡ ወገራት፡ ወበኤድራት፡ ክንቅሮን፡ በስመ፡ ኮን፡ ሕትም፡ ሕማመ፡ ዕቃሁ፡ ለውግአት፡ እም<surplus>ላዕላ</surplus>ዕላ፡ 
+                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡</hi> ፩ አምላክ፡ ጸሎት፡ በእንተ፡ ሕማመ፡ ውግአት፡ አላህ፡
+                                ባላህ፡ ማላህ፡ አድራት፡ ወገራት፡ ወበኤድራት፡ ክንቅሮን፡ በስመ፡ ኮን፡ ሕትም፡ ሕማመ፡ ዕቃሁ፡ ለውግአት፡ እም<surplus>ላዕላ</surplus>ዕላ፡
                                 ገብርከ። <persName ref="PRS13851TaklaM"><hi rend="rubric">ተክለ፡ ማርያም፡</hi></persName>
                             </ab>
                         </div>
-                        
+
                         <div type="textpart" subtype="text" n="9" corresp="#ms_i9" xml:id="text9">
                             <ab>
                                 ጸሎት፡ በእንተ፡ ሕማመ፡ ቍርጥማት፡ ካኤል፡ ካካኤል<supplied reason="omitted">፡</supplied> አዶናኤል፡ ኢዩኤል፡
@@ -457,11 +457,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </ab>
                         </div>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="7" xml:id="sec7">
                         <div type="textpart" subtype="picture" n="4" xml:id="pic4" corresp="#d4"/>
                     </div>
-                    
+
                 </div>
             </div>
         </body>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0"
     xml:id="BDLaethg45"
@@ -15,7 +15,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <editor key="JG"/>
                 <editor key="MV"/>
                 <editor key="SH"/>
-                <editor key="EDS"/>                
+                <editor key="EDS"/>
                  <editor key="JK"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
@@ -37,36 +37,36 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <idno>Juel-Jensen 33</idno>
                         </altIdentifier>
                     </msIdentifier>
-                    
+
                     <msContents>
                         <summary/>
-                        
+
                         <msItem xml:id="ms_i1">
                       <locus from="1r1" to="1r21"/>
                                   <title type="complete" ref="LIT6714PPIllness"/>
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ስቡሕ፡ ወውዱስ፡ ዘሣረረ፡ ኵሎ፡ ዓለም፡
-                                በ</hi>አሐቲ፡ ቃል፡ ሃሌ፡ ሉያ፡ እ<hi rend="ligature">ግዚ</hi>ኦ፡ መሐረነ፡ እ<hi rend="ligature">ግዚ</hi>ኦ፡ መሐከነ፡ 
+                                በ</hi>አሐቲ፡ ቃል፡ ሃሌ፡ ሉያ፡ እ<hi rend="ligature">ግዚ</hi>ኦ፡ መሐረነ፡ እ<hi rend="ligature">ግዚ</hi>ኦ፡ መሐከነ፡
                                 እ<hi rend="ligature">ግዚ</hi>ኦ፡ ተሠሃለነ፡ ስብሐት፡ ለአብ፡ ስብሐት፡ ለወልድ፡ ስብሐት፡ ለመንፈስ፡ ቅዱስ፡
                                 ቅዱ<hi rend="rubric">ስ፡ ቅዱስ፡ ቅዱስ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ አምላከ፡ አማልክት፡</hi></incipit>
                             <explicit xml:lang="gez">ወእምኵሉ፡ ደዌ፡ ወሕማም፡ አድኅና፡ ለአመትከ፡ ወለተ፡ <space reason="rubrication"/>
                             <hi rend="rubric">ወገጽ፡ ዘፍፁም፡ በጽልመት፡ ፈርሃ፡ ወደንገፀ፡</hi> ዲያብሎስ፡ ርእዮ፡ ብሁተ፡ ልደት፡ በሥጋ፡ አምላክ፡ በሲኦል፡ በዝ፡ ቃለ፡ መለኮትከ፡
                                 አድኅና፡ ለአመትከ፡ <persName ref="PRS13850WalattaS" role="owner">ወለተ፡ <hi rend="rubric">ሰንበት፡ ትበርህ፡</hi></persName></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i2">
                             <locus from="1r21" to="1r30"/>
                                <title type="complete" ref="LIT6715PPQwerdat"/>
                             <textLang mainLang="gez"/>
                             <!--this is the complete text-->
-                            <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ሕማመ፡ ቍርፀት፡ ኪስ፡ ኪስ፡ ኪስ፡ አራኪስ፡  ስርንኪስ፡ ስርዋጽ፡ 
+                            <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ሕማመ፡ ቍርፀት፡ ኪስ፡ ኪስ፡ ኪስ፡ አራኪስ፡  ስርንኪስ፡ ስርዋጽ፡
                             ምርዋጽ፡ ስር፡ ነኬር፡ ሲቃ፡ ወጼቃ፡ ወቤቓ፡ ድማኄል፡ አዶናይ፡ ቄጼቤ፡ ቄጼቤ፡ ቄጼቤ፡
                          ቄፌኑ፡ ቄፌኑ፡ ቄፌኑ፡ ቡያክ፡ ቡያክ፡ ሞሊ፡ ሞሊ፡ ሞሊ፡ ኪያሞሌ፡ ኪያሞሌ፡ ኪያሞሌ፡ ዘአርጋእክ፡ ኃይለ፡
                                 በረድ፡ ወነፋስ፡ ከማሁ፡ አርግዕ፡ ወአቁም፡ ሕማመ፡ ቁርፀት፡ እምላእለ፡ አመትከ፡
                                 <persName ref="PRS13850WalattaS">ወለተ፡ <hi rend="rubric">ሰንበት፡ ወለተ፡ ትበርሂ፡</hi></persName>
                             </incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i3">
                             <locus from="1r30" to="1r39"/>
                             <title type="complete" ref="LIT6716PPWegat"/>
@@ -74,10 +74,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <!--this is the complete text-->
                             <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ሕማመ፡ ውግዓት፡ እልመክኩን፡ እልመክኩን፡ እልመክኩን፡
                             አዝቤ፡ ረቤ፡ ታኦስ፡ ብርስባሔል፡ አልፋ፡ ወዕ፡ ቤጣ፡ ምድምያስ፡ ምድምያ፡ ምድምያስ፡ የሐቄ፡ የሐቄ፡ የሐቄ፡
-                            የኃብራስቄ፡ የኃብራስቄ፡ የኃብራስቄ፡ ክርስትቂ፡ ክርስቂ፡ ክርስቄ፡ በከመ፡ አድኃንከ፡ ለወለተ፡ ከራስቄ፡ ከማሃ፡ 
+                            የኃብራስቄ፡ የኃብራስቄ፡ የኃብራስቄ፡ ክርስትቂ፡ ክርስቂ፡ ክርስቄ፡ በከመ፡ አድኃንከ፡ ለወለተ፡ ከራስቄ፡ ከማሃ፡
                             አድኅና፡ በእንተ፡ ሕማመ፡ ውግዓት፡ ለአመትከ፡ <persName ref="PRS13850WalattaS">ወለተ፡ <hi rend="rubric">ሰንበት፡ ወለተ፡ ትበርሄ፡</hi></persName></incipit>
             </msItem>
-                        
+
                         <msItem xml:id="ms_i4">
                             <locus from="1r39" to="1r49"/>
                                <title type="complete" ref="LIT6717PPFelsat"/>
@@ -85,25 +85,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <!--this is the complete text-->
                             <incipit xml:lang="gez"><hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ፍልፀት፡ ያጣውጢ፡ ያጣውጢ፡ ያጣውጢ፡ ያሽላክፊ፡ ያሽላክፊ፡ ያሽላክፊ፡
                             ያበጋር፡ ሽሩራን፡ ሽኃል፡ መጃል፡ ካፍ፡ ላፍ፡ አፈና፡ ጋዲን፡ ታኦስ፡ አብኖዲ፡ ብርስባኄል፡ አዶናይ፡ አማኑኤል፡ እምንስቲት፡ ሙኬርያ፡
-                            መዓግያ፡ ሙዳሱጣ፡ ኢየሱስ፡ ክርስቶስ። ወልደ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ሕያው፡ ዘኢይመውት፡ በኃይለ፡ ዝንቱ፡ አስማቲከ፡ 
+                            መዓግያ፡ ሙዳሱጣ፡ ኢየሱስ፡ ክርስቶስ። ወልደ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ሕያው፡ ዘኢይመውት፡ በኃይለ፡ ዝንቱ፡ አስማቲከ፡
                                 አርኅቆሙ፡ ለምታት፡ <sic>ወለፍፀተ፡</sic> ርክስ፡ እምላእለ፡ አመትከ፡ <persName ref="PRS13850WalattaS">ወለተ፡ <hi rend="rubric">ሰንበት፡ ትበርሄ።</hi></persName></incipit>
                       </msItem>
-                        
+
                         <msItem xml:id="ms_i5">
                             <locus from="1r50" to="1r148"/>
                             <title type="complete" ref="LIT1878Marbab"/>
-                            <note>The version of the work attested here is close to that attested in <ref type="mss" corresp="EMIP00616"/> 
+                            <note>The version of the work attested here is close to that attested in <ref type="mss" corresp="EMIP00616"/>
                                 (<locus from="51r" to="53v"/>) and <ref type="mss" corresp="EMIP00292"/> (<locus from="7v" to="9v"/>).</note>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ አስማተ፡ ሰሎሞን፡</hi>
-                            ዘረበቦሙ<supplied reason="omitted">፡</supplied> <sic>ለአንንት፡</sic> ወለነሃብት፡ ከመ፡ መርበብተ፡ አሣ፡ እንዘ፡ ይብል፡ ሰዳቃኤል፡ አዳናኤል፡ አዳዳኤል፡ ኤል፡ 
+                            ዘረበቦሙ<supplied reason="omitted">፡</supplied> <sic>ለአንንት፡</sic> ወለነሃብት፡ ከመ፡ መርበብተ፡ አሣ፡ እንዘ፡ ይብል፡ ሰዳቃኤል፡ አዳናኤል፡ አዳዳኤል፡ ኤል፡
                                 ርሜል፡ ስርማ፡ ሩባ፡ ዕፍ፡ በዕፍ፡ ጸልለኒ፡ በክንፍከ፡
                             እ<hi rend="ligature">ግዚ</hi>ኦ፡ እምፀርየ፡ ወአድኅነኒ፡ እምሕማመ፡ ፀላኢ፡</incipit>
-                            <explicit xml:lang="gez">አድኅነኒ<supplied reason="omitted">፡</supplied> እምፀርየ፡ ወነገርጋር፡ ከመ፡ ኢይንበሩ፡ በትርአስየ፡ ወኢበትርጋጽየ፡ 
+                            <explicit xml:lang="gez">አድኅነኒ<supplied reason="omitted">፡</supplied> እምፀርየ፡ ወነገርጋር፡ ከመ፡ ኢይንበሩ፡ በትርአስየ፡ ወኢበትርጋጽየ፡
                                 ወኢይብቡኒ፡ ነገረ፡ እኵይ፡ ላእሌየ፡ ወእምኵሎሙ፡
                                 መናፍስት፡ ርኵሳን፡ ወሰብዕ፡ መሠርያን፡ ሠርከ፡ ወነግሃ፡ <sic>ወዓልተ፡</sic> ወሌሊተ፡ ከመ፡ ኢያህሶም፡ ላእሌየ፡ ኵሎሙ፡ ገበርተ፡ አመፃ፡ ሊተ፡ ለአመትከ፡ <persName ref="PRS13850WalattaS">ወለተ፡
                             <hi rend="rubric">ሰንበት፡ ትበርሄ፡</hi></persName></explicit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i6">
                             <locus from="1r148" to="1r261"/>
                                 <title type="complete" ref="LIT6718PPAqweyasat"/>
@@ -115,11 +115,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             ወእለ፡ ይትሜሰሉ፡ ዝእበ፡</incipit>
                             <explicit xml:lang="gez">ከመ፡ ኢይማዑኒ፡ ኵሎሙ፡ አቃብያነ፡ ሥራይ፡ ወገበርተ፡ አመፃ፡ እለ፡ የሐውሩ፡ በሌሊት፡ ኀበ፡ ኵሉ፡ ሰብዕ፡ ይደምስሱ፡
                             ወይዘረው፡ <sic>ሠራዊትሙ፡</sic> ለአጋንንት፡ በኵሉ፡ ጊዜ፡ ወበኵሉ፡ ሠአት፡ ዘመዓልት፡ ወዘሌሊት፡ በቀትር፡ ወበሠአት፡ ለአለመ፡ አለም፡ አሜን፡ ለአመትከ፡
-                                <persName ref="PRS13850WalattaS">ወለተ፡ <hi rend="rubric">ሰንበት፡</hi></persName> እስመ፡ አልቦ፡ ነገር፡ ዘይስእኖ፡ 
+                                <persName ref="PRS13850WalattaS">ወለተ፡ <hi rend="rubric">ሰንበት፡</hi></persName> እስመ፡ አልቦ፡ ነገር፡ ዘይስእኖ፡
                                 ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ ሥጋ፡ ቃል፡ ኮነ፡ ቃል፡ ሥጋ፡ ኮነ፡</explicit>
                       </msItem>
                     </msContents>
-                    
+
                     <physDesc>
                         <objectDesc form="Scroll">
                             <supportDesc>
@@ -142,7 +142,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <width>112</width>
                                     </dimensions>
                                 </extent>
-                                <condition key="good">The state of preservation of the manuscript is good. The part of the verso that is exposed
+                                <condition key="good">The verso side which is exposed
                                 when the scroll is rolled up is darkened.</condition>
                             </supportDesc>
                             <layoutDesc>
@@ -161,7 +161,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </dimensions>
                                     <ab type="pricking">Ruling and pricking are not visible.</ab>
                                 </layout>
-                                
+
                                 <layout columns="1" writtenLines="146" corresp="#sec4 #strip2">
                                     <note>Number of characters per line: 22–27.</note>
                                     <note>The outer margins are delimited by a black line.</note>
@@ -177,10 +177,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </dimensions>
                                     <ab type="pricking">Ruling and pricking are not visible.</ab>
                                 </layout>
-                                
+
                             </layoutDesc>
                         </objectDesc>
-                        
+
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <date notBefore="1800" notAfter="2006"/>
@@ -190,7 +190,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <seg type="rubrication">Incipits, holy name as part of the name of the owner.</seg>
                             </handNote>
                         </handDesc>
-                        
+
                    <!--     <decoDesc>
                             <decoNote xml:id="d1" type="miniature" corresp="#pic1">
                                 <desc></desc>
@@ -199,7 +199,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            <width>112</width>
                         </dimensions>
                             </decoNote>
-                            
+
                             <decoNote xml:id="d2" type="miniature" corresp="#pic2">
                                 <desc></desc>
                                    <dimensions unit="mm">
@@ -208,46 +208,46 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </dimensions>
                             </decoNote>
                         </decoDesc>-->
-                        
+
                         <additions>
                             <list>
                                 <item xml:id="e1">
-                                    <desc>The name of the owner, mentioned in supplications throughout, was 
+                                    <desc>The name of the owner, mentioned in supplications throughout, was
                                         <persName ref="PRS13850WalattaS"/>. The last part of the name is spelled with variation
                                         <foreign xml:lang="gez">ትበርህ፡</foreign>, <foreign xml:lang="gez">ትበርሂ፡</foreign> and <foreign xml:lang="gez">ትበርሄ፡</foreign>.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e2">
                                     <desc>There are no corrections or other scribal interventions in the text.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e3">
-                                    <desc>In the bottom margin of the scroll, following the end of the last text, four <!--italics--> Brillenbuchstaben are 
+                                    <desc>In the bottom margin of the scroll, following the end of the last text, four <!--italics--> Brillenbuchstaben are
                                         drawn. Between them, the characters <foreign xml:lang="gez">ሽ</foreign> or  <foreign xml:lang="gez">፳</foreign>, <foreign xml:lang="gez">ሐ</foreign>,
                                         and <foreign xml:lang="gez">ሩ</foreign> are written.</desc>
                                 </item>
-                                
+
                                 <item xml:id="e4">
                                     <desc>Few remains of writing on the verso.</desc>
                                    <!-- I cannot see them in the images, but noted this on the metadata-->
                                 </item>
                             </list>
                         </additions>
-                        
+
                        <bindingDesc>
                            <binding xml:id="binding">
                                <decoNote xml:id="b1">The strips are sewn together with small parchment strips.</decoNote>
                            </binding>
                        </bindingDesc>
-                        
+
                     </physDesc>
-                    
+
                     <history>
                         <origin>
                             <origDate notBefore="1800" notAfter="2006" evidence="lettering"/>
                         </origin>
                     </history>
-                    
+
                     <additional>
                         <adminInfo>
                             <recordHist>
@@ -259,7 +259,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </recordHist>
                         </adminInfo>
                     </additional>
-                    
+
                 </msDesc>
             </sourceDesc>
         </fileDesc>
@@ -290,7 +290,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="DR" when="2020-01-20">Created record</change>
-            <change who="SH" when="2020-04-22">Added editors</change>   
+            <change who="SH" when="2020-04-22">Added editors</change>
             <change who="DR" when="2022-07-30">Continued description</change>
         </revisionDesc>
     </teiHeader>
@@ -298,12 +298,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <body>
             <div type="edition">
                 <div type="textpart" subtype="recto">
-                    
+
                     <div type="textpart" subtype="section" n="1" xml:id="sec1">
                         <div type="textpart" subtype="picture" n="1" xml:id="pic1" corresp="#d1"/>
                     </div>
-                    
-                    
+
+
                     <div type="textpart" subtype="section" n="2" xml:id="sec2">
                         <div type="textpart" subtype="text" n="1" corresp="#ms_i1" xml:id="text1">
                             <ab>
@@ -312,7 +312,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </div>
                         <div type="textpart" subtype="text" n="2" corresp="#ms_i2" xml:id="text2">
                             <ab>
-                                <hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ሕማመ፡ ቍርፀት፡ ኪስ፡ ኪስ፡ ኪስ፡ አራኪስ፡  ስርንኪስ፡ ስርዋጽ፡ 
+                                <hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ሕማመ፡ ቍርፀት፡ ኪስ፡ ኪስ፡ ኪስ፡ አራኪስ፡  ስርንኪስ፡ ስርዋጽ፡
                                     ምርዋጽ፡ ስር፡ ነኬር፡ ሲቃ፡ ወጼቃ፡ ወቤቓ፡ ድማኄል፡ አዶናይ፡ ቄጼቤ፡ ቄጼቤ፡ ቄጼቤ፡
                                ቄፌኑ፡ ቄፌኑ፡ ቄፌኑ፡ ቡያክ፡ ቡያክ፡ ሞሊ፡ ሞሊ፡ ሞሊ፡ ኪያሞሌ፡ ኪያሞሌ፡ ኪያሞሌ፡ ዘአርጋእክ፡ ኃይለ፡
                                     በረድ፡ ወነፋስ፡ ከማሁ፡ አርግዕ፡ ወአቁም፡ ሕማመ፡ ቁርፀት፡ እምላእለ፡ አመትከ፡ <persName ref="PRS13850WalattaS">ወለተ፡ <hi rend="rubric">ሰንበት፡ ወለተ፡ ትበርሂ፡</hi></persName>
@@ -322,16 +322,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <ab>
                                 <hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ሕማመ፡ ውግዓት፡ እልመክኩን፡ እልመክኩን፡ እልመክኩን፡
                                     አዝቤ፡ ረቤ፡ ታኦስ፡ ብርስባሔል፡ አልፋ፡ ወዕ፡ ቤጣ፡ ምድምያስ፡ ምድምያ፡ ምድምያስ፡ የሐቄ፡ የሐቄ፡ የሐቄ፡
-                                የኃብራስቄ፡ የኃብራስቄ፡ የኃብራስቄ፡ ክርስትቂ፡ ክርስቂ፡ ክርስቄ፡ በከመ፡ አድኃንከ፡ ለወለተ፡ ከራስቄ፡ ከማሃ፡ 
+                                የኃብራስቄ፡ የኃብራስቄ፡ የኃብራስቄ፡ ክርስትቂ፡ ክርስቂ፡ ክርስቄ፡ በከመ፡ አድኃንከ፡ ለወለተ፡ ከራስቄ፡ ከማሃ፡
                                     አድኅና፡ በእንተ፡ ሕማመ፡ ውግዓት፡ ለአመትከ፡ <persName ref="PRS13850WalattaS">ወለተ፡ <hi rend="rubric">ሰንበት፡ ወለተ፡ ትበርሄ፡</hi></persName>
-                                
+
                             </ab>
                         </div>
                         <div type="textpart" subtype="text" n="4" corresp="#ms_i4" xml:id="text4">
                             <ab>
                                 <hi rend="rubric">ጸሎት፡</hi> በእንተ፡ ፍልፀት፡ ያጣውጢ፡ ያጣውጢ፡ ያጣውጢ፡ ያሽላክፊ፡ ያሽላክፊ፡ ያሽላክፊ፡
                                     ያበጋር፡ ሽሩራን፡ ሽኃል፡ መጃል፡ ካፍ፡ ላፍ፡ አፈና፡ ጋዲን፡ ታኦስ፡ አብኖዲ፡ ብርስባኄል፡ አዶናይ፡ አማኑኤል፡ እምንስቲት፡ ሙኬርያ፡
-                                መዓግያ፡ ሙዳሱጣ፡ ኢየሱስ፡ ክርስቶስ። ወልደ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ሕያው፡ ዘኢይመውት፡ በኃይለ፡ ዝንቱ፡ አስማቲከ፡ 
+                                መዓግያ፡ ሙዳሱጣ፡ ኢየሱስ፡ ክርስቶስ። ወልደ፡ እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ሕያው፡ ዘኢይመውት፡ በኃይለ፡ ዝንቱ፡ አስማቲከ፡
                                     አርኅቆሙ፡ ለምታት፡ <sic>ወለፍፀተ፡</sic> ርክስ፡ እምላእለ፡ አመትከ፡ <persName ref="PRS13850WalattaS">ወለተ፡ <hi rend="rubric">ሰንበት፡ ትበርሄ።</hi></persName>
                             </ab>
                         </div>
@@ -339,13 +339,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <ab/>
                         </div>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="3" xml:id="sec3">
                         <div type="textpart" subtype="picture" n="2" xml:id="pic2" corresp="#d2">
                             <milestone unit="parchmentStrip" n="2"/>
                         </div>
                     </div>
-                    
+
                     <div type="textpart" subtype="section" n="4" xml:id="sec4">
                         <div type="textpart" subtype="text" n="6" corresp="#ms_i5" xml:id="text5part2">
                             <ab/>

--- a/OxfordBodleian/Ullendorff/BDLeu1.xml
+++ b/OxfordBodleian/Ullendorff/BDLeu1.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!-- 
+                <!--
                 <title xml:lang="gez" xml:id="title1">መዝሙረ፡ ዳዊት፡, መሓልየ፡ ነቢያት፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Mazmura Dāwit, Maḥālǝya nabiyāt</title>
                  -->
@@ -341,11 +341,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <width>152</width>
                                     </dimensions>
                                     <note corresp="#leafdim">Data on the dimensions of folios taken from <locus target="#2r"/>.</note>
-                                    <!-- <measure type="weight" unit="g"></measure>-->  
+                                    <!-- <measure type="weight" unit="g"></measure>-->
                                 </extent>
- 
-                                <foliation>Pencil foliation in the upper right corner (1–154). One folio after <locus target="#135"/> 
-                                    had been skipped in the original foliation and has then been 
+
+                                <foliation>Pencil foliation in the upper right corner (1–154). One folio after <locus target="#135"/>
+                                    had been skipped in the original foliation and has then been
                                     foliated <locus target="#136a"/>, with the original <locus target="#136"/> becoming <locus target="#136b"/>.</foliation>
                                 <collation>
                                     <note>All quires have been reinforced with modern parchment strips sewn on with a running stitch; the folios are probably partly detached.</note>
@@ -412,7 +412,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <item xml:id="q15" n="15">
                                             <dim unit="leaf">10</dim>
                                             <locus from="130r" to="138v"/>
-                                            <note>One folio after <locus target="#135"/> has been skipped in the original foliation and has been 
+                                            <note>One folio after <locus target="#135"/> has been skipped in the original foliation and has been
                                                 foliated <locus target="#135a"/>.</note>
                                             <!-- This information is already given in foliation, so it is unnecessary here, but there the leaf is said to be <locus target="#136a"/>.
                                             The picture is missing, has to be checked again. Added to REQUESTS FOR FURTHER ACTION -->
@@ -428,7 +428,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
 
-                                <condition key="good">The borders of the folios are darkened by use. Small stains throughout. The upper margin shows traces of
+                                <condition key="good">The borders of the folios are darkened by use. Small stains throughout. The upper margins show traces of
                                 humidity (e.g. <locus from="134v" to="135r"/>).</condition>
                             </supportDesc>
 

--- a/OxfordBodleian/Ullendorff/BDLeu10.xml
+++ b/OxfordBodleian/Ullendorff/BDLeu10.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0"
     xml:id="BDLeu10"
@@ -33,17 +33,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <repository ref="INS0312BDL"/>
                         <idno>Bodleian Ullendorff 10</idno>
                     </msIdentifier>
-                    
+
                     <msContents>
                         <summary/>
-                        
+
                         <msItem xml:id="ms_i1">
                             <locus from="1r1" to="1r67"/>
                             <title type="complete" ref="LIT6811Protect"/>
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez">
                                 <hi rend="rubric">በስመ<supplied reason="omitted">፡</supplied> አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ጸሎት፡ በእንተ፡ ማ</hi>ዕሠረ፡
-                                አጋንንት፡ ወአልቦ፡ ስም፡ ዘየሐዩ፡ በታሕተ፡ ሰማይ፡ ወምድር፡ ዘእንበለ፡ ስሙ፡ ለእግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ ጋኔን፡ ዘትሬኢ፡ በዓይነ፡ ጠባይዕ፡ 
+                                አጋንንት፡ ወአልቦ፡ ስም፡ ዘየሐዩ፡ በታሕተ፡ ሰማይ፡ ወምድር፡ ዘእንበለ፡ ስሙ፡ ለእግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ ጋኔን፡ ዘትሬኢ፡ በዓይነ፡ ጠባይዕ፡
                                 እሳታዊ፡
                             </incipit>
                             <explicit xml:lang="gez">
@@ -70,18 +70,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <title type="complete" ref="LIT6854Prayer"/>
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez">
-                                <hi rend="rubric">በስመ<supplied reason="omitted">፡</supplied> አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩፡ አምላክ፡ ጸሎ</hi>ት፡ 
-                                በእንተ፡ ማዕሠረ፡ አጋንንት፡ አካዕ፡ አካብ<supplied reason="omitted">፡</supplied> ክስብኤል፡ ቤቃ፡ ሴቃ፡ ጼቃ፡ ዮድ፡ አኽያ፡ ሸራኽያ፡ በራኽያ፡ 
+                                <hi rend="rubric">በስመ<supplied reason="omitted">፡</supplied> አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩፡ አምላክ፡ ጸሎ</hi>ት፡
+                                በእንተ፡ ማዕሠረ፡ አጋንንት፡ አካዕ፡ አካብ<supplied reason="omitted">፡</supplied> ክስብኤል፡ ቤቃ፡ ሴቃ፡ ጼቃ፡ ዮድ፡ አኽያ፡ ሸራኽያ፡ በራኽያ፡
                                 ኤልሻዳይ፡ ጸባዖት፡ አዶናይ፡ አማኑኤል፡ እልመክኑን፡
                             </incipit>
                             <explicit xml:lang="gez">
-                                መጋኛ፡ ወጉስምት፡ ቡዳ፡ ወትግሪዳ፡ ዛር፡ ወቸነፈር፡ ወእምኵሉ፡ ሕማም፡ አድኅና፡ ለዓመትከ፡ 
-                                <persName ref="PRS14046WalattaSa" role="owner">ወለተ፡ <hi rend="rubric">ሰንበት፡ እንጐቻ፡</hi></persName> 
+                                መጋኛ፡ ወጉስምት፡ ቡዳ፡ ወትግሪዳ፡ ዛር፡ ወቸነፈር፡ ወእምኵሉ፡ ሕማም፡ አድኅና፡ ለዓመትከ፡
+                                <persName ref="PRS14046WalattaSa" role="owner">ወለተ፡ <hi rend="rubric">ሰንበት፡ እንጐቻ፡</hi></persName>
                                 ሥመር፡ እግዚኦ፡ እስመ፡ ኵሉ፡ ይትከሃለከ፡ እስመ፡ አልቦ፡ ነገር፡ ዘይሰአኖ፡ ለእግዚአብሔር።
                             </explicit>
                         </msItem>
                     </msContents>
-                    
+
                     <physDesc>
                         <objectDesc form="Scroll">
                             <supportDesc>
@@ -108,9 +108,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </dimensions>
                                     <!--   <measure type="weight" unit="g"</>
                                         weight is missing (MV) -->
-                       
-                                </extent> 
-                                <condition key="good">The manuscript is in a good state of preservation. 
+
+                                </extent>
+                                <condition key="good"> 
                                     The parchment is slightly crumpled due to rolling.
                                 </condition>
                             </supportDesc>
@@ -132,7 +132,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </layout>
                             </layoutDesc>
                         </objectDesc>
-                        
+
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <date notBefore="1900" notAfter="2006"/>
@@ -140,14 +140,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     The script is hasty. Characters have been executed with a thin nib.
                                 </desc>
                                 <seg type="ink">Black, red.</seg>
-                                <seg type="rubrication">Few incipit lines of each text, the name of the Trinity, the words <foreign xml:lang="gez">ዘአሠሮ፡</foreign> and 
+                                <seg type="rubrication">Few incipit lines of each text, the name of the Trinity, the words <foreign xml:lang="gez">ዘአሠሮ፡</foreign> and
                                     <foreign xml:lang="gez">ዘአሠርኮ፡</foreign> (in full or in part), the name of the owner, some elements of the punctuation signs.</seg>
                             </handNote>
                         </handDesc>
-                        
+
                        <!-- <decoDesc>
                         </decoDesc>-->
-                        
+
                         <additions>
                             <list>
                                 <item xml:id="a1">
@@ -156,7 +156,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         Part of the writing is poorly legible. The name of the original owner, <persName ref="PRS14046WalattaSa" role="owner"/>, is clearly readable.
                                     </desc>
                                 </item>
-                                
+
                                 <item xml:id="e1">
                                     <desc>The verso is blank.</desc>
                                 </item>
@@ -164,7 +164,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <desc>Scribal corrections are not frequent and consist of minimal interlinear additions.</desc>
                                 </item>
                                 <item xml:id="e3">
-                                    <desc>The name of the owner, <persName ref="PRS14046WalattaSa" role="owner"/>, is mentioned in supplications throughout and introduced by the epithet 
+                                    <desc>The name of the owner, <persName ref="PRS14046WalattaSa" role="owner"/>, is mentioned in supplications throughout and introduced by the epithet
                                         <foreign xml:lang="gez">አመትከ፡</foreign>, "your maid".
                                     </desc>
                                 </item>
@@ -175,26 +175,26 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </item>
                             </list>
                         </additions>
-                        
+
                         <bindingDesc>
                             <binding xml:id="binding">
                                 <decoNote xml:id="b1">The three parchment strips are slightly overlapping and sewn together with a running stitch.</decoNote>
                             </binding>
                         </bindingDesc>
-                        
+
                     </physDesc>
-                    
+
                     <history>
                         <origin>
                             <origDate when="1900" evidence="2006"/>
                         </origin>
                         <provenance>The provenance and circumstances of production of the manuscript are unknown.
-                            The original owner, indicated in the supplication formulas as <foreign xml:lang="gez">ዓመትከ፡</foreign> "your maid", was 
+                            The original owner, indicated in the supplication formulas as <foreign xml:lang="gez">ዓመትከ፡</foreign> "your maid", was
                             <persName ref="PRS14046WalattaSa" role="owner"/>.
                             The scroll was acquired at some point by <persName ref="PRS9622Ullendor" role="owner"/>.
                         </provenance>
                     </history>
-                    
+
                     <additional>
                         <adminInfo>
                             <recordHist>
@@ -206,7 +206,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </recordHist>
                         </adminInfo>
                     </additional>
-                    
+
                 </msDesc>
             </sourceDesc>
         </fileDesc>

--- a/OxfordBodleian/Ullendorff/BDLeu2.xml
+++ b/OxfordBodleian/Ullendorff/BDLeu2.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!--  
+                <!--
                <title xml:lang="gez" xml:id="title1">ጸሎት፡ ዘእግዝእትነ፡ ማርያም፡ ዘሰኔ፡ በደብረ፡ ጎልጎታ፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Ṣalot za-ʾǝgzǝʾǝtǝna Māryām za-sane ba-Dabra Golgotā</title>
                 -->
@@ -122,7 +122,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </item>
                                     </list>
                                 </collation>
-                                <condition key="intact">The manuscript is in good condition and shows no damage.</condition>
+                                <condition key="intact">The manuscript shows no damage.</condition>
                             </supportDesc>
 
                             <layoutDesc>

--- a/OxfordBodleian/Ullendorff/BDLeu3.xml
+++ b/OxfordBodleian/Ullendorff/BDLeu3.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!--  
+                <!--
                 <title xml:lang="gez" xml:id="title1">መጽሐፈ፡ ሰዓታት፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Maṣḥafa saʿātāt</title>
                 -->
@@ -179,17 +179,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>-->
                                 <condition key="deficient">
-                                    The manuscript is in poor condition. Some folios present tears and losses, some likely caused by rodents (e.g. <locus from="10" to="12"/>).
+                                    Some folios present tears and losses, some likely caused by rodents (e.g. <locus from="10" to="12"/>).
                                     The edges of most folios are darkened by use and humidity.
-                                    Some folios are stained, others are torn (e.g. <locus from="10" to="13"/>). Some folios are probably partly detached or missing,
+                                    Some folios are stained, others are torn (e.g. <locus from="10" to="13"/>). Some folios are partly detached or missing,
                                     e.g. <locus from="31" to="33"/>, <locus target="#43"/> and <locus target="#50"/>.
                                     The ink is partly faded away, making some portions of text nearly illegible (e.g. on <locus target="#3ra #22va"/>).
-                                      The sewing is broken in several points.
-                                      The back cover is split vertically in half. The two parts are held together by threads passing through pairs of holes drilled through the covers.
-                                      Large tunnels formed by insects are carved into the covers.
-                                      The hinging strap of the satchel is torn into two pieces.
-
-                                    </condition>
+                                    The sewing is broken in several points.
+                                    The back cover is split vertically in half. The two parts are held together by threads passing through pairs of holes drilled through the covers.
+                                    Large tunnels formed by insects open into the covers.
+                                    The hinging strap of the satchel is torn into two pieces.
+                                </condition>
                             </supportDesc>
 
                             <layoutDesc>

--- a/OxfordBodleian/Ullendorff/BDLeu5.xml
+++ b/OxfordBodleian/Ullendorff/BDLeu5.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!--  
+                <!--
                 <title xml:lang="gez" xml:id="title1">መጽሐፈ፡ ሄኖክ፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Maṣḥafa Henok</title>
                 -->
@@ -207,7 +207,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
                                 <condition key="good">
-                                    The manuscript is in good condition. Some folios are slightly stained, especially at the upper corners.
+                                    Some folios are slightly stained, especially at the upper corners.
                                    <!-- Further information might be retrieved after inspecting or photographing the entire MS -->
                                 </condition>
                             </supportDesc>

--- a/OxfordBodleian/Ullendorff/BDLeu6.xml
+++ b/OxfordBodleian/Ullendorff/BDLeu6.xml
@@ -10,7 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <!--  
+                <!--
                 <title xml:lang="gez" xml:id="title1">ገድለ፡ ዘሚካኤል፡ አረጋዊ፡, ጥንተ፡ ልደቶሙ፡ ለመነኮሳት፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Gadla Zamikāʾel ʾAragāwi, Ṭǝnta lǝdatomu la-manakosāt</title>
                 -->
@@ -135,7 +135,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </list>
                                 </collation>
                                 <condition key="good">
-                                    The manuscript shows no damage. Some folios are stained or slightly darkened by use (e.g. <locus target="#1r #39v"/>).
+                                    Some folios are stained or slightly darkened by use (e.g. <locus target="#1r #39v"/>).
                                     Stains are present on <locus target="#63 #64"/> and on <locus target="#8v"/>.
                                 </condition>
                             </supportDesc>

--- a/OxfordBodleian/Ullendorff/BDLeu7.xml
+++ b/OxfordBodleian/Ullendorff/BDLeu7.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0"
     xml:id="BDLeu7"
@@ -33,36 +33,36 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <repository ref="INS0312BDL"/>
                         <idno>Bodleian Ullendorff 7</idno>
                     </msIdentifier>
-                    
+
                     <msContents>
                         <summary/>
-                        
+
                         <msItem xml:id="ms_i1">
                             <locus from="1r1" to="1r9"/>
                             <title type="complete" ref="LIT6850Prayer"/>
                             <textLang mainLang="gez"/>
                             <note>The following is the entire text.</note>
                             <incipit xml:lang="gez">
-                                ጸሎቱ፡ ወበረከቱ፡ ለቅዱስ፡ ሱስንዮስ፡ ወኃይለ፡ ረድኤቱ፡ ለእግዚአብሔር፡ ይዕቀባ፡ ወይፈውሳ፡ እምሕማመ፡ ባርያ፡ ወሌጌዎን፡ 
+                                ጸሎቱ፡ ወበረከቱ፡ ለቅዱስ፡ ሱስንዮስ፡ ወኃይለ፡ ረድኤቱ፡ ለእግዚአብሔር፡ ይዕቀባ፡ ወይፈውሳ፡ እምሕማመ፡ ባርያ፡ ወሌጌዎን፡
                                 ወዓይነት፡ ዛር፡ ወትግሪዳ፡ ጠቢብ፡ ወቡዳ፡ ተያያዥ፡ ወእጀ፡ ሰብአ፡ ጽላ፡ ወጊ፡ ወፍጊን፡ አልጉም፡ ወሾተላይ፡ ወኵሎሙ፡ ሕምዘ፡
-                                አጋንንት፡ ከመ፡ ኢይቅረቡ፡ ኀበ፡ አመትከ፡ <hi rend="rubric"><persName ref="PRS14045WalattaKi" role="owner">ወለተ፡ ኪዳን።</persName></hi> 
+                                አጋንንት፡ ከመ፡ ኢይቅረቡ፡ ኀበ፡ አመትከ፡ <hi rend="rubric"><persName ref="PRS14045WalattaKi" role="owner">ወለተ፡ ኪዳን።</persName></hi>
                              </incipit>
                         </msItem>
-                        
-                        
+
+
                         <msItem xml:id="ms_i2">
                             <locus from="1r10" to="1r38"/>
                             <title type="complete" ref="LIT4697MagicPr"/>
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez">
-                                <hi rend="rubric">ጸሎት፡ በእንተ፡ ሕማመ፡ ባርያ፡ ወሌጌዎን፡ ሰላም፡ ለከ፡ ሰዳዴ፡ አጋንንት፡ ፋኑኤል፡ ለእግዚአብሔር፡ እምጽርሁ፡ ከመ፡ 
+                                <hi rend="rubric">ጸሎት፡ በእንተ፡ ሕማመ፡ ባርያ፡ ወሌጌዎን፡ ሰላም፡ ለከ፡ ሰዳዴ፡ አጋንንት፡ ፋኑኤል፡ ለእግዚአብሔር፡ እምጽርሁ፡ ከመ፡
                                     አ</hi>ይስክዩ፡ ሰብአ፡ እለ፡ ይኔስሁ፡ ለጌጋይ፡ ዘዘዚአሁ፡ <hi rend="rubric">ሰላም፡ ለከ፡</hi> ሰዳዴ፡ አጋንንት፡ ፋኑኤል፡ እምገጸ፡ ፈጣሪ፡
-                                ልዑል፡ ኢያስ<hi rend="rubric">ተዋድዩ፡ ሰብአ፡ በነገረ፡ ኃጕል፡ እስመ፡ አንተ፡ መልአከ፡ ሣህል፡ ሰላም፡ ለከ፡</hi>                                
+                                ልዑል፡ ኢያስ<hi rend="rubric">ተዋድዩ፡ ሰብአ፡ በነገረ፡ ኃጕል፡ እስመ፡ አንተ፡ መልአከ፡ ሣህል፡ ሰላም፡ ለከ፡</hi>
                             </incipit>
                             <explicit xml:lang="gez">
                             በማኅፀነ፡ ሐና፡ እምኪ፡ ተማኅፀነ፡ ፈንዊዮ፡ ለፋ<supplied reason="omitted">ኑ</supplied>ኤል፡ ይዕቀብ፡ ኪያነ፡ በረምሐ፡ መስቀሉ፡ ረጊዞ፡
-                                ሰይጣነ፡ ኦአምለከ፡ ፋኑኤል፡ ዕቀባ፡ ወአድኅና፡ እምሕማመ፡ ዛር፡ ወትግሪዳ፡ ለአመትከ፡ 
-                                <hi rend="rubric"><persName ref="PRS14045WalattaKi" role="owner">ወለተ፡ ኪዳን።</persName></hi> 
+                                ሰይጣነ፡ ኦአምለከ፡ ፋኑኤል፡ ዕቀባ፡ ወአድኅና፡ እምሕማመ፡ ዛር፡ ወትግሪዳ፡ ለአመትከ፡
+                                <hi rend="rubric"><persName ref="PRS14045WalattaKi" role="owner">ወለተ፡ ኪዳን።</persName></hi>
                             </explicit>
                         </msItem>
                         <msItem xml:id="ms_i3">
@@ -70,14 +70,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <title type="complete" ref="LIT6851Prayer"/>
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez">
-                                <hi rend="rubric">ጸሎት፡ በእንተ፡ ሕማመ፡ ቡዳ፡ ወቁመኛ፡ በስሙ፡ ለእግዚአብሔር፡ አብ፡ በስሙ፡ ለእግዚአብሔር፡ ወልድ፡ በስሙ፡ 
+                                <hi rend="rubric">ጸሎት፡ በእንተ፡ ሕማመ፡ ቡዳ፡ ወቁመኛ፡ በስሙ፡ ለእግዚአብሔር፡ አብ፡ በስሙ፡ ለእግዚአብሔር፡ ወልድ፡ በስሙ፡
                                     ለእግዚአብሔር፡ መንፈስ፡ ቅዱስ፡ ታኦስ፡ አዝ</hi>ዮስ፡ ማሲ፡ ማስያስ፡ አብፌድርስ፡ ሩፋ<gap reason="illegible" unit="chars" quantity="1"/>ን፡
                                 በጠጄን፡ ዘሐጄን፡ ዋኅ፡ ዋኅ፡ ዋኅ፡
                             </incipit>
                             <explicit xml:lang="gez">
-                                ዓምደ፡ ብርሃን፡ ልብሰ፡ ብርሃን፡ ይበርቅ፡ ቅድመ፡ ገጹ፡ ለኃይለ፡ ፀላኢ፡ ወፀር፡ ባርያ፡ ፓንዋማ፡ ፒልሜ፡ ጴልሜ፡ ኢይርአይ፡ ገጻ፡ አርእየኒ፡ ኃይለ፡ 
-                                ግርማከ፡ ንጉሠ፡ ስብሐት፡ ራማ፡ ኢይርአይ፡ ገጻከ፡ ኢይልክፍ፡ ነፍሳ፡ ወሥጋሃ፡ ለአመትከ፡ 
-                                <hi rend="rubric"><persName ref="PRS14045WalattaKi" role="owner">ወለተ፡ ኪዳን።</persName></hi> 
+                                ዓምደ፡ ብርሃን፡ ልብሰ፡ ብርሃን፡ ይበርቅ፡ ቅድመ፡ ገጹ፡ ለኃይለ፡ ፀላኢ፡ ወፀር፡ ባርያ፡ ፓንዋማ፡ ፒልሜ፡ ጴልሜ፡ ኢይርአይ፡ ገጻ፡ አርእየኒ፡ ኃይለ፡
+                                ግርማከ፡ ንጉሠ፡ ስብሐት፡ ራማ፡ ኢይርአይ፡ ገጻከ፡ ኢይልክፍ፡ ነፍሳ፡ ወሥጋሃ፡ ለአመትከ፡
+                                <hi rend="rubric"><persName ref="PRS14045WalattaKi" role="owner">ወለተ፡ ኪዳን።</persName></hi>
                             </explicit>
                         </msItem>
                         <msItem xml:id="ms_i4">
@@ -85,13 +85,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <title type="complete" ref="LIT6852Prayer"/>
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez">
-                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ጸሎት፡ በእንተ፡ ማእሠሮሙ፡ ለአጋንንት፡ ዘተናገሮ፡ እስክንድር፡ ንጉሥ፡ 
+                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ጸሎት፡ በእንተ፡ ማእሠሮሙ፡ ለአጋንንት፡ ዘተናገሮ፡ እስክንድር፡ ንጉሥ፡
                                     በዕለተ፡ ዓርብ፡ በቅድመ፡ ጎግ፡ ወማጎግ፡ በጊዜ፡ ምጽአቱ፡ ለሰ<add place="interlinear">በ</add>ድአት፡</hi> እንዘ፡ ይብል፡ አሌፍ፡
                             </incipit>
                             <explicit xml:lang="gez">
-                                ወቡዳ፡ ተያያዥ፡ ወእጀ፡ ሰብአ፡ ጽላ፡ ወጊ፡ ወፍጌን፡ ወንለ<gap reason="illegible" unit="chars" quantity="1"/>ሽ፡ ዓይነት፡ ወዓይነ፡ ወዓይነ፡ ወርቅ፡ 
-                                መንሶ፡ ወሥራይ፡ ይትሐተሙ፡ በማኅተመ፡ እሌኒ፡ ንግሥት፡ ወበማኅተመ፡ ሰሎሞን፡ ንጉሥ፡ ከመ፡ ኢይቅረቡ፡ ኀበ፡ ነፍሳ፡ ወሥጋሃ፡ 
-                                ለአመተ፡ እግዚአብሔር፡ <hi rend="rubric"><persName ref="PRS14045WalattaKi" role="owner">ወለተ፡ ኪዳን።</persName></hi> 
+                                ወቡዳ፡ ተያያዥ፡ ወእጀ፡ ሰብአ፡ ጽላ፡ ወጊ፡ ወፍጌን፡ ወንለ<gap reason="illegible" unit="chars" quantity="1"/>ሽ፡ ዓይነት፡ ወዓይነ፡ ወዓይነ፡ ወርቅ፡
+                                መንሶ፡ ወሥራይ፡ ይትሐተሙ፡ በማኅተመ፡ እሌኒ፡ ንግሥት፡ ወበማኅተመ፡ ሰሎሞን፡ ንጉሥ፡ ከመ፡ ኢይቅረቡ፡ ኀበ፡ ነፍሳ፡ ወሥጋሃ፡
+                                ለአመተ፡ እግዚአብሔር፡ <hi rend="rubric"><persName ref="PRS14045WalattaKi" role="owner">ወለተ፡ ኪዳን።</persName></hi>
                             </explicit>
                         </msItem>
                         <msItem xml:id="ms_i5">
@@ -100,7 +100,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <textLang mainLang="gez"/>
                             <note>The following is the entire text.</note>
                             <incipit xml:lang="gez">
-                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ እፎ፡ ቤተ፡</hi> <gap reason="illegible" unit="chars" quantity="3"/> ኃደረ፡ 
+                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ እፎ፡ ቤተ፡</hi> <gap reason="illegible" unit="chars" quantity="3"/> ኃደረ፡
                                 ከመ፡ ምስኪን፡ <gap reason="illegible" unit="chars" quantity="1"/>አያያት፡ ገብረ፡ ነሢኦ፡ በሥጋ፡ <gap reason="illegible" unit="chars" quantity="3"/>
                                 ወተቀትለ፡ ወተንሥአ፡ እሙታን፡ ዓርገ፡ በስብሐት፡ ውስተ፡ ሰማያት፡ ዳግመ፡ ይመጽእ፡ በስብሐት፡ ይኰንን፡ ሕያዋነ፡ ወሙታነ፡ ሎቱ፡ ስብሐት፡ ወላዕሌነ፡
                                 ይኩን፡ ምሕረት፡ ወሣህል፡ ለዓለመ፡ ዓለም፡ አሜን፡
@@ -117,7 +117,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <note>The explicit is poorly readable due to the condition of the parchment.</note>
                         </msItem>
                     </msContents>
-                    
+
                     <physDesc>
                         <objectDesc form="Scroll">
                             <supportDesc>
@@ -144,7 +144,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </dimensions>
                                     <measure type="weight" unit="g">39</measure>
                                 </extent>
-                              <condition key="good">The manuscript is in a mediocre state of preservation. 
+                              <condition key="good">
                               The parchment is crumpled due to rolling and is darkened toward the lower border; subsequently, the text is barely legible.
                               Small areas of loss and tears are present, especially along the upper and lower margins.
                               Some letters are illegible due to material damage.
@@ -192,7 +192,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </layout>
                             </layoutDesc>
                         </objectDesc>
-                        
+
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <date notBefore="1800" notAfter="2006"/>
@@ -200,14 +200,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     The ligature <foreign xml:lang="gez">ግዚ</foreign> is occasionally used e.g. on <locus target="#1r18"/>.
                                   </desc>
                                 <seg type="ink">Black, red.</seg>
-                                <seg type="rubrication">Few lines of the incipits and other lines within the text, the name of Mary and of the owner in the supplications, 
+                                <seg type="rubrication">Few lines of the incipits and other lines within the text, the name of Mary and of the owner in the supplications,
                                     the refrain <foreign xml:lang="gez">ሰላም፡ ለኪ፡</foreign>, captions of the miniatures.</seg>
                             </handNote>
                         </handDesc>
-                        
+
                        <!-- <decoDesc>
                         </decoDesc>-->
-                        
+
                         <additions>
                             <list>
                                 <item xml:id="e1">
@@ -217,34 +217,34 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <desc>Scribal corrections or interventions are very rare: they consist of letters added interlineally.</desc>
                                 </item>
                                 <item xml:id="e3">
-                                    <desc>The name of the owner, <persName ref="PRS14045WalattaKi" role="owner"/>, is mentioned in supplications throughout and introduced by the epithet 
+                                    <desc>The name of the owner, <persName ref="PRS14045WalattaKi" role="owner"/>, is mentioned in supplications throughout and introduced by the epithet
                                         <foreign xml:lang="gez">አመትከ፡</foreign>, "your maid". Her name has been sometimes overwritten with another one, poorly legible.
                                     </desc>
                                 </item>
                                 </list>
                         </additions>
-                        
-                        
+
+
                         <bindingDesc>
                             <binding xml:id="binding">
                                 <decoNote xml:id="b1">The three parchment strips are slightly overlapping and sewn together with a running stitch.</decoNote>
                                 <decoNote xml:id="b2">The scroll is kept in a pipe case.</decoNote>
                             </binding>
                         </bindingDesc>
-                        
+
                     </physDesc>
-                    
+
                 <history>
                         <origin>
                             <origDate when="1800" evidence="2006"/>
                         </origin>
                          <provenance>The provenance and circumstances of production of the manuscript are unknown.
-                         The original owner, indicated in the supplication formulas as <foreign xml:lang="gez">ዓመትከ፡</foreign> "your maid", was 
+                         The original owner, indicated in the supplication formulas as <foreign xml:lang="gez">ዓመትከ፡</foreign> "your maid", was
                              <persName ref="PRS14045WalattaKi" role="owner"/>.
                          The scroll was acquired at some point by <persName ref="PRS9622Ullendor" role="owner"/>.
                         </provenance>
                     </history>
-                    
+
                     <additional>
                         <adminInfo>
                             <recordHist>
@@ -256,7 +256,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </recordHist>
                         </adminInfo>
                     </additional>
-                    
+
                 </msDesc>
             </sourceDesc>
         </fileDesc>

--- a/OxfordBodleian/Ullendorff/BDLeu9.xml
+++ b/OxfordBodleian/Ullendorff/BDLeu9.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0"
     xml:id="BDLeu9"
@@ -33,10 +33,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <repository ref="INS0312BDL"/>
                         <idno>Bodleian Ullendorff 9</idno>
                     </msIdentifier>
-                    
+
                     <msContents>
                         <summary/>
-                        
+
                         <msItem xml:id="ms_i1">
                       <locus from="1r1" to="1r25"/>
                             <title type="complete" ref="LIT6829PPAyna"/>
@@ -48,27 +48,27 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 አ<gap reason="illegible" unit="chars" quantity="1"/>ዊን<hi rend="rubric" rendition="#partialRubric">፨</hi> ጢትሮስ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                 <gap reason="illegible" unit="chars" quantity="1"/>ሮፎሮ<hi rend="rubric">ድሩኤል፡ ይ</hi>መትር<hi rend="rubric" rendition="#partialRubric">፨</hi> የሐር፡ አዝራዊ<hi rend="rubric" rendition="#partialRubric">፨</hi> ደላዊ<supplied reason="omitted">፡</supplied>
                                 ቀተናዊ<hi rend="rubric" rendition="#partialRubric">፨</hi> ለ<del rend="overUnderlined">ብ</del>ተናዊ፡ አሰኮራላጵስ<hi rend="rubric" rendition="#partialRubric">፨</hi> አስከራፋጲስ<hi rend="rubric" rendition="#partialRubric">፨</hi> አረጋዎን<hi rend="rubric" rendition="#partialRubric">፨</hi> ፈሐዝር፡ አትናውጲ<hi rend="rubric" rendition="#partialRubric">፨</hi>
-                                ስዕሉ<hi rend="rubric" rendition="#partialRubric">፨</hi> 
-                                <seg type="supplication">አድኀና፡ ወዕ<add place="interlinear">ቀ</add>ባ<hi rend="rubric" rendition="#partialRubric">፨</hi> ለአመትከ<hi rend="rubric" rendition="#partialRubric">፨</hi> <persName role="owner" ref="PRS14023WalattaM"><add place="inline">ወለተ፡ ሚካኤል፡ 
+                                ስዕሉ<hi rend="rubric" rendition="#partialRubric">፨</hi>
+                                <seg type="supplication">አድኀና፡ ወዕ<add place="interlinear">ቀ</add>ባ<hi rend="rubric" rendition="#partialRubric">፨</hi> ለአመትከ<hi rend="rubric" rendition="#partialRubric">፨</hi> <persName role="owner" ref="PRS14023WalattaM"><add place="inline">ወለተ፡ ሚካኤል፡
                                     በተሐ።</add> በተሐ፡ በተሃ</persName></seg>
-                            </incipit> 
-                          
+                            </incipit>
+
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i2">
                             <locus from="1r26" to="1r41"/>
                             <title type="complete" ref="LIT6830PPAyna"/>
                             <textLang mainLang="gez"/>
                             <!-- this is the entire text-->
                             <incipit xml:lang="gez">
-                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡</hi> ፩ አምላክ፡ ጸሎት። በእንተ<hi rend="rubric" rendition="#partialRubric">፨</hi> ዓይነ፡ ጥላ፡ ወዓይነ፡ ዛር፡ ወሾተላይ፡ 
+                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡</hi> ፩ አምላክ፡ ጸሎት። በእንተ<hi rend="rubric" rendition="#partialRubric">፨</hi> ዓይነ፡ ጥላ፡ ወዓይነ፡ ዛር፡ ወሾተላይ፡
                                 <hi rend="rubric">ኢየሱስ፡</hi> ናዝራዊ<hi rend="rubric" rendition="#partialRubric">፨</hi> <sic>በትምርተ<supplied reason="omitted">፡</supplied></sic> መስቀል<hi rend="rubric" rendition="#partialRubric">፨</hi>
-                                መርአዊ፡ ጸረ፡ ፈውስ<supplied reason="omitted">፡</supplied> ሲቃ<hi rend="rubric" rendition="#partialRubric">፨</hi> ጳጢቃ<hi rend="rubric" rendition="#partialRubric">፨</hi> ኢዮሎን<hi rend="rubric" rendition="#partialRubric">፨</hi> አኽያ፡ ሾራኽያ<hi rend="rubric" rendition="#partialRubric">፨</hi> አልሸይ<hi rend="rubric" rendition="#partialRubric">፨</hi> ኢማኑኤል<hi rend="rubric" rendition="#partialRubric">፨</hi> 
+                                መርአዊ፡ ጸረ፡ ፈውስ<supplied reason="omitted">፡</supplied> ሲቃ<hi rend="rubric" rendition="#partialRubric">፨</hi> ጳጢቃ<hi rend="rubric" rendition="#partialRubric">፨</hi> ኢዮሎን<hi rend="rubric" rendition="#partialRubric">፨</hi> አኽያ፡ ሾራኽያ<hi rend="rubric" rendition="#partialRubric">፨</hi> አልሸይ<hi rend="rubric" rendition="#partialRubric">፨</hi> ኢማኑኤል<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                 ለእግዚአብሔር<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                 <seg type="supplication">አድኅና<hi rend="rubric" rendition="#partialRubric">፨</hi> ለአመትከ፡ <persName ref="PRS14023WalattaM" role="owner"><add place="inline">ወለተ፡ ሚካኤል፡ በተሐ፡</add> በተሐ፨</persName></seg>
                             </incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i3">
                             <locus from="1r41" to="1r76"/>
                             <title type="complete" ref="LIT5920JohnBeg"/>
@@ -78,24 +78,24 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <hi rend="rubric"><sic>ቀ</sic> በስመ፡ <supplied reason="omitted">አብ፡</supplied>
                                     <add place="interlinear">ወ</add>ወልድ፡ ወመንፈ</hi>ስ፡ ቅዱስ፡
                                 <hi rend="rubric" rendition="#partialRubric">፩</hi> አምላክ<supplied reason="omitted">፡</supplied>
-                                በእንተ፡ ዓይነ፡ ጥላ፡ ወባርያ፡ ወሌጌዎን፡ ርኩስ፡ <hi rend="rubric">ቀዳሚሁ፡</hi> <add place="interlinear">ቃል፡</add> ውእቱ፡ 
+                                በእንተ፡ ዓይነ፡ ጥላ፡ ወባርያ፡ ወሌጌዎን፡ ርኩስ፡ <hi rend="rubric">ቀዳሚሁ፡</hi> <add place="interlinear">ቃል፡</add> ውእቱ፡
                                 ቃል፡ ቃለ፡ እግዚአብሔር። ውእቱ<hi rend="rubric" rendition="#partialRubric">፨</hi> ቃል፡
                                 ወ<add place="interlinear">እ</add>ግዚአብሔር፨ ውእቱ፡ ቃል፡ ወከማሁ<supplied reason="omitted">፡</supplied>
                                 እምቀዲሙ<hi rend="rubric" rendition="#partialRubric">፨</hi> ኀበ፡ እግዚአብሔር<hi rend="rubric" rendition="#partialRubric">፨</hi> ውእቱ፡ ቃል፡
                                 <del rend="overUnderlined">ወከማሁ<hi rend="rubric" rendition="#partialRubric">፨</hi></del> ወኵሉ<hi rend="rubric" rendition="#partialRubric">፨</hi> ኮነ<supplied reason="omitted">፡</supplied>
                                 ወዘእንበሌሁሰ<hi rend="rubric" rendition="#partialRubric">፨</hi> ዘኮነ፡ ወኢምንትኒ፡
-                                እምዘኮነ<hi rend="rubric" rendition="#partialRubric">፨</hi> ወዘሂ፡ በእንቲአሁ<hi rend="rubric" rendition="#partialRubric">፨</hi> 
+                                እምዘኮነ<hi rend="rubric" rendition="#partialRubric">፨</hi> ወዘሂ፡ በእንቲአሁ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                 ቦቱ<hi rend="rubric" rendition="#partialRubric">፨</hi>
-                                ሕይወት፡ ውእቱ<hi rend="rubric" rendition="#partialRubric">፨</hi> ወሕይዎሰ፡ ብርሃኑ<hi rend="rubric" rendition="#partialRubric">፨</hi> ለእጓለ፡ እመሕ<add place="interlinear">ያ</add>ው፡ ውእቱ፡ ወብርሃነ፡ 
-                                ጽድቅሰ<hi rend="rubric" rendition="#partialRubric">፨</hi> ዘውስተ<hi rend="rubric" rendition="#partialRubric">፨</hi> ጽልመት፡ ወያርኢ<hi rend="rubric" rendition="#partialRubric">፨</hi> 
-                                ወያበርህ<hi rend="rubric" rendition="#partialRubric">፨</hi> ወያርኢ<hi rend="rubric" rendition="#partialRubric">፨</hi> <sic>ወጽመትኒ<hi rend="rubric" rendition="#partialRubric">፨</hi></sic> 
-                                ኢረከቦ<hi rend="rubric" rendition="#partialRubric">፨</hi> ወኢይቀርከቦ<hi rend="rubric" rendition="#partialRubric">፨</hi> ሰማይ፡ <sic>ወምምድር</sic> የሐልፍ<hi rend="rubric" rendition="#partialRubric">፨</hi> 
+                                ሕይወት፡ ውእቱ<hi rend="rubric" rendition="#partialRubric">፨</hi> ወሕይዎሰ፡ ብርሃኑ<hi rend="rubric" rendition="#partialRubric">፨</hi> ለእጓለ፡ እመሕ<add place="interlinear">ያ</add>ው፡ ውእቱ፡ ወብርሃነ፡
+                                ጽድቅሰ<hi rend="rubric" rendition="#partialRubric">፨</hi> ዘውስተ<hi rend="rubric" rendition="#partialRubric">፨</hi> ጽልመት፡ ወያርኢ<hi rend="rubric" rendition="#partialRubric">፨</hi>
+                                ወያበርህ<hi rend="rubric" rendition="#partialRubric">፨</hi> ወያርኢ<hi rend="rubric" rendition="#partialRubric">፨</hi> <sic>ወጽመትኒ<hi rend="rubric" rendition="#partialRubric">፨</hi></sic>
+                                ኢረከቦ<hi rend="rubric" rendition="#partialRubric">፨</hi> ወኢይቀርከቦ<hi rend="rubric" rendition="#partialRubric">፨</hi> ሰማይ፡ <sic>ወምምድር</sic> የሐልፍ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                 ወቃ<del rend="overUnderlined">የ</del>ልየ<del rend="overUnderlined">ሑ</del>ሰ፨ ኢየሐልፍ፡ ለዓለም፨ ዓለም፨ አሜን፨
                                <seg type="supplication"> አድኅና፡
                                    ለአመትከ<hi rend="rubric" rendition="#partialRubric">፨</hi> <persName ref="PRS14023WalattaM" role="owner">ወለተ፡ ሚካኤል፡ በተሐ</persName></seg>
                             </incipit>
                         </msItem>
-                        
+
                         <msItem xml:id="ms_i4">
                             <locus from="1r77" to="1r109"/>
                             <title type="complete" ref="LIT5690MagicPrayer"/>
@@ -108,14 +108,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <hi rend="rubric">ኢየሱስ፡ ክርስቶስ፡</hi> ምስለ፡ አርዳኢሁ፡ ርዕዩ፡ መልክ፡ ብእሲት፡ አረጊት፡ መፍርህት፡ ወመጸንግፅት፡ ወእንዘ፡ ይበርቅ፡ ዓይና፡ ከመ<supplied reason="omitted">፡</supplied>
                                 ወርቅ፡ ቀይህ፡ አዕዳዊሃኒ። ወአዕጋሪሃኒ<supplied reason="omitted">፡</supplied> ከመ፡ ሰረገላ፡ እሳት፡ መጠናሂ፡ ወቆማ፡ ከመ፡ በቀልት፡ ወይቤልዎ<supplied reason="omitted">፡</supplied>
                                 አርዳኢሁ፡ ለእግዚእነ<supplied reason="omitted">፡</supplied> ምንት፡ ይእቲ፡ ዓይነ፡ እኪት፡ ወርግምት፡ በምንት፡ <sic>ናጥፋአጥፍዕዋ፡</sic> በእሳት፡
-                                ወዝርዕዋ፡ በነፋስ። ምስራቀ፡ ወምዕራበ። 
+                                ወዝርዕዋ፡ በነፋስ። ምስራቀ፡ ወምዕራበ።
                                 ሰሜነ፡ ወደቡበ<supplied reason="omitted">፡</supplied> ቦር። ፎሪኮን፡ አትሪክን። አተርዋን፡ ቶሪፍ። ቶራኒቆ፡ ቶሲሰ። ጉሄል፡ አማኑኤል።
                                 <seg type="supplication">አድኅና፡ ወዕቀባ። ለአመትከ፡ <persName ref="PRS14023WalattaM" role="owner">በተሐ፡ ወለተ፡ ሚካኤል፡</persName></seg>
                             </incipit>
                         </msItem>
-                        
+
                     </msContents>
-                    
+
                     <physDesc>
                         <objectDesc form="Scroll">
                             <supportDesc>
@@ -138,11 +138,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <width>84</width>
                                     </dimensions>
                                     <measure type="weight" unit="g">28</measure>
-                                </extent> 
-                                <condition key="good">The scroll is in a good state of preservation. The verso is darkened, and the upper and lower margins are slightly crumpled.
-                                A small hole and a tear near the upper end.</condition>
+                                </extent>
+                                <condition key="good">The verso is darkened, and the upper and lower margins are slightly crumpled.
+                                A small hole and a tear are present near the upper end.</condition>
                             </supportDesc>
-                           
+
                             <layoutDesc>
                                 <layout columns="1" writtenLines="25">
                                     <note>Number of characters per line: 10–11.</note>
@@ -157,7 +157,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </dimensions>
                                     <ab type="pricking">Pricking and ruling are not visible.</ab>
                                 </layout>
-                                
+
                                 <layout columns="1" writtenLines="51">
                                     <note>Number of characters per line: 9–10.</note>
                                     <note>The outer margins are delimited by a black line.</note>
@@ -171,7 +171,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </dimensions>
                                     <ab type="pricking">Pricking and ruling are not visible.</ab>
                                 </layout>
-                                
+
                                 <layout columns="1" writtenLines="33">
                                     <note>Number of characters per line: 10–13.</note>
                                     <note>The outer margins are delimited by a black line.</note>
@@ -186,12 +186,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <ab type="pricking">Pricking and ruling are not visible.</ab>
                                 </layout>
                             </layoutDesc>
-                            
+
                         </objectDesc>
-                        
+
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                           <desc>Modern bulky script, somewhat irregular. The nine-dotted asterisk is used often as word separator, and the word separator is often omitted when the end of a word 
+                           <desc>Modern bulky script, somewhat irregular. The nine-dotted asterisk is used often as word separator, and the word separator is often omitted when the end of a word
                                coincides with the end of the line.</desc>
                                 <date notBefore="1800" notAfter="2002"/>
                                 <seg type="ink">Black, red.</seg>
@@ -199,14 +199,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 punctuation marks is omitted.</seg>
                             </handNote>
                         </handDesc>
-                        
+
                         <decoDesc>
                          <decoNote xml:id="d1" type="miniature">
                              <height>110</height>
                              <width>80</width>
                          </decoNote>
                         </decoDesc>
-                        
+
                         <additions>
                             <list>
                                 <item xml:id="e1">
@@ -224,31 +224,31 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <desc>Each prayer ends with a supplication for the owner, who is introduced by the epithet
                                         <foreign xml:lang="gez">አመትከ፡</foreign> ‘your maid’, after which a space had originally been left blank. Following the blank space, the
                                         word <foreign xml:lang="gez">በተሐ፡</foreign> / <foreign xml:lang="gez">በተሃ፡</foreign>, sometimes repeated several times, is written in the main hand and script. Inside the space originally left
-                                        blank, the name <foreign xml:lang="gez">ወለተ፡ ሚካኤል፡</foreign> / <foreign xml:lang="gez">ወለተ፡ ሚካኤል፡ በተሐ፡</foreign> has been written, 
-                                        probably also by the main hand, but in a smaller script. It seems likely that both names are the given and baptismal name of the owner, 
+                                        blank, the name <foreign xml:lang="gez">ወለተ፡ ሚካኤል፡</foreign> / <foreign xml:lang="gez">ወለተ፡ ሚካኤል፡ በተሐ፡</foreign> has been written,
+                                        probably also by the main hand, but in a smaller script. It seems likely that both names are the given and baptismal name of the owner,
                                         <persName ref="PRS14023WalattaM" role="owner"/>.</desc>
                                 </item>
                             </list>
                         </additions>
-                        
+
                         <bindingDesc>
                             <binding>
                                 <decoNote xml:id="b1">The two parchment strips that compose the scroll are sewn together with a running stitch.</decoNote>
                                 <decoNote xml:id="b2">The manuscript is kept in a pipe case.</decoNote>
                             </binding>
                         </bindingDesc>
-                        
+
                     </physDesc>
-                    
+
                     <history>
                         <origin>
                             <origDate notBefore="1800" notAfter="2002" evidence="lettering"/>
                         </origin>
                         <provenance>According to the sticker on the backside, the scroll came from <placeName ref="LOC4244Laliba"/>. The same sticker, typewritten
-                            in French and indicating the scroll’s price in francs, suggests that the scroll was offered for sale before 2002 in France (unless the currency refers to Swiss francs, 
+                            in French and indicating the scroll’s price in francs, suggests that the scroll was offered for sale before 2002 in France (unless the currency refers to Swiss francs,
                             in which case 2002 would not constitute a terminus ante quem).</provenance>
                     </history>
-                    
+
                     <additional>
                         <adminInfo>
                             <recordHist>
@@ -260,7 +260,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </recordHist>
                         </adminInfo>
                     </additional>
-                    
+
                 </msDesc>
             </sourceDesc>
         </fileDesc>
@@ -309,8 +309,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <div type="textpart" subtype="section" n="1" xml:id="sec1">
                         <div type="textpart" subtype="picture" n="1" xml:id="pic1" corresp="#d1"/>
                     </div>
-                    
-                    
+
+
                     <div type="textpart" subtype="section" n="2" xml:id="sec2">
                         <div type="textpart" subtype="text" n="1" corresp="#ms_i1" xml:id="text1">
                             <ab>
@@ -319,48 +319,48 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 አ<gap reason="illegible" unit="chars" quantity="1"/>ዊን<hi rend="rubric" rendition="#partialRubric">፨</hi> ጢትሮስ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                 <gap reason="illegible" unit="chars" quantity="1"/>ሮፎሮ<hi rend="rubric">ድሩኤል፡ ይ</hi>መትር<hi rend="rubric" rendition="#partialRubric">፨</hi> የሐር፡ አዝራዊ<hi rend="rubric" rendition="#partialRubric">፨</hi> ደላዊ<supplied reason="omitted">፡</supplied>
                                 ቀተናዊ<hi rend="rubric" rendition="#partialRubric">፨</hi> ለ<del rend="overUnderlined">ብ</del>ተናዊ፡ አሰኮራላጵስ<hi rend="rubric" rendition="#partialRubric">፨</hi> አስከራፋጲስ<hi rend="rubric" rendition="#partialRubric">፨</hi> አረጋዎን<hi rend="rubric" rendition="#partialRubric">፨</hi> ፈሐዝር፡ አትናውጲ<hi rend="rubric" rendition="#partialRubric">፨</hi>
-                                ስዕሉ<hi rend="rubric" rendition="#partialRubric">፨</hi> 
-                                <seg type="supplication">አድኀና፡ ወዕ<add place="interlinear">ቀ</add>ባ<hi rend="rubric" rendition="#partialRubric">፨</hi> ለአመትከ<hi rend="rubric" rendition="#partialRubric">፨</hi> <persName role="owner" ref="PRS14023WalattaM"><add place="inline">ወለተ፡ ሚካኤል፡ 
+                                ስዕሉ<hi rend="rubric" rendition="#partialRubric">፨</hi>
+                                <seg type="supplication">አድኀና፡ ወዕ<add place="interlinear">ቀ</add>ባ<hi rend="rubric" rendition="#partialRubric">፨</hi> ለአመትከ<hi rend="rubric" rendition="#partialRubric">፨</hi> <persName role="owner" ref="PRS14023WalattaM"><add place="inline">ወለተ፡ ሚካኤል፡
                                     በተሐ።</add> በተሐ፡ በተሃ</persName></seg>
                             </ab>
                         </div>
                         <milestone unit="parchmentStrip" n="2"/>
-                        
+
                         <div type="textpart" subtype="section" n="3" xml:id="sec3">
                         <div type="textpart" subtype="text" n="2" corresp="#ms_i2" xml:id="text2">
                             <ab>
-                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡</hi> ፩ አምላክ፡ ጸሎት። በእንተ<hi rend="rubric" rendition="#partialRubric">፨</hi> ዓይነ፡ ጥላ፡ ወዓይነ፡ ዛር፡ ወሾተላይ፡ 
+                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡</hi> ፩ አምላክ፡ ጸሎት። በእንተ<hi rend="rubric" rendition="#partialRubric">፨</hi> ዓይነ፡ ጥላ፡ ወዓይነ፡ ዛር፡ ወሾተላይ፡
                                 <hi rend="rubric">ኢየሱስ፡</hi> ናዝራዊ<hi rend="rubric" rendition="#partialRubric">፨</hi> <sic>በትምርተ<supplied reason="omitted">፡</supplied></sic> መስቀል<hi rend="rubric" rendition="#partialRubric">፨</hi>
-                                መርአዊ፡ ጸረ፡ ፈውስ<supplied reason="omitted">፡</supplied> ሲቃ<hi rend="rubric" rendition="#partialRubric">፨</hi> ጳጢቃ<hi rend="rubric" rendition="#partialRubric">፨</hi> ኢዮሎን<hi rend="rubric" rendition="#partialRubric">፨</hi> አኽያ፡ ሾራኽያ<hi rend="rubric" rendition="#partialRubric">፨</hi> አልሸይ<hi rend="rubric" rendition="#partialRubric">፨</hi> ኢማኑኤል<hi rend="rubric" rendition="#partialRubric">፨</hi> 
+                                መርአዊ፡ ጸረ፡ ፈውስ<supplied reason="omitted">፡</supplied> ሲቃ<hi rend="rubric" rendition="#partialRubric">፨</hi> ጳጢቃ<hi rend="rubric" rendition="#partialRubric">፨</hi> ኢዮሎን<hi rend="rubric" rendition="#partialRubric">፨</hi> አኽያ፡ ሾራኽያ<hi rend="rubric" rendition="#partialRubric">፨</hi> አልሸይ<hi rend="rubric" rendition="#partialRubric">፨</hi> ኢማኑኤል<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                 ለእግዚአብሔር<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                 <seg type="supplication">አድኅና<hi rend="rubric" rendition="#partialRubric">፨</hi> ለአመትከ፡ <persName ref="PRS14023WalattaM" role="owner"><add place="inline">ወለተ፡ ሚካኤል፡ በተሐ፡</add> በተሐ፨</persName></seg>
                             </ab>
                         </div>
-                        
+
                         <div type="textpart" subtype="text" n="3" corresp="#ms_i3" xml:id="text3">
                             <ab>
                                 <hi rend="rubric"><sic>ቀ</sic> በስመ፡ <supplied reason="omitted">አብ፡</supplied>
                                     <add place="interlinear">ወ</add>ወልድ፡ ወመንፈ</hi>ስ፡ ቅዱስ፡
                                 <hi rend="rubric" rendition="#partialRubric">፩</hi> አምላክ<supplied reason="omitted">፡</supplied>
-                                በእንተ፡ ዓይነ፡ ጥላ፡ ወባርያ፡ ወሌጌዎን፡ ርኩስ፡ <hi rend="rubric">ቀዳሚሁ፡</hi> <add place="interlinear">ቃል፡</add> ውእቱ፡ 
+                                በእንተ፡ ዓይነ፡ ጥላ፡ ወባርያ፡ ወሌጌዎን፡ ርኩስ፡ <hi rend="rubric">ቀዳሚሁ፡</hi> <add place="interlinear">ቃል፡</add> ውእቱ፡
                                 ቃል፡ ቃለ፡ እግዚአብሔር። ውእቱ<hi rend="rubric" rendition="#partialRubric">፨</hi> ቃል፡
                                 ወ<add place="interlinear">እ</add>ግዚአብሔር፨ ውእቱ፡ ቃል፡ ወከማሁ<supplied reason="omitted">፡</supplied>
                                 እምቀዲሙ<hi rend="rubric" rendition="#partialRubric">፨</hi> ኀበ፡ እግዚአብሔር<hi rend="rubric" rendition="#partialRubric">፨</hi> ውእቱ፡ ቃል፡
                                 <del rend="overUnderlined">ወከማሁ<hi rend="rubric" rendition="#partialRubric">፨</hi></del> ወኵሉ<hi rend="rubric" rendition="#partialRubric">፨</hi> ኮነ<supplied reason="omitted">፡</supplied>
                                 ወዘእንበሌሁሰ<hi rend="rubric" rendition="#partialRubric">፨</hi> ዘኮነ፡ ወኢምንትኒ፡
-                                እምዘኮነ<hi rend="rubric" rendition="#partialRubric">፨</hi> ወዘሂ፡ በእንቲአሁ<hi rend="rubric" rendition="#partialRubric">፨</hi> 
+                                እምዘኮነ<hi rend="rubric" rendition="#partialRubric">፨</hi> ወዘሂ፡ በእንቲአሁ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                 ቦቱ<hi rend="rubric" rendition="#partialRubric">፨</hi>
-                                ሕይወት፡ ውእቱ<hi rend="rubric" rendition="#partialRubric">፨</hi> ወሕይዎሰ፡ ብርሃኑ<hi rend="rubric" rendition="#partialRubric">፨</hi> ለእጓለ፡ እመሕ<add place="interlinear">ያ</add>ው፡ ውእቱ፡ ወብርሃነ፡ 
-                                ጽድቅሰ<hi rend="rubric" rendition="#partialRubric">፨</hi> ዘውስተ<hi rend="rubric" rendition="#partialRubric">፨</hi> ጽልመት፡ ወያርኢ<hi rend="rubric" rendition="#partialRubric">፨</hi> 
-                                ወያበርህ<hi rend="rubric" rendition="#partialRubric">፨</hi> ወያርኢ<hi rend="rubric" rendition="#partialRubric">፨</hi> <sic>ወጽመትኒ<hi rend="rubric" rendition="#partialRubric">፨</hi></sic> 
-                                ኢረከቦ<hi rend="rubric" rendition="#partialRubric">፨</hi> ወኢይቀርከቦ<hi rend="rubric" rendition="#partialRubric">፨</hi> ሰማይ፡ <sic>ወምምድር</sic> የሐልፍ<hi rend="rubric" rendition="#partialRubric">፨</hi> 
+                                ሕይወት፡ ውእቱ<hi rend="rubric" rendition="#partialRubric">፨</hi> ወሕይዎሰ፡ ብርሃኑ<hi rend="rubric" rendition="#partialRubric">፨</hi> ለእጓለ፡ እመሕ<add place="interlinear">ያ</add>ው፡ ውእቱ፡ ወብርሃነ፡
+                                ጽድቅሰ<hi rend="rubric" rendition="#partialRubric">፨</hi> ዘውስተ<hi rend="rubric" rendition="#partialRubric">፨</hi> ጽልመት፡ ወያርኢ<hi rend="rubric" rendition="#partialRubric">፨</hi>
+                                ወያበርህ<hi rend="rubric" rendition="#partialRubric">፨</hi> ወያርኢ<hi rend="rubric" rendition="#partialRubric">፨</hi> <sic>ወጽመትኒ<hi rend="rubric" rendition="#partialRubric">፨</hi></sic>
+                                ኢረከቦ<hi rend="rubric" rendition="#partialRubric">፨</hi> ወኢይቀርከቦ<hi rend="rubric" rendition="#partialRubric">፨</hi> ሰማይ፡ <sic>ወምምድር</sic> የሐልፍ<hi rend="rubric" rendition="#partialRubric">፨</hi>
                                 ወቃ<del rend="overUnderlined">የ</del>ልየ<del rend="overUnderlined">ሑ</del>ሰ፨ ኢየሐልፍ፡ ለዓለም፨ ዓለም፨ አሜን፨
                                 <seg type="supplication"> አድኅና፡
                                     ለአመትከ<hi rend="rubric" rendition="#partialRubric">፨</hi> <persName ref="PRS14023WalattaM" role="owner">ወለተ፡ ሚካኤል፡ በተሐ</persName></seg>
                             </ab>
                         </div>
                         </div>
-                        
+
                         <div type="textpart" subtype="section" n="4" xml:id="sec4">
                         <div type="textpart" subtype="text" n="4" corresp="#ms_i4" xml:id="text4">
                             <ab>
@@ -370,7 +370,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <hi rend="rubric">ኢየሱስ፡ ክርስቶስ፡</hi> ምስለ፡ አርዳኢሁ፡ ርዕዩ፡ መልክ፡ ብእሲት፡ አረጊት፡ መፍርህት፡ ወመጸንግፅት፡ ወእንዘ፡ ይበርቅ፡ ዓይና፡ ከመ<supplied reason="omitted">፡</supplied>
                                 ወርቅ፡ ቀይህ፡ አዕዳዊሃኒ። ወአዕጋሪሃኒ<supplied reason="omitted">፡</supplied> ከመ፡ ሰረገላ፡ እሳት፡ መጠናሂ፡ ወቆማ፡ ከመ፡ በቀልት፡ ወይቤልዎ<supplied reason="omitted">፡</supplied>
                                 አርዳኢሁ፡ ለእግዚእነ<supplied reason="omitted">፡</supplied> ምንት፡ ይእቲ፡ ዓይነ፡ እኪት፡ ወርግምት፡ በምንት፡ <sic>ናጥፋአጥፍዕዋ፡</sic> በእሳት፡
-                                ወዝርዕዋ፡ በነፋስ። ምስራቀ፡ ወምዕራበ። 
+                                ወዝርዕዋ፡ በነፋስ። ምስራቀ፡ ወምዕራበ።
                                 ሰሜነ፡ ወደቡበ<supplied reason="omitted">፡</supplied> ቦር። ፎሪኮን፡ አትሪክን። አተርዋን፡ ቶሪፍ። ቶራኒቆ፡ ቶሲሰ። ጉሄል፡ አማኑኤል።
                                 <seg type="supplication">አድኅና፡ ወዕቀባ። ለአመትከ፡ <persName ref="PRS14023WalattaM" role="owner">በተሐ፡ ወለተ፡ ሚካኤል፡</persName></seg>
                             </ab>


### PR DESCRIPTION
Dear all,

This is my revision of the condition element. 
I basically:
- ordered the descriptions, describing the condition of the leaves first then the condition of the binding;
- abbreviated where possible the descriptions, eliminating, for example, redundant phrases like 'the manuscript is in good condition';
- checked if the attribution of the state of conservation was coherent;
-  Aeth. c. 14: I moved a phrase regarding the textile which wraps the manuscript from `condition` to `other` in bindingDesc.

Perhaps, what can be discussed is how to deal with the condition of composite manuscripts. I suggest to keep one general element `condition` to avoid redundancy, when the different msParts show the same damage and it cannot be established a clear difference in their conservation history, like in Aeth. b. 6. Different `condition` elements may appear if the different msParts show clearly a different conservation state deriving from a different conservation history, like in Aeth. c. 14 and Aeth. d. 18.

Let me know what you think!

Eliana