### PR TITLE
Create BLorient2083

### DIFF
--- a/LondonBritishLibrary/orient/BLorient2083.xml
+++ b/LondonBritishLibrary/orient/BLorient2083.xml
@@ -2368,31 +2368,34 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <additions>
                             <list>
                                 <item xml:id="a1">
-                                    <locus from="218ra" to="218vb"/>
-                                    <desc type="Supplication">Benediction</desc>
-                                    <q xml:lang="gez"><title>ጸሎተ፡ ቡራኬ፡</title> <gap reason="ellipsis"/></q>
-                                </item>
-                                <item xml:id="a2">
                                     <locus target="#28va"/>
                                     <desc type="Record">Record with the name of King <persName ref="PRS5616IyasuI">Iyāsu I</persName>.</desc>
+                                </item>
+                                <item xml:id="a2">
+                                    <locus from="137r" to="177r"/>
+                                    <desc type="Comment">Short notes summarizing the main events of the Passion in the upper margins of the 
+                                        readings for Good Friday.</desc>
                                 </item>
                                 <item xml:id="a3">
                                     <locus target="#217ra"/>
                                     <desc type="Record">Record with the names of Patriarch 
                                         <persName ref="PRS5711JohnXVI"><roleName type="title">ʾAbbā</roleName> Yoḥannǝs</persName> and
                                         Metropolitan <persName ref="PRS6777Marqos"><roleName type="title">ʾAbbā</roleName> Mārqos</persName>.</desc>
-                                </item>
+                                </item> 
                                 <item xml:id="a4">
-                                    <locus from="137r" to="177r"/>
-                                    <desc type="Comment">Short notes summarizing the main events of the Passion in the upper margins of the 
-                                        readings for Good Friday.</desc>
+                                    <locus from="218ra" to="218vb"/>
+                                    <desc type="Supplication">Benediction</desc>
+                                    <q xml:lang="gez"><title>ጸሎተ፡ ቡራኬ፡</title> <gap reason="ellipsis"/></q>
                                 </item>
                                 <item xml:id="e1">
-                                    <desc type="OwnershipNote"><persName role="owner" ref="PRS14419Maryamawit">Māryāmāwit</persName>
-                                        is named as an owner, together with her son <persName ref="PRS14420TaklaHaymanot">Takla Hāymānot</persName>.</desc> 
+                                    <locus target="#1ra"/>
+                                    <desc type="AcquisitionNote"/>
+                                    <q xml:lang="de">Gebra Hemamat angekauft fuer 16 Maria Theresia Thaler 
+                                        <date when="1870-08-08">d. 8 August 1870</date>. 
+                                        <persName role="owner" ref="PRS14422FMayer">F. Mayer</persName></q>
                                 </item>
                                 <item xml:id="e2">
-                                    <locus target="48va"/>
+                                    <locus target="#48va"/>
                                     <desc type="OwnershipNote">A note in the margin indicating, that this manuscript belonged to the church of
                                         <placeName ref="INS000000000000000000">Babaḥa ʾAbbo</placeName>. A person with the name
                                         <persName ref="PRS14421WaldaHanna">Walda Ḥannā</persName>, who was possibly a priest of this 
@@ -2400,11 +2403,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <q xml:lang="gez">ዝመጽሐፍ፡ ዘደብረ፡ በበሐ፡ አቦ፡</q>
                                 </item>
                                 <item xml:id="e3">
-                                    <locus target="1ra"/>
-                                    <desc type="AcquisitionNote"/>
-                                    <q xml:lang="de">Gebra Hemamat angekauft fuer 16 Maria Theresia Thaler 
-                                        <date when="1870-08-08">d. 8 August 1870</date>. 
-                                        <persName role="owner" ref="PRS14422FMayer">F. Mayer</persName></q>
+                                    <locus target="#122vb"/>
+                                    <desc type="OwnershipNote"><persName role="owner" ref="PRS14419Maryamawit">Māryāmāwit</persName>
+                                        is named as an owner, together with her son <persName ref="PRS14420TaklaHaymanot">Takla Hāymānot</persName>.</desc> 
                                 </item>
                             </list>
                         </additions>

--- a/LondonBritishLibrary/orient/BLorient2083.xml
+++ b/LondonBritishLibrary/orient/BLorient2083.xml
@@ -2392,6 +2392,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         is named as an owner, together with her son <persName ref="PRS14420TaklaHaymanot">Takla Hāymānot</persName>.</desc> 
                                 </item>
                                 <item xml:id="e2">
+                                    <locus target="48va"/>
                                     <desc type="OwnershipNote">A note in the margin indicating, that this manuscript belonged to the church of
                                         <placeName ref="INS000000000000000000">Babaḥa ʾAbbo</placeName>. A person with the name
                                         <persName ref="PRS14421WaldaHanna">Walda Ḥannā</persName>, who was possibly a priest of this 

--- a/LondonBritishLibrary/orient/BLorient2083.xml
+++ b/LondonBritishLibrary/orient/BLorient2083.xml
@@ -65,7 +65,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <title ref="LIT1544Gebrah#PalmSundayGH"/>
                             <msItem xml:id="ms_i1.3.1">
                                 <locus from="8vb" to="10vb"/>
-                                <title>Readings for Palm Sunday morning</title>
+                                <title ref="LIT1544Gebrah#PalmSundayMor">Readings for Palm Sunday morning</title>
                                 <note>Indicated by a note: <foreign xml:lang="gez">በዝየ፡ ያንብቡ፡ ምዕዳነ፡ በሰንበተ፡ ሆሣዕና፡ ነግህ።</foreign>.</note> 
                                     <msItem xml:id="ms_i1.3.1.1">
                                         <locus from="8vb"/>
@@ -90,7 +90,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </msItem>
                             <msItem xml:id="ms_i1.3.2">
                                 <locus from="10vb" to="16ra"/>
-                                <title>Readings for the procession on Palm Sunday morning</title>
+                                <title ref="LIT1544Gebrah#PalmSundayProc">Readings for the procession on Palm Sunday morning</title>
                                     <msItem xml:id="ms_i1.3.2.1">
                                         <locus from="10vb"/>
                                         <title ref="LIT1544Gebrah#Directives">Liturgical direction</title>
@@ -176,7 +176,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                </msItem>
                                <msItem xml:id="ms_i1.3.3">
                                   <locus from="16ra" to="18ra"/>
-                                  <title>Readings  for the Mass of Palm Sunday</title>
+                                   <title ref="LIT1544Gebrah#PalmSundayMass">Readings  for the Mass of Palm Sunday</title>
                                     <msItem xml:id="ms_i1.3.3.1">
                                         <locus from="16ra"/>
                                         <title ref="LIT1544Gebrah#Directives">Liturgical direction</title>
@@ -221,7 +221,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <title ref="LIT1544Gebrah#PalmSundayGH">Readings for Palm Sunday</title>
                                     <msItem xml:id="ms_i1.5.1">
                                         <locus from="18rb" to="19va"/>    
-                                        <title ref="LIT1544Gebrah#PalmSundayGH">Readings for the 11th day hour</title>
+                                        <title ref="LIT1544Gebrah#PalmSundayEleven">Readings for the 11th day hour</title>
                                         <note>Indicated by a note: <foreign xml:lang="gez">በ፲ወ፩ሰዓት፡ በዕለተ፡ ሆሳዕና፡</foreign></note>
                                         <msItem xml:id="ms_i1.5.1.1">
                                             <locus target="#18rb"/>
@@ -249,7 +249,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <title ref="LIT1544Gebrah#MondayNight">Readings for Monday Night</title>
                                             <msItem xml:id="ms_i1.6.1.1">
                                                 <locus from="19va" to="20vb"/>
-                                                <title>Readings for the first night hour</title>
+                                                <title ref="LIT1544Gebrah#MondayNightFirst">Readings for the first night hour</title>
                                                 <note>Indicated by <foreign xml:lang="gez">በሰኑይ፡ በ፩ሰአተ፡ ሌሊት፡</foreign></note>
                                                 <msItem xml:id="ms_i1.6.1.1.1">
                                                     <locus from="19va"/>
@@ -266,7 +266,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             </msItem>
                                             <msItem xml:id="ms_i1.6.1.2">
                                                 <locus from="20vb" to="21va"/>
-                                                <title>Readings for the third night hour</title>
+                                                <title ref="LIT1544Gebrah#MondayNightThird">Readings for the third night hour</title>
                                                 <note>Indicated by <foreign xml:lang="gez">በ፫ሰአተ፡ ሌሊት፡ ዘሰኑይ፡</foreign></note>
                                                     <msItem xml:id="ms_i1.6.1.2.1">
                                                         <locus from="20vb"/>
@@ -283,7 +283,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             </msItem>
                                             <msItem xml:id="ms_i1.6.1.3">
                                                 <locus from="21va" to="22rb"/>
-                                                <title ref="LIT1544Gebrah#MondayNight">Readings for the sixth night hour</title>
+                                                <title ref="LIT1544Gebrah#MondayNightSixth">Readings for the sixth night hour</title>
                                                 <note>Indicated by <foreign xml:lang="gez">በ፮ሰአተ፡ ሌሊት፡ ዘሰኑይ፡</foreign></note>
                                                     <msItem xml:id="ms_i1.6.1.3.1">
                                                         <locus from="21va"/>
@@ -327,7 +327,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 </msItem>
                                                 <msItem xml:id="ms_i1.6.2.2">
                                                     <locus from="24vb" to="36rb"/>
-                                                    <title ref="LIT1544Gebrah#MondayDay">Readings for the first day hour</title>
+                                                    <title ref="LIT1544Gebrah#MondayDayFirst">Readings for the first day hour</title>
                                                     <note>Indicated by <foreign xml:lang="gez">በ፩ሰዓት፡ ዘመዓልት፡ በዕለተ፡ ሰኑይ፡ </foreign>.</note>
                                                         <msItem xml:id="ms_i1.6.2.2.1">
                                                             <locus from="24vb"/>
@@ -372,7 +372,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 </msItem>
                                                 <msItem xml:id="ms_i1.6.2.3">
                                                     <locus from="36rb" to="38vb"/>
-                                                    <title>Readings for the third day hour</title>
+                                                    <title ref="LIT1544Gebrah#MondayDayThird">Readings for the third day hour</title>
                                                     <note>Indicated by <foreign xml:lang="gez">በ፫ሰዓት፡ ዘሰኑይ፡</foreign>.</note>
                                                         <msItem xml:id="ms_i1.6.2.3.1">
                                                             <locus from="36rb"/>
@@ -393,7 +393,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                     </msItem>
                                                     <msItem xml:id="ms_i1.6.2.4">
                                                        <locus from="38vb" to="43vb"/>
-                                                        <title>Readings for the ninth day hour</title>
+                                                        <title ref="LIT1544Gebrah#MondayDayNinth">Readings for the ninth day hour</title>
                                                         <note>Indicated by <foreign xml:lang="gez">በ፱ሰዓት፡ ዘሰኑይ፡</foreign>.</note>
                                                             <msItem xml:id="ms_i1.6.2.4.1">
                                                                 <locus from="38vb"/>
@@ -424,7 +424,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                    </msItem>
                                                    <msItem xml:id="ms_i1.6.2.5">
                                                        <locus from="43vb" to="46rb"/>
-                                                       <title ref="LIT1544Gebrah#MondayDay">Readings for the eleventh day hour</title>
+                                                       <title ref="LIT1544Gebrah#MondayDayElev">Readings for the eleventh day hour</title>
                                                        <note>Indicated by <foreign xml:lang="gez">በ፲ወ፩ሰዓት፡ ዘሰኑይ፡</foreign>.</note>
                                                             <msItem xml:id="ms_i1.6.2.5.1">
                                                                 <locus from="43vb"/>
@@ -467,7 +467,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <title ref="LIT1544Gebrah#TuesdayNight">Readings for the Tuesday Night</title>
                                                 <msItem xml:id="ms_i1.7.1.1">
                                                     <locus from="46rb" to="47ra"/>
-                                                    <title>Readings for the first night hour</title>
+                                                    <title ref="LIT1544Gebrah#TuesdayNightFirst">Readings for the first night hour</title>
                                                      <note>Indicated by <foreign xml:lang="gez">በቀዳሚት፡ ሰዓተ፡ ሌሊት፡ ዘሠሉስ፡</foreign>.</note>
                                                         <msItem xml:id="ms_i1.7.1.1.1">
                                                             <locus target="#46rb"/>
@@ -484,7 +484,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 </msItem>
                                                 <msItem xml:id="ms_i1.7.1.2">
                                                     <locus from="47ra" to="47vb"/>
-                                                    <title>Readings for the third night hour</title>
+                                                    <title ref="LIT1544Gebrah#TuesdayNightThird">Readings for the third night hour</title>
                                                     <note>Indicated by <foreign xml:lang="gez">በ፫ሰዓተ፡ ሌሊት፡ ዘሠሉስ፡</foreign>.</note>
                                                         <msItem xml:id="ms_i1.7.1.2.1">
                                                             <locus from="47ra"/>
@@ -502,7 +502,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 </msItem>
                                                 <msItem xml:id="ms_i1.7.1.3">
                                                     <locus from="47vb" to="48va"/>
-                                                    <title>Readings for the sixth night hour</title>
+                                                    <title ref="LIT1544Gebrah#TuesdayNightSixth">Readings for the sixth night hour</title>
                                                     <note>Indicated by <foreign xml:lang="gez">በ፮ሰዓተ፡ ሌሊት፡ ዘሠሉስ፡</foreign>.</note>
                                                         <msItem xml:id="ms_i1.7.1.3.1">
                                                             <locus target="#47vb"/>
@@ -519,7 +519,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 </msItem>
                                                 <msItem xml:id="ms_i1.7.1.4">
                                                     <locus from="48va" to="49va"/>
-                                                    <title>Readings for the ninth night hour</title>
+                                                    <title ref="LIT1544Gebrah#TuesdayNightNinth">Readings for the ninth night hour</title>
                                                     <note>Indicated by <foreign xml:lang="gez">በ፱ሰዓተ፡ ሌሊት፡ ዘሠሉስ፡</foreign>.</note>
                                                         <msItem xml:id="ms_i1.7.1.4.1">
                                                             <locus from="48va"/>
@@ -536,7 +536,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 </msItem>
                                                 <msItem xml:id="ms_i1.7.1.5">
                                                     <locus from="49va" to="50rb"/>
-                                                    <title>Readings for the eleventh night hour</title>
+                                                    <title ref="LIT1544Gebrah#TuesdayNightElev">Readings for the eleventh night hour</title>
                                                     <note>Indicated by <foreign xml:lang="gez">በ፲ወ፩ሰዓተ፡ ሌሊት፡ ዘሠሉስ፡</foreign>.</note>
                                                         <msItem xml:id="ms_i1.7.1.5.1">
                                                             <locus from="49vb"/>
@@ -557,7 +557,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <title ref="LIT1544Gebrah#TuesdayDay">Readings for the Tuesday Day</title>
                                         <msItem xml:id="ms_i1.7.2.1">
                                             <locus from="50rb" to="57va"/>
-                                            <title>Readings for the morning (i.e. the first day hour)</title>
+                                            <title ref="LIT1544Gebrah#TuesdayDayFirst">Readings for the morning (i.e. the first day hour)</title>
                                             <note>Indicated by <foreign xml:lang="gez">በሠሉስ፡ ነግህ፡</foreign>.</note>
                                                 <msItem xml:id="ms_i1.7.2.1.1">
                                                     <locus from="50rb"/>
@@ -614,7 +614,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 </msItem>
                                                 <msItem xml:id="ms_i1.7.2.2">
                                                     <locus from="57va" to="58rb"/>
-                                                    <title>Readings for the third day hour</title>
+                                                    <title ref="LIT1544Gebrah#ThuesdayDayThird">Readings for the third day hour</title>
                                                     <note>Indicated by <foreign xml:lang="gez">በ፫ሰዓት፡ በሠሉስ፡</foreign>.</note>
                                                         <msItem xml:id="ms_i1.7.2.2.1">
                                                             <locus from="57va"/>
@@ -635,7 +635,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 </msItem>
                                                 <msItem xml:id="ms_i1.7.2.3">
                                                     <locus from="58rb" to="59va"/>
-                                                    <title>Readings for the sixth day hour</title>
+                                                    <title ref="LIT1544Gebrah#TuesdayDaySixth">Readings for the sixth day hour</title>
                                                     <note>Indicated by <foreign xml:lang="gez">በ፮ሰዓት፡ ዘሠሉስ፡</foreign>.</note>
                                                         <msItem xml:id="ms_i1.7.2.3.1">
                                                             <locus target="#58rb"/>
@@ -656,7 +656,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                     </msItem>
                                                     <msItem xml:id="ms_i1.7.2.4">
                                                         <locus from="59va" to="67va"/>
-                                                        <title>Readings für the ninth day hour</title>
+                                                        <title ref="LIT1544Gebrah#TuesdayDayNinth">Readings für the ninth day hour</title>
                                                         <note>Indicated by <foreign xml:lang="gez">በ፱ሰዓት፡ ዘሠሉስ፡</foreign>.</note>
                                                             <msItem xml:id="ms_i1.7.2.4.1">
                                                                 <locus from="59va"/>
@@ -699,7 +699,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 </msItem>
                                                 <msItem xml:id="ms_i1.7.2.5">
                                                     <locus from="67va" to="70ra"/>
-                                                    <title>Readings for the eleventh day hour</title>
+                                                    <title ref="LIT1544Gebrah#TuesdayDayElev">Readings for the eleventh day hour</title>
                                                     <note>Indicated by <foreign xml:lang="gez">በ፲ወ፩፡ በሠሉስ፡</foreign>.</note>
                                                         <msItem xml:id="ms_i1.7.2.5.1">
                                                             <locus from="67va"/>
@@ -740,7 +740,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <title ref="LIT1544Gebrah#WednesdayNight">Readings for Wednesday Night</title>
                                                 <msItem xml:id="ms_i1.8.1.1">
                                                     <locus from="70ra" to="70vb"/>
-                                                    <title>Readings for the first night hour</title>
+                                                    <title ref="LIT1544Gebrah#WedNightFirst">Readings for the first night hour</title>
                                                     <note>Indicated by <foreign xml:lang="gez">በቀዳሚት፡ ሰዓተ፡ ሌሊት፡ ዘረቡዕ፡</foreign>.</note>
                                                         <msItem xml:id="ms_i1.8.1.1.1">
                                                             <locus from="70ra"/>
@@ -757,7 +757,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 </msItem>
                                                 <msItem xml:id="ms_i1.8.1.2">
                                                     <locus from="70vb" to="71va"/>
-                                                    <title>Readings for the third night hour</title>
+                                                    <title ref="LIT1544Gebrah#WedNightThird">Readings for the third night hour</title>
                                                     <note>Indicated by <foreign xml:lang="gez">በ፫ሰዓተ፡ ሌሊት፡ ዘረቡዕ፡</foreign>.</note>
                                                         <msItem xml:id="ms_i1.8.1.2.1">
                                                             <locus from="70vb"/>
@@ -774,7 +774,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                    </msItem>
                                                    <msItem xml:id="ms_i1.8.1.3">
                                                        <locus from="71va" to="78va"/>
-                                                       <title>Reading for the sixth night hour</title>
+                                                       <title ref="LIT1544Gebrah#WedNightSixth">Reading for the sixth night hour</title>
                                                        <note>Indicated by <foreign xml:lang="gez">በ፮ሰዓተ፡ ሌሊት፡ ዘረቡዕ፡</foreign>.</note>
                                                         <msItem xml:id="ms_i1.8.1.3.1">
                                                             <locus target="#71va"/>
@@ -795,7 +795,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             </msItem>
                                             <msItem xml:id="ms_i1.8.1.4">
                                                 <locus from="78va" to="79ra"/>
-                                                <title>Readings for the ninth night hour</title>
+                                                <title ref="LIT1544Gebrah#WedNightNinth">Readings for the ninth night hour</title>
                                                 <note>Indicated by <foreign xml:lang="gez">በ፱፡ ሰዓተ፡ ሌሊት፡ ዘረቡዕ፡</foreign>.</note>
                                                     <msItem xml:id="ms_i1.8.1.4.1">
                                                         <locus target="#78va"/>
@@ -812,7 +812,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             </msItem>
                                             <msItem xml:id="ms_i1.8.1.5">
                                                 <locus from="79ra" to="79rb"/>
-                                                <title>Readings for the eleventh night hour</title>
+                                                <title ref="LIT1544Gebrah#WedNightElev">Readings for the eleventh night hour</title>
                                                 <note>Indicated by <foreign xml:lang="gez">በ፲ወ፩፡ ሰዓተ፡ ሌሊት፡ ዘረቡዕ፡</foreign>.</note>
                                                     <msItem xml:id="ms_i1.8.1.5.1">
                                                         <locus from="79ra"/>
@@ -828,9 +828,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                     </msItem>
                                                </msItem>
                                             </msItem>
-                                            <msItem xml:id="ms_i1.8.2.1">
+                                            <msItem xml:id="ms_i1.8.2">
                                                 <locus from="79va" to="84vb"/>
-                                                <title ref="LIT1544Gebrah#WednesdayDay">For the morning (i.e. for the first day hour)</title>
+                                                <title ref="LIT1544Gebrah#WednesdayDay">Readings for Wednesday Day</title>
+                                                <msItem xml:id="ms_i1.8.2.1">
+                                                <title ref="LIT1544Gebrah#WedDayFirst">For the morning (i.e. for the first day hour)</title>
                                                 <note>Indicated by <foreign xml:lang="gez">በረቡዕ፡ ጽባሕ፡ ዘይትነባብ፡</foreign>.</note>
                                                     <msItem xml:id="ms_i1.8.2.1.1">
                                                         <locus from="79va"/>
@@ -873,10 +875,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                         <title>Admonition</title>
                                                         <incipit xml:lang="gez"><title>ተግሣጽ፡ በረቡዕ፡ ነግህ፡</title> ዘይትነበብ፡</incipit>
                                                     </msItem>
-                                            </msItem>
+                                                </msItem>
                                             <msItem xml:id="ms_i1.8.2.2">
                                                 <locus from="84vb" to="85vb"/>
-                                                <title>For the third day hour</title>
+                                                <title ref="LIT1544Gebrah#WedDayThird">For the third day hour</title>
                                                 <note>Indicated by <foreign xml:lang="gez">በ፫ሰዓተ፡ ዘረቡዕ፡</foreign>.</note>
                                                     <msItem xml:id="ms_i1.8.2.2..1">
                                                         <locus target="#84vb"/>
@@ -897,7 +899,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             </msItem>
                                             <msItem xml:id="ms_i1.8.2.3">
                                                 <locus from="85vb" to="86vb"/>
-                                                <title>For the sixth day hour</title>
+                                                <title ref="LIT1544Gebrah#WedDaySixth">For the sixth day hour</title>
                                                 <note>Indicated by <foreign xml:lang="gez">በ፮ሰዓት፡ ዘረቡዕ፡</foreign>.</note>
                                                     <msItem xml:id="ms_i1.8.2.3.1">
                                                         <locus from="85vb"/>
