### PR TITLE
Create BLorient13267

### DIFF
--- a/LondonBritishLibrary/orient/BLorient13267.xml
+++ b/LondonBritishLibrary/orient/BLorient13267.xml
@@ -34,9 +34,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <msItem xml:id="ms_i1">
                             <locus from="1ra" to="49vb"/>
                             <title ref="LIT2200Qalaha">Qāla hāymānot</title>
+                            <textLang xml:lang="am"/>
                             <msItem xml:id="ms_i1.1">
                                 <locus from="1ra"/>
-                                <title ref="LIT2200Qalaha#0000000000000000000000">Introduction</title>
+                                <title ref="LIT2200Qalaha#Introduction"/>
                             </msItem>
                             <msItem xml:id="ms_i1.2">
                                 <locus from="3rb"/>

--- a/LondonBritishLibrary/orient/BLorient13267.xml
+++ b/LondonBritishLibrary/orient/BLorient13267.xml
@@ -34,35 +34,41 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <msItem xml:id="ms_i1">
                             <locus from="1ra" to="49vb"/>
                             <title ref="LIT2200Qalaha">Qāla hāymānot</title>
-                            <textLang xml:lang="am"/>
+                            <textLang mainLang="gez" otherLangs="am"/>
                             <msItem xml:id="ms_i1.1">
                                 <locus from="1ra"/>
                                 <title ref="LIT2200Qalaha#Introduction"/>
+                                <textLang mainLang="gez" otherLangs="am"/>
                             </msItem>
                             <msItem xml:id="ms_i1.2">
                                 <locus from="3rb"/>
                                 <title ref="LIT2200Qalaha#Sellase"/>
                                 <incipit xml:lang="am">የምሥጢረ፡ ሥላሴ፡ </incipit>
+                                <textLang mainLang="gez" otherLangs="am"/>
                             </msItem>
                             <msItem xml:id="ms_i1.3">
                                 <locus from="12va"/>
                                 <title ref="LIT2200Qalaha#Seggawe"/>
                                 <incipit xml:lang="am">የምሥጢረ፡ ሥጋዌ፡ </incipit>
+                                <textLang mainLang="gez" otherLangs="am"/>
                             </msItem>
                             <msItem xml:id="ms_i1.4">
                                 <locus from="25vb"/>
                                 <title ref="LIT2200Qalaha#Temqat"/>
                                 <incipit xml:lang="am">የምሥጢረ፡ ጥምቀት፡ </incipit>
+                                <textLang mainLang="gez" otherLangs="am"/>
                             </msItem>
                             <msItem xml:id="ms_i1.5">
                                 <locus from="34va"/>
                                 <title ref="LIT2200Qalaha#Qurban"/>
                                 <incipit xml:lang="am">የምሥጢረ፡ ቍርባን፡ </incipit>
+                                <textLang mainLang="gez" otherLangs="am"/>
                             </msItem>
                             <msItem xml:id="ms_i1.6">
                                 <locus from="42va"/>
                                 <title ref="LIT2200Qalaha#Tensae"/>
                                 <incipit xml:lang="am">የትን<sic>ሤ</sic>ኤ፡ ሙታን፡ </incipit>
+                                <textLang mainLang="gez" otherLangs="am"/>
                             </msItem>         
                         </msItem>
                     </msContents>
@@ -93,30 +99,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <date notBefore="1800" notAfter="1970" resp="PRS8999Strelcyn"/>
                             </handNote>
                         </handDesc> 
-                        <additions>
-                            <list>
-                                <item xml:id="a1">
-                                    <desc type="GuestText">Magical prayer against hail written by a second hand</desc>
-                                    <q xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> አብ፡ ቍሔት፡ ወልድ፡ ቍሔት፡ መንፈስ፡ ቅዱስ፡ ቍሔት፡ <gap reason="ellipsis"/>
-                                        ኢታወርድ፡ በረደ፡ በምድረ፡ እገሌ፡ ዘእንበለ፡ ጽሩየ፡ ማየ፡ <gap reason="ellipsis"/></q>
-                                </item>
-                                <item xml:id="e1">
-                                    <locus target="#Ir"/>
-                                    <desc type="AcquisitionNote"/>
-                                    <q xml:lang="en">Bequeathed by <persName role="bequeather" ref="PRS14320DareaCurzon">Darea 
-                                        <roleName type="title">Baroness</roleName> Zouche</persName>. <date when="1917">13 Oct. 1917</date>.</q>
-                                </item>
-                                <item xml:id="e2">
-                                    <locus target="#2v"/>
-                                    <desc>Pen trials.</desc>  
-                                </item>
-                                <item xml:id="e3">
-                                    <locus target="#2v"/>
-                                    <desc type="StampExlibris"/>
-                                    <q xml:lang="la">Liturgia et Cantica Ecclesiae Aethiopicae</q>
-                                </item>
-                            </list>
-                        </additions>
                         <bindingDesc>
                             <binding xml:id="binding">
                                 <decoNote xml:id="b1" type="Boards">According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/>
@@ -167,6 +149,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <langUsage>
                 <language ident="en">English</language>
                 <language ident="la">Amharic</language>
+                <language ident="gez">Gǝʿǝz</language>
             </langUsage>
         </profileDesc>
         <revisionDesc>

