### PR TITLE
Blank fix1

### DIFF
--- a/ES/ESbmqm004.xml
+++ b/ES/ESbmqm004.xml
@@ -167,7 +167,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      <handNote xml:id="h1" script="Ethiopic">
                         <seg type="script">Careful</seg>
                         <seg type="ink">Black, red</seg>
-                        <persName role="scribe" ref="PRS13136HaylaMaryamScribe ">Ḫāyla Māryām</persName>
+                        <persName role="scribe" ref="PRS13136HaylaMaryamScribe">Ḫāyla Māryām</persName>
                         is mentioned as the scribe in the supplication formulas on <locus target="#25ra">25ra</locus> and 73vb.<date>20th century</date>
                         <seg type="rubrication">Divine names; names of the protagonist and of other
                            characters like Gabrǝʾel (fols. 21v-23r, 74v-78r, 86v-87v, 93r-94r);

--- a/ES/ESbqm006.xml
+++ b/ES/ESbqm006.xml
@@ -137,7 +137,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      <colophon xml:id="coloph1" xml:lang="gez">
                         <locus from="152ra" to="152vb">152ra-152vb</locus>ተፈጸመ፡ ዝንተ፡ መጽሐፍ፡ በሰላመ፡ እግዚአብሔር፡
                         አሜን፡ ይዕቀቦ፡ ለጸሓፊሁ፡ ኃጥእ፡ ወምኑን፡ ገብረ፡ ዋህድ፡ ዝንቱ፡ መጽሐፍ፡ ተፈጸመ፡ በወርኃ፡ ሚዝያ፡ በ፲ወ፮፡ ዕለት፡
-                        በዘመነ፡ ሉቃስ፡ እንዘ፡ ሠርቀ፡ ሌሊት፡ ፲ወ፭፡ <note>The book was completed by the scribe <persName role="scribe" ref="PRS12937GabraWahedScribe ">Gabra Wahǝd</persName>
+                        በዘመነ፡ ሉቃስ፡ እንዘ፡ ሠርቀ፡ ሌሊት፡ ፲ወ፭፡ <note>The book was completed by the scribe <persName role="scribe" ref="PRS12937GabraWahedScribe">Gabra Wahǝd</persName>
                         on the 16th of Miyāzyā in the time of Luke the Evangelist. </note></colophon>
                   </msItem>
                   
@@ -281,7 +281,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      <handNote xml:id="h1" script="Ethiopic">
                         <seg type="script"/>
                         <seg type="ink">Black, red</seg>
-                        <persName role="scribe" ref="PRS12937GabraWahedScribe ">Gabra Wahǝd</persName> is
+                        <persName role="scribe" ref="PRS12937GabraWahedScribe">Gabra Wahǝd</persName> is
                         mentioned in the colophon as the scribe.<date/>
                         <list type="abbreviations">
                            <item>

--- a/ES/ESdd029.xml
+++ b/ES/ESdd029.xml
@@ -286,7 +286,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </item>
                         <item xml:id="a4">
                            <locus target="#151v">f. 151v</locus>
-                           <desc>: <ref type="work" corresp="LIT2835RepCh119 ">Malkǝʾa Mikāʾel “Image of Michael”</ref>.</desc>
+                           <desc>: <ref type="work" corresp="LIT2835RepCh119">Malkǝʾa Mikāʾel “Image of Michael”</ref>.</desc>
                            <q xml:lang="gez"/>
 
                         </item>

--- a/ES/ESmgm013.xml
+++ b/ES/ESmgm013.xml
@@ -139,7 +139,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      <handNote xml:id="h1" script="Ethiopic">
                         <seg type="script">Mediocre, irregular.</seg>
                         <seg type="ink">Black; red (vivid vermillion).</seg>
-                        <persName role="scribe" ref="PRS12921GabraMaryamScribe ">Gabra Māryām</persName>
+                        <persName role="scribe" ref="PRS12921GabraMaryamScribe">Gabra Māryām</persName>
                         is mentioned as the scribe on <locus target="#54rb">54rb</locus> (<ref target="#coloph1">colophon
                            1</ref>).<date notBefore="1600" notAfter="1700">17th century (?)</date>
                         <seg type="rubrication">Name of the protagonist; a few lines alternating

--- a/ES/ESmr015.xml
+++ b/ES/ESmr015.xml
@@ -136,7 +136,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      <handNote xml:id="h1" script="Ethiopic">
                         <seg type="script">Mediocre but careful</seg>
                         <seg type="ink">Black, red</seg>