@@ -918,7 +920,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             </msItem>
                                             <msItem xml:id="ms_i1.8.3.3">
                                                 <locus from="86vb" to="91va"/>
-                                                <title>For the ninth day hour</title>
+                                                <title ref="LIT1544Gebrah#WedDayNinth">For the ninth day hour</title>
                                                 <note>Indicated by <foreign xml:lang="gez">በ፱ሰዓት፡ ዘረቡዕ፡</foreign>.</note>
                                                     <msItem xml:id="ms_i1.8.3.3.1">
                                                         <locus from="86vb"/>
@@ -954,7 +956,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             </msItem>
                                             <msItem xml:id="ms_i1.8.3.4">
                                                 <locus from="91va" to="92vb"/>
-                                                <title>For the eleventh day hour</title>
+                                                <title ref="LIT1544Gebrah#WedDayElev">For the eleventh day hour</title>
                                                 <note>Indicated by <foreign xml:lang="gez">በ፲ወ፩፡ ዘረቡዕ፡</foreign>.</note>
                                                     <msItem xml:id="ms_i1.8.3.4.1">
                                                         <locus from="91va"/>
@@ -977,6 +979,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                         <title ref="LIT2715John" type="incomplete">John 12:27-35</title>
                                                     </msItem>
                                             </msItem>
+                                     </msItem>
                                 </msItem>
                                 <msItem xml:id="ms_i1.9">
                                     <locus from="92vb" to="107vb"/>
@@ -986,7 +989,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <title ref="LIT1544Gebrah#ThursdayNight">Readings for Thursday Night</title>
                                                 <msItem xml:id="ms_i1.9.1.1">
                                                     <locus from="92vb" to="93rb"/>
-                                                    <title>For the first night hour</title>
+                                                    <title ref="LIT1544Gebrah#ThursNightFirst">For the first night hour</title>
                                                     <note>Indicated by <foreign xml:lang="gez">በ፩ሰዓተ፡ ሌሊት፡ ዘሐሙስ፡</foreign>.</note>
                                                         <msItem xml:id="ms_i1.9.1.1.1">
                                                             <locus from="92vb"/>
@@ -1003,7 +1006,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 </msItem>
                                                 <msItem xml:id="ms_i1.9.1.2">
                                                     <locus from="93rb" to="94ra"/>
-                                                    <title>For the third night hour</title>
+                                                    <title ref="LIT1544Gebrah#ThursNightThird">For the third night hour</title>
                                                     <note>Indicated by <foreign xml:lang="gez">በ፫ሰዓተ፡ ሌሊት፡ ዘሐሙስ፡</foreign>.</note>
                                                         <msItem xml:id="ms_i1.9.1.2.1">
                                                             <locus from="93rb"/>
@@ -1021,7 +1024,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 </msItem>
                                                 <msItem xml:id="ms_i1.9.1.3">
                                                     <locus from="94ra" to="94va"/>
-                                                    <title>For the sixth night hour</title>
+                                                    <title ref="LIT1544Gebrah#ThursNightSixth">For the sixth night hour</title>
                                                     <note>Indicated by <foreign xml:lang="gez">በ፮ሰዓተ፡ ሌሊት፡ ዘሐሙስ፡</foreign>.</note>
                                                         <msItem xml:id="ms_i1.9.1.3.1">
                                                             <locus from="94ra"/>
@@ -1039,7 +1042,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 </msItem>
                                                 <msItem xml:id="ms_i1.9.1.4">
                                                     <locus from="94va" to="95ra"/>
-                                                    <title>For the ninth night hour</title>
+                                                    <title ref="LIT1544Gebrah#ThursNightNinth">For the ninth night hour</title>
                                                     <note>Indicated by <foreign xml:lang="gez">በ፱ሰዓተ፡ ሌሊት፡ ዘሐሙስ፡</foreign>.</note>
                                                         <msItem xml:id="ms_i1.9.1.4.1">
                                                             <locus from="94va"/>
@@ -1056,7 +1059,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 </msItem>
                                                 <msItem xml:id="ms_i1.9.1.5">
                                                     <locus from="95ra" to="95va"/>
-                                                    <title>For the eleventh night hour</title>
+                                                    <title ref="LIT1544Gebrah#ThursNightElev">For the eleventh night hour</title>
                                                     <note>Indicated by <foreign xml:lang="gez">በ፲ወ፩ሰዓተ፡ ሌሊት፡ ዘሐሙስ፡</foreign>.</note>
                                                         <msItem xml:id="ms_i1.9.1.5.1">
                                                             <locus from="95ra"/>
@@ -1077,7 +1080,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 <title ref="LIT1544Gebrah#ThursdayDay">Readings for Thursday Day</title>
                                                     <msItem xml:id="ms_i1.9.2.1">
                                                         <locus from="95va" to="97va"/>
-                                                        <title>For the first day hour</title>
+                                                        <title ref="LIT1544Gebrah#ThursDayFirst">For the first day hour</title>
                                                         <note>Indicated by <foreign xml:lang="gez"> በጽባሕ፡ ሐሙስ፡ በ፩ሰዓት፡</foreign>.</note>
                                                             <msItem xml:id="ms_i1.9.2.1.1">
                                                             <locus from="95va"/>
@@ -1104,10 +1107,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                             ወናስተ፡ ዳሉ፡ ወኢንኩን፡ ፩እምኔነ፡ ከመ፡ ይሁዳ፡ ወኢእኩየ፡ ዘቦቱ፡ ጽልሑት። </incipit>
                                                     </msItem>
                                                 </msItem>
-                                            </msItem>
                                             <msItem xml:id="ms_i1.9.2.2">
                                                 <locus from="97va" to="99ra"/>
-                                                <title ref="LIT1544Gebrah#ThursdayDay">For the third day hour</title>
+                                                <title ref="LIT1544Gebrah#ThursDayThird">For the third day hour</title>
                                                 <note>Indicated by <foreign xml:lang="gez"> በ፫ሰዓት፡ ዘሐሙስ፡</foreign>.</note>
                                                     <msItem xml:id="ms_i1.9.2.2.1">
                                                     <locus target="#97va"/>
@@ -1132,7 +1134,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </msItem>
                                         <msItem xml:id="ms_i1.9.2.3">
                                             <locus from="99ra" to="101rb"/>
-                                            <title>For the sixth day hour</title>
+                                            <title ref="LIT1544Gebrah#ThursDaySixth">For the sixth day hour</title>
                                             <note>Indicated by <foreign xml:lang="gez"> በ፮ሰዓት፡ ዘሐሙስ፡</foreign>.</note>
                                                 <msItem xml:id="ms_i1.9.2.3.1">
                                                     <locus from="99ra"/>
@@ -1165,7 +1167,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             </msItem>
                                             <msItem xml:id="ms_i1.9.2.4">
                                                 <locus from="101rb" to="107vb"/>
-                                                <title>For the ninth day hour</title>
+                                                <title ref="LIT1544Gebrah#ThursDayNinth">For the ninth day hour</title>
                                                 <note>Indicated by <foreign xml:lang="gez"> በ፱ሰዓት፡ ዘሐሙስ፡</foreign>.</note>
                                                     <msItem xml:id="ms_i1.9.2.4.1">
                                                         <locus from="101rb"/>
@@ -1209,6 +1211,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                             ወመደንግልጽት፡ አነ፡ እመርህክሙ፡ በቃልየ፡ ከመ፡ ይኩን፡ ለክሙ፡ ረባሐ፡ ክልኤ፡ ገጽ፡ ሑሩ፡ በፍርሃት፡</incipit>
                                                     </msItem>
                                             </msItem>
+                                      </msItem>
                                 </msItem>
                                 <msItem xml:id="ms_i1.10">
                                     <locus from="107vb" to="113vb"/>
@@ -1336,7 +1339,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </msItem>
                                                 <msItem xml:id="ms_i1.11.1.3">
                                                     <locus from="120rb" to="122vb"/>
-                                                    <title>Readings for the eleventh day hour</title>
+                                                    <title ref="LIT1544Gebrah#ThursDayElev">Readings for the eleventh day hour</title>
                                                         <msItem xml:id="ms_i1.11.1.3.1">
                                                             <locus target="#120rb"/>
                                                             <title ref="LIT1544Gebrah#Directives">Liturgical direction</title>
@@ -1368,7 +1371,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 </msItem>
                                 </msItem>
                                 </msItem>
-                                <msItem xml:id="ms_i1.12">
+                                <msItem xml:id="ms_i1.12"> 
                                     <locus from="122vb" to="185va"/>
                                     <title ref="LIT1544Gebrah#Friday">Readings for Friday</title>
                                         <msItem xml:id="ms_i1.12.1">
@@ -1376,7 +1379,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <title ref="LIT1544Gebrah#FridayNight">Readings for Friday Night</title>
                                                 <msItem xml:id="ms_i1.12.1.1">
                                                     <locus from="122vb" to="126va"/>
-                                                    <title>Readings for the first night hour</title>
+                                                    <title ref="LIT1544Gebrah#FriNightFirst">Readings for the first night hour</title>
                                                     <note>Indicated by <foreign xml:lang="gez"> በ፩ሰዓተ፡ ሌሊት፡ ዘዓርብ፡</foreign>.</note>
                                                 <msItem xml:id="ms_i1.12.1.1.1">
                                                     <locus from="122vb"/>
@@ -1407,7 +1410,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                               </msItem>
                                         <msItem xml:id="ms_i1.12.1.2">
                                             <locus from="126va" to="128ra"/>
-                                            <title>Readings for the third night hour</title>
+                                            <title ref="LIT1544Gebrah#FriNightThird">Readings for the third night hour</title>
                                             <note>Indicated by <foreign xml:lang="gez"> በ፫ሰዓተ፡ ሌሊት፡ ዘዓርብ፡</foreign>.</note>
                                                 <msItem xml:id="ms_i1.12.1.2.1">
                                                     <locus from="126va"/>
@@ -1440,7 +1443,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </msItem>
                                         <msItem xml:id="ms_i1.12.1.3">
                                             <locus from="128ra" to="129ra"/>
-                                            <title>Readings for the sixth night hour</title>
+                                            <title ref="LIT1544Gebrah#FridaySixthNight">Readings for the sixth night hour</title>
                                             <note>Indicated by <foreign xml:lang="gez"> በ፮ሰዓተ፡ ሌሊት፡ ዘዓርብ፡</foreign>.</note>
                                                 <msItem xml:id="ms_i1.12.1.3.1">
                                                     <locus target="#128ra"/>
@@ -1477,7 +1480,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         </msItem>
                                         <msItem xml:id="ms_i1.12.1.4">
                                             <locus from="129ra" to="134va"/>
-                                            <title>Readings for the ninth night hour</title>
+                                            <title ref="LIT1544Gebrah#FriNightNinth">Readings for the ninth night hour</title>
                                             <note>Indicated by <foreign xml:lang="gez"> በ፱ሰዓተ፡ ሌሊት፡ ዘዓርብ፡</foreign>.</note>
                                                 <msItem xml:id="ms_i1.12.1.4.1">
                                                     <locus from="129ra"/>
@@ -1976,7 +1979,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             </msItem>
                                             <msItem xml:id="ms_i1.12.2.6">
                                                 <locus from="180va" to="185va"/>
-                                                <title>Readings for the twelfth day hour</title>
+                                                <title ref="LIT1544Gebrah#FriDayTwelth">Readings for the twelfth day hour</title>
                                                 <note>Indicated by <foreign xml:lang="gez"> በ፲ወ፪ሰዓት፡ ዘዓርብ፡</foreign>.</note>
                                                     <msItem xml:id="ms_i1.12.2.6.1">
                                                         <locus from="180va"/>
@@ -2055,7 +2058,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <title ref="LIT1544Gebrah#SaturdayDay">Readings for Saturday Day</title>
                                             <msItem xml:id="ms_i1.13.1.1">
                                                 <locus from="185va" to="191va"/>
-                                                <title>Readings for the morning</title>
+                                                <title ref="LIT1544Gebrah#SatDayFirst">Readings for the morning</title>
                                                     <msItem xml:id="ms_i1.13.1.1.1">
                                                         <locus from="185va"/>
                                                         <title ref="LIT1544Gebrah#Song" type="incomplete">Song of Songs</title>
@@ -2115,7 +2118,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             </msItem>
                                             <msItem xml:id="ms_i1.13.1.2">
                                                 <locus from="191va" to="208rb"/>
-                                                <title>Readings for the sixth day hour</title>
+                                                <title ref="LIT1544Gebrah#SatDaySixth">Readings for the sixth day hour</title>
                                                 <note>Indicated by <foreign xml:lang="gez"> በ፮ሰዓት፡ አንብቡ፡ ዘንተ፡</foreign>.</note>
                                                     <msItem xml:id="ms_i1.13.1.2.1">
                                                         <locus from="191va"/>
@@ -2330,7 +2333,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                     <explicit xml:lang="gez">ተፈጸመ፡ በዝየ፡ በጸጋሁ፡ ለክርስቶስ፡ መጽሐፈ፡ ኅብረተ፡ ቃላት፡ ዘይደሉ፡ ለአንብቦ፡ በሰሙነ፡ ሕማማት፡ 
                                                         እምቅዳሚት፡ ለስንበተ፡ ሆሣዕና፡ ሰርክ፡ እስከ፡ እሁድ፡ ትንሣኤ፡ ሰርክ።</explicit>
                                                 </msItem>
-                                                <colophon xml:lang="gez" xml:id="coloph1">
+                                                <colophon xml:lang="gez" xml:id="coloph3">
                                                     <locus target="#218ra"/>
                                                     <note>Colophon containing the names of the scribe
                                                         <persName role="scribe" ref="PRS14424TasfaIyasus">Tasfā ʾIyasus</persName> and of
@@ -2368,21 +2371,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <additions>
                             <list>
                                 <item xml:id="a1">
-                                    <locus target="#28va"/>
-                                    <desc type="Record">Record with the name of King <persName ref="PRS5616IyasuI">ʾIyāsu I</persName>.</desc>
-                                </item>
-                                <item xml:id="a2">
                                     <locus from="137r" to="177r"/>
                                     <desc type="Comment">Short notes summarizing the main events of the Passion in the upper margins of the 
                                         readings for Good Friday.</desc>
                                 </item>
-                                <item xml:id="a3">
-                                    <locus target="#217ra"/>
-                                    <desc type="Record">Record with the names of Patriarch 
-                                        <persName ref="PRS5711JohnXVI"><roleName type="title">ʾAbbā</roleName> Yoḥannǝs</persName> and
-                                        Metropolitan <persName ref="PRS6777Marqos"><roleName type="title">ʾAbbā</roleName> Mārqos</persName>.</desc>
-                                </item> 
-                                <item xml:id="a4">
+                                <item xml:id="a2">
                                     <locus from="218ra" to="218vb"/>
                                     <desc type="Supplication">Benediction</desc>
                                     <q xml:lang="gez"><title>ጸሎተ፡ ቡራኬ፡</title> <gap reason="ellipsis"/></q>
@@ -2395,18 +2388,28 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <persName role="owner" ref="PRS14422FMayer">F. Mayer</persName></q>
                                 </item>
                                 <item xml:id="e2">
+                                    <locus target="#28va"/>
+                                    <desc>Record with the name of King <persName ref="PRS5616IyasuI">ʾIyāsu I</persName>.</desc>
+                                </item>
+                                <item xml:id="e3">
                                     <locus target="#48va"/>
                                     <desc type="OwnershipNote">A note in the margin indicating, that this manuscript belonged to the church of
-                                        <placeName ref="INS000000000000000000">Babaḥa ʾAbbo</placeName>. A person with the name
+                                        <placeName ref="LOC7449BabahaAbbo">Babaḥa ʾAbbo</placeName>. A person with the name
                                         <persName ref="PRS14421WaldaHanna">Walda Ḥannā</persName>, who was possibly a priest of this 
                                         church, is also mentioned.</desc> 
                                     <q xml:lang="gez">ዝመጽሐፍ፡ ዘደብረ፡ በበሐ፡ አቦ፡</q>
                                 </item>
-                                <item xml:id="e3">
+                                <item xml:id="e4">
                                     <locus target="#122vb"/>
                                     <desc type="OwnershipNote"><persName role="owner" ref="PRS14419Maryamawit">Māryāmāwit</persName>
                                         is named as an owner, together with her son <persName ref="PRS14420TaklaHaymanot">Takla Hāymānot</persName>.</desc> 
                                 </item>
+                                <item xml:id="e5">
+                                    <locus target="#217ra"/>
+                                    <desc>Supplication with the names of Patriarch 
+                                        <persName ref="PRS5711JohnXVI"><roleName type="title">ʾAbbā</roleName> Yoḥannǝs</persName> and
+                                        Metropolitan <persName ref="PRS6777Marqos"><roleName type="title">ʾAbbā</roleName> Mārqos</persName>.</desc>
+                                </item> 
                             </list>
                         </additions>
                         <bindingDesc>
@@ -2464,7 +2467,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text>
         <body>
-            <div type="bibliography"/><!---->
+            <div type="bibliography"/>         
+            <!---->
         </body>
     </text>
 </TEI>

--- a/LondonBritishLibrary/orient/BLorient2083.xml
+++ b/LondonBritishLibrary/orient/BLorient2083.xml
@@ -621,7 +621,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                             <title ref="LIT2637Deuteronomy" type="incomplete">Deuteronomy 8:11-19</title>
                                                         </msItem>
                                                         <msItem xml:id="ms_i1.7.2.2.2">
-                                                            <locus target="58ra"/>
+                                                            <locus target="#58ra"/>
                                                             <title ref="LIT2358Sirach" type="incomplete">Ecclesiasticus 3</title>
                                                         </msItem>
                                                         <msItem xml:id="ms_i1.7.2.2.3">
@@ -747,7 +747,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                             <title ref="LIT1373Bookof" type="incomplete">Ezekiel 22:17-32</title>
                                                         </msItem>
                                                         <msItem xml:id="ms_i1.8.1.1.2">
-                                                            <locus target="70rb"/>
+                                                            <locus target="#70rb"/>
                                                             <title ref="LIT3985Mazmura#Ps59" type="incomplete">Psalm 59:16-17</title>
                                                         </msItem>
                                                         <msItem xml:id="ms_i1.8.1.1.3">
@@ -2382,12 +2382,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </item>
                                 <item xml:id="e1">
                                     <locus target="#1ra"/>
-                                    <desc type="AcquisitionNote"/>
+                                    <desc type="OwnershipNote"/>
                                     <q xml:lang="de">Gebra Hemamat angekauft fuer 16 Maria Theresia Thaler 
                                         <date when="1870-08-08">d. 8 August 1870</date>. 
                                         <persName role="owner" ref="PRS14422FMayer">F. Mayer</persName></q>
                                 </item> 
                                 <item xml:id="e2">
+                                    <locus target="#1ra"/>
+                                    <desc type="AcquisitionNote"/>
+                                    <q xml:lang="en">Presented by <persName ref="PRS14494GeorgeElliot" role="bequeather">
+                                        <roleName type="title">Sir</roleName> Geo. Elliot <roleName type="function">M. P.</roleName></persName>,
+                                        <date when="1878-09-10">10 Sept. 1878</date>.</q>
+                                </item>
+                                <item xml:id="e3">
                                     <locus target="#48va"/>
                                     <desc type="OwnershipNote">A note in the margin indicating, that this manuscript belonged to the church of
                                         <placeName ref="LOC7449BabahaAbbo">Babaḥa ʾAbbo</placeName>. A person with the name

--- a/LondonBritishLibrary/orient/BLorient2083.xml
+++ b/LondonBritishLibrary/orient/BLorient2083.xml
@@ -2406,13 +2406,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </bindingDesc>
                     </physDesc>
                     <history>
-                        <origin><origDate notBefore="1694" notAfter="1706">Between 1694 and 1706</origDate>.
+                        <origin><origDate notBefore="1694" notAfter="1706">Between 1694 and 1706.
                             King <persName ref="PRS5616IyasuI">ʾIyāsu I</persName> is mentioned on <locus target="#28va"/>, 
                             while Patriarch <persName ref="PRS5711JohnXVI"><roleName type="title">ʾAbbā</roleName> Yoḥannǝs</persName> 
                             and Metropolitan <persName ref="PRS6777Marqos"><roleName type="title">ʾAbbā</roleName> Mārqos</persName>    
-                            are mentioned on <locus target="#217ra"/>.</origin>
+                            are mentioned on <locus target="#217ra"/>.</origDate></origin>
                         <provenance><persName role="owner" ref="PRS14419Maryamawit">Māryāmāwit</persName> is named as an owner, 
-                            along with her son <persName ref="PRS14420TaklaHaymanot">Takla Hāymānot</persName>. </provenance>
+                            along with her son <persName ref="PRS14420TaklaHaymanot">Takla Hāymānot</persName> on 
+                            <locus target="#122vb"/>. </provenance>
                     </history>
                     <additional>
                         <adminInfo>

--- a/LondonBritishLibrary/orient/BLorient2083.xml
+++ b/LondonBritishLibrary/orient/BLorient2083.xml
@@ -1298,7 +1298,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title ref="LIT1544Gebrah#MassThur">Reading for the Mass</title>
                                         <msItem xml:id="ms_i1.11.1.2.1">
                                             <locus from="116va"/>
-                                            <title>Homily by Abba Sinoda</title>
+                                            <title>Homily by ʾAbbā Sinodā</title>
                                             <incipit xml:lang="gez"><title>ድርሳን፡ ዘአቡነ፡ ቅዱስ፡ አባ፡ ሲኖዳ፡ በረከቱ፡ ላዕለነ፡</title> አሜን። ለንኅፈር፡ ይእዜኒ፡ ኦአኃው፡ በእንተ፡ 
                                                 ዘሐመ፡ በእንቲአነ። ወንፍራህ፡ በእንተ፡ ዘቀነተ፡ ለንጸ፡ ወወደየ፡ ማየ፡ ውስተ፡ ምሕፃብ፡ ወሐፀበ፡ እግረ፡ አርዳኢሁ፡ በእደዊሁ፡ ንጽሐት።</incipit>
                                         </msItem>
@@ -2362,14 +2362,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <handDesc>
                             <handNote script="Ethiopic" xml:id="h1">
                                 <desc>Neat gʷǝlḥ script, decreasing in height from 6 mm at the beginning to about 4 mm at the end of the manuscript.</desc>
-                                <date notBefore="1800" notAfter="1899" resp="PRS8999Strelcyn"/>
+                                <date notBefore="1694" notAfter="1706" resp="PRS8999Strelcyn"/>
                             </handNote>
                         </handDesc>
                         <additions>
                             <list>
                                 <item xml:id="a1">
                                     <locus target="#28va"/>
-                                    <desc type="Record">Record with the name of King <persName ref="PRS5616IyasuI">Iyāsu I</persName>.</desc>
+                                    <desc type="Record">Record with the name of King <persName ref="PRS5616IyasuI">ʾIyāsu I</persName>.</desc>
                                 </item>
                                 <item xml:id="a2">
                                     <locus from="137r" to="177r"/>