--- a/LondonBritishLibrary/orient/BLorient13267.xml
+++ b/LondonBritishLibrary/orient/BLorient13267.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="BLorient13267" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Qāla hāymānot</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS00001BL"/>
+                        <collection>Oriental</collection>
+                        <idno>BL Oriental 13267</idno>
+                        <altIdentifier><idno>Or. 13267</idno></altIdentifier>
+                        <altIdentifier><idno>Strelcyn 51</idno></altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                        <msItem xml:id="ms_i1">
+                            <locus from="1ra" to="49vb"/>
+                            <title ref="LIT2200Qalaha">Qāla hāymānot</title>
+                            <msItem xml:id="ms_i1.1">
+                                <locus from="1ra"/>
+                                <title ref="LIT2200Qalaha#0000000000000000000000">Introduction</title>
+                            </msItem>
+                            <msItem xml:id="ms_i1.2">
+                                <locus from="3rb"/>
+                                <title ref="LIT2200Qalaha#Sellase"/>
+                                <incipit xml:lang="am">የምሥጢረ፡ ሥላሴ፡ </incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.3">
+                                <locus from="12va"/>
+                                <title ref="LIT2200Qalaha#Seggawe"/>
+                                <incipit xml:lang="am">የምሥጢረ፡ ሥጋዌ፡ </incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.4">
+                                <locus from="25vb"/>
+                                <title ref="LIT2200Qalaha#Temqat"/>
+                                <incipit xml:lang="am">የምሥጢረ፡ ጥምቀት፡ </incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.5">
+                                <locus from="34va"/>
+                                <title ref="LIT2200Qalaha#Qurban"/>
+                                <incipit xml:lang="am">የምሥጢረ፡ ቍርባን፡ </incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.6">
+                                <locus from="42va"/>
+                                <title ref="LIT2200Qalaha#Tensae"/>
+                                <incipit xml:lang="am">የትን<sic>ሤ</sic>ኤ፡ ሙታን፡ </incipit>
+                            </msItem>         
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Codex">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf">51</measure>
+                                    <measure unit="leaf" type="blank">2</measure><locus from="50" to="51"/>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>177</height>
+                                        <width>132</width>
+                                    </dimensions>
+                                </extent>
+                                <condition key="deficient">The manuscript is badly damaged, especially on the left side at the foot (corroded or 
+                                    worm-eaten), <locus from="1" to="9"/> being partly lost.</condition>
+                            </supportDesc>
+                            <layoutDesc>
+                                <layout columns="2" writtenLines="23"/>
+                            </layoutDesc>
+                        </objectDesc> 
+                        <handDesc>
+                            <handNote script="Ethiopic" xml:id="h1">
+                                <desc>Careful handwriting.</desc>
+                                <date notBefore="1800" notAfter="1970" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                        </handDesc> 
+                        <additions>
+                            <list>
+                                <item xml:id="a1">
+                                    <desc type="GuestText">Magical prayer against hail written by a second hand</desc>
+                                    <q xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> አብ፡ ቍሔት፡ ወልድ፡ ቍሔት፡ መንፈስ፡ ቅዱስ፡ ቍሔት፡ <gap reason="ellipsis"/>
+                                        ኢታወርድ፡ በረደ፡ በምድረ፡ እገሌ፡ ዘእንበለ፡ ጽሩየ፡ ማየ፡ <gap reason="ellipsis"/></q>
+                                </item>
+                                <item xml:id="e1">
+                                    <locus target="#Ir"/>
+                                    <desc type="AcquisitionNote"/>
+                                    <q xml:lang="en">Bequeathed by <persName role="bequeather" ref="PRS14320DareaCurzon">Darea 
+                                        <roleName type="title">Baroness</roleName> Zouche</persName>. <date when="1917">13 Oct. 1917</date>.</q>
+                                </item>
+                                <item xml:id="e2">
+                                    <locus target="#2v"/>
+                                    <desc>Pen trials.</desc>  
+                                </item>
+                                <item xml:id="e3">
+                                    <locus target="#2v"/>
+                                    <desc type="StampExlibris"/>
+                                    <q xml:lang="la">Liturgia et Cantica Ecclesiae Aethiopicae</q>
+                                </item>
+                            </list>
+                        </additions>
+                        <bindingDesc>
+                            <binding xml:id="binding">
+                                <decoNote xml:id="b1" type="Boards">According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                    <citedRange unit="page">79</citedRange></bibl> the codex is 'unbound'. It is not clear, whether the codex
+                                    is not bound at all, or whether only the boards are missing.</decoNote>
+                                <decoNote xml:id="b2" type="Other"><term key="leafStringMark">Small pieces of red and blue yarn.</term>
+                                </decoNote>
+                            </binding>
+                        </bindingDesc>
+                    </physDesc>
+                    <history>
+                        <origin><origDate notBefore="1800" notAfter="1970">19th/20th century</origDate></origin>
+                        <acquisition>Presented by the <placeName ref="INS0775LWC">Wellcome Institute</placeName> 
+                            in <date when="1970">1970</date>.</acquisition>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                            <citedRange unit="page">79</citedRange>
+                                        </bibl> 
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="AmharicLiterature"/>
+                    <term key="Theology"/>
+                    <term key="ChristianLiterature"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="la">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-05-28">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/>      
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
There is no sub-ID for an introduction in the record of LIT2200Qalaha. However Strelcyn recorded a fairly extensive introduction from 1ra to 3rb (alas without incipit). In both witnesses linked to LIT2200Qalaha, there are also introductions of similar size attested as in BDLaethf9 and InEtn210317a . I propose therefore to update LIT2200Qalaha and add a sub-ID "introduction".

The problem of the so-called "unbound" is similar to https://github.com/BetaMasaheft/Manuscripts/pull/2431/files. For this reason, I made the same comment in the binding description.