### PR TITLE
Create BLorient13275

### DIFF
--- a/EMIP/magicscrolls/EMIPms00473/EMIPms00473.xml
+++ b/EMIP/magicscrolls/EMIPms00473/EMIPms00473.xml
@@ -48,7 +48,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <measure unit="strips">4</measure>
                            <dimensions type="outer" unit="mm">
                               <height>195</height>
-                              <width>7.0</width>
+                              <width>70</width>
                               <depth/>
                            </dimensions>
                         </extent>
@@ -85,7 +85,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <change when="2022-07-06" who="RL">Edited idno to include images</change>
          <change when="2022-09-02" who="CS">added include statements to incorporate transkribus output</change>
          <change when="2022-09-23" who="RL">Corrected include code errors</change>
-         <change when="2022-09-26" who="RL">Removed text body code lines</change></revisionDesc>
+         <change when="2022-09-26" who="RL">Removed text body code lines</change>
+         <change when="2024-05-23" who="CH">Corrected dimensions</change>
+      </revisionDesc>
    </teiHeader>
       <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
       href="facsimileEMIPms00473.xml">

--- a/LondonBritishLibrary/orient/BLorient13275.xml
+++ b/LondonBritishLibrary/orient/BLorient13275.xml
@@ -1,0 +1,123 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="BLorient13275" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Lǝsāna sabʾ</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS00001BL"/>
+                        <idno>BL Oriental 13275</idno>
+                        <altIdentifier><idno>Or. 13275</idno></altIdentifier>
+                        <altIdentifier><idno>Strelcyn 49</idno></altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                        <summary/>
+                        <msItem xml:id="ms_i1">
+                            <title ref="LIT00000000000000000000"/>        
+                            <incipit xml:lang="gez">በሐብለ፡ እዴሁ፡ ተሐንቀ፡ ወሞተ፡ ይሁዳ። ተማኅፀንኩ፡ በዘባንከ፡ ዘተአገሰ፡ ጥብጣቤ። ወለኵልያቲከ፡ ጥብሉል፡ በጸዋግ፡ ጽንዓ፡ ምንዳቤ።
+                                ኦአቡየ፡ ክርስቶስ፡ ዘኢወለድከኒ፡ በሩካቤ። ጸግወኒ፡ ሀብተ፡ ወልድና፡ እስመ፡ ልሳንየ፡ ይቤ፤ እስከ፡ በሰማያት፡ ይከውን፡ ይባቤ። </incipit>
+                            <explicit xml:lang="gez">አድኅነኒ፡ ክርስቶስ፡ በመስቀልከ፡ መድኅን። እስም፡ ልሳነ፡ ሰብእ፡ ውእቱ፡ ሙጻእ፡ ሐዘን። <gap reason="ellipsis"/></explicit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Scroll">
+                            <supportDesc>
+                                <support>
+                                    <material key="paper">Paper, partly pasted on to another piece of paper to reinforce it.</material>
+                                </support>
+                                <extent>
+                                    <measure unit="strips">2</measure>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>855</height>
+                                        <width>82</width>
+                                    </dimensions>
+                                </extent>
+                            </supportDesc>
+                        </objectDesc>
+                        <handDesc>
+                            <handNote xml:id="h1" script="Ethiopic">
+                                <date notBefore="1900" notAfter="1978" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                        </handDesc>
+                        <bindingDesc>
+                            <binding xml:id="binding">
+                                <decoNote xml:id="b1" type="Other"><material key="leather"/><material key="wood"/>Placed in a bamboo and
+                                    leather cylindrical container.</decoNote>
+                            </binding>
+                        </bindingDesc>
+                    </physDesc>
+                    <history>
+                        <origin><origDate notBefore="1900" notAfter="1978">20th century</origDate></origin>
+                        <provenance>The two owners were <persName role="owner" ref="PRS14436SahlaGiyorgis">Śāhla Giyorgis</persName> 
+                            and <persName role="owner" ref="PRS14437TaklaHaymanot">Takla Hāymānot</persName>. 
+                            Presented by the <placeName ref="INS0775LWC">Wellcome Institute</placeName>, 
+                            <date when="1970">1970</date>.
+                        </provenance>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                            <citedRange unit="page">77</citedRange>
+                                        </bibl>
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Poetry"/>
+                    <term key="Magic"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-05-23">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>
+


### PR DESCRIPTION
I created a record for BLorient13275. I could not identify the text, that is entitled "The hymn-invocation Lǝsāna sabʾ" by Strelcyn as discussed in https://github.com/BetaMasaheft/Documentation/issues/2547.

For the cylindrical container, I encoded it as wood, because, we do not have a keyword for bamboo.

I came across the record EMIPms00473 and I found, that width: 7.0 could be read as width 7,0. I think, this must be 70 mm, because otherwise it can hardly carry any text.