--- a/LondonBritishLibrary/orient/BLorient2083.xml
+++ b/LondonBritishLibrary/orient/BLorient2083.xml
@@ -2333,7 +2333,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                     <explicit xml:lang="gez">ተፈጸመ፡ በዝየ፡ በጸጋሁ፡ ለክርስቶስ፡ መጽሐፈ፡ ኅብረተ፡ ቃላት፡ ዘይደሉ፡ ለአንብቦ፡ በሰሙነ፡ ሕማማት፡ 
                                                         እምቅዳሚት፡ ለስንበተ፡ ሆሣዕና፡ ሰርክ፡ እስከ፡ እሁድ፡ ትንሣኤ፡ ሰርክ።</explicit>
                                                 </msItem>
-                                                <colophon xml:lang="gez" xml:id="coloph3">
+                                                <colophon xml:lang="gez" xml:id="coloph1">
                                                     <locus target="#218ra"/>
                                                     <note>Colophon containing the names of the scribe
                                                         <persName role="scribe" ref="PRS14424TasfaIyasus">Tasfā ʾIyasus</persName> and of

--- a/LondonBritishLibrary/orient/BLorient2083.xml
+++ b/LondonBritishLibrary/orient/BLorient2083.xml
@@ -1,0 +1,2468 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="BLorient2083" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Gǝbra Ḥǝmāmāt</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS00001BL"/>
+                        <collection>Oriental</collection>
+                        <idno>BL Oriental 2083</idno>
+                        <altIdentifier><idno>Strelcyn 40</idno></altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                      <msItem xml:id="ms_i1">
+                        <locus from="1ra" to="217vb"/>
+                        <title ref="LIT1544Gebrah"/>
+                        <msItem xml:id="ms_i1.1">
+                            <locus from="1ra" to="4va"/> 
+                            <title ref="LIT1544Gebrah#Introduction"/>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/>ንቀድም፡ በረድኤተ፡ እግዚአብሔር፡ ወበሥምረቱ፡ ንጽሕፍ፡ ዘንተ፡ መጽሐፈ፡ ቅዱስ፡ 
+                                ዘይደሉ፡ አንብቦቱ፡ እምኦሪት፡ ወነቢያት፡ ወመዝሙረ፡ ዳዊት፡ ወወንጌላት፡ ቅዱሳት፡ በከመ፡ ይደሉ፡ አንብቦቱ፡ በበፆታሁ፡ በመዋዕለ፡ ሰሙን፡ ክብርት፡ እንተ፡ ይእቲ፡ 
+                                ሰሙነ፡ ፍሥሕ፡ ዘበአማን፡ በግዕ<supplied reason="omitted" resp="CH">ዝ</supplied>፡ ጥዩቅ፡ ወቅዱስ። </incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i1.2">
+                            <locus from="5ra" to="8vb"/>
+                            <title ref="LIT1544Gebrah#EvePalmSunday"/>
+                            <note>Indicated by the note: <foreign xml:lang="gez">በስመ፡ <gap reason="ellipsis"/>ዝንቱ፡ መጽሐፍ፡ ዘይትነበብ፡ በሰንበት፡
+                                በዕለተ፡ ሆሣዕና፡ ሰርክ። </foreign>.</note>
+                            <msItem xml:id="ms_i1.2.1">
+                                <locus from="5ra"/>
+                                <title ref="LIT3985Mazmura#Ps121" type="incomplete">Psalm 121:1-2 and 121:4</title>
+                                <note>To be read before the Gospels.</note>
+                            </msItem>
+                            <msItem xml:id="ms_i1.2.2">
+                                <locus from="5ra"/>
+                                <title ref="LIT2715John" type="incomplete">John 12:1-2</title>
+                            </msItem>
+                            <msItem xml:id="ms_i1.2.3">
+                                <locus from="5va" to="8vb"/>
+                                <title ref="LIT1544Gebrah#HomilyEvePalmSun">Homily by John Chrysostom</title>
+                                <incipit xml:lang="gez"><title>ተግሣጽ፡ 
+                                    ዘ<persName role="author" ref="PRS5720JohnChr">ዮሐንስ፡ አፈ፡ ወርቅ፡</persName></title></incipit>
+                            </msItem>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3">
+                            <locus from="8vb" to="10vb"/>
+                            <title ref="LIT1544Gebrah#PalmSundayGH"/>
+                            <msItem xml:id="ms_i1.3.1">
+                                <locus from="8vb" to="10vb"/>
+                                <title>Readings for Palm Sunday morning</title>
+                                <note>Indicated by a note: <foreign xml:lang="gez">በዝየ፡ ያንብቡ፡ ምዕዳነ፡ በሰንበተ፡ ሆሣዕና፡ ነግህ።</foreign>.</note> 
+                                    <msItem xml:id="ms_i1.3.1.1">
+                                        <locus from="8vb"/>
+                                        <title ref="LIT1546Genesi" type="incomplete">Genesis 49:1-12</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.1.2">
+                                        <locus from="9rb"/>
+                                        <title ref="LIT3150Zechar" type="incomplete">Zechariah 8:2-8</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.1.3">
+                                        <locus from="9vb"/>
+                                        <title ref="LIT1672Isaiah" type="incomplete">Isaiah 49:5-18</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.1.4">
+                                        <locus from="9vb"/>
+                                        <title ref="LIT3985Mazmura#Ps117" type="incomplete">Psalm 117:24-26</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.1.5">
+                                        <locus from="9vb" to="10vb"/>
+                                        <title ref="LIT1812GospelLuke" type="incomplete">Luke 19:1-10</title>
+                                    </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i1.3.2">
+                                <locus from="10vb" to="16ra"/>
+                                <title>Readings for the procession on Palm Sunday morning</title>
+                                    <msItem xml:id="ms_i1.3.2.1">
+                                        <locus from="10vb"/>
+                                        <title ref="LIT1544Gebrah#Directives">Liturgical direction</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.2.2">
+                                        <locus from="10vb"/>
+                                        <title ref="LIT1558Matthew" type="incomplete">Matthew 20:29-34</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.2.3">
+                                        <locus from="11ra"/>
+                                        <title ref="LIT3985Mazmura#Ps147" type="incomplete">Psalm 147:1-2</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.2.4">
+                                        <locus from="11ra"/>
+                                        <title ref="LIT1882MarkGo" type="incomplete">Mark 10:46-52</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.2.5">
+                                        <locus from="11va"/>
+                                        <title ref="LIT3985Mazmura#Ps9" type="incomplete">Psalm 9:22-23</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.2.6">
+                                        <locus from="11va"/>
+                                        <title ref="LIT1812GospelLuke" type="incomplete">Luke 18:35-43</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.2.7">
+                                        <locus from="11vb"/>
+                                        <title ref="LIT3985Mazmura#Ps46" type="incomplete">Psalm 46:10</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.2.8">
+                                        <locus from="11vb"/>
+                                        <title ref="LIT1558Matthew" type="incomplete">Matthew 9:27-31</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.2.9">
+                                        <locus from="12va"/>
+                                        <title ref="LIT3507Epistle" type="incomplete">1 Peter 4:11</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.2.10">
+                                        <locus from="13ra"/>
+                                        <title ref="LIT1019Actsof" type="incomplete">Acts 28:11-31</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.2.11">
+                                        <locus from="13vb"/>
+                                        <title ref="LIT1544Gebrah#Directives">Liturgical direction</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.2.12">
+                                        <locus from="13vb"/>
+                                        <title ref="LIT3985Mazmura#Ps67" type="incomplete">Psalm 67:20 and 67:38</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.2.13">
+                                        <locus from="14ra"/>
+                                        <title>Prayer</title>
+                                        <note>To be said by the priest before the Gospel: 
+                                            <foreign xml:lang="gez">እግዚአብሔር፡ እግዚኦ፡ ኢየሱስ፡ ክርስቶስ፡ አምላክነ።</foreign></note>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.2.14">
+                                        <locus from="14ra"/>
+                                        <title ref="LIT1558Matthew" type="incomplete">Matthew 21:1-16</title>
+                                     </msItem>
+                                    <msItem xml:id="ms_i1.3.2.15">
+                                        <locus from="14va"/>
+                                        <title ref="LIT3985Mazmura#Ps8" type="incomplete">Psalm 8:3</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.2.16">
+                                        <locus from="14va"/>
+                                        <title ref="LIT1882MarkGo" type="incomplete">Mark 11:1-11</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.2.17">
+                                        <locus from="15ra"/>
+                                        <title ref="LIT3985Mazmura#Ps112" type="incomplete">Psalm 112:1-2</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.2.18">
+                                        <locus from="15ra"/>
+                                        <title ref="LIT1812GospelLuke" type="incomplete">Luke 19:29-48</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.2.19">
+                                        <locus from="15vb"/>
+                                        <title ref="LIT3985Mazmura#Ps80" type="incomplete">Psalm 80:5; 80:3 and 80:1-2</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.2.20">
+                                        <locus from="15vb" to="16ra"/>
+                                        <title ref="LIT2715John" type="incomplete">John 12:12-19</title>
+                                    </msItem>
+                               </msItem>
+                               <msItem xml:id="ms_i1.3.3">
+                                  <locus from="16ra" to="18ra"/>
+                                  <title>Readings  for the Mass of Palm Sunday</title>
+                                    <msItem xml:id="ms_i1.3.3.1">
+                                        <locus from="16ra"/>
+                                        <title ref="LIT1544Gebrah#Directives">Liturgical direction</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.3.2">
+                                       <locus from="16rb"/>
+                                        <title ref="LIT1672Isaiah" type="incomplete">Isaiah 62:10 - 63:1</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.3.3">
+                                        <locus from="16rb"/>
+                                        <title ref="LIT3516Epistle" type="incomplete">1 Corinthians 15:1-19</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.3.4">
+                                        <locus from="17va"/>
+                                        <title ref="LIT2715John" type="incomplete">John 5:11-30</title>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.3.3.5">
+                                        <locus from="17vb"/>
+                                        <title ref="LIT1544Gebrah#Directives">Liturgical direction</title>
+                                        <incipit xml:lang="gez">ወእምድኅረ፡ ተፈጸመ፡ ቍርባን፡ ይግበሩ፡ ኵሉ፡ ሕዝብ፡ ወካህናት፡ ወይቁም፡ ካህን፡ ዘሠርዓ፡ ቍርባነ፡ ወያስተብቍዕ፡ በእንተ፡
+                                            እለ፡ ኖሙ፡ ወይብሉ፡ ሕዝብ፡ አቡነ፡ ዘበሰማይት።</incipit>
+                                    </msItem>
+                                </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i1.4">
+                                <locus from="18ra" to="18rb"/>
+                                <title>Readings for midnight during Passion Week</title>
+                                    <msItem xml:id="ms_i1.4.1">
+                                        <locus from="18ra"/>
+                                        <title ref="LIT1544Gebrah#PrayerMidnight">Prayer</title>
+                                        <incipit xml:lang="gez">ጸሎት፡ ዘይትነበብ፡ በሰሙነ፡ ሕማማት፡ ወይእቲ፡ ስባሔ፡ ይብሉ፡ ኵሉ፡ ሕዝብ፡ ፲ወ፪ጊዜ፡ በመንፈቀ፡ ሌሊት፡ በበ፩አፍ፡</incipit>
+                                    </msItem>
+                                    <msItem xml:id="ms_i1.4.2">
+                                        <locus target="#18rb"/>
+                                        <title ref="LIT1544Gebrah#Directives">Liturgical direction</title>
+                                        <incipit xml:lang="gez">ወይብል፡ ዘንተ፡ ቅድመ፡ ወንጌል፡ ቁሙ፡ ወአጽምኡ፡ ከመ፡ ንኩን፡ ድልዋነ፡ ለሰሚዓ፡ ወንጌል፡ ቅዱስ፡ ኦእግዚእነ፡
+                                            ወአምላክነ፡ ተሣሃለነ፡ ወመሐረነ፡ ወረስየነ፡ ድልዋነ፡ ለሰሚዓ፡ ወንጌል፡ ቅዱስ።</incipit>
+                                    </msItem>
+                            </msItem>                                
+                            <msItem xml:id="ms_i1.5">
+                                <locus from="18rb" to="19va"/>
+                                <title ref="LIT1544Gebrah#PalmSundayGH">Readings for Palm Sunday</title>
+                                    <msItem xml:id="ms_i1.5.1">
+                                        <locus from="18rb" to="19va"/>    
+                                        <title ref="LIT1544Gebrah#PalmSundayGH">Readings for the 11th day hour</title>
+                                        <note>Indicated by a note: <foreign xml:lang="gez">በ፲ወ፩ሰዓት፡ በዕለተ፡ ሆሳዕና፡</foreign></note>
+                                        <msItem xml:id="ms_i1.5.1.1">
+                                            <locus target="#18rb"/>
+                                            <title ref="LIT1672Isaiah" type="incomplete">Isaiah 48:12-22</title>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.5.1.2">
+                                            <locus from="18rb"/>
+                                            <title ref="LIT2057Bookof" type="incomplete">Nahum 1:2-8</title>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.5.1.3">
+                                            <locus target="#19ra"/>
+                                            <title ref="LIT3985Mazmura#Ps8" type="incomplete">Psalm 8:3</title>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.5.1.4">
+                                            <locus from="19ra" to="19va"/>
+                                            <title ref="LIT1558Matthew" type="incomplete">Matthew 20:20-28</title>
+                                        </msItem>
+                                    </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i1.6">
+                                <locus from="19va" to="46rb"/>
+                                <title ref="LIT1544Gebrah#Monday">Readings for Monday</title>
+                                    <msItem xml:id="ms_i1.6.1">
+                                        <locus from="19va" to="20vb"/>
+                                        <title ref="LIT1544Gebrah#MondayNight">Readings for Monday Night</title>
+                                            <msItem xml:id="ms_i1.6.1.1">
+                                                <locus from="19va" to="20vb"/>
+                                                <title>Readings for the first night hour</title>
+                                                <note>Indicated by <foreign xml:lang="gez">በሰኑይ፡ በ፩ሰአተ፡ ሌሊት፡</foreign></note>
+                                                <msItem xml:id="ms_i1.6.1.1.1">
+                                                    <locus from="19va"/>
+                                                    <title ref="LIT3148Zephan" type="incomplete">Zephania 1:1-12</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.6.1.1.2">
+                                                    <locus from="20ra"/>
+                                                    <title ref="LIT3985Mazmura#Ps26" type="incomplete">Psalm 26:11-13</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.6.1.1.3">
+                                                    <locus from="20ra" to="20vb"/>
+                                                    <title ref="LIT2715John" type="incomplete">John 12:20-30</title>
+                                                </msItem>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.6.1.2">
+                                                <locus from="20vb" to="21va"/>
+                                                <title>Readings for the third night hour</title>
+                                                <note>Indicated by <foreign xml:lang="gez">በ፫ሰአተ፡ ሌሊት፡ ዘሰኑይ፡</foreign></note>
+                                                    <msItem xml:id="ms_i1.6.1.2.1">
+                                                        <locus from="20vb"/>
+                                                        <title ref="LIT3148Zephan" type="incomplete">Zephania 1:13 - 2:3</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.6.1.2.2">
+                                                       <locus target="#21rb"/>
+                                                        <title ref="LIT3985Mazmura#Ps27" type="incomplete">Psalm 27:12 and 27:8</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.6.1.2.3">
+                                                        <locus from="21rb" to="21va"/>
+                                                        <title ref="LIT1812GospelLuke" type="incomplete">Luke 9:18-22</title>
+                                                   </msItem>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.6.1.3">
+                                                <locus from="21va" to="22rb"/>
+                                                <title ref="LIT1544Gebrah#MondayNight">Readings for the sixth night hour</title>
+                                                <note>Indicated by <foreign xml:lang="gez">በ፮ሰአተ፡ ሌሊት፡ ዘሰኑይ፡</foreign></note>
+                                                    <msItem xml:id="ms_i1.6.1.3.1">
+                                                        <locus from="21va"/>
+                                                        <title ref="LIT1689Joel" type="incomplete">Joel 1:5-16</title>
+                                                        <note>Wrongly indicated with <foreign xml:lang="gez">ዘኢሳይያስ፡</foreign>.</note>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.6.1.3.2">
+                                                        <locus target="#22ra"/>
+                                                        <title ref="LIT3985Mazmura#Ps28" type="incomplete">Psalm 28:1-2</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.6.1.3.3">
+                                                        <locus from="22ra" to="22rb"/>
+                                                        <title ref="LIT1882MarkGo" type="incomplete">Mark 10:32-34</title>
+                                                    </msItem>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.6.1.4">
+                                                <locus from="23ra" to="23va"/>
+                                                <title ref="LIT1544Gebrah#MondayNight">Readings for the eleventh night hour</title>
+                                                <note>Indicated by <foreign xml:lang="gez">በ፲ወ፩ሰአተ፡ ሌሊት፡ ዘሰኑይ፡</foreign></note>
+                                                    <msItem xml:id="ms_i1.6.1.4.1">
+                                                        <locus from="23ra"/>
+                                                        <title ref="LIT3146Micah" type="incomplete">Micah 3:1-4</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.6.1.4.2">
+                                                        <locus target="#23rb"/>
+                                                        <title ref="LIT3985Mazmura#Ps17" type="incomplete">Psalm 17:51-52</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.6.1.4.3">
+                                                        <locus from="23rb" to="23va"/>
+                                                        <title ref="LIT1558Matthew" type="incomplete">Matthew 17:19-23</title>
+                                                  </msItem>
+                                            </msItem>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.6.2">
+                                            <locus from="23va" to="46rb"/>
+                                            <title ref="LIT1544Gebrah#MondayDay">Readings for Monday Day</title>
+                                                <msItem xml:id="ms_i1.6.2.1">
+                                                    <locus from="23va" to="24vb"/>
+                                                    <title ref="LIT1546Genesi" type="incomplete">Readings for dawn: Genesis 1:1 to 2:3</title>
+                                                    <note>Indicated by <foreign xml:lang="gez">በሰኑይ፡ ጽባሕ፡</foreign>.</note>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.6.2.2">
+                                                    <locus from="24vb" to="36rb"/>
+                                                    <title ref="LIT1544Gebrah#MondayDay">Readings for the first day hour</title>
+                                                    <note>Indicated by <foreign xml:lang="gez">በ፩ሰዓት፡ ዘመዓልት፡ በዕለተ፡ ሰኑይ፡ </foreign>.</note>
+                                                        <msItem xml:id="ms_i1.6.2.2.1">
+                                                            <locus from="24vb"/>
+                                                            <title ref="LIT1672Isaiah" type="incomplete">Isaiah 5:1-9</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.6.2.2.2">
+                                                            <locus from="25rb"/>
+                                                            <title>Comment on <ref type="work" corresp="LIT1672Isaiah">Isaiah 5:1-9</ref></title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.6.2.2.3">
+                                                            <locus from="28ra"/>
+                                                            <title ref="LIT2358Sirach" type="incomplete">Ecclesiasticus 1:1-24</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.6.2.2.4">
+                                                            <locus from="28va"/>
+                                                            <title ref="LIT1544Gebrah#AbbaSinodaMoMor">Admonition by Abba Sinoda concerning salvation</title>
+                                                            <incipit xml:lang="gez">ኦአኃው፡ ሶበ፡ ፈቀድነ፡ ናምሥጥ፡ እመዓተ፡ እግዚአብሔር፡ ወንረክብ፡ ምሕረተ፡ በኀቤሁ።</incipit>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.6.2.2.5">
+                                                            <locus target="#29ra"/>
+                                                            <title ref="LIT3985Mazmura#Ps71" type="incomplete">Psalm 71:19-20</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.6.2.2.6">
+                                                            <locus from="29ra"/>
+                                                            <title ref="LIT1882MarkGo" type="incomplete">Mark 11:12-26</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.6.2.2.7">
+                                                            <locus from="29va"/>
+                                                            <title ref="LIT1544Gebrah#JohnMonday">Homily by John Chrysostom</title>
+                                                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/><title>ድርሳን፡ ዘቅዱስ፡ 
+                                                                <persName role="author" ref="PRS5720JohnChr">ዮሐንስ፡ አፈ፡ ወርቅ፡ </persName>ዘይትነበብ፡ 
+                                                                በዕለተ፡ ሰኑይ፡ ነግህ።</title><cb n="29vb"/>ነዋ፡ ሰማዕነ፡ ይእዜኒ፡ ከመ፡ እለ፡ ይትሜሰሉ፡ በኦም፡ ዘዕሩቅ፡ </incipit>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.6.2.2.8">
+                                                            <locus from="31rb" to="36rb"/>
+                                                            <title ref="LIT1544Gebrah#JohnFig">Homily by John Chrysostom concerning the fig-tree</title>
+                                                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/><title>ድርሳን ዘብፁዕ፡ ወቅዱስ፡ 
+                                                                <persName role="author" ref="PRS5720JohnChr">ዮሐንስ፡ አፈ፡ ወርቅ፡</persName> በእንተ፡ ዕፀ፡ በለስ፡ ዘይትነበብ፡ በሰኑይ፡ 
+                                                                ዕለት፡ ዘሕማማት።</title> ወሶበ፡ ነጸረት፡ ዓይን፡ ኀበ፡ ኦም፡ ዘባቲ፡ ዘዘዚአሁ፡ አንቅዕት፡ ማያት፡ እስመኪ፡ በእንቲአሃ፡ ይትፌሣሕ፡ ልብ። ወየሐውር፡ ኀቤሃ፡ 
+                                                                ከማሁ፡ አስተማስል፡ ለእለ፡ ይሰምዑ፡ አንብቦ፡ ዘመጻሕፍት፡ ቅዱሳት።</incipit>
+                                                        </msItem>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.6.2.3">
+                                                    <locus from="36rb" to="38vb"/>
+                                                    <title>Readings for the third day hour</title>
+                                                    <note>Indicated by <foreign xml:lang="gez">በ፫ሰዓት፡ ዘሰኑይ፡</foreign>.</note>
+                                                        <msItem xml:id="ms_i1.6.2.3.1">
+                                                            <locus from="36rb"/>
+                                                            <title ref="LIT1672Isaiah" type="incomplete">Isaiah 5:21-30</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.6.2.3.2">
+                                                            <locus from="36vb"/>
+                                                            <title ref="LIT1689Joel" type="incomplete">Joel 2:21 - 3:21</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.6.2.3.3">
+                                                            <locus from="38va"/>
+                                                            <title ref="LIT3985Mazmura#Ps71" type="complete">Psalm 121</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.6.2.3.4">
+                                                            <locus target="#38vb"/>
+                                                            <title ref="LIT2715John" type="incomplete">John 2:13-17</title>
+                                                        </msItem>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.6.2.4">
+                                                       <locus from="38vb" to="43vb"/>
+                                                        <title>Readings for the ninth day hour</title>
+                                                        <note>Indicated by <foreign xml:lang="gez">በ፱ሰዓት፡ ዘሰኑይ፡</foreign>.</note>
+                                                            <msItem xml:id="ms_i1.6.2.4.1">
+                                                                <locus from="38vb"/>
+                                                                <title ref="LIT1546Genesi" type="incomplete">Genesis 2:15 - 3:24</title>
+                                                            </msItem>
+                                                            <msItem xml:id="ms_i1.6.2.4.2">
+                                                                <locus from="41rb"/>
+                                                                <title ref="LIT1672Isaiah" type="incomplete">Isaiah 40:1-8</title>
+                                                            </msItem>
+                                                            <msItem xml:id="ms_i1.6.2.4.3">
+                                                                <locus from="41va"/>
+                                                                <title ref="LIT2195Prover" type="incomplete">Proverbs 1:1-9</title>
+                                                            </msItem> 
+                                                            <msItem xml:id="ms_i1.6.2.4.4">
+                                                                <locus target="#41vb"/>
+                                                                <title ref="LIT3985Mazmura#Ps42" type="incomplete">Psalms 42:6</title>
+                                                            </msItem>
+                                                            <msItem xml:id="ms_i1.6.2.4.5">
+                                                                <locus from="41vb"/>
+                                                                <title ref="LIT1558Matthew" type="incomplete">Matthew 21:23-27</title>
+                                                            </msItem>
+                                                            <msItem xml:id="ms_i1.6.2.4.6">
+                                                                <locus from="42ra" to="43vb"/>
+                                                                <title ref="LIT1544Gebrah#MondayNinth">Homily</title>
+                                                                <incipit xml:lang="gez">ድርሳን፡ በሰኑይ፡ ዕለት፡ በ፱ሰዓት፡ ዘይትነበብ፡ ወለእመ፡ ኮነ፡ እለ፡ ያነብቡ፡ መጽሐፈ፡ ጥበብ፡ ዘአፍአ፡ ወዜና፡ ገድል፡
+                                                                    ዘበዓለም፡ ይበጽሑ፡ በተጠናቅቆ፡ ምንባብ፡ ወለአእምሮ፡ ፍካሬ፡ ቃላት።</incipit>
+                                                            </msItem>
+                                                   </msItem>
+                                                   <msItem xml:id="ms_i1.6.2.5">
+                                                       <locus from="43vb" to="46rb"/>
+                                                       <title ref="LIT1544Gebrah#MondayDay">Readings for the eleventh day hour</title>
+                                                       <note>Indicated by <foreign xml:lang="gez">በ፲ወ፩ሰዓት፡ ዘሰኑይ፡</foreign>.</note>
+                                                            <msItem xml:id="ms_i1.6.2.5.1">
+                                                                <locus from="43vb"/>
+                                                                <title ref="LIT1672Isaiah" type="incomplete">Isaiah 50:1-3</title>
+                                                            </msItem>
+                                                            <msItem xml:id="ms_i1.6.2.5.2">
+                                                                <locus from="44ra"/>
+                                                                <title ref="LIT2358Sirach" type="incomplete">Ecclesiasticus 1</title>
+                                                            </msItem>
+                                                            <msItem xml:id="ms_i1.6.2.5.3">
+                                                                <locus target="#44rb"/>
+                                                                <title ref="LIT1672Isaiah" type="incomplete">Isaiah 26:2-27</title>
+                                                            </msItem>
+                                                            <msItem xml:id="ms_i1.6.2.5.4">
+                                                                <locus from="44rb"/>
+                                                                <title ref="LIT3144Hosea">Hosea 14:1-9</title>
+                                                            </msItem>
+                                                            <msItem xml:id="ms_i1.6.2.5.5">
+                                                                <locus from="45va"/>
+                                                                <title ref="LIT1544Gebrah#AbbaSinodaMoEve">Admoninition by Abba Sinoda</title>
+                                                                <incipit xml:lang="gez">ተግሣጽ፡ ዘአቡነ፡ አባ፡ ሲኖዳ፡ በረከቱ፡ <gap reason="ellipsis"/> እስመ፡ ይትረከብ፡ ምግባራተ፡ 
+                                                                    ዘትመስል፡ ይእቲ፡ ሠናይት፡ ወይእቲ፡ እኪት፡ በኀበ፡ እግዚአብሔር።</incipit>
+                                                            </msItem>
+                                                            <msItem xml:id="ms_i1.6.2.5.6">
+                                                                <locus target="#46ra"/>
+                                                                <title ref="LIT3985Mazmura#Ps12">Psalm 12:2-3</title>
+                                                            </msItem>
+                                                            <msItem xml:id="ms_i1.6.2.5.7">
+                                                                <locus from="46ra" to="46rb"/>
+                                                                <title ref="LIT2715John" type="incomplete">John 8:51-59</title>
+                                                            </msItem>
+                                                    </msItem>
+                                             </msItem>
+                                </msItem>
+                                <msItem xml:id="ms_i1.7">
+                                    <locus from="46rb" to="70ra"/>
+                                    <title ref="LIT1544Gebrah#Tuesday">Readings for Tuesday</title>
+                                        <msItem xml:id="ms_i1.7.1">
+                                            <locus from="46rb" to="50rb"/>
+                                            <title ref="LIT1544Gebrah#TuesdayNight">Readings for the Tuesday Night</title>
+                                                <msItem xml:id="ms_i1.7.1.1">
+                                                    <locus from="46rb" to="47ra"/>
+                                                    <title>Readings for the first night hour</title>
+                                                     <note>Indicated by <foreign xml:lang="gez">በቀዳሚት፡ ሰዓተ፡ ሌሊት፡ ዘሠሉስ፡</foreign>.</note>
+                                                        <msItem xml:id="ms_i1.7.1.1.1">
+                                                            <locus target="#46rb"/>
+                                                            <title ref="LIT3150Zechar" type="incomplete">Zechariah 1:1-6</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.7.1.1.2">
+                                                            <locus target="#46rb"/>
+                                                            <title ref="LIT3985Mazmura#Ps61">Psalm 61: 5-6</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.7.1.1.3">
+                                                            <locus from="46rb" to="47ra"/>
+                                                            <title ref="LIT1812GospelLuke" type="incomplete">Luke 13:31-35</title>
+                                                        </msItem>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.7.1.2">
+                                                    <locus from="47ra" to="47vb"/>
+                                                    <title>Readings for the third night hour</title>
+                                                    <note>Indicated by <foreign xml:lang="gez">በ፫ሰዓተ፡ ሌሊት፡ ዘሠሉስ፡</foreign>.</note>
+                                                        <msItem xml:id="ms_i1.7.1.2.1">
+                                                            <locus from="47ra"/>
+                                                            <title ref="LIT3151Malachi" type="incomplete">Malachi 1:1-13</title>
+                                                            <note>Indicated as <foreign xml:lang="gez">ዘሚክያስ፡ </foreign></note>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.7.1.2.2">
+                                                            <locus target="#47va"/>
+                                                            <title ref="LIT3985Mazmura#Ps12" type="incomplete">Psalm 12:3-7</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.7.1.2.3">
+                                                            <locus from="47va" to="47vb"/>
+                                                            <title ref="LIT1812GospelLuke" type="incomplete">Luke 13:31-35</title>
+                                                        </msItem>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.7.1.3">
+                                                    <locus from="47vb" to="48va"/>
+                                                    <title>Readings for the sixth night hour</title>
+                                                    <note>Indicated by <foreign xml:lang="gez">በ፮ሰዓተ፡ ሌሊት፡ ዘሠሉስ፡</foreign>.</note>
+                                                        <msItem xml:id="ms_i1.7.1.3.1">
+                                                            <locus target="#47vb"/>
+                                                            <title ref="LIT3144Hosea">Hosea 4:15 - 5:7</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.7.1.3.2">
+                                                            <locus target="#47vb"/>
+                                                            <title ref="LIT3985Mazmura#90">Psalm 90:2-3</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.7.1.3.3">
+                                                            <locus from="47vb" to="48va"/>
+                                                            <title ref="LIT1812GospelLuke">Luke 21:31-38</title>
+                                                        </msItem>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.7.1.4">
+                                                    <locus from="48va" to="49va"/>
+                                                    <title>Readings for the ninth night hour</title>
+                                                    <note>Indicated by <foreign xml:lang="gez">በ፱ሰዓተ፡ ሌሊት፡ ዘሠሉስ፡</foreign>.</note>
+                                                        <msItem xml:id="ms_i1.7.1.4.1">
+                                                            <locus from="48va"/>
+                                                            <title ref="LIT3144Hosea" type="incomplete">Hosea 10:12-15</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.7.1.4.2">
+                                                            <locus target="#48vb"/>
+                                                            <title ref="LIT3985Mazmura#Ps32" type="incomplete">Psalm 32:10-11</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.7.1.4.3">
+                                                            <locus from="48vb" to="49va"/>
+                                                            <title ref="LIT1812GospelLuke" type="incomplete">Luke 11:37-52</title>
+                                                        </msItem>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.7.1.5">
+                                                    <locus from="49va" to="50rb"/>
+                                                    <title>Readings for the eleventh night hour</title>
+                                                    <note>Indicated by <foreign xml:lang="gez">በ፲ወ፩ሰዓተ፡ ሌሊት፡ ዘሠሉስ፡</foreign>.</note>
+                                                        <msItem xml:id="ms_i1.7.1.5.1">
+                                                            <locus from="49vb"/>
+                                                            <title ref="LIT3145Amos" type="incomplete">Amos 5:6-14</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.7.1.5.2">
+                                                            <locus target="#50ra"/>
+                                                            <title ref="LIT3985Mazmura#Ps121" type="incomplete">Psalm 121:4</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.7.1.5.3">
+                                                            <locus from="50ra" to="50rb"/>
+                                                            <title ref="LIT1882MarkGo" type="incomplete">Mark 13:32-37</title>
+                                                        </msItem>
+                                                 </msItem>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.7.2">
+                                            <locus from="50rb" to="69ra"/>
+                                            <title ref="LIT1544Gebrah#TuesdayDay">Readings for the Tuesday Day</title>
+                                        <msItem xml:id="ms_i1.7.2.1">
+                                            <locus from="50rb" to="57va"/>
+                                            <title>Readings for the morning (i.e. the first day hour)</title>
+                                            <note>Indicated by <foreign xml:lang="gez">በሠሉስ፡ ነግህ፡</foreign>.</note>
+                                                <msItem xml:id="ms_i1.7.2.1.1">
+                                                    <locus from="50rb"/>
+                                                    <title ref="LIT1367Exodus" type="incomplete">Exodus 19:1-9</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.7.2.1.2">
+                                                    <locus from="50vb"/>
+                                                    <title ref="LIT1688Job" type="incomplete">Job 23:2 - 24:25</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.7.2.1.3">
+                                                    <locus from="51vb"/>
+                                                    <title>Comment on <ref type="work" corresp="LIT1688Job">Job 23:2 - 24:25</ref></title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.7.2.1.4">
+                                                    <locus from="54rb"/>
+                                                    <title ref="LIT1672Isaiah" type="incomplete">Isaiah 1:21-31</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.7.2.1.5">
+                                                    <locus from="54va"/>
+                                                    <title ref="LIT3144Hosea" type="incomplete">Hosea 4:1-8</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.7.2.1.6">
+                                                    <locus from="55ra"/>
+                                                    <title ref="LIT1544Gebrah#AbbaSinodaTu">Admonition by Abba Sinoda</title>
+                                                    <incipit xml:lang="gez"><title>ተግሣጽ፡ ዘአቡነ፡ ቅዱስ፡ አባ፡ ሲኖዳ፡</title> <gap reason="ellipsis"/>ወአጤይቀክሙ፡ 
+                                                        አነ፡ በ፪ገብር፡ እስመ፡ እለ፡ ይትፌሣሕ፡ ሎሙ፡ እግዚአብሔር፡ በውስተ፡ ሰማይ፡ በእንተ፡ ንስሐሆሙ፡ በዲበ፡ ምድር፡ እስመ፡ እሙንቱ፡ ኢይሬእዩ፡ 
+                                                        ኅዘነ፡ ወኢሕማመ፡ በውስተ፡ መካን፡ ደሐሪ።</incipit>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.7.2.1.7">
+                                                    <locus target="#55va"/>
+                                                    <title ref="LIT3985Mazmura" type="incomplete">Psalms</title>
+                                                        <msItem xml:id="ms_i1.7.6.7.1">
+                                                            <locus target="#55va"/>
+                                                            <title ref="LIT3985Mazmura#Ps34" type="incomplete">Psalm 34:4-6</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.7.2.1.7.2">
+                                                            <locus target="#55va"/>
+                                                           <title ref="LIT3985Mazmura#Ps119" type="incomplete">Psalm 119:2 and 119:6-7</title>
+                                                        </msItem>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.7.2.1.8">
+                                                        <locus from="55va"/>
+                                                        <title ref="LIT1558Matthew" type="incomplete">Matthew 26:1-16</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.7.2.1.9">
+                                                        <locus from="56ra"/>
+                                                        <title ref="LIT2715John" type="incomplete">John 7:33-35 and 8:23-29</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.7.2.1.10">
+                                                        <locus from="56va" to="57va"/>
+                                                        <title>Explanation of the Gospel readings</title>
+                                                        <incipit xml:lang="gez">ነዋ፡ ሰማዕነ፡ ይእዜኒ፡ እግዚእነ፡ ዘሎቱ፡ ስብሐት፡ ዘከረ፡ ለደቂቀ፡ እስራኤል፡ በግብጻዊያን፡ በእንቲአሆሙ።</incipit>
+                                                    </msItem>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.7.2.2">
+                                                    <locus from="57va" to="58rb"/>
+                                                    <title>Readings for the third day hour</title>
+                                                    <note>Indicated by <foreign xml:lang="gez">በ፫ሰዓት፡ በሠሉስ፡</foreign>.</note>
+                                                        <msItem xml:id="ms_i1.7.2.2.1">
+                                                            <locus from="57va"/>
+                                                            <title ref="LIT2637Deuteronomy" type="incomplete">Deuteronomy 8:11-19</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.7.2.2.2">
+                                                            <locus target="58ra"/>
+                                                            <title ref="LIT2358Sirach" type="incomplete">Ecclesiasticus 3</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.7.2.2.3">
+                                                            <locus from="58ra"/>
+                                                            <title ref="LIT3985Mazmura#Ps118" type="incomplete">Psalm 118:154-155</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.7.2.2.4">
+                                                            <locus target="#58rb"/>
+                                                            <title ref="LIT1558Matthew" type="incomplete">Matthew 23:37-39</title>
+                                                        </msItem>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.7.2.3">
+                                                    <locus from="58rb" to="59va"/>
+                                                    <title>Readings for the sixth day hour</title>
+                                                    <note>Indicated by <foreign xml:lang="gez">በ፮ሰዓት፡ ዘሠሉስ፡</foreign>.</note>
+                                                        <msItem xml:id="ms_i1.7.2.3.1">
+                                                            <locus target="#58rb"/>
+                                                            <title ref="LIT1373Bookof" type="incomplete">Ezekiel 21:3-17</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.7.2.3.2">
+                                                            <locus from="58rb"/>
+                                                            <title ref="LIT2358Sirach" type="incomplete">Ecclesiasticus 4</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.7.2.3.3">
+                                                            <locus target="#59rb"/>
+                                                            <title ref="LIT3985Mazmura#Ps17">Psalm 17:51-52</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.7.2.3.4">
+                                                            <locus from="59rb" to="59va"/>
+                                                            <title ref="LIT2715John" type="incomplete">John 8:12-20</title>
+                                                        </msItem>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.7.2.4">
+                                                        <locus from="59va" to="67va"/>
+                                                        <title>Readings für the ninth day hour</title>
+                                                        <note>Indicated by <foreign xml:lang="gez">በ፱ሰዓት፡ ዘሠሉስ፡</foreign>.</note>
+                                                            <msItem xml:id="ms_i1.7.2.4.1">
+                                                                <locus from="59va"/>
+                                                                <title ref="LIT1546Genesi" type="incomplete">Genesis 6:5 to 9:7</title>
+                                                            </msItem>
+                                                            <msItem xml:id="ms_i1.7.2.4.2">
+                                                                <locus from="61vb"/>
+                                                                <title ref="LIT2195Prover" type="incomplete">Proverbs 9:1-11</title>
+                                                            </msItem>
+                                                            <msItem xml:id="ms_i1.7.2.4.3">
+                                                                <locus from="62ra"/>
+                                                                <title>Comment on <ref type="work" corresp="LIT2195Prover">Proverbs 9:1-11</ref></title>
+                                                            </msItem>
+                                                            <msItem xml:id="ms_i1.7.2.4.4">
+                                                                <locus from="63ra"/>
+                                                                <title ref="LIT1672Isaiah" type="incomplete">Isaiah 40:9-31</title>
+                                                            </msItem>
+                                                            <msItem xml:id="ms_i1.7.2.4.5">
+                                                                <locus from="63vb"/>
+                                                                <title ref="LIT3529Daniel" type="incomplete">Daniel 7:2-14</title>
+                                                            </msItem>
+                                                            <msItem xml:id="ms_i1.7.2.4.6">
+                                                                <locus from="64rb"/>
+                                                                <title>Comment on <ref type="work" corresp="LIT3529Daniel">Daniel 7:2-14</ref></title>
+                                                            </msItem>
+                                                            <msItem xml:id="ms_i1.7.2.4.7">
+                                                                <locus target="#65ra"/>
+                                                                <title ref="LIT3985Mazmura#Ps24" type="incomplete">Psalm 24:1-2</title>
+                                                            </msItem>
+                                                            <msItem xml:id="ms_i1.7.2.4.8">
+                                                                <locus from="65ra"/>
+                                                                <title ref="LIT1558Matthew" type="incomplete">Matthew 24:3-35</title>
+                                                            </msItem>
+                                                            <msItem xml:id="ms_i1.7.2.4.9">
+                                                                <locus from="66rb" to="67va"/>
+                                                                <title ref="LIT1544Gebrah#AnonAdmonTu">Admonition</title>
+                                                                <incipit xml:lang="gez">ተግሣጽ፡ በ፱ሰዓት፡ በሠሉስ፡ ዘይትነበብ፡ ይደሉ፡ እለ፡ ይእዜኒ፡ ከመ፡ ንጠይቅ፡ ፍካሬ፡ እመጻሕፍት፡ 
+                                                                    ዘመለኮት፡ ሠናይ፡ አኮ፡ ለሰሚዕ፡ ባሕቲቱ፡ ዳእሙ፡ ንብራኅ፡ በብርሃና፡ ዘየሐቱ፡ ውስተ፡ አልባቢነ፡</incipit>
+                                                            </msItem>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.7.2.5">
+                                                    <locus from="67va" to="70ra"/>
+                                                    <title>Readings for the eleventh day hour</title>
+                                                    <note>Indicated by <foreign xml:lang="gez">በ፲ወ፩፡ በሠሉስ፡</foreign>.</note>
+                                                        <msItem xml:id="ms_i1.7.2.5.1">
+                                                            <locus from="67va"/>
+                                                            <title ref="LIT1672Isaiah" type="incomplete">Isaiah 29:6-21</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.7.2.5.2">
+                                                            <locus from="68rb"/>
+                                                            <title ref="LIT1672Isaiah" type="incomplete">Isaiah 18:16-28</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.7.12.5.3">
+                                                            <locus from="68va"/>
+                                                            <title ref="LIT2195Prover" type="incomplete">Proverbs 6:20 - 7:4</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.7.2.5.4">
+                                                            <locus target="#69ra"/>
+                                                            <title>Psalms</title>
+                                                                <msItem xml:id="ms_i1.7.2.5.4.1">
+                                                                    <locus target="#69ra"/>
+                                                                    <title ref="LIT3985Mazmura#Ps46" type="incomplete">Psalm 46:8</title>
+                                                                </msItem>
+                                                                <msItem xml:id="ms_i1.7.2.5.4.2">
+                                                                    <locus target="#69ra" to="70ra"/>
+                                                                    <title ref="LIT3985Mazmura#Ps40" type="incomplete">Psalm 40:1</title>
+                                                                </msItem>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.7.2.5.5">
+                                                            <locus from="69ra"/>
+                                                            <title ref="LIT1558Matthew" type="incomplete">Matthew 25:14 - 26:2</title>
+                                                        </msItem>
+                                            </msItem>
+                                        </msItem>
+                                </msItem>
+                                <msItem xml:id="ms_i1.8">
+                                    <locus from="70ra" to="92vb"/>
+                                    <title ref="LIT1544Gebrah#Wednesday">Readings for Wednesday</title>
+                                        <msItem xml:id="ms_i1.8.1">
+                                            <locus from="70ra" to="79rb"/>
+                                            <title ref="LIT1544Gebrah#WednesdayNight">Readings for Wednesday Night</title>
+                                                <msItem xml:id="ms_i1.8.1.1">
+                                                    <locus from="70ra" to="70vb"/>
+                                                    <title>Readings for the first night hour</title>
+                                                    <note>Indicated by <foreign xml:lang="gez">በቀዳሚት፡ ሰዓተ፡ ሌሊት፡ ዘረቡዕ፡</foreign>.</note>
+                                                        <msItem xml:id="ms_i1.8.1.1.1">
+                                                            <locus from="70ra"/>
+                                                            <title ref="LIT1373Bookof" type="incomplete">Ezekiel 22:17-32</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.8.1.1.2">
+                                                            <locus target="70rb"/>
+                                                            <title ref="LIT3985Mazmura#Ps59" type="incomplete">Psalm 59:16-17</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.8.1.1.3">
+                                                            <locus from="70rb" to="70vb"/>
+                                                            <title ref="LIT1558Matthew" type="incomplete">Matthew 22:1-14</title>
+                                                        </msItem>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.8.1.2">
+                                                    <locus from="70vb" to="71va"/>
+                                                    <title>Readings for the third night hour</title>
+                                                    <note>Indicated by <foreign xml:lang="gez">በ፫ሰዓተ፡ ሌሊት፡ ዘረቡዕ፡</foreign>.</note>
+                                                        <msItem xml:id="ms_i1.8.1.2.1">
+                                                            <locus from="70vb"/>
+                                                            <title ref="LIT3145Amos" type="incomplete">Amos 5:18-27</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.8.1.2.2">
+                                                            <locus target="#71ra"/>
+                                                            <title ref="LIT3985Mazmura#Ps56" type="incomplete">Psalm 56:4-5</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.8.1.2.3">
+                                                            <locus from="71ra" to="71va"/>
+                                                            <title ref="LIT1558Matthew" type="incomplete">Matthew 24:36-51</title>
+                                                        </msItem>
+                                                   </msItem>
+                                                   <msItem xml:id="ms_i1.8.1.3">
+                                                       <locus from="71va" to="78va"/>
+                                                       <title>Reading for the sixth night hour</title>
+                                                       <note>Indicated by <foreign xml:lang="gez">በ፮ሰዓተ፡ ሌሊት፡ ዘረቡዕ፡</foreign>.</note>
+                                                        <msItem xml:id="ms_i1.8.1.3.1">
+                                                            <locus target="#71va"/>
+                                                            <title ref="LIT1685Bookof" type="incomplete">Jeremiah 16:9-13</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.8.1.3.2">
+                                                            <locus from="71va"/>
+                                                            <title ref="LIT1882MarkGo" type="incomplete">Mark 25:1-14</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.8.1.3.3">
+                                                            <locus from="72ra" to="78va"/>
+                                                            <title ref="LIT2144OntheT"/>
+                                                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/><title>ድርሳን፡ ዘአቡነ፡ ቅዱስ፡ አባ፡ አትናትዮስ፡ ሊቀ፡ ጳጳሳት፡ 
+                                                                እለ፡ እስክንድርያ፡ በእንተ፡ አሥሮን፡ ደናግል፡</title><gap reason="ellipsis"/> እከሥት፡ አፉየ፡ ወእብል፡ በላህ፡ ወበሐዘን፡ 
+                                                                ወብካይ፡ አላ፡ እትናገር፡ ወኢያረምም፡ በእንተ፡ ዘኮነ፡ ወዘይከውን፡ ወይሊተ፡ ወአሌሊተ፡ ምንተ፡ እብል፡ በእንተ፡ እሏለ፡ 
+                                                                እ<cb n="71vb"/>መሕያው፡ ውእቶሙ፡ </incipit>
+                                                </msItem>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.8.1.4">
+                                                <locus from="78va" to="79ra"/>
+                                                <title>Readings for the ninth night hour</title>
+                                                <note>Indicated by <foreign xml:lang="gez">በ፱፡ ሰዓተ፡ ሌሊት፡ ዘረቡዕ፡</foreign>.</note>
+                                                    <msItem xml:id="ms_i1.8.1.4.1">
+                                                        <locus target="#78va"/>
+                                                        <title ref="LIT3144Hosea">Hosea 9:14 - 10:2</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.1.4.2">
+                                                        <locus target="#78va"/>
+                                                        <title ref="LIT3985Mazmura#Ps21">Psalm 21:21-22</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.1.4.3">
+                                                        <locus from="78va" to="79ra"/>
+                                                        <title ref="LIT1558Matthew">Matthew 23:29-36</title>
+                                                    </msItem>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.8.1.5">
+                                                <locus from="79ra" to="79rb"/>
+                                                <title>Readings for the eleventh night hour</title>
+                                                <note>Indicated by <foreign xml:lang="gez">በ፲ወ፩፡ ሰዓተ፡ ሌሊት፡ ዘረቡዕ፡</foreign>.</note>
+                                                    <msItem xml:id="ms_i1.8.1.5.1">
+                                                        <locus from="79ra"/>
+                                                        <title ref="LIT2516Wisdom" type="incomplete">The Wisdom of Solomon 7:23-30</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.1.5.2">
+                                                        <locus target="#79rb"/>
+                                                        <title ref="LIT3985Mazmura#Ps7" type="incomplete">Psalm 7:23-30</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.1.5.3">   
+                                                        <locus target="#79rb"/>
+                                                        <title ref="LIT2715John" type="incomplete">John 11:55-57</title>
+                                                    </msItem>
+                                               </msItem>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.8.2.1">
+                                                <locus from="79va" to="84vb"/>
+                                                <title ref="LIT1544Gebrah#WednesdayDay">For the morning (i.e. for the first day hour)</title>
+                                                <note>Indicated by <foreign xml:lang="gez">በረቡዕ፡ ጽባሕ፡ ዘይትነባብ፡</foreign>.</note>
+                                                    <msItem xml:id="ms_i1.8.2.1.1">
+                                                        <locus from="79va"/>
+                                                        <title ref="LIT1367Exodus" type="incomplete">Exodus 17:1-17</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.2.1.2">
+                                                        <locus from="79vb"/>
+                                                        <title ref="LIT1672Isaiah" type="incomplete">Isaiah 2:1-7</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.2.1.3">
+                                                        <locus from="80rb"/>
+                                                        <title ref="LIT2195Prover" type="incomplete">Proverbs 3:5-15</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.2.1.4">
+                                                        <locus from="80va"/>
+                                                        <title>Comment on <ref type="work" corresp="LIT2195Prover">Proverbs 3:5-15</ref></title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.2.1.5">
+                                                        <locus from="83rb"/>
+                                                        <title>Psalms</title>
+                                                            <msItem xml:id="ms_i1.8.2.1.5.1">
+                                                                <locus target="#83rb"/>
+                                                                <title ref="LIT3985Mazmura#Ps82">Psalm 82:5-6</title>
+                                                            </msItem>
+                                                            <msItem xml:id="ms_i1.8.2.1.5.2">
+                                                            <locus target="#83rb"/>
+                                                            <title ref="LIT3985Mazmura#Ps32">Psalm 32:10</title>
+                                                          </msItem>
+                                                          <msItem xml:id="ms_i1.8.2.1.5.3">
+                                                               <locus target="#83rb"/>
+                                                               <title ref="LIT3985Mazmura#Ps50">Psalm 50:5</title>
+                                                          </msItem>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.2.1.6">
+                                                        <locus from="83rb"/>
+                                                        <title ref="LIT2715John">John 11:46-55</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.2.1.7">
+                                                        <locus from="83va" to="84vb"/>
+                                                        <title>Admonition</title>
+                                                        <incipit xml:lang="gez"><title>ተግሣጽ፡ በረቡዕ፡ ነግህ፡</title> ዘይትነበብ፡</incipit>
+                                                    </msItem>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.8.2.2">
+                                                <locus from="84vb" to="85vb"/>
+                                                <title>For the third day hour</title>
+                                                <note>Indicated by <foreign xml:lang="gez">በ፫ሰዓተ፡ ዘረቡዕ፡</foreign>.</note>
+                                                    <msItem xml:id="ms_i1.8.2.2..1">
+                                                        <locus target="#84vb"/>
+                                                        <title ref="LIT1367Exodus" type="incomplete">Exodus 13:17-20</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.2.2.2">
+                                                        <locus from="84vb"/>
+                                                        <title ref="LIT2358Sirach" type="incomplete">Ecclesiasticus 22</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.2.2.3">
+                                                        <locus target="#85vb"/>
+                                                        <title ref="LIT3985Mazmura#Ps41" type="incomplete">Psalm 41:6-7</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.2.2.4">
+                                                        <locus target="#85vb"/>
+                                                        <title ref="LIT1812GospelLuke" type="incomplete">Luke 22:1-6</title>
+                                                    </msItem>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.8.2.3">
+                                                <locus from="85vb" to="86vb"/>
+                                                <title>For the sixth day hour</title>
+                                                <note>Indicated by <foreign xml:lang="gez">በ፮ሰዓት፡ ዘረቡዕ፡</foreign>.</note>
+                                                    <msItem xml:id="ms_i1.8.2.3.1">
+                                                        <locus from="85vb"/>
+                                                        <title ref="LIT1367Exodus" type="incomplete">Exodus 14:13 - 15:11</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.2.3.2">
+                                                        <locus target="#86rb"/>
+                                                        <title ref="LIT2358Sirach" type="incomplete">Ecclesiasticus 23</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.2.3.3">
+                                                        <locus from="86rb"/>
+                                                        <title ref="LIT3985Mazmura#Ps40" type="incomplete">Psalm 40:5-8</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.2.3.4">
+                                                        <locus from="86va" to="86vb"/>
+                                                        <title ref="LIT1812GospelLuke" type="incomplete">Luke 7:36-50</title>
+                                                    </msItem>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.8.3.3">
+                                                <locus from="86vb" to="91va"/>
+                                                <title>For the ninth day hour</title>
+                                                <note>Indicated by <foreign xml:lang="gez">በ፱ሰዓት፡ ዘረቡዕ፡</foreign>.</note>
+                                                    <msItem xml:id="ms_i1.8.3.3.1">
+                                                        <locus from="86vb"/>
+                                                        <title ref="LIT1546Genesi" type="incomplete">Genesis 24:1-9</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.3.3.2">
+                                                        <locus from="87ra"/>
+                                                        <title ref="LIT2075Number" type="incomplete">Numbers 20:1-13</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.3.3.3">
+                                                        <locus from="87va"/>
+                                                        <title ref="LIT2195Prover" type="incomplete">Proverbs 1:10-33</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.3.3.4">
+                                                        <locus from="88ra"/>
+                                                        <title>Comment on <ref type="work" corresp="LIT2195Prover">Proverbs 1:10-33</ref></title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.3.3.5">
+                                                        <locus target="#90ra"/>
+                                                        <title ref="LIT3985Mazmura#Ps82" type="incomplete">Psalm 82:3 and 82:5</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.3.3.6">
+                                                        <locus from="90ra"/>
+                                                        <title ref="LIT1558Matthew" type="incomplete">Matthew 26:3-16</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.3.3.7">
+                                                        <locus from="90rb" to="91va"/>
+                                                        <title ref="LIT1544Gebrah#JohnChrWed">Admonition by John Chrysostom</title>
+                                                        <incipit xml:lang="gez">በረቡዕ፡ በ፱ሰዓት፡ ዘይትነበብ፡ <title>ተግሣጽ፡ 
+                                                            ዘ<persName role="author" ref="PRS5720JohnChr">ዮሐንስ፡ አፈ፡ ወርቅ፡</persName></title> በረከቱ፡ 
+                                                            <gap reason="ellipsis"/> ወቀናዒሰ፡ የአኪ፡ እማርዌ፡ ዘይጥኅር፡ ወየሐስም፡ እምነ፡ አጋንንት፡ እኩያን።</incipit>
+                                                    </msItem>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.8.3.4">
+                                                <locus from="91va" to="92vb"/>
+                                                <title>For the eleventh day hour</title>
+                                                <note>Indicated by <foreign xml:lang="gez">በ፲ወ፩፡ ዘረቡዕ፡</foreign>.</note>
+                                                    <msItem xml:id="ms_i1.8.3.4.1">
+                                                        <locus from="91va"/>
+                                                        <title ref="LIT1672Isaiah" type="incomplete">Isaiah 58:1 - 59:8</title>        
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.3.4.2">
+                                                        <locus from="92rb"/>
+                                                        <title ref="LIT1544Gebrah#SawirosWed">Admonition by Severianus of Gabala</title>
+                                                        <incipit xml:lang="gez"><title>ተግሣጽ፡ ዘአቡነ፡ ቅዱስ፡ አባ፡ 
+                                                            <persName role="author" ref="PRS8787Severian">ሳዊሮስ፡ ኤጲስ፡ ቆጶስ፡ ዘሀገረ፡ ገብላህ፡</persName> 
+                                                            በረከቱ፡</title><gap reason="ellipsis"/>ናሁ፡ ይእዜ፡ ኦአኃው፡ ንዜንወክሙ፡ በቃል፡ በዘይከውን፡ ላዕለ፡ ኃጥአን፡ ወዓላውያን፡ ሕግ፡ 
+                                                            ወትእዛዘ፡ ሕይወትሰ፡ ይብል፡ ሑሩ፡ እምኔየ፡ ውስተ፡ እሳት፡ ዘለዓለም፡ ዘድልው፡ ለሰይጣን፡ ወለመላእክቲሁ።</incipit>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.3.4.3">
+                                                        <locus target="#92va"/>
+                                                        <title ref="LIT3985Mazmura#Ps6" type="incomplete">Psalm 6:2</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.8.3.4.4">
+                                                        <locus from="92va" to="92vb"/>
+                                                        <title ref="LIT2715John" type="incomplete">John 12:27-35</title>
+                                                    </msItem>
+                                            </msItem>
+                                </msItem>
+                                <msItem xml:id="ms_i1.9">
+                                    <locus from="92vb" to="107vb"/>
+                                    <title ref="LIT1544Gebrah#Thursday">Readings for Thursday</title>
+                                        <msItem xml:id="ms_i1.9.1">
+                                            <locus from="92vb" to="95rb"/>
+                                            <title ref="LIT1544Gebrah#ThursdayNight">Readings for Thursday Night</title>
+                                                <msItem xml:id="ms_i1.9.1.1">
+                                                    <locus from="92vb" to="93rb"/>
+                                                    <title>For the first night hour</title>
+                                                    <note>Indicated by <foreign xml:lang="gez">በ፩ሰዓተ፡ ሌሊት፡ ዘሐሙስ፡</foreign>.</note>
+                                                        <msItem xml:id="ms_i1.9.1.1.1">
+                                                            <locus from="92vb"/>
+                                                            <title ref="LIT1373Bookof" type="incomplete">Ezekiel 42:1-14</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.9.1.1.2">
+                                                            <locus target="#93ra"/>
+                                                            <title ref="LIT3985Mazmura#Ps68" type="incomplete">Psalm 68:1 and 68:20</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.9.1.1.3">
+                                                            <locus from="93ra" to="93rb"/>
+                                                            <title ref="LIT2715John">John 10:17-21</title>
+                                                        </msItem>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.9.1.2">
+                                                    <locus from="93rb" to="94ra"/>
+                                                    <title>For the third night hour</title>
+                                                    <note>Indicated by <foreign xml:lang="gez">በ፫ሰዓተ፡ ሌሊት፡ ዘሐሙስ፡</foreign>.</note>
+                                                        <msItem xml:id="ms_i1.9.1.2.1">
+                                                            <locus from="93rb"/>
+                                                            <title ref="LIT3145Amos" type="incomplete">Amos 4:4-13</title>
+                                                            <note>Wrongly indicated with <foreign xml:lang="gez">ኢሳይያስ፡ </foreign></note>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.9.1.2.2">
+                                                    <locus from="93va"/>
+                                                    <title ref="LIT3985Mazmura#Ps54" type="incomplete">Psalm 54:24</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.9.1.2.3">
+                                                    <locus from="93vb"/>
+                                                    <title ref="LIT1882MarkGo" type="incomplete">Mark 14:3-14</title>
+                                                </msItem>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.9.1.3">
+                                                    <locus from="94ra" to="94va"/>
+                                                    <title>For the sixth night hour</title>
+                                                    <note>Indicated by <foreign xml:lang="gez">በ፮ሰዓተ፡ ሌሊት፡ ዘሐሙስ፡</foreign>.</note>
+                                                        <msItem xml:id="ms_i1.9.1.3.1">
+                                                            <locus from="94ra"/>
+                                                            <title ref="LIT3145Amos" type="incomplete">Amos 3:1-2</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.9.1.3.2">
+                                                            <locus target="#94rb"/>
+                                                            <title ref="LIT3985Mazmura#139">Psalm 139:1-3</title>
+                                                            <note>Wrongly attributed with 'CXXIX'.</note>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.9.1.3.3">
+                                                            <locus from="94rb"/>
+                                                            <title ref="LIT2715John">John 12:36-43</title>
+                                                        </msItem>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.9.1.4">
+                                                    <locus from="94va" to="95ra"/>
+                                                    <title>For the ninth night hour</title>
+                                                    <note>Indicated by <foreign xml:lang="gez">በ፱ሰዓተ፡ ሌሊት፡ ዘሐሙስ፡</foreign>.</note>
+                                                        <msItem xml:id="ms_i1.9.1.4.1">
+                                                            <locus from="94va"/>
+                                                            <title ref="LIT1373Bookof" type="incomplete">Ezekiel 20:27-34</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.9.1.4.2">
+                                                            <locus target="#94vb"/>
+                                                            <title ref="LIT3985Mazmura#Ps7" type="incomplete">Psalm 7:1-2</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.9.1.4.3">
+                                                            <locus from="94vb"/>
+                                                            <title ref="LIT2715John" type="incomplete">John 10:29-38</title>
+                                                        </msItem>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.9.1.5">
+                                                    <locus from="95ra" to="95va"/>
+                                                    <title>For the eleventh night hour</title>
+                                                    <note>Indicated by <foreign xml:lang="gez">በ፲ወ፩ሰዓተ፡ ሌሊት፡ ዘሐሙስ፡</foreign>.</note>
+                                                        <msItem xml:id="ms_i1.9.1.5.1">
+                                                            <locus from="95ra"/>
+                                                            <title ref="LIT1685Bookof" type="incomplete">Jeremiah 8:1-9</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.9.1.5.2">
+                                                            <locus target="#95rb"/>
+                                                            <title ref="LIT3985Mazmura#Ps61" type="incomplete">Psalm 61:1-2</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.9.1.5.3">
+                                                            <locus from="95rb"/>
+                                                            <title ref="LIT2715John" type="incomplete">John 13:44-50</title>
+                                                        </msItem>
+                                                </msItem>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.9.2">
+                                                <locus from="95va" to="97va"/>
+                                                <title ref="LIT1544Gebrah#ThursdayDay">Readings for Thursday Day</title>
+                                                    <msItem xml:id="ms_i1.9.2.1">
+                                                        <locus from="95va" to="97va"/>
+                                                        <title>For the first day hour</title>
+                                                        <note>Indicated by <foreign xml:lang="gez"> በጽባሕ፡ ሐሙስ፡ በ፩ሰዓት፡</foreign>.</note>
+                                                            <msItem xml:id="ms_i1.9.2.1.1">
+                                                            <locus from="95va"/>
+                                                            <title ref="LIT1367Exodus" type="incomplete">Exodus 18:8-16</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.9.2.1.2">
+                                                        <locus from="95vb"/>
+                                                        <title ref="LIT1544Gebrah#Directives">Liturgical direction</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.9.2.1.3">
+                                                        <locus target="#96rb"/>
+                                                        <title ref="LIT3985Mazmura#Ps54" type="incomplete">Psalm 54:24 and 54:12</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.9.2.1.4">
+                                                        <locus from="96rb"/>
+                                                        <title ref="LIT1812GospelLuke" type="incomplete">Luke 22:1-14</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.9.2.1.5">
+                                                        <locus from="96va" to="97va"/>
+                                                        <title ref="LIT1544Gebrah#JohnChrThurMor">Admonition by John Chrysostom</title>
+                                                        <incipit xml:lang="gez">በጸሎተ፡ ሐሙስ፡ ነግህ፡ ዘይትነበብ፡ <title>ተግሣጽ፡ 
+                                                            ዘ<persName role="author" ref="PRS5720JohnChr">ዮሐንስ፡ አፈ፡ ወርቅ፡</persName></title> በረከቱ፡ 
+                                                            <gap reason="ellipsis"/>ዛቲ፡ ይእቲ፡ ዕለት፡ እንተ፡ ንቀርብ፡ ኀበ፡ ዝንቱ፡ ማዕድ፡ መፍርህ፡ ንቅረብኬ፡ ኀበ፡ ዝንቱ፡ ኵልነ፡ በንቅሀት።
+                                                            ወናስተ፡ ዳሉ፡ ወኢንኩን፡ ፩እምኔነ፡ ከመ፡ ይሁዳ፡ ወኢእኩየ፡ ዘቦቱ፡ ጽልሑት። </incipit>
+                                                    </msItem>
+                                                </msItem>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.9.2.2">
+                                                <locus from="97va" to="99ra"/>
+                                                <title ref="LIT1544Gebrah#ThursdayDay">For the third day hour</title>
+                                                <note>Indicated by <foreign xml:lang="gez"> በ፫ሰዓት፡ ዘሐሙስ፡</foreign>.</note>
+                                                    <msItem xml:id="ms_i1.9.2.2.1">
+                                                    <locus target="#97va"/>
+                                                    <title ref="LIT1367Exodus" type="incomplete">Exodus 32:30 - 33:3</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.9.2.2.2">
+                                                    <locus from="97va"/>
+                                                    <title ref="LIT3146Micah" type="incomplete">Micah 2:3-13</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.9.2.2.3">
+                                                    <locus from="98rb"/>
+                                                    <title ref="LIT2358Sirach" type="incomplete">Ecclesiasticus 24:1-15</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.9.2.2.4">
+                                                    <locus target="#98vb"/>
+                                                    <title ref="LIT3985Mazmura#Ps93" type="incomplete">Psalm 93:21</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.9.2.2.5">
+                                                    <locus from="98vb" to="99ra"/>
+                                                    <title ref="LIT1558Matthew" type="incomplete">Matthew 24:17-19</title>
+                                                </msItem>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.9.2.3">
+                                            <locus from="99ra" to="101rb"/>
+                                            <title>For the sixth day hour</title>
+                                            <note>Indicated by <foreign xml:lang="gez"> በ፮ሰዓት፡ ዘሐሙስ፡</foreign>.</note>
+                                                <msItem xml:id="ms_i1.9.2.3.1">
+                                                    <locus from="99ra"/>
+                                                    <title ref="LIT1685Bookof" type="incomplete">Jeremiah 7:2-15</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.9.2.3.2">
+                                                    <locus from="99va"/>
+                                                    <title ref="LIT1373Bookof" type="incomplete">Ezekiel 22:39-44</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.9.2.3.3">
+                                                    <locus from="99vb"/>
+                                                    <title ref="LIT3146Micah" type="incomplete">Micah 2:7 to 3:8</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.9.2.3.4">
+                                                    <locus from="100rb"/>
+                                                    <title ref="LIT3148Zephan" type="incomplete">Zephania 1:7 to 2:3</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.9.2.3.5">
+                                                    <locus from="100vb"/>
+                                                    <title ref="LIT2358Sirach" type="incomplete">Ecclesiasticus 24</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.9.2.3.6">
+                                                    <locus target="#101ra"/>
+                                                    <title ref="LIT3985Mazmura#Ps30" type="incomplete">Psalm 30:16-18</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.9.2.3.7">
+                                                    <locus from="101ra"/>
+                                                    <title ref="LIT1882MarkGo" type="incomplete">Mark 14:12-13</title>
+                                                </msItem>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.9.2.4">
+                                                <locus from="101rb" to="107vb"/>
+                                                <title>For the ninth day hour</title>
+                                                <note>Indicated by <foreign xml:lang="gez"> በ፱ሰዓት፡ ዘሐሙስ፡</foreign>.</note>
+                                                    <msItem xml:id="ms_i1.9.2.4.1">
+                                                        <locus from="101rb"/>
+                                                        <title ref="LIT1546Genesi" type="incomplete">Genesis 22:1-19</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.9.2.4.2">
+                                                        <locus from="101vb"/>
+                                                        <title ref="LIT1672Isaiah" type="incomplete">Isaiah 61:1-7</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.9.2.4.3">
+                                                        <locus from="102ra"/>
+                                                        <title>Comment on <ref type="work" corresp="LIT1672Isaiah">Isaiah 61:1-7</ref></title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.9.2.4.4">
+                                                        <locus from="103rb"/>
+                                                        <title ref="LIT1688Job" type="incomplete">Job 27:1 to 28:12</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.9.2.4.5">
+                                                        <locus from="104ra"/>
+                                                        <title>Comment on <ref type="work" corresp="LIT1688Job">Job 27:1 to 28:12</ref></title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.9.2.4.6">
+                                                        <locus from="106vb"/>
+                                                        <title ref="LIT3151Malachi" type="incomplete">Malachi 1:9 to 2:8</title>
+                                                        <note>Indicated by <foreign xml:lang="gez">ዘሚክያስ፡</foreign>.</note>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.9.2.4.7">
+                                                        <locus target="#107rb"/>
+                                                        <title ref="LIT3985Mazmura#Ps22" type="incomplete">Psalm 22:1-2</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.9.2.4.8">
+                                                        <locus from="107rb"/>
+                                                        <title ref="LIT1812GospelLuke" type="incomplete">Luke 22:7-13</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.9.2.4.9">
+                                                        <locus from="107va"/>
+                                                        <title ref="LIT1544Gebrah#JohnChrThurNine">Admonition by John Chrysostom</title>
+                                                        <incipit xml:lang="gez"><title>ተግሣጽ፡ ዘአቡነ፡ ቅዱስ፡ ወብፁዕ፡ 
+                                                            <persName role="author" ref="PRS5720JohnChr">ዮሐንስ፡ አፈ፡ ወርቅ፡</persName></title> በረከቱ፡ 
+                                                            <gap reason="ellipsis"/>እሬኢ፡ ዮም፡ ብዙኃነ፡ ወሃይምናነ፡ ይፈጥኑ፡ ይትሜጠው፡ እምሥጢራት፡ ቅዱሳት፡ መፍርህት፡ 
+                                                            ወመደንግልጽት፡ አነ፡ እመርህክሙ፡ በቃልየ፡ ከመ፡ ይኩን፡ ለክሙ፡ ረባሐ፡ ክልኤ፡ ገጽ፡ ሑሩ፡ በፍርሃት፡</incipit>
+                                                    </msItem>
+                                            </msItem>
+                                </msItem>
+                                <msItem xml:id="ms_i1.10">
+                                    <locus from="107vb" to="113vb"/>
+                                    <title ref="LIT1544Gebrah#Cock">Maṣḥafa dorho</title>
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/>ድርሳን፡ ትምህርት፡ ዘአበዊነ፡ ሐዋርያት፡ ቅዱሳን፡ ዘመሀሩነ፡ መንፈሳውያን፡ እሉ፡ 
+                                        እሙንቱ፡ እለ፡ ገብሩ፡ ኃይላተ፡ ወተአምራተ፡ ወትምህርተ፡ መድኃኒት፡ ግብረ፡ ዘገብሩ፡ አይሁድ፡ ላዕለ፡ እግዚእነ፡ ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ። ዘጻረ፡ ሕማማተ፡
+                                        በዲበ፡ ዕፀ፡ መስቀል፡ በእንቲ፡ <pb n="108ra"/> አነ፡ ክርስቶሳውያን፡ ዘተንሥአ፡ እሙታን፡ በዕለተ፡ እኁድ። እንተ፡ ትንሣኤሁ፡ ቅድስት፡ ከመ፡ ያድኅነነ። 
+                                        ወካዕበ፡ በእንተ፡ ዘክሕደ፡ ጴጥሮስ፡ ረድአ፡ በሰላመ፡ እግዚአብሔር፡ </incipit>
+                                    <explicit xml:lang="gez">ተፈጸመ፡ መጽሐፈ፡ ዶርሆ፡ በሰላመ፡ እግዚአብሔር፡ ለዓለመ፡ ዓለም፡ አሜን።</explicit>
+                                </msItem>
+                          <msItem xml:id="ms_i1.11">
+                              <locus from="113vb" to="122vb"/>
+                              <title ref="LIT1544Gebrah#Thursday">Readings for Thursday</title>
+                              <msItem xml:id="ms_i1.11.1">
+                                  <locus from="113vb" to="122vb"/>
+                                  <title ref="LIT1544Gebrah#ThursdayDay">Readings for Thursday Day</title>
+                                <msItem xml:id="ms_i1.11.1.1">
+                                    <locus from="113vb" to="116va"/>
+                                    <title ref="LIT1544Gebrah#FeetThur">Readings for the Washing of the Feet</title>
+                                        <msItem xml:id="ms_i1.11.1.1.1">
+                                            <locus from="113vb"/>
+                                            <title ref="LIT1544Gebrah#Directives">Liturgical direction</title>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.11.1.1.2">
+                                            <locus from="114ra"/>
+                                            <title ref="LIT1546Genesi" type="incomplete">Genesis 18:2-23</title>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.11.1.1.3">
+                                            <locus from="114va"/>
+                                            <title ref="LIT1367Exodus" type="incomplete">Exodus 14:29 to 15:1</title>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.11.1.1.4">
+                                            <locus from="114vb"/>
+                                            <title ref="LIT1672Isaiah" type="incomplete">Isaiah 4:2-4 and 55:1-13</title>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.11.1.1.5">
+                                            <locus from="115rb"/>
+                                            <title ref="LIT1373Bookof" type="incomplete">Ezekiel 36:25-29 and 47:2-9</title>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.11.1.1.6">
+                                            <locus target="#115va"/>
+                                            <title>Psalms</title>
+                                                <msItem xml:id="ms_i1.11.1.1.6.1">
+                                                    <locus target="#115va"/>
+                                                    <title ref="LIT3985Mazmura#Ps50">Psalm 50</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.11.1.1.6.2">
+                                                    <locus target="#115va"/>
+                                                    <title ref="LIT3985Mazmura#Ps113">Psalm 113 (not certain)</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.11.1.1.6.3">
+                                                    <locus target="#115va"/>
+                                                    <title ref="LIT3985Mazmura#Ps68">Psalm 68</title>
+                                                </msItem>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.11.1.1.7">
+                                            <locus from="115va"/>
+                                            <title ref="LIT3525Epistle" type="incomplete">1 Timothy 4:9 to 5:10</title>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.11.1.1.8">
+                                            <locus from="115vb"/>
+                                            <title ref="LIT1544Gebrah#Directives">Liturgical direction</title>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.11.1.1.9">
+                                            <locus target="#116ra"/>
+                                            <title>Psalms</title>
+                                                <msItem xml:id="ms_i1.11.1.1.9.1">
+                                                    <locus target="#116ra"/>
+                                                    <title ref="LIT3985Mazmura#Ps50">Psalm 50:8</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.11.1.1.9.2">
+                                                    <locus target="#116ra"/>
+                                                    <title ref="LIT3985Mazmura#Ps11">Psalm 11</title>
+                                                </msItem>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.11.1.1.10">
+                                            <locus from="116ra"/>
+                                            <title ref="LIT2715John" type="incomplete">John 13:1-20</title>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.11.1.1.11">
+                                            <locus from="116va"/>
+                                            <title ref="LIT3985Mazmura#Ps85" type="incomplete">Psalm 85:14-16</title>
+                                        </msItem>
+                                </msItem>
+                                <msItem xml:id="ms_i1.11.1.2">
+                                    <locus from="116va" to="120rb"/>
+                                    <title ref="LIT1544Gebrah#MassThur">Reading for the Mass</title>
+                                        <msItem xml:id="ms_i1.11.1.2.1">
+                                            <locus from="116va"/>
+                                            <title>Homily by Abba Sinoda</title>
+                                            <incipit xml:lang="gez"><title>ድርሳን፡ ዘአቡነ፡ ቅዱስ፡ አባ፡ ሲኖዳ፡ በረከቱ፡ ላዕለነ፡</title> አሜን። ለንኅፈር፡ ይእዜኒ፡ ኦአኃው፡ በእንተ፡ 
+                                                ዘሐመ፡ በእንቲአነ። ወንፍራህ፡ በእንተ፡ ዘቀነተ፡ ለንጸ፡ ወወደየ፡ ማየ፡ ውስተ፡ ምሕፃብ፡ ወሐፀበ፡ እግረ፡ አርዳኢሁ፡ በእደዊሁ፡ ንጽሐት።</incipit>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.11.1.2.2">
+                                            <locus from="116vb"/>
+                                            <title ref="LIT1544Gebrah#Directives">Liturgical direction</title>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.11.1.2.3">
+                                            <locus from="117ra"/>
+                                            <title>Supplications</title>
+                                            <incipit xml:lang="gez">ናስተብቍዕ፡ ኀቤከ፡ ኦክርስቶስ፡ አምላክነ፡ ወመሐረነ፡ ክርስቶስ፡ አምላክነ፡ </incipit>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.11.1.2.4">
+                                            <locus from="117va"/>
+                                            <title ref="LIT1544Gebrah#Directives">Liturgical direction</title>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.11.1.2.5">
+                                            <locus from="119va"/>
+                                            <title ref="LIT1019Actsof" type="incomplete">Acts 8:26-40</title>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.11.1.2.6">
+                                            <locus from="119vb"/>
+                                            <title>Psalms</title>
+                                                <msItem xml:id="ms_i1.11.1.2.6.1">
+                                                    <title ref="LIT3985Mazmura#Ps22">Psalm 22</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.11.1.2.6.2">
+                                                    <title ref="LIT3985Mazmura#Ps40">Psalm 40</title>
+                                                </msItem>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.11.1.2.7">
+                                            <locus from="120ra" to="120rb"/>
+                                            <title ref="LIT1558Matthew" type="incomplete">Matthew 26:20-29</title>
+                                        </msItem>
+                                </msItem>
+                                                <msItem xml:id="ms_i1.11.1.3">
+                                                    <locus from="120rb" to="122vb"/>
+                                                    <title>Readings for the eleventh day hour</title>
+                                                        <msItem xml:id="ms_i1.11.1.3.1">
+                                                            <locus target="#120rb"/>
+                                                            <title ref="LIT1544Gebrah#Directives">Liturgical direction</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.11.1.3.2">
+                                                            <locus target="#120rb"/>
+                                                            <title ref="LIT3985Mazmura#Ps49">Psalm 49</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.11.1.3.3">
+                                                            <locus from="120rb"/>
+                                                            <title ref="LIT2715John" type="incomplete">John 13:21-30</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.11.1.3.4">
+                                                            <locus from="120ra"/>
+                                                            <title ref="LIT1672Isaiah" type="incomplete">Isaiah 52:13 to 54:8</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.11.1.3.5">
+                                                            <locus from="121rb"/>
+                                                            <title ref="LIT1685Bookof" type="incomplete">Jeremiah 31:15-26</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.11.1.3.6">
+                                                            <locus target="#121vb"/>
+                                                            <title ref="LIT1544Gebrah#Directives" type="incomplete">Liturgical direction</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.11.1.3.7">
+                                                            <locus from="121vb"/>
+                                                            <title ref="LIT1672Isaiah" type="incomplete">Isaiah 31:9 to 33:10</title>
+                                                        </msItem>
+                                                </msItem>
+                                </msItem>
+                                </msItem>
+                                <msItem xml:id="ms_i1.12">
+                                    <locus from="122vb" to="185va"/>
+                                    <title ref="LIT1544Gebrah#Friday">Readings for Friday</title>
+                                        <msItem xml:id="ms_i1.12.1">
+                                            <locus from="122vb" to="136va"/>
+                                            <title ref="LIT1544Gebrah#FridayNight">Readings for Friday Night</title>
+                                                <msItem xml:id="ms_i1.12.1.1">
+                                                    <locus from="122vb" to="126va"/>
+                                                    <title>Readings for the first night hour</title>
+                                                    <note>Indicated by <foreign xml:lang="gez"> በ፩ሰዓተ፡ ሌሊት፡ ዘዓርብ፡</foreign>.</note>
+                                                <msItem xml:id="ms_i1.12.1.1.1">
+                                                    <locus from="122vb"/>
+                                                    <title ref="LIT1685Bookof">Jeremiah 8:17 to 9:3</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.1.2">
+                                                    <locus target="#123ra"/>
+                                                    <title>Psalms</title>
+                                                        <msItem xml:id="ms_i1.12.1.1.2.1">
+                                                            <locus target="#123ra"/>
+                                                            <title ref="LIT3985Mazmura#Ps101">Psalm 101</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.12.1.1.2.2">
+                                                           <locus target="#123ra"/>
+                                                            <title ref="LIT3985Mazmura#Ps1" type="incomplete">Psalm 1:9</title>
+                                                        </msItem> 
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.1.3">
+                                                     <locus from="123ra"/>
+                                                     <title ref="LIT2715John">John 13:33 to 17:26</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.1.4">
+                                                    <locus from="126rb" to="126va"/>
+                                                    <title>Lecture</title>
+                                                    <incipit xml:lang="gez">በቀዳሚት፡ ሰዓት፡ እምሌሊተ፡ ዓርብ፡ ምንባብ። ተናገረ፡ እግዚእነ፡ ኢየሱስ፡ ዘንተ፡ ካዕበ፡ አንቃዕደወ፡ አዕይንቲሁ፡ 
+                                                        ኀበ፡ መልዕልት፡ መንገለ፡ አብ፡ ወይቤ፡ </incipit>
+                                                </msItem>                                            
+                                              </msItem>
+                                        <msItem xml:id="ms_i1.12.1.2">
+                                            <locus from="126va" to="128ra"/>
+                                            <title>Readings for the third night hour</title>
+                                            <note>Indicated by <foreign xml:lang="gez"> በ፫ሰዓተ፡ ሌሊት፡ ዘዓርብ፡</foreign>.</note>
+                                                <msItem xml:id="ms_i1.12.1.2.1">
+                                                    <locus from="126va"/>
+                                                    <title ref="LIT1373Bookof" type="incomplete">Ezekiel 36:16-20</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.2.2">
+                                                    <locus target="#126vb"/>
+                                                    <title ref="LIT3985Mazmura#Ps108" type="incomplete">Psalm 108:1-2</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.2.3">
+                                                    <locus from="126vb"/>
+                                                    <title ref="LIT1558Matthew" type="incomplete">Matthew 26:30-35</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.2.4">
+                                                    <locus target="#127ra"/>
+                                                    <title ref="LIT1882MarkGo" type="incomplete">Mark 14:26-31</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.2.5">
+                                                    <locus from="127ra"/>
+                                                    <title ref="LIT1812GospelLuke" type="incomplete">Luke 22:31-39</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.2.6">
+                                                    <locus target="#127rb"/>
+                                                    <title ref="LIT2715John" type="incomplete">John 18:1-9</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.2.7">
+                                                    <locus from="127rb"/>
+                                                    <title ref="LIT1544Gebrah#Directives">Liturgical Direction</title>
+                                                </msItem>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.12.1.3">
+                                            <locus from="128ra" to="129ra"/>
+                                            <title>Readings for the sixth night hour</title>
+                                            <note>Indicated by <foreign xml:lang="gez"> በ፮ሰዓተ፡ ሌሊት፡ ዘዓርብ፡</foreign>.</note>
+                                                <msItem xml:id="ms_i1.12.1.3.1">
+                                                    <locus target="#128ra"/>
+                                                    <title ref="LIT1373Bookof" type="incomplete">Ezekiel 20:23-28</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.3.2">
+                                                    <locus target="#128ra"/>
+                                                    <title>Psalms</title>
+                                                        <msItem xml:id="ms_i1.12.1.3.2.1">
+                                                            <locus target="#128ra"/>
+                                                            <title ref="LIT3985Mazmura#Ps58">Psalm 58:1</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.12.1.3.2.2">
+                                                            <locus target="#128ra"/>
+                                                            <title ref="LIT3985Mazmura#Ps68">Psalm 68:24</title>
+                                                        </msItem>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.3.3">
+                                                    <locus from="128ra"/>
+                                                    <title ref="LIT1558Matthew" type="incomplete">Matthew 26:36-45</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.3.4">
+                                                    <locus from="128va"/>
+                                                    <title ref="LIT1882MarkGo" type="incomplete">Mark 14:32-42</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.3.5">
+                                                    <locus target="#128vb"/>
+                                                    <title ref="LIT1812GospelLuke" type="incomplete">Luke 22:40-46</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.3.6">
+                                                    <locus from="128vb"/>
+                                                    <title ref="LIT2715John" type="incomplete">John 18:3-9</title>
+                                                </msItem>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.12.1.4">
+                                            <locus from="129ra" to="134va"/>
+                                            <title>Readings for the ninth night hour</title>
+                                            <note>Indicated by <foreign xml:lang="gez"> በ፱ሰዓተ፡ ሌሊት፡ ዘዓርብ፡</foreign>.</note>
+                                                <msItem xml:id="ms_i1.12.1.4.1">
+                                                    <locus from="129ra"/>
+                                                    <title>Lecture</title>
+                                                    <incipit xml:lang="gez">ወኀደጉ፡ ደብረ፡ ዘይት፡ ወሖሩ፡ ሐዋርያት፡ ኀበ፡ እልገ፡ ሰማርያ፡ ምስለ፡ መድኃኒነ፡</incipit>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.4.2">
+                                                    <locus from="129va"/>
+                                                    <title ref="LIT2142OntheS"/>
+                                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/><title>ድርሳን፡ 
+                                                        ዘ<persName role="author" ref="PRS5720JohnChr">ዮሐንስ፡ ኤጲስ፡ ቆጶስ፡ ዘቍስጥንጥንያ፡ ጶሊስ፡</persName> 
+                                                        በእንተ፡ ዘይቤ፡ እግዚእነ፡ ኢየሱስ፡ ለእመ፡ ይትከሀል፡ ይኅልፍ፡ እምኔየ፡ ዝንቱ፡ ጽዋዕ፡ ኢያምስሉ።</title></incipit>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.4.3">
+                                                    <locus from="132vb"/>
+                                                    <title ref="LIT1685Bookof" type="incomplete">Jeremiah 9:7-11</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.4.4">
+                                                    <locus from="133ra"/>
+                                                    <title ref="LIT1373Bookof" type="incomplete">Ezekiel 21:28-32</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.4.5">
+                                                    <locus target="#133rb"/>
+                                                    <title>Psalms</title>
+                                                        <msItem xml:id="ms_i1.12.1.4.5.1">
+                                                            <locus target="#133rb"/>
+                                                            <title ref="LIT3985Mazmura#Ps27" type="incomplete">Psalm 27:4-6</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.12.1.4.5.2">
+                                                            <locus target="#133rb"/>
+                                                            <title ref="LIT3985Mazmura#Ps34" type="incomplete">Psalm 34:29-30</title>
+                                                        </msItem>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.4.6">
+                                                    <locus from="133rb"/>
+                                                    <title ref="LIT1558Matthew" type="incomplete">Matthew 26:47-58</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.4.7">
+                                                    <locus from="133vb"/>
+                                                    <title ref="LIT1882MarkGo" type="incomplete">Mark 14:43-54</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.4.8">
+                                                    <locus from="134ra"/>
+                                                    <title ref="LIT1812GospelLuke" type="incomplete">Luke 12:47-54</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.4.9">
+                                                    <locus target="#134rb"/>
+                                                    <title ref="LIT2715John" type="incomplete">John 18:11-14</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.1.4.10">
+                                                    <locus from="134rb"/>
+                                                    <title>Explanation of the Gospel readings</title>
+                                                    <incipit xml:lang="gez">ወሶበ፡ ፈጸመ፡ መድኃኒነ፡ ይትናገር፡ ምስለ፡ አርዳኢሁ፡ በእንተ፡ ሕማማቲሁ። መጽአ፡ ፩እም፲ወ፪ዘውእቱ፡ 
+                                                        ይሁዳ፡ ወምስሌሁ፡ ጉባዔ፡ ምስለ፡ ሰይፋት፡ ወአብትር፡ </incipit>
+                                                </msItem>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.12.1.5">
+                                            <locus from="134va" to="137ra"/>
+                                            <title>Readings for the eleventh night hour</title>
+                                            <note>Indicated by <foreign xml:lang="gez"> በ፲ወ፩ሰዓተ፡ ሌሊት፡ ዘዓርብ፡</foreign>.</note>
+                                                <msItem xml:id="ms_i1.12.5.1">
+                                                    <locus from="134va"/>
+                                                    <title ref="LIT1672Isaiah" type="incomplete">Isaiah 27:2 to 28:15</title>
+                                                </msItem>
+                                            <msItem xml:id="ms_i1.12.1.5.2">
+                                                <locus from="135ra"/>
+                                                <title ref="LIT3985Mazmura#Ps2" type="incomplete">Psalm 2:1-4</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.1.5.3">
+                                                <locus from="135rb"/>
+                                                <title ref="LIT1558Matthew" type="incomplete">Matthew 26:59-75</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.1.5.4">
+                                                <locus from="135va"/>
+                                                <title ref="LIT1882MarkGo" type="incomplete">Mark 14:55-72</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.1.5.5">
+                                                <locus from="136ra"/>
+                                                <title ref="LIT1812GospelLuke" type="incomplete">Luke 22:56-65</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.1.5.6">
+                                                <locus from="136rb"/>
+                                                <title ref="LIT2715John" type="incomplete">John 18:15-27</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.1.5.7">
+                                                <locus from="136va"/>
+                                                <title>Explanation of the Gospel readings</title>
+                                                <incipit xml:lang="gez">አጽምኡ፡ ኀበ፡ ዳዊት፡ ንጉሠ፡ እስራኤል፡ ይዘለፎሙ፡ ለእደዊሃ፡ ወላ<cb n="136vb"/>እለ፡ ይነብሩ፡ ውስቴታ፡ 
+                                                    እንዘ፡ ይብል፡ ለምንት፡ አንሥኡ፡ ቃላቲሆሙ።</incipit>
+                                            </msItem>
+                                        </msItem>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.12.2">                                            
+                                            <locus from="136va" to="185va"/>
+                                            <title ref="LIT1544Gebrah#FridayDay">Readings for Friday Day</title>
+                                                <msItem xml:id="ms_i1.12.2.1">
+                                                    <locus from="136va" to="137ra"/>
+                                                    <title ref="LIT1544Gebrah#FridayMorning">Readings for the morning (i.e. for the first day hour)</title>
+                                                    <note>Indicated by <foreign xml:lang="gez"> በጽባሕ፡ ዕለተ፡ ዓርብ፡ ዘስቅለት፡</foreign>.</note>
+                                                <msItem xml:id="ms_i1.12.2.1.1">
+                                                    <locus from="136ra"/>
+                                                    <title ref="LIT2637Deuteronomy" type="incomplete">Deuteronomy 8:19 to 9:24</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.2">
+                                                    <locus from="138ra"/>
+                                                    <title ref="LIT1672Isaiah" type="incomplete">Isaiah 1:2-9</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.3">
+                                                    <locus from="138rb"/>
+                                                    <title>Comment on <ref type="work" corresp="LIT1672Isaiah">Isaiah 1:2-9</ref></title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.4">
+                                                    <locus from="139rb"/>
+                                                    <title ref="LIT1672Isaiah" type="incomplete">Isaiah 33:5-22</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.5">
+                                                    <locus from="140ra"/>
+                                                    <title ref="LIT1685Bookof" type="incomplete">Jeremiah 22:29 to 23:6</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.6">
+                                                    <locus from="140rb"/>
+                                                    <title>Comment on <ref type="work" corresp="LIT1685Bookof">Jeremiah 22:29 to 23:6</ref></title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.7">
+                                                    <locus target="#141rb"/>
+                                                    <title ref="LIT1685Bookof" type="incomplete">Jeremiah 12:1-18</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.8">
+                                                    <locus from="141rb"/>
+                                                    <title>Comment on <ref type="work" corresp="LIT1685Bookof">Jeremiah 12:1-18</ref></title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.9">
+                                                    <locus from="142rb"/>
+                                                    <title ref="LIT1685Bookof" type="incomplete">Jeremiah 12:1-8</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.10">
+                                                    <locus from="142va"/>
+                                                    <title ref="LIT2516Wisdom" type="incomplete">The Wisdom of Solomon 2:6-22</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.11">
+                                                    <locus from="142vb"/>
+                                                    <title>Comment on <ref type="work" corresp="LIT2516Wisdom">The Wisdom of Solomon 2:6-22</ref></title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.12">
+                                                    <locus from="144ra"/>
+                                                    <title ref="LIT3150Zechar" type="incomplete">Zechariah 11:2-14</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.13">
+                                                    <locus from="144rb"/>
+                                                    <title ref="LIT3146Micah" type="incomplete">Micah 7:1-8</title>
+                                                    <note>Indicated by <foreign xml:lang="gez">ዘሜልክያስ፡</foreign></note>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.14">
+                                                    <locus from="144vb"/>
+                                                    <title ref="LIT3145Amos" type="incomplete">Amos 2:4 to 3:7</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.15">
+                                                    <locus target="#145ra"/>
+                                                    <title ref="LIT3144Hosea" type="incomplete">Hosea 10:5-9</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.16">
+                                                    <locus from="145ra"/>
+                                                    <title>Admonition by John Chrysostom concerning the treason of Judas</title>
+                                                    <incipit xml:lang="gez"><title>ተግሣጽ፡ ዘአባ፡ 
+                                                        <persName role="author" ref="PRS5720JohnChr">ዮሐንስ፡ አፈ፡ ወርቅ፡</persName></title></incipit>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.17">
+                                                    <locus target="#145rb"/>
+                                                    <title>Psalms</title>
+                                                        <msItem xml:id="ms_i1.12.2.1.17.1">
+                                                            <locus target="#145rb"/>
+                                                            <title ref="LIT3985Mazmura#Ps26" type="incomplete">Psalm 26:18</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.12.2.1.17.2">
+                                                            <locus target="#145rb"/>
+                                                            <title ref="LIT3985Mazmura#Ps34" type="incomplete">Psalm 34:13</title>
+                                                        </msItem>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.18">
+                                                    <locus from="145rb"/>
+                                                    <title ref="LIT1558Matthew" type="incomplete">Matthew 23:1-14</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.19">
+                                                    <locus target="#145vb"/>
+                                                    <title ref="LIT1882MarkGo" type="incomplete">Mark 15:1-5</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.20">
+                                                    <locus from="145vb"/>
+                                                    <title ref="LIT1812GospelLuke" type="incomplete">Luke 22:66 to 23:12</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.21">
+                                                    <locus from="146rb"/>
+                                                    <title ref="LIT2715John" type="incomplete">John 18:28-40</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.22">
+                                                    <locus from="146va"/>
+                                                    <title>Explanation of the Gospel readings</title>
+                                                    <incipit xml:lang="gez">ዘይትነበብ፡ እምድኅረ፡ ወንጌል። ነግሃ፡ ዕለተ፡ ዓርብ፡ ተጋብኡ፡ ሊቃነ፡ ካህናት፡ ውስተ፡ ምካን፡ ወገብሩ፡ ፍትሐ፡ 
+                                                        በእንተ፡ መድኃኒነ፡ ከመ፡ ያግብእዎ፡ ኀበ፡ ጲላጦስ፡ ከመ፡ ይቅትሎ። ወይሁዳስ፡ </incipit>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.1.23">
+                                                    <locus from="147ra"/>
+                                                    <title>Admonition</title>
+                                                    <incipit xml:lang="gez">ተግሣጽ፡ በዓርብ፡ ነግህ፡ ዘይትነበብ፡</incipit>
+                                                </msItem>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.12.2.2">
+                                            <locus from="147vb" to="161vb"/>
+                                            <title ref="LIT1544Gebrah#FridayThird">Readings for the third day hour</title>
+                                            <note>Indicated by <foreign xml:lang="gez"> በ፫ሰዓት፡ ዘዓርብ፡</foreign>.</note>
+                                                <msItem xml:id="ms_i1.12.2.2.1">
+                                                    <locus from="147vb"/>
+                                                    <title ref="LIT1546Genesi" type="incomplete">Genesis 40:1-19</title>
+                                                </msItem>
+                                            <msItem xml:id="ms_i1.12.2.2.2">
+                                                <locus target="#148rb"/>
+                                                <title ref="LIT1672Isaiah" type="incomplete">Isaiah 43:1 to 44:3</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.2.3">
+                                                <locus from="148rb"/>
+                                                <title>Comment on <ref type="work" corresp="LIT1672Isaiah">Isaiah 43:1 to 44:3</ref></title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.2.4">
+                                                <locus from="149vb"/>
+                                                <title ref="LIT1672Isaiah" type="incomplete">Isaiah 5:9-16</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.2.5">
+                                                <locus from="150ra"/>
+                                                <title ref="LIT1672Isaiah" type="incomplete">Isaiah 50:4-9 and 3:9-15</title>
+                                                <note>Wrongly attributed to <foreign xml:lang="gez">ዘኤርምያስ፡</foreign>.</note>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.2.6">
+                                                <locus from="150rb"/>
+                                                <title ref="LIT3146Micah" type="incomplete">Micah 9:9-20</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.2.7">
+                                                <locus from="150va"/>
+                                                <title ref="LIT1688Job" type="incomplete">Job 29:21 to 30:10</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.2.8">
+                                                <locus from="151ra"/>
+                                                <title>Comment on <ref type="work" corresp="LIT1688Job">Job 29:21 to 30:10</ref></title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.2.9">
+                                                <locus from="152ra"/>
+                                                <title ref="LIT1544Gebrah#Directives" type="incomplete">Liturgical direction</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.2.10">
+                                                <locus target="#152va"/>
+                                                <title>Psalms</title>
+                                                    <msItem xml:id="ms_i1.12.2.2.10.1">
+                                                        <locus target="#152va"/>
+                                                        <title ref="LIT3985Mazmura#Ps34">Psalm 34</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.12.2.2.10.2">
+                                                        <locus target="#152va"/>
+                                                        <title ref="LIT3985Mazmura#Ps31" type="incomplete">Psalm 31:13</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.12.2.2.10.3">
+                                                        <locus target="#152va"/>
+                                                        <title ref="LIT3985Mazmura#Ps37" type="incomplete">Psalm 37:18</title>
+                                                    </msItem>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.2.11">
+                                                <locus from="152va"/>
+                                                <title ref="LIT1558Matthew" type="incomplete">Matthew 27:15-25</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.2.12">
+                                                <locus target="#153ra"/>
+                                                <title ref="LIT1882MarkGo" type="incomplete">Mark 15:7-15</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.2.13">
+                                                <locus from="153ra"/>
+                                                <title ref="LIT1812GospelLuke" type="incomplete">Luke 27:4-25</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.2.14">
+                                                <locus from="153rb"/>
+                                                <title ref="LIT2715John" type="incomplete">John 19:1-12</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.2.15">
+                                                <locus from="153vb"/>
+                                                <title>Explanation of the Gospel readings</title>
+                                                <incipit xml:lang="gez">በ፫ሰዓት፡ እምዕለተ፡ ዓርብ፡ አንሰ፡ ተጸመምኩ፡ ምስለ፡ ዝንቱ፡ ነቢይ፡ ዘቃል፡ ዓቢይ፡ ኢሳይያስ፡ ንጺሕ፡
+                                                    ቀድመ፡ ርእየ፡ ምስጢር። በእንተ፡ ሕማማት፡ መድኃኒነ፡ ለዘእግዚአብሔር፡ ቃል።</incipit>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.2.16">
+                                                <locus from="154ra"/>
+                                                <title>Admonition</title>
+                                                <incipit xml:lang="gez"><title>ተግሣጽ፡ በ፫ሰዓት፡ ዘይትነበብ፡</title></incipit>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.2.17">
+                                                <locus from="154va"/>
+                                                <title ref="LIT1544Gebrah#Abraham">Homily by Jacob, Bishop of Serug</title>
+                                                <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/><title>ድርሳን፡ ዘደረሰ፡ ቅዱስ፡ <cb n="154vb"/>
+                                                    አባ፡ ያዕቆብ፡ ኤጲስ፡ ቆጶስ፡ ዘስሩግ፡ በእንተ፡ አብርሃም፡ አቡነ፡ ዓርከ፡ እግዚአብሔር፡ ወበእንተ፡ አቅርቦቱ፡ ይስሐቅሃ፡ ወልዶ፡</title></incipit>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.2.18">
+                                                <locus from="161va"/>
+                                                <title ref="LIT1544Gebrah#AthanFrThird">Homily by Athanasius of Alexandria</title>
+                                                <incipit xml:lang="gez">ወካዕበ፡ ይቤ፡ አቡነ፡ 
+                                                    <persName role="author" ref="PRS2209Athanasi">አትናቴዎስ፡ ሐዋርያዊ፡</persName> በውስተ፡ ድርሳኑ፡ ዘተናገረ፡ ቦቱ፡ 
+                                                    ምስለ፡ አይሁድ፡ በእንተ፡ እግዚእነ፡ ኢየሱስ፡ ክርስቶስ። </incipit>
+                                            </msItem>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.12.2.3">
+                                            <locus from="161vb" to="171va"/>
+                                            <title ref="LIT1544Gebrah#FridaySixth">Readings for the sixth day hour</title>
+                                            <note>Indicated by <foreign xml:lang="gez"> በ፮ሰዓት፡ ዘዓርብ፡</foreign>.</note>
+                                                <msItem xml:id="ms_i1.12.2.3.1">
+                                                    <locus from="161vb"/>
+                                                    <title ref="LIT2075Number" type="incomplete">Numbers 21:1-8</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.3.2">
+                                                    <locus from="162ra"/>
+                                                    <title ref="LIT1672Isaiah" type="incomplete">Isaiah 53:7-12, 12:2-6, 13:2-10 and 50:10 to 51:8</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.3.3">
+                                                    <locus from="165va"/>
+                                                    <title ref="LIT3145Amos" type="incomplete">Amos 8:8 to 9:15</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.3.4">
+                                                    <locus from="166rb"/>
+                                                    <title ref="LIT1373Bookof" type="incomplete">Ezekiel 37:15-22</title>
+                                                </msItem>                               
+                                                <msItem xml:id="ms_i1.12.2.3.5">
+                                                    <locus target="#166va"/>
+                                                    <title ref="LIT3518Epistle" type="incomplete">Galatians 6:14-17</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.3.6">
+                                                    <locus from="166va"/>
+                                                    <title ref="LIT1544Gebrah#Directives">Liturgical direction for the priests</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.3.7">
+                                                    <locus target="#167rb"/>
+                                                    <title>Psalms</title>
+                                                    <msItem xml:id="ms_i1.12.2.3.7.1">
+                                                        <locus target="#167rb"/>
+                                                        <title ref="LIT3985Mazmura#Ps37" type="incomplete">Psalm 37:21-22</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.12.2.3.7.2">
+                                                        <locus target="#167rb"/>
+                                                        <title ref="LIT3985Mazmura#Ps21" type="incomplete">Psalm 21:17-19 and 7-8</title>
+                                                    </msItem>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.3.8">
+                                                    <locus from="167rb"/>
+                                                    <title ref="LIT1558Matthew" type="incomplete">Matthew 27:27-45</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.3.9">
+                                                    <locus from="167vb"/>
+                                                    <title ref="LIT1882MarkGo" type="incomplete">Mark 15:16-33</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.3.10">
+                                                    <locus from="168rb"/>
+                                                    <title ref="LIT1812GospelLuke" type="incomplete">Luke 23:27-44</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.3.11">
+                                                    <locus from="168va"/>
+                                                    <title ref="LIT2715John" type="incomplete">John 19:13-27</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.3.12">
+                                                    <locus from="169ra"/>
+                                                    <title>Explanation of the Gospel readings</title>
+                                                    <incipit xml:lang="gez">በ፮ሰዓት፡ እምዕለተ፡ ዓርብ፡ ዘይትነበብ፡ እምድኅረ፡ ወንጌል፡ ኦኵልክሙ፡ እላ፡ ትነብሩ፡ ውስተ፡ ኢየሩሳሌም፡ ንዑ፡ 
+                                                        ርእዩ፡ ኀበ፡ ዛቲ፡ ራእይ፡ </incipit>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.3.13">
+                                                   <locus from="169vb"/>
+                                                    <title ref="LIT1544Gebrah#Directives">Liturgical direction for priests and deacons</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.3.14">
+                                                    <locus from="170rb"/>
+                                                    <title ref="LIT1544Gebrah#JohnChrFrSixth">Admonition by John Chrysostom</title>
+                                                    <incipit xml:lang="gez">ተግሣጽ፡ ዘ<persName role="author" ref="PRS5720JohnChr">ዮሐንስ፡ አፈ፡ ወርቅ፡</persName>
+                                                        ዘይትነበብ፡ በ፮ሰዓት፡ ዘዓርብ።</incipit>
+                                                </msItem>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.12.2.4">
+                                            <locus from="171va" to="177rb"/>
+                                            <title ref="LIT1544Gebrah#FridayNinth">Readings for the ninth day hour</title>
+                                            <note>Indicated by <foreign xml:lang="gez"> በ፱ሰዓት፡ ዘዓርብ፡</foreign>.</note>
+                                                <msItem xml:id="ms_i1.12.2.4.1">
+                                                    <locus target="#171va"/>
+                                                    <title>Paraphrase of Ezra 6:9</title>
+                                                    <note>According to the catalogue a paraphrase of 
+                                                        <ref type="work" corresp="LIT3581Bookof">Ezra 6:9</ref>, which is indicated as 
+                                                        <foreign xml:lang="gez">ኦሪት፡ ዘሆሤዕ፡</foreign>.</note>
+                                                </msItem>
+                                            <msItem xml:id="ms_i1.12.2.4.2">
+                                                <locus target="#171va"/>
+                                                <title ref="LIT2229RuthBo" type="incomplete">Ruth 2:11-14</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.4.3">
+                                                <locus from="171va"/>
+                                                <title ref="LIT1685Bookof" type="incomplete">Jeremiah 11:18 to 12:13</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.4.4">
+                                                <locus from="172ra"/>
+                                                <title ref="LIT1672Isaiah" type="incomplete">Isaiah 24:1 to 26:8</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.4.5">
+                                                <locus from="173rb"/>
+                                                <title ref="LIT3150Zechar" type="incomplete">Zechariah 14:5-11</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.4.6">
+                                                <locus from="173va"/>
+                                                <title>Comment on <ref type="work" corresp="LIT3150Zechar">Zechariah 14:5-11</ref></title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.4.7">
+                                                <locus from="175va"/>
+                                                <title ref="LIT1688Job">Job 16:11-19</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.4.8">
+                                                <locus from="175vb"/>
+                                                <title ref="LIT1544Gebrah#Directives">Liturgical direction</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.4.9">
+                                                <locus target="#176rb"/>
+                                                <title ref="LIT3985Mazmura#Ps68" type="incomplete">Psalm 68:26 and 68:1-2</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.4.10">
+                                                <locus from="176rb"/>
+                                                <title ref="LIT1558Matthew" type="incomplete">Matthew 27:46-50</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.4.11">
+                                                <locus target="#176va"/>
+                                                <title ref="LIT1882MarkGo" type="incomplete">Mark 15:34-37</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.4.12">
+                                                <locus target="#176va"/>
+                                                <title ref="LIT1812GospelLuke" type="incomplete">Luke 23:45-47</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.4.13">
+                                                <locus target="#176va"/>
+                                                <title ref="LIT2715John" type="incomplete">John 19:28-30</title>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.4.14">
+                                                <locus from="176vb" to="177rb"/>
+                                                <title>Explanation of the Gospel readings</title>
+                                            </msItem>
+                                        </msItem>
+                                        <msItem xml:id="ms_i1.12.2.5">
+                                            <locus from="177rb" to="180va"/>
+                                            <title ref="LIT1544Gebrah#FridayEleventh">Readings for the eleventh day hour</title>
+                                            <note>Indicated by <foreign xml:lang="gez"> በ፲ወ፩ሰዓት፡ ዘዓርብ፡</foreign>.</note>
+                                                <msItem xml:id="ms_i1.1.12.2.5.1">
+                                                    <locus from="177rb"/>
+                                                    <title ref="LIT1367Exodus" type="incomplete">Exodus 12:1-15</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.5.2">
+                                                  <locus from="177va"/>
+                                                    <title ref="LIT1672Isaiah" type="incomplete">Isaiah 51:9 to 52:4</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.5.3">
+                                                    <locus from="178vb"/>
+                                                    <title ref="LIT3148Zephan" type="incomplete">Zephania 2:5 to 3:7</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.5.4">
+                                                    <locus from="179rb"/>
+                                                    <title ref="LIT1544Gebrah#AthanFrEleventh">Admonition by Athanasius</title>
+                                                    <incipit xml:lang="gez">ተግሥጽ፡ ዘአቡነ፡ ቅዱስ፡ አትናቴዎስ፡ <gap reason="ellipsis"/> ጽሑፍ፡ ዘውስተ፡ መጻሕፍተ፡ ነቢያት፡ 
+                                                        ነፍሳቲነ፡ ሶበ፡ ትከውን፡ እሥርተ፡ በሕገ፡ እግዚአብሔር፡ </incipit>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.5.5">
+                                                    <locus from="179va"/>
+                                                    <title>Psalms</title>
+                                                        <msItem xml:id="ms_i1.12.2.5.5.1">
+                                                            <title ref="LIT3985Mazmura#Ps142" type="incomplete">Psalm 142:6-8</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.12.2.5.5.2">
+                                                            <title ref="LIT3985Mazmura#Ps30" type="incomplete">Psalm 30:6</title>
+                                                            <note>Wrongly indicated as Psalm 40.</note>
+                                                        </msItem>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.5.6">
+                                                    <locus target="#179vb"/>
+                                                    <title ref="LIT1558Matthew" type="incomplete">Matthew 27:51-56</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.5.7">
+                                                    <locus from="179vb"/>
+                                                    <title ref="LIT1882MarkGo" type="incomplete">Mark 16:38-41</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.5.8">
+                                                    <locus target="#180ra"/>
+                                                    <title ref="LIT1812GospelLuke" type="incomplete">Luke 23:47-49</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.5.9">
+                                                    <locus from="180ra"/>
+                                                    <title ref="LIT2715John" type="incomplete">John 19:31-37</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.12.2.5.10">
+                                                    <locus from="180rb"/>
+                                                    <title>Explanation of the Gospel readings</title>
+                                                    <incipit xml:lang="gez">በ፲ወ፩ሰዓት፡ ዘዓርብ፡ እስራኤል፡ ምኑን፡ ዘፄወወ፡ አበሳቲሁ፡ ከደና፡ ዓይር። </incipit>
+                                                </msItem>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.12.2.6">
+                                                <locus from="180va" to="185va"/>
+                                                <title>Readings for the twelfth day hour</title>
+                                                <note>Indicated by <foreign xml:lang="gez"> በ፲ወ፪ሰዓት፡ ዘዓርብ፡</foreign>.</note>
+                                                    <msItem xml:id="ms_i1.12.2.6.1">
+                                                        <locus from="180va"/>
+                                                        <title ref="LIT1753Lament" type="incomplete">Lamentations 3:1-22</title>
+                                                        <note>Indicated as <foreign xml:lang="gez">ዘኤርምያስ፡</foreign>.</note>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.12.2.6.2">
+                                                        <locus target="#181rb"/>
+                                                        <title ref="LIT1544Gebrah#Song" type="incomplete">Song of Songs 4:14 to 5:2</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.12.2.6.3">
+                                                        <locus target="#181rb"/>
+                                                        <title>Psalms</title>
+                                                        <msItem xml:id="ms_i1.12.2.6.3.1">
+                                                            <locus target="#181rb"/>
+                                                            <title ref="LIT3985Mazmura#Ps87" type="incomplete">Psalm 87:6</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.12.2.6.3.2">
+                                                            <locus target="#181rb"/>
+                                                            <title ref="LIT3985Mazmura#Ps22" type="incomplete">Psalm 22:3-4</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.12.2.6.3.3">
+                                                            <locus target="#181rb"/>
+                                                            <title ref="LIT3985Mazmura#Ps44" type="incomplete">Psalm 44:8-10</title>
+                                                        </msItem>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.12.2.6.4">
+                                                        <locus from="181rb"/>
+                                                        <title ref="LIT1558Matthew" type="incomplete">Matthew 26:57-61</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.12.2.6.5">
+                                                        <locus from="181va"/>
+                                                        <title ref="LIT1882MarkGo" type="incomplete">Mark 16:42-47</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.12.2.6.6">
+                                                        <locus target="#181vb"/>
+                                                        <title ref="LIT1812GospelLuke" type="incomplete">Luke 23:50-56</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.12.2.6.7">
+                                                        <locus from="181vb"/>
+                                                        <title ref="LIT2715John" type="incomplete">John 19:38-42</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.12.2.6.8">
+                                                        <locus from="182ra"/>
+                                                        <title>Explanation of the Gospel readings</title>
+                                                        <incipit xml:lang="gez">በ፲ወ፪ዘዓርብ፡ ወኮነ፡ ሰርከ፡ ለውእቱ፡ ዕለተ፡ ዓርብ፡ ዘለበዓል፡ ዓቢይ፡ እንተ፡ መጽአት፡ እምቅድመ፡ ሰንበት፡ 
+                                                            ዘለምሥጢረ፡ ፈጣሪ።</incipit>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.12.2.6.9">
+                                                        <locus from="182rb"/>
+                                                        <title ref="LIT1544Gebrah#Directives" type="incomplete">Liturgical direction</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.12.2.6.10">
+                                                        <locus from="183ra"/>
+                                                        <title>Song of Moses and Song of the Three Children</title>
+                                                        <msItem xml:id="ms_i1.12.2.6.10.1">
+                                                            <title>Song of Moses</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.12.2.6.10.2">
+                                                            <title>Song of the <persName ref="PRS11288AnAzMi">Three Children</persName></title>
+                                                        </msItem>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.12.2.6.11">
+                                                        <locus from="184ra"/>
+                                                        <title ref="LIT2250salota"/>
+                                                        <incipit xml:lang="gez">ይትባረክ፡ እግዚአብሔር፡ አምላከ፡ <sic>አምላከ፡</sic> አበዊነ፡ እኩት፡ ወስቡሕ፡ ስምከ፡ ለዓለም።</incipit>
+                                                    </msItem>
+                                                </msItem>
+                                        </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i1.13">
+                                <locus from="185va" to="208rb"/>
+                                <title ref="LIT1544Gebrah#Saturday">Readings for Saturday</title>
+                                    <msItem xml:id="ms_i1.13.1">
+                                        <locus from="185va" to="208rb"/>
+                                        <title ref="LIT1544Gebrah#SaturdayDay">Readings for Saturday Day</title>
+                                            <msItem xml:id="ms_i1.13.1.1">
+                                                <locus from="185va" to="191va"/>
+                                                <title>Readings for the morning</title>
+                                                    <msItem xml:id="ms_i1.13.1.1.1">
+                                                        <locus from="185va"/>
+                                                        <title ref="LIT1544Gebrah#Song" type="incomplete">Song of Songs</title>
+                                                    </msItem>
+                                                <msItem xml:id="ms_i1.13.1.1.2">
+                                                    <locus from="188ra"/>
+                                                    <title ref="LIT1544Gebrah#Directives" type="incomplete">Liturgical direction</title>
+                                                    <incipit xml:lang="gez"><gap reason="ellipsis"/>ወዝንቱ፡ ጸሎት፡ ዘእንበለ፡ ይብጻሕ፡ ሰንበተ፡ አይሁድ፡ ይትጋብኡ፡ ካህናት፡ </incipit>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.13.1.1.3">
+                                                    <locus from="188vb"/>
+                                                    <title ref="LIT1672Isaiah" type="incomplete">Isaiah 55:2-13</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.13.1.1.4">
+                                                    <locus from="189ra"/>
+                                                    <title>Admonition by Athanasius</title>
+                                                    <incipit xml:lang="gez">ተግሣጽ፡ ዘአቡነ፡ ቅዱስ፡ አትናቴዎስ፡ ናህ፡ በጽሐ፡ ዘመነ፡ በዓል፡ ኦአኃው፡ ለንትፈሣሕ፡ በእግዚአብሔር፡ 
+                                                        ኵሎ፡ ጊዜ፡</incipit>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.13.1.1.5">
+                                                    <locus from="189rb"/>
+                                                    <title ref="LIT3516Epistle" type="incomplete">Corinthians 5:7-13</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.13.1.1.6">
+                                                    <locus from="189va"/>
+                                                    <title ref="LIT3507Epistle" type="incomplete">1 Peter 3:15-22</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.13.1.1.7">
+                                                    <locus from="189vb"/>
+                                                    <title ref="LIT1019Actsof" type="incomplete">Acts 2:22-33</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.13.1.1.8">
+                                                    <locus target="#190rb"/>
+                                                    <title>Psalms</title>
+                                                        <msItem xml:id="ms_i1.13.1.1.8.1">
+                                                            <locus target="#190rb"/>
+                                                            <title  ref="LIT3985Mazmura#Ps87" type="incomplete">Psalm 87:4</title>
+                                                        </msItem>
+                                                    <msItem xml:id="ms_i1.13.1.1.8.2">
+                                                        <locus target="#190rb"/>
+                                                        <title  ref="LIT3985Mazmura#Ps43" type="incomplete">Psalm 43:25</title>
+                                                        <note>Wrongly indicated as Psalm 28.</note>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.13.1.1.8.3">
+                                                        <locus target="#190rb"/>
+                                                        <title  ref="LIT3985Mazmura#Ps125" type="incomplete">Psalm 125:2</title>
+                                                    </msItem>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.13.1.1.9">
+                                                    <locus from="190rb"/>
+                                                    <title ref="LIT1558Matthew" type="incomplete">Matthew 28:62-66</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.13.1.1.10">
+                                                    <locus from="190va"/>
+                                                    <title ref="LIT1544Gebrah#Directives" type="incomplete">Liturgical direction</title>
+                                                </msItem>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.13.1.2">
+                                                <locus from="191va" to="208rb"/>
+                                                <title>Readings for the sixth day hour</title>
+                                                <note>Indicated by <foreign xml:lang="gez"> በ፮ሰዓት፡ አንብቡ፡ ዘንተ፡</foreign>.</note>
+                                                    <msItem xml:id="ms_i1.13.1.2.1">
+                                                        <locus from="191va"/>
+                                                        <title ref="LIT1672Isaiah" type="incomplete">Isaiah 50:10 to 51:6</title>
+                                                    </msItem>
+                                                <msItem xml:id="ms_i1.13.1.2.2">
+                                                    <locus from="192ra"/>
+                                                    <title ref="LIT1544Gebrah#Revelation">Revelation</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.13.1.2.3">
+                                                    <locus target="#206ra"/>
+                                                    <title ref="LIT1672Isaiah" type="incomplete">Isaiah 45:15-20</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.13.1.2.4">
+                                                    <locus from="206ra"/>
+                                                    <title ref="LIT1685Bookof" type="incomplete">Jeremiah 31:27-34</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.13.1.2.5">
+                                                    <locus from="206rb"/>
+                                                    <title ref="LIT3516Epistle" type="incomplete">Corinthians 15:1-19</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.13.1.2.6">
+                                                    <locus from="206vb"/>
+                                                    <title ref="LIT3507Epistle" type="incomplete">1 Peter 1:1-9</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.13.1.2.7">
+                                                    <locus from="207ra"/>
+                                                    <title ref="LIT1019Actsof" type="incomplete">Acts 3:2-4</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.13.1.2.8">
+                                                    <locus from="207ra"/>
+                                                    <title>Psalms</title>
+                                                        <msItem xml:id="ms_i1.13.1.2.8.1">
+                                                            <title ref="LIT3985Mazmura#Ps3" type="incomplete">Psalm 3:3</title>
+                                                        </msItem>
+                                                        <msItem xml:id="ms_i1.13.1.2.8.2">
+                                                            <title ref="LIT3985Mazmura#Ps81" type="incomplete">Psalm 81:8</title>
+                                                        </msItem>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.13.1.2.9">
+                                                    <locus from="207rb"/>
+                                                    <title ref="LIT1558Matthew" type="incomplete">Matthew 28:1-20</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.13.1.2.10">
+                                                    <locus target="#208ra"/>
+                                                    <title ref="LIT1544Gebrah#Directives" type="incomplete">Liturgical direction</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.13.1.2.11">
+                                                    <locus from="208ra"/>
+                                                    <title>Psalms</title>
+                                                    <msItem xml:id="ms_i1.13.1.2.11.1">
+                                                        <title ref="LIT3985Mazmura#Ps67" type="incomplete">Psalm 67:1</title>
+                                                        <note>Wrongly indicated as Psalm 64.</note>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.13.1.2.11.2">
+                                                        <title ref="LIT3985Mazmura#Ps21" type="incomplete">Psalm 21:1</title>
+                                                    </msItem>
+                                                </msItem>
+                                            </msItem>
+                                    </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i1.14">
+                                <locus from="208rb" to="217vb"/>
+                                <title ref="LIT1544Gebrah#Sunday">Readings for Easter</title>
+                                            <msItem xml:id="ms_i1.14.1">
+                                                <locus from="208rb" to="212va"/>
+                                                <title>Readings for the third night hour</title>
+                                                <note>Indicated by <foreign xml:lang="gez">ወእምከመ፡ ኮነ፡ ሌሊት፡</foreign>.</note>
+                                                    <msItem xml:id="ms_i1.14.1.1">
+                                                        <locus from="208rb"/>
+                                                        <title ref="LIT1544Gebrah#Directives">Direction to read St John's Gospel</title>
+                                                    </msItem>
+                                                <msItem xml:id="ms_i1.14.1.2">
+                                                    <locus from="208va"/>
+                                                    <title ref="LIT1672Isaiah" type="incomplete">Isaiah 60:1-7, 42:5-16 and 49:13-23</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.14.1.3">
+                                                    <locus from="209rb"/>
+                                                    <title ref="LIT1685Bookof" type="incomplete">Jeremiah 30:23-28</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.14.1.4">
+                                                    <locus from="209va"/>
+                                                    <title ref="LIT1567Bookof" type="incomplete">Habakkuk 3</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.14.1.5">
+                                                    <locus from="210ra"/>
+                                                    <title ref="LIT3150Zechar" type="incomplete">Zechariah 2:10-13</title>
+                                                    <note>Wrongly indicated as: <foreign xml:lang="gez">ዘኢሳይያስ፡</foreign></note>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.14.1.6">
+                                                    <locus from="210rb"/>
+                                                    <title ref="LIT1672Isaiah" type="incomplete">Isaiah 49:13-26</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.14.1.7">
+                                                    <locus target="#210va"/>
+                                                    <title ref="LIT2516Wisdom" type="incomplete">The Wisdom of Solomon 5:1-7</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.14.1.8">
+                                                    <locus from="208ra"/>
+                                                    <title>Psalms</title>
+                                                    <msItem xml:id="ms_i1.14.1.8.1">
+                                                        <title ref="LIT3985Mazmura#Ps7" type="incomplete">Psalm 7:7-8</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.14.1.8.2">
+                                                        <title ref="LIT3985Mazmura#Ps11" type="incomplete">Psalm 11:4-6</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.14.1.8.3">
+                                                        <title ref="LIT3985Mazmura#Ps23" type="incomplete">Psalm 23:7-10</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.14.1.8.4">
+                                                        <title ref="LIT3985Mazmura#Ps46" type="incomplete">Psalm 46:5-8</title>
+                                                        <note>Wrongly indicated as Psalm 43</note>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.14.1.8.5">
+                                                        <title ref="LIT3985Mazmura#Ps67" type="incomplete">Psalm 67:19-20 and 67:35-36</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.14.1.8.6">
+                                                        <title ref="LIT3985Mazmura#Ps77" type="incomplete">Psalm 77:71-72</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.14.1.8.7">
+                                                        <title ref="LIT3985Mazmura#Ps81" type="incomplete">Psalm 81:1 and 81:8</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.14.1.8.8">
+                                                        <title ref="LIT3985Mazmura#Ps95" type="incomplete">Psalm 95:1-2</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.14.1.8.9">
+                                                        <title ref="LIT3985Mazmura#Ps96" type="incomplete">Psalm 96:1-2</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.14.1.8.10">
+                                                        <title ref="LIT3985Mazmura#Ps97" type="incomplete">Psalm 97:1-3</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.14.1.8.11">
+                                                        <title ref="LIT3985Mazmura#Ps106" type="incomplete">Psalm 106:13-15</title>
+                                                    </msItem>
+                                                    <msItem xml:id="ms_i1.14.1.8.12">
+                                                        <title ref="LIT3985Mazmura#Ps117" type="incomplete">Psalm 117:21-23; 117:26 and 117:24</title>
+                                                    </msItem>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.14.1.9">
+                                                    <locus target="#211rb"/>
+                                                    <title ref="LIT1544Gebrah#Directives" type="incomplete">Direction to read the 
+                                                        <ref type="work" corresp="LIT2509Weddas">Wǝddase Māryām</ref> for Saturday</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.14.1.10">
+                                                    <locus target="#211rb"/>
+                                                    <title ref="LIT3985Mazmura#Ps77" type="incomplete">Psalm 77:71-72</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.14.1.11">
+                                                    <locus from="211rb"/>
+                                                    <title ref="LIT1558Matthew" type="incomplete">Matthew 28:1-20</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.14.1.12">
+                                                    <locus from="211vb"/>
+                                                    <title ref="LIT1882MarkGo" type="incomplete">Mark 16:9-20</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.14.1.13">
+                                                    <locus from="212rb"/>
+                                                    <title ref="LIT1812GospelLuke" type="incomplete">Luke 24:1-12</title>
+                                                </msItem>
+                                            </msItem>
+                                            <msItem xml:id="ms_i1.14.2">
+                                                <locus from="212va" to="217vb"/>
+                                                <title ref="LIT1544Gebrah#Mass">For the Mass of the sixth night hour</title>
+                                                    <msItem xml:id="ms_i1.14.2.1">
+                                                        <locus from="212va"/>
+                                                        <title ref="LIT3516Epistle" type="incomplete">1 Corinthians 15:23-43</title>
+                                                        <incipit xml:lang="gez">ሥርዓተ፡ ቍርባን፡ ዘይትነበብ፡ ጳውሎስ፡ ቆርንቶስ፡ ቀዳሚ፡ ክርስቶስ፡</incipit>
+                                                    </msItem>
+                                                <msItem xml:id="ms_i1.14.2.2">
+                                                    <locus from="213ra"/>
+                                                    <title ref="LIT3507Epistle" type="incomplete">1 Peter 3:15-22</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.14.2.3">
+                                                    <locus from="213va"/>
+                                                    <title ref="LIT1019Actsof" type="incomplete">Acts 2:22-36</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.14.2.4">
+                                                    <locus from="213vb"/>
+                                                    <title ref="LIT1544Gebrah#Directives">Liturgical direction</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.14.2.5">
+                                                    <locus target="#214ra"/>
+                                                    <title ref="LIT3985Mazmura#Ps117">Psalm 117:23-24</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.14.2.6">
+                                                    <locus from="214ra"/>
+                                                    <title ref="LIT2715John">John 20:1-18</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.14.2.7">
+                                                    <locus from="214va"/>
+                                                    <title ref="LIT1544Gebrah#Directives">Liturgical direction</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.14.2.8">
+                                                    <locus from="214vb"/>
+                                                    <title ref="LIT6688TeachingMysteries"/>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.14.2.9">
+                                                    <locus from="216rb"/>
+                                                    <title ref="LIT1544Gebrah#Directives">Liturgical direction</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.14.2.10">
+                                                    <locus target="#216va"/>
+                                                    <title ref="LIT3985Mazmura#Ps47">Psalm 47:1-2</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.14.2.11">
+                                                    <locus from="216va"/>
+                                                    <title ref="LIT2715John">John 20:20-23</title>
+                                                </msItem>
+                                                <msItem xml:id="ms_i1.14.2.12">
+                                                    <locus from="217vb"/>
+                                                    <title ref="LIT1544Gebrah#Directives">Liturgical direction and prayers</title>
+                                                    <explicit xml:lang="gez">ተፈጸመ፡ በዝየ፡ በጸጋሁ፡ ለክርስቶስ፡ መጽሐፈ፡ ኅብረተ፡ ቃላት፡ ዘይደሉ፡ ለአንብቦ፡ በሰሙነ፡ ሕማማት፡ 
+                                                        እምቅዳሚት፡ ለስንበተ፡ ሆሣዕና፡ ሰርክ፡ እስከ፡ እሁድ፡ ትንሣኤ፡ ሰርክ።</explicit>
+                                                </msItem>
+                                                <colophon xml:lang="gez" xml:id="coloph1">
+                                                    <locus target="#218ra"/>
+                                                    <note>Colophon containing the names of the scribe
+                                                        <persName role="scribe" ref="PRS14424TasfaIyasus">Tasfā ʾIyasus</persName> and of
+                                                        <persName role="patron" ref="PRS14423Malakotawit">Malakotāwit</persName>, who commissioned 
+                                                        the manuscript.</note>
+                                                </colophon>
+                                            </msItem>
+                            </msItem>
+                      </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Codex">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf">218</measure>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>350</height>
+                                        <width>307</width>
+                                    </dimensions>
+                                </extent>
+                            </supportDesc>
+                            <layoutDesc>
+                                <layout columns="2" writtenLines="22"/>
+                            </layoutDesc>
+                        </objectDesc> 
+                        <handDesc>
+                            <handNote script="Ethiopic" xml:id="h1">
+                                <desc>Neat gʷǝlḥ script, decreasing in height from 6 mm at the beginning to about 4 mm at the end of the manuscript.</desc>
+                                <date notBefore="1800" notAfter="1899" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                        </handDesc>
+                        <additions>
+                            <list>
+                                <item xml:id="a1">
+                                    <locus from="218ra" to="218vb"/>
+                                    <desc type="Supplication">Benediction</desc>
+                                    <q xml:lang="gez"><title>ጸሎተ፡ ቡራኬ፡</title> <gap reason="ellipsis"/></q>
+                                </item>
+                                <item xml:id="a2">
+                                    <locus target="#28va"/>
+                                    <desc type="Record">Record with the name of King <persName ref="PRS5616IyasuI">Iyāsu I</persName>.</desc>
+                                </item>
+                                <item xml:id="a3">
+                                    <locus target="#217ra"/>
+                                    <desc type="Record">Record with the names of Patriarch 
+                                        <persName ref="PRS5711JohnXVI"><roleName type="title">ʾAbbā</roleName> Yoḥannǝs</persName> and
+                                        Metropolitan <persName ref="PRS6777Marqos"><roleName type="title">ʾAbbā</roleName> Mārqos</persName>.</desc>
+                                </item>
+                                <item xml:id="a4">
+                                    <locus from="137r" to="177r"/>
+                                    <desc type="Comment">Short notes summarizing the main events of the Passion in the upper margins of the 
+                                        readings for Good Friday.</desc>
+                                </item>
+                                <item xml:id="e1">
+                                    <desc type="OwnershipNote"><persName role="owner" ref="PRS14419Maryamawit">Māryāmāwit</persName>
+                                        is named as an owner, together with her son <persName ref="PRS14420TaklaHaymanot">Takla Hāymānot</persName>.</desc> 
+                                </item>
+                                <item xml:id="e2">
+                                    <desc type="OwnershipNote">A note in the margin indicating, that this manuscript belonged to the church of
+                                        <placeName ref="INS000000000000000000">Babaḥa ʾAbbo</placeName>. A person with the name
+                                        <persName ref="PRS14421WaldaHanna">Walda Ḥannā</persName>, who was possibly a priest of this 
+                                        church, is also mentioned.</desc> 
+                                    <q xml:lang="gez">ዝመጽሐፍ፡ ዘደብረ፡ በበሐ፡ አቦ፡</q>
+                                </item>
+                                <item xml:id="e3">
+                                    <locus target="1ra"/>
+                                    <desc type="AcquisitionNote"/>
+                                    <q xml:lang="de">Gebra Hemamat angekauft fuer 16 Maria Theresia Thaler 
+                                        <date when="1870-08-08">d. 8 August 1870</date>. 
+                                        <persName role="owner" ref="PRS14422FMayer">F. Mayer</persName></q>
+                                </item>
+                            </list>
+                        </additions>
+                        <bindingDesc>
+                            <binding xml:id="binding">
+                                <decoNote type="bindingMaterial" xml:id="b1"><material key="wood"/></decoNote>
+                                <decoNote xml:id="b2" type="Boards">Repaired in <placeName ref="INS00001BL">British Museum</placeName>.</decoNote>
+                                <decoNote xml:id="b3" type="Cover"><material key="leather">Blind-tooled leather.</material></decoNote>
+                            </binding>
+                        </bindingDesc>
+                    </physDesc>
+                    <history>
+                        <origin><origDate notBefore="1694" notAfter="1706">Between 1694 and 1706</origDate></origin>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                            <citedRange unit="page">57-71</citedRange>
+                                        </bibl> 
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianContent"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="Prayers"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+                <language ident="de">German</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-04-22">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>

