### PR TITLE
Create BLorient8818

### DIFF
--- a/LondonBritishLibrary/orient/BLorient8818.xml
+++ b/LondonBritishLibrary/orient/BLorient8818.xml
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="BLorient8818" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>ʾAʿmāda mǝsṭir, Sǝnna fǝṭratāt, Mazgaba hāymānot</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS00001BL"/>
+                        <collection>Oriental</collection>
+                        <idno>BL Oriental 8818</idno>
+                        <altIdentifier><idno>Or. 8818</idno></altIdentifier>
+                        <altIdentifier><idno>Strelcyn 50</idno></altIdentifier>
+                        <altIdentifier><idno>Curzon, Cat. E10</idno></altIdentifier>
+                        <altIdentifier><idno>Parham 64</idno></altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                        <msItem xml:id="ms_i1">
+                            <locus from="3ra" to="26rb"/>
+                            <title ref="LIT1097Ammest"/>
+                            <msItem xml:id="ms_i1.1">
+                                <locus from="3ra"/>
+                                <title ref="LIT1097Ammest#Introduction" type="incomplete"/>
+                                <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ንወጥን፡ በረድኤተ፡ እግዚአብሔር፡ ጽሒፈ፡ መቅድመ፡ ሃይማኖት፡ ርትዕት፡ ወፍኖተ፡ 
+                                    አምልኮ፡ ጽይሕት፡ ዘጼሕዋ፡ አበዊነ፡ ሐዋርያት፡ ወአርትዕዋ፡ ወአብርህዋ፡ ውስተ፡ ኵሉ፡ ዓለም፡ ወደሰያት፡ ወተለውዋ፡ ፸ወ፪አርድእት፡ ፫፻፲ወ፰ርቱዓነ፡ ሃይማኖት፡
+                                    መምህራኒነ፡ ሊቃውንት፡ ጸሎቶሙ፡ ተሀሉ፡ ምስለ፡ ፍቁሮሙ፡ ገብረ፡ መስቀል፡ ለዓለመ፡ ዓለም፡ አሜን፡ </incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.2">
+                                <locus from="9va" to="26rb"/>
+                                <title ref="LIT1097Ammest#Trinity"/>
+                            </msItem>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <locus from="26rb" to="38rb"/>
+                            <title ref="LIT2314senafe"/>
+                            <note>This composition normally follows the <ref type="work" corresp="LIT1097Ammest"/>, but in a few manuscripts
+                                it is placed, as here, after the Mystery of the Trinity.</note>
+                        </msItem>
+                        <msItem xml:id="ms_i3">
+                            <locus from="38rb" to="77va"/>
+                            <title ref="LIT1097Ammest" type="incomplete"/>
+                            <msItem xml:id="ms_i3.1">
+                                <locus from="38ra" to="61vb"/>
+                                <title ref="LIT1097Ammest#Incarnation"/>
+                            </msItem>
+                            <msItem xml:id="ms_i3.2">
+                                <locus from="62ra" to="66vb"/>
+                                <title ref="LIT1097Ammest#Baptism"/>
+                            </msItem>
+                            <msItem xml:id="ms_i3.3">
+                                <locus from="67ra" to="73rb"/>
+                                <title ref="LIT1097Ammest#Eucharist"/>
+                            </msItem>
+                            <msItem xml:id="ms_i3.4">
+                                <locus from="73ra" to="77va"/>
+                                <title ref="LIT1097Ammest#Resurrection"/>
+                            </msItem>      
+                        </msItem>
+                        <msItem xml:id="ms_i4">
+                            <locus from="77va" to="79rb"/>
+                            <title ref="LIT000000000000000000000000000000000">List of Patriarchs of Alexandria</title>
+                            <note>The last named in No. 109 - 
+                                <persName ref="PRS11721PeterVIIAlex"><roleName type="title">ʾAbba</roleName> Ṗeṭros</persName>.</note>
+                        </msItem>
+                        <msItem xml:id="ms_i5">
+                            <locus from="79va" to="84va"/>
+                            <title ref="LIT1994Mazgab"/>
+                            <note>The end is missing. The text ended before the end of the account of the third Council 
+                                (<foreign xml:lang="gez">ነገረ፡ ጉባኤ፡ ሣልስ፡ </foreign>).</note>
+                            <incipit xml:lang="gez">በስመ፡ ሥሉስ፡ ቅዱስ፡ ዘኢይሰደቅ፡ ዋሕድ፡ ዘኢይትነፈቅ፡ መሐሪ፡ ርሑቀ፡ መዓት፡ <gap reason="ellipsis"/> ንጽሕፍ፡ ዘንተ፡ 
+                                መጽሐፈ፡ ዘይሰመይ፡ መዝገበ፡ ሃይማኖት፡ ከመ፡ ይለብውዎ፡ ማኅበረ፡ መሃይምናን፡ ወመሃይምንት፡ ካህናት፡ 
+                                ወዲያ<sic resp="PRS8999Strelcyn">ቶ</sic>ናት፡ አዕሩግ፡ ወሕፃናት፡ </incipit>
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Codex">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf">3+85+2</measure>
+                                    <measure unit="leaf" type="blank">6</measure><locus target="#2 #I #II #III #IV #V"/>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>156</height>
+                                        <width>102</width>
+                                    </dimensions>
+                                </extent></supportDesc>
+                            <layoutDesc>
+                                <layout columns="2" writtenLines="22 24"/>
+                            </layoutDesc>
+                        </objectDesc> 
+                        <handDesc>
+                            <handNote script="Ethiopic" xml:id="h1">
+                                <desc>Fine, regular handwriting.</desc>
+                                <date notBefore="1800" notAfter="1842" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                        </handDesc>
+                        <additions>
+                            <list>
+                                <item xml:id="a1">
+                                    <locus target="#1r"></locus>
+                                    <desc type="GuestText">Eight lines containing the beginning of the Psalter</desc>
+                                </item>   
+                            </list>  
+                        </additions> 
+                        <bindingDesc>
+                            <binding xml:id="binding">
+                                <decoNote type="bindingMaterial" xml:id="b1"><material key="wood">Wooden boards</material>, supplied in the
+                                    <placeName ref="INS00001BL">British Museum</placeName>.</decoNote>
+                                <decoNote xml:id="b2" type="Spine"><material key="leather">Leather spine, supplied in the
+                                    <placeName ref="INS00001BL">British Museum</placeName>.</material></decoNote>
+                                <decoNote xml:id="b3" type="Other"><term key="leafStringMark">Small pieces of red and blue yarn.</term>
+                                    </decoNote>
+                                <decoNote xml:id="b4" type="SlipCase">Preserved in a <material key="leather">leather case</material>.</decoNote>
+                            </binding>
+                        </bindingDesc>
+                        <accMat>Before <ref target="#1r"/> a double leaf of blue <material key="paper">paper</material> measuring 188x227 mm. 
+                            has been bound in. It contains a letter written by 
+                            <persName role="owner" ref="PRS14438Lieder">J. R. T. Lieder</persName> to 
+                            <persName role="owner" ref="PRS3244Curzon">Robert Curzon</persName>, 
+                            then in the British Embassy at<placeName ref="LOC2196Consta">Constantinople</placeName> 
+                            (<date when="1842-02-01">1 February 1842</date>) concerning manuscripts (mainly Ethiopic) supplied by him from Egypt, 
+                            including this manuscript.</accMat>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1800" notAfter="1842">First half of 19th century</origDate>
+                        </origin>
+                        <provenance>The first owner was <persName role="owner" ref="PRS14440GabraMasqal">Gabra Masqal</persName>. 
+                                </provenance>
+                        <acquisition>According to <bibl><ptr target="bm:Emmel2023Curzon"/><citedRange unit="page">236-241</citedRange></bibl> 
+                            the manuscript was acquired by <persName ref="PRS3244Curzon"/> during his stay in Egypt in 
+                            <date notBefore="1837" notAfter="1838">1837-1838</date>. 
+                            Three years after his death on <date when="1876-04-19">19 April 1876</date>the codex was given to 
+                            the British Museum (later: <placeName ref="INS00001BL">British Library</placeName>), then as a bequest from his 
+                            daughter <persName ref="PRS14320DareaCurzon">Darea</persName> in <date when="1917-10-13">13 October 1917</date> 
+                        </acquisition>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                            <citedRange unit="page">78-79</citedRange>
+                                        </bibl> 
+                                    </listBibl>
+                                    <listBibl type="secondary">
+                                        <bibl>
+                                            <ptr target="bm:Emmel2023Curzon"/>
+                                            <citedRange unit="page">236-241</citedRange>
+                                        </bibl>
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="Apocrypha"/>
+                    <term key="ChristianContent"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="AmharicLiterature"/>
+                    <term key="Miracle"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+                <language ident="la">Latin</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-02-02">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listBibl type="catalogue">
+                    <bibl>
+                        <ptr target="bm:Curzon1849Catalogue"/>
+                    </bibl>
+                </listBibl>
+            </div>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I created a record for BLorient8818. This is a manuscript, in which a text of Śǝna fǝṭrat (LIT2314senafe) is placed in between the first and the second chapter of LIT1097Ammest. I was puzzled, whether this text should be nested inside ms_i1 as part of LIT1097Ammest or kept independantly. 

For ms_i4, I do not know, whether it is reasonable to create a general record for "List of Patriarchs of Alexandria". Since there is no further information, I do not know, whether it is probably related to the accounts of Walda Amid or Abušāker. 

I found information on B. (= J.) R. T. Lieder. I understood this, as Lieder bought this manuscript and sold it to Curzon, who brought it to England:

<img width="796" alt="Screenshot 2024_Lieder" src="https://github.com/BetaMasaheft/Manuscripts/assets/40291787/3e64610b-2a0a-4622-aef7-1cda9a0f46dd">