-                        The scribe ʾalaqā  <persName role="scribe" ref="PRS12932TawaldaHesan ">Tawalda Ḥǝḍān </persName> is mentioned in Additio
+                        The scribe ʾalaqā  <persName role="scribe" ref="PRS12932TawaldaHesan">Tawalda Ḥǝḍān </persName> is mentioned in Additio
                         1 (the note adds also what can be his baptismal or his father's name Gabra
                            Śǝllāse).<date>Late 19th - early 20th century</date>
                         <seg type="rubrication">Holy names; name of the protagonist; names of the

--- a/ES/ESsdgm006.xml
+++ b/ES/ESsdgm006.xml
@@ -424,7 +424,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <seg type="script">Hand b: mediocre.</seg>
                         <seg type="ink">Black, red (strong crimson).</seg>
                         The unit is written in the same hand as Ms. <ref type="mss" target="ESbmqm004">BMQM-004</ref> (the
-                        scribe <persName role="scribe" ref="PRS13136HaylaMaryamScribe ">Ḫāyla Māryām</persName>).
+                        scribe <persName role="scribe" ref="PRS13136HaylaMaryamScribe">Ḫāyla Māryām</persName>).
                         <date> first
                            half of the 20th cent.</date>
                         <seg type="rubrication">Divine names; several groups of lines
@@ -439,7 +439,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         
                         <item xml:id="a4">
                            <locus target="#18ra"></locus>
-                           <desc type="ScribalSignature">Scribal signature of <persName role="scribe" ref="PRS13136HaylaMaryamScribe ">Ḫāyla Māryām</persName>.</desc>
+                           <desc type="ScribalSignature">Scribal signature of <persName role="scribe" ref="PRS13136HaylaMaryamScribe">Ḫāyla Māryām</persName>.</desc>
                            <q xml:lang="gez"/>
                         </item>
                         <item xml:id="e3">
@@ -585,7 +585,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            Probably the text was written at several
                            stages.</seg>
                         <seg type="ink">Black, red (strong red).</seg>
-                        <persName role="scribe" ref="PRS13137TawaladaMadhen ">Tawalada Madḫǝn</persName> is mentioned as the scribe in
+                        <persName role="scribe" ref="PRS13137TawaladaMadhen">Tawalada Madḫǝn</persName> is mentioned as the scribe in
                         the subscriptio on <locus target="#181rb">181rb</locus> (erased but
                         legible). 
                         <date>Second half of the 16th cent</date>

--- a/ES/EStzm002.xml
+++ b/ES/EStzm002.xml
@@ -683,7 +683,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     ካህናት<supplied reason="omitted" resp="DR">፡</supplied> <hi rend="rubric">፳፡</hi> ዓመተ፡
                     ዐ<cb n="b"/>ፀወ፡ ነፍሶ፡ ውስተ፡ ቤተ፡ ክርስቲያን፡
                     ወኢይትመየጥ፡ <hi rend="rubric">፩</hi>ሂ፡ ዘይኔጽሮ፡ እስከ፡ ተፍጻሜተ፡ <hi rend="rubric">፲ወ፭፡</hi> 
-                    ዓመት፡ ወኮነ፡ በውስተ፡ ዛቲ፡ ዓመታት፡ <sic resp="DR ">ኢይጥዕ፡</sic> ዘእንበለ፡ ቀዳሚት፡ ሰንበት፡
+                    ዓመት፡ ወኮነ፡ በውስተ፡ ዛቲ፡ ዓመታት፡ <sic resp="DR">ኢይጥዕ፡</sic> ዘእንበለ፡ ቀዳሚት፡ ሰንበት፡
                     ወእሑድ። ወሶበ፡ አልጸቀት፡
                     ፍልሰቱ፡ አስተርአዮ፡ መልአከ፡ እግዚአብሔር፡ በውስተ፡ ንዋሙ፡ 
                     ወ<gap reason="illegible" unit="chars" extent="1"/>ዎ፡ ወአርአዮ፡ መስቀለ፡ ዘእሳተ፡ ወይቤሎ፡ 

--- a/FlorenceBML/BMLacq756/BMLacq756.xml
+++ b/FlorenceBML/BMLacq756/BMLacq756.xml
@@ -40,7 +40,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                             <textLang mainLang="gez" otherLangs="am"></textLang>
                             <incipit xml:lang="gez"><gap reason="illegible" unit="lines" quantity="3"/> ጸሎት፡ በእንተ፡ <term key="demon">ባርያ፡</term> 
                                 ወ<term key="demon">ትግርትያ፡</term> <term key="demon">ቤልሲባ፡</term></incipit>