--- a/LondonBritishLibrary/orient/BLorient2083.xml
+++ b/LondonBritishLibrary/orient/BLorient2083.xml
@@ -2377,7 +2377,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </item>
                                 <item xml:id="a2">
                                     <locus from="218ra" to="218vb"/>
-                                    <desc type="Supplication">Benediction</desc>
+                                    <desc type="GuestText">Benediction</desc>
                                     <q xml:lang="gez"><title>ጸሎተ፡ ቡራኬ፡</title> <gap reason="ellipsis"/></q>
                                 </item>
                                 <item xml:id="e1">
@@ -2386,12 +2386,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <q xml:lang="de">Gebra Hemamat angekauft fuer 16 Maria Theresia Thaler 
                                         <date when="1870-08-08">d. 8 August 1870</date>. 
                                         <persName role="owner" ref="PRS14422FMayer">F. Mayer</persName></q>
-                                </item>
+                                </item> 
                                 <item xml:id="e2">
-                                    <locus target="#28va"/>
-                                    <desc>Record with the name of King <persName ref="PRS5616IyasuI">ʾIyāsu I</persName>.</desc>
-                                </item>
-                                <item xml:id="e3">
                                     <locus target="#48va"/>
                                     <desc type="OwnershipNote">A note in the margin indicating, that this manuscript belonged to the church of
                                         <placeName ref="LOC7449BabahaAbbo">Babaḥa ʾAbbo</placeName>. A person with the name
@@ -2399,17 +2395,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         church, is also mentioned.</desc> 
                                     <q xml:lang="gez">ዝመጽሐፍ፡ ዘደብረ፡ በበሐ፡ አቦ፡</q>
                                 </item>
-                                <item xml:id="e4">
-                                    <locus target="#122vb"/>
-                                    <desc type="OwnershipNote"><persName role="owner" ref="PRS14419Maryamawit">Māryāmāwit</persName>
-                                        is named as an owner, together with her son <persName ref="PRS14420TaklaHaymanot">Takla Hāymānot</persName>.</desc> 
-                                </item>
-                                <item xml:id="e5">
-                                    <locus target="#217ra"/>
-                                    <desc>Supplication with the names of Patriarch 
-                                        <persName ref="PRS5711JohnXVI"><roleName type="title">ʾAbbā</roleName> Yoḥannǝs</persName> and
-                                        Metropolitan <persName ref="PRS6777Marqos"><roleName type="title">ʾAbbā</roleName> Mārqos</persName>.</desc>
-                                </item> 
                             </list>
                         </additions>
                         <bindingDesc>
@@ -2421,7 +2406,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </bindingDesc>
                     </physDesc>
                     <history>
-                        <origin><origDate notBefore="1694" notAfter="1706">Between 1694 and 1706</origDate></origin>
+                        <origin><origDate notBefore="1694" notAfter="1706">Between 1694 and 1706</origDate>.
+                            King <persName ref="PRS5616IyasuI">ʾIyāsu I</persName> is mentioned on <locus target="#28va"/>, 
+                            while Patriarch <persName ref="PRS5711JohnXVI"><roleName type="title">ʾAbbā</roleName> Yoḥannǝs</persName> 
+                            and Metropolitan <persName ref="PRS6777Marqos"><roleName type="title">ʾAbbā</roleName> Mārqos</persName>    
+                            are mentioned on <locus target="#217ra"/>.</origin>
+                        <provenance><persName role="owner" ref="PRS14419Maryamawit">Māryāmāwit</persName> is named as an owner, 
+                            along with her son <persName ref="PRS14420TaklaHaymanot">Takla Hāymānot</persName>. </provenance>
                     </history>
                     <additional>
                         <adminInfo>