-                            <explicit xml:lang="gez">ለ<persName ref="PRS11330Devil ">ሰይጣና</persName><gap reason="ellipsis" unit="chars" quantity="2"/> 
+                            <explicit xml:lang="gez">ለ<persName ref="PRS11330Devil">ሰይጣና</persName><gap reason="ellipsis" unit="chars" quantity="2"/> 
                                 አስማቲከ፡ <gap reason="illegible" unit="chars" quantity="4"/> ለአመትከ፡ </explicit>
                         </msItem>
                         <msItem xml:id="ms_i2">

--- a/LondonBritishLibrary/orient/BLorient13223.xml
+++ b/LondonBritishLibrary/orient/BLorient13223.xml
@@ -74,7 +74,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <list>
                                 <item xml:id="a1">
                                     <locus from="32r" to="34r"/>
-                                    <desc type="GuestText">Beginning of the Gǝʿǝz text of <ref type="work" corresp="LIT2051Nagara "/>.</desc>
+                                    <desc type="GuestText">Beginning of the Gǝʿǝz text of <ref type="work" corresp="LIT2051Nagara"/>.</desc>
                                     <q xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ንዌጥን፡ በረድኤተ፡ እግዚአብሔር፡ ጽሒፈ፡ ነገረ፡ ማርያም፡ ጸሎታ፡ ወበረከታ፡ የሃሉ፡ ምስለ፡ ገብራ፡ 
                                         <persName role="owner" ref="PRS14346WaldaAb">ወል<corr resp="PRS8999Strelcyn">ደ፡</corr> አብ፡</persName> 
                                         ለዓለመ፡ አለም፡ አሜን። ወኮነ፡ በመዋዕለ፡ ስደታ፡ ለእግዝ<supplied reason="undefined" resp="PRS8999Strelcyn">እ</supplied>ትነ፡ 

--- a/LondonBritishLibrary/orient/BLorient4930.xml
+++ b/LondonBritishLibrary/orient/BLorient4930.xml
@@ -315,7 +315,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </item>
                                 <item xml:id="a6">
                                     <locus target="#84r"/>
-                                    <desc type="GuestText"><ref type="work" corresp="LIT3308Nicene ">Creed (Ṣalota hāymānot)</ref> 
+                                    <desc type="GuestText"><ref type="work" corresp="LIT3308Nicene">Creed (Ṣalota hāymānot)</ref> 
                                         after Psalm 100.</desc>
                                 </item>
                                 <item xml:id="e1">

--- a/ParisBNF/et/BNFet138.xml
+++ b/ParisBNF/et/BNFet138.xml
@@ -107,7 +107,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                      <title type="complete" ref="LIT1929Mashaf">Maṣḥafa fǝlsatu la-Takla Hāymānot</title>
                      <textLang mainLang="gez"/>
                      <note>The text starts with the story about the last days of Moses,
-                       <bibl><ptr target="bm:Nosnitsin2003Felsatu "/></bibl>.
+                       <bibl><ptr target="bm:Nosnitsin2003Felsatu"/></bibl>.
                           </note>
                   </msItem>
 

--- a/ParisBNF/et/BNFet19.xml
+++ b/ParisBNF/et/BNFet19.xml
@@ -25,7 +25,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   <repository ref="INS0303BNF"/>
                   <collection>Manuscrits orientaux</collection>
                   <collection>Fonds éthiopien</collection>
-                  <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b10099888g   ">BnF Éthiopien 19</idno>  
+                  <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b10099888g">BnF Éthiopien 19</idno>  
                   <altIdentifier>
                      <idno>Éth. 92</idno>
                   </altIdentifier>


### PR DESCRIPTION
we all sometimes forget a blank space inside of quotation marks in mark up.
this is not highlighted in oxygen but renders the tags invalid and causes problems for the application, sometimes as far as a crash (e.g. the tag "bm:Strelcyn1987XXX " with a space at the end is not the same as "bm:Strelcyn1987XXX" and cannot be read or inserted into the string needed to produce a formatted bibliography; same for tags of persons works etc - a space is a symbol)

let us all try to pay attention

please do not merge this at the moment (i have updated the files on the backend to minimize the errors but the system is at the moment too instable to merge batches)