### PR DESCRIPTION
I created a record for BLorient2083, which contains a Gebra ḥemāmāt (LIT1544Gebrah), which was described by Strelcyn with great detail. 

I added some sub-IDs in the work record, that I pushed a minute ago according to our discussion in https://github.com/BetaMasaheft/Documentation/issues/2531. I identified each of the admonitions and homilies, that I newly encoded in LIT1544Gebrah in another witness (ESqmb001). However, I was not able to identify an admonition by John Chrysostomus on f. 145ra; an anonymous admonition in 147ra (both Friday morning) and an admonition by Athanasius on f. 189ra (Saturday morning) and left these without a sub ID.

Concerning a reading in f. 171va, that was entitled a 'paraphrase of Ezra' in the catalogue, I am not certain, whether I took the correct ID for the book of Ezra (and Nehemia).

Also for 183ra, I was not able to identify the correct LIT for "Song of Moses and Song of the Three Children". I took ESqmb001 as a comparison and found similar readings on folio 128vb to 129ra. However I did not find the incipits in ESqmb001 (ማኅሌት፡ ሙሴ፡)  either or it was not specific enough for an identification (ጸሎተ፡ ፫ደቅ፡).

I did not find a place or an institution with the name በበሐ፡ አቦ፡ as found in an extra (e2) on folio 48va. I would like to create a place name (LOC) and an ID for a repository (INS) as suggested in https://github.com/BetaMasaheft/Documentation/issues/2532.