### PR TITLE
Update BLorient8192

### DIFF
--- a/LondonBritishLibrary/orient/BLorient8192.xml
+++ b/LondonBritishLibrary/orient/BLorient8192.xml
@@ -26,279 +26,362 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <repository ref="INS00001BL"/>
                         <collection>Oriental</collection>
                         <idno>BL Oriental 8192</idno>
-                        <altIdentifier><idno>Strelcyn cat. 56</idno></altIdentifier>
+                        <altIdentifier><idno>Or. 8192</idno></altIdentifier>
+                        <altIdentifier><idno>Strelcyn 56</idno></altIdentifier>
                     </msIdentifier>
-<msContents>
-
-<msItem xml:id="ms_i1">
+<msContents><summary/></msContents>
+<physDesc>
+    <objectDesc form="Codex">
+        <supportDesc>
+            <support>
+                <material key="parchment"/>
+            </support>
+            <extent>
+                <measure unit="leaf">149+1</measure>
+                <measure unit="page" type="blank">2</measure><locus target="#1v #Iv"/>
+            </extent>
+        <condition key="good"><locus from="1" to="20"/> are stained by some liquid, particularly the first few. 
+            <locus from="140"/> have been repaired at the bottom.</condition>
+        </supportDesc>   
+    </objectDesc>
+    <additions>
+        <list> 
+            <item xml:id="e1">
+                <locus target="#Ir"/>
+                <desc type="PurchaseNote">A type-written note on the recto of the back guard leaf.</desc>
+                <q xml:lang="en">This ms. was brought from Abyssinia after the campaign of <date when="1868">1868</date> by 
+                    <persName role="owner" ref="PRS14474JohnHills"><roleName type="title">Sir</roleName>John Hills, 
+                    <roleName type="title">K. C. B.</roleName></persName>, and sold to the Trustees of the 
+                    <placeName ref="INS00001BL">British Museum</placeName> in <date when="1918">1918</date> by his sister, 
+                    <persName role="owner" ref="PRS14475VeronicaHills"><roleName type="title">Mrs</roleName> Lewis Pugh</persName>, 
+                    late of Abermaed, Cardiganshire, for the benefit of
+                    the <placeName ref="INS0000000000000000000000000">British Red Cross Society</placeName>.</q>
+            </item>    
+        </list>
+    </additions>
+    <bindingDesc>
+        <binding xml:id="binding" contemporary="false">
+            <decoNote xml:id="b1">Bound in the <placeName ref="INS00001BL">British Museum</placeName>.</decoNote>
+        </binding>
+    </bindingDesc>
+</physDesc>
+<history>
+    <origin><origDate notBefore="1700" notAfter="1800">18th century</origDate></origin>
+    <provenance></provenance>
+</history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                            <citedRange unit="page">89-92</citedRange>
+                                        </bibl>
+                                    </listBibl>
+                                    
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                    <msPart xml:id="p1">
+                        <msIdentifier/>
+                    <msContents><summary/>
+                    <msItem xml:id="p1_i1">
 <locus from="2r" to="149v"/>
 <title type="complete" xml:lang="en">Collection of homilies by various authors for the period since the beginning of Lent until the 2nd of Maskaram</title>
 
-<msItem xml:id="ms_i1.1">
-<locus from="2r" to="5r"/>
+<msItem xml:id="p1_i1.1">
+<locus from="2ra" to="5rb"/>
 <title type="complete" xml:lang="en" ref="LIT6621TagSom">Admonition by bishop Tǝyoflos regarding Lent</title>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ቃለ፡ ተግሣጽ፡ ዘደረሰ፡ ብፁዕ፡ ትዮፍሎስ፡ ኤጲስ፡ ቆጶስ፡ በእንተ፡ ጾም፡ ከመ፡ ታእምሩ፡ ንነግረክሙ።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.2">
-<locus from="5v" to="11r"/>
+<msItem xml:id="p1_i1.2">
+<locus from="5va" to="11rb"/>
 <title type="complete" xml:lang="en" ref="LIT6582RHSunday1">Homily by the Orthodox for Lent</title>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ዘቅድስት፡ ጾመ፡ ፋሲካ፡ ዘደረሰ፡ ርቱዐ፡ ሃይማኖት፡ ለሕንጻ፡ ማእመናን።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.3">
-<locus from="11r" to="17v"/>
+<msItem xml:id="p1_i1.3">
+<locus from="11rb" to="17va"/>
 <title type="complete" xml:lang="en" ref="LIT6582RHSunday1">Homily for the second Sunday in Lent</title>
 <note>This is continuation of the preceeding homily.</note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>በካዕብ፡ ሰንበት፡ ዘይትነበብ፡ ድርሳን፡</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.4">
-<locus from="17v" to="19r"/>
+<msItem xml:id="p1_i1.4">
+<locus from="17vb" to="19rb"/>
 <title type="complete" xml:lang="en" ref="LIT6623HomSaturday3">Homily for the third Saturday in Lent</title>
 <note>Indication for reading: <foreign xml:lang="gez">በ፫፡ ሰንበተ፡ አይሁድ፡</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ በሣልስ፡ ሰንበተ፡ ጾም፡</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.5">
-<locus from="19r" to="25r"/>
+<msItem xml:id="p1_i1.5">
+<locus from="19rb" to="25rb"/>
 <title type="complete" xml:lang="en" ref="LIT1618Homily">Homily by ʾabbā Yāʿqob for the third Sunday in Lent</title>
 <note>Indication for reading: <foreign xml:lang="gez">በሣልስ፡ ሰንበተ፡ ክርስቲያን፡ ምንባብ፡</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ ዘአባ፡ ያዕቆብ፡ በሣልስ፡ ሰንበተ፡ ክርስቲያን፡ ዘጾም፡ ዘይትነበብ፡ በሰላም።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.6">
-<locus from="25r" to="30r"/>
+<msItem xml:id="p1_i1.6">
+<locus from="25rb" to="30ra"/>
 <title type="complete" xml:lang="en" ref="LIT6700ThirdSunday">Homily for the third Sunday in Lent</title>
 <note>Indication for reading: <foreign xml:lang="gez">በሣልስ፡ ሰንበተ፡ ክርስቲያን፡ ምንባብ፡</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ድርሳን፡ በእንተ፡ ጾም።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.7">
-<locus from="30r" to="31v"/>
+<msItem xml:id="p1_i1.7">
+<locus from="30ra" to="31va"/>
 <title type="complete" xml:lang="en" ref="LIT6698FourthSunday">Homily by John Chrysostom for the fourth Sunday in Lent</title>
 <note>Indication for reading: <foreign xml:lang="gez">በራብዕ፡ ሰንበተ፡ ጾም፡</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ ዘዮሐንስ፡ አፈ፡ ወርቅ፡ ዘይትነበብ፡ በራብዕ፡ ሰንበተ፡ ጾም።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.8">
-<locus from="31v" to="34r"/>
+<msItem xml:id="p1_i1.8">
+<locus from="31va" to="34rb"/>
 <title type="complete" xml:lang="en" ref="LIT6587RHFast">Homily by the Orthodox for the fourth Sunday in Lent</title>
 <note>Indication for reading: <foreign xml:lang="gez">በራብዕ፡ ሰንበተ፡ ጾም፡</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ ዘርቱዐ፡ ሃይማኖት፡ ዘበእንተ፡ ጾም።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.9">
-<locus from="34r" to="38r"/>
-<title type="complete" xml:lang="en" ref="LIT6415ChrProdSon">Homily by Gregory of Antioch for the fifth Sunday in Lent</title>
-<note>Indication for reading: <foreign xml:lang="gez">በ፭ሰንበተ፡ ጾም፡</foreign></note>
+<msItem xml:id="p1_i1.9">
+<locus from="34rb" to="41vb"/>
+<title type="complete" xml:lang="en" ref="LIT6415ChrProdSon">Homily by Gregory of Antioch for the fifth Sunday in Lent and for the
+    sixth week in Lent</title>
+<note>Indication for reading on <locus target="#34r"/>: <foreign xml:lang="gez">በ፭ሰንበተ፡ ጾም፡</foreign>; 
+    on <locus target="#38r"/>: <foreign xml:lang="gez">በዓርበ፡ ሳድስ፡ ምንባብ፡</foreign>.</note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ ዘጎርጎርዮስ፡ ቀሲስ፡ ዘአንጾኪያ።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.10">
-<locus from="38r" to="41v"/>
-<title type="complete" xml:lang="en" ref="LIT6415ChrProdSon">Homily for the Friday of the sixth week in Lent</title>
-<note>Indication for reading: <foreign xml:lang="gez">በዓርበ፡ ሳድስ፡ ምንባብ፡</foreign></note>
-<note>This is continuation of the preceeding homily.</note>
-<textLang mainLang="gez"/>
-</msItem>
-
-<msItem xml:id="ms_i1.11">
-<locus from="42r" to="42v"/>
+<msItem xml:id="p1_i1.10">
+<locus from="42ra" to="42vb"/>
 <title type="complete" xml:lang="en" ref="LIT6745Dersan">Homily for the Saturday of the sixth week in Lent</title>
 <note>Indication for reading: <foreign xml:lang="gez">በ፮፡ ሰንበተ፡ አይሁድ፡</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ በእንተ፡ ዘይቤ፡ በወንጌል።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.12">
-<locus from="42v" to="46r"/>
+<msItem xml:id="p1_i1.11">
+<locus from="42vb" to="46rb"/>
 <title type="complete" xml:lang="en" ref="LIT6535DersYaqLenten">Homily by ʾabbā Yāʿqob for the Sunday of the sixth week in Lent</title>
 <note>Indication for reading: <foreign xml:lang="gez">በ፮፡ ሰንበተ፡ ክርስቲያን፡ ምንባብ፡</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>በስመ፡ <gap reason="ellipsis"/> ድርሳን፡ ዘአባ፡ ያዕቆብ፡ ዘይትነበብ፡ በሰንበተ፡ ክርስቲያን፡ በጾም።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.13">
-<locus from="46r" to="50r"/>
+<msItem xml:id="p1_i1.12">
+<locus from="46rb" to="50rb"/>
 <title type="complete" xml:lang="en" ref="LIT6588RHHosanna">Homily by the Orthodox for Palm Sunday</title>
 <note>Indication for reading: <foreign xml:lang="gez">በሆሳዕና፡ ምንባብ፡</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ ዘደረሰ፡ ርቱዐ፡ ሃይማኖት፡ በመዋዕለ፡ ኣጽዋም።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.14">
-<locus from="50r" to="53v"/>
-<title type="complete" xml:lang="en" ref="LIT6687EphrThurs">Homily by ʾabbā Efrem for reading at the service on Holy Thursday</title>
+<msItem xml:id="p1_i1.13">
+<locus from="50rb" to="53vb"/>
+<title type="complete" xml:lang="en" ref="LIT6687EphrThurs">Homily by ʾabbā ʾEfrem for reading at the service on Holy Thursday</title>
 <note>Indication for reading: <foreign xml:lang="gez">በጸሎተ፡ ኃሙስ፡ ምንባብ፡</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>በስመ፡ <gap reason="ellipsis"/> ቅዱስ፡ ድርሳን፡ ዘአባ፡ ኤፍሬም፡ ዘይትነበብ፡ በጸሎተ፡ ኀሙስ።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.15">
-<locus from="54r" to="56r"/>
-<title type="complete" xml:lang="en" ref="LIT6689EphrEaster">Homily by ʾabbā Efrem for Easter Eve</title>
+<msItem xml:id="p1_i1.14">
+<locus from="54ra" to="56rb"/>
+    <title type="complete" xml:lang="en" ref="LIT6689EphrEaster">Homily by ʾabbā ʾEfrem for Easter Eve</title>
 <note>Indication for reading: <foreign xml:lang="gez">በመኃትወ፡ ፋሲካ፡</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ ዘዚአሁ፡ <surplus>ዘዚአሁ፡</surplus> ዘአባ፡ ኤፍሬም፡ በስመ፡</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.16">
-<locus from="56v" to="63v"/>
-<title type="complete" xml:lang="en" ref="LIT6589RHFasika">Homily by the Orthodox for Easter Sunday</title>
-<note>Indication for reading: <foreign xml:lang="gez">በዕለተ፡ ፋሲካ፡ ምንባብ፡</foreign></note>
+<msItem xml:id="p1_i1.15">
+<locus from="56va" to="69rb"/>
+<title type="complete" xml:lang="en" ref="LIT6589RHFasika">Homily by the Orthodox for Easter Sunday and for Monday in Easter-week.</title>
+<note>Indication for reading on <locus target="#56v"/>: <foreign xml:lang="gez">በዕለተ፡ ፋሲካ፡ ምንባብ፡</foreign> and on
+    <locus target="#63v"/>: <foreign xml:lang="gez">በሰኑየ፡ ፋሲካ፡ ምንባብ፡</foreign>.</note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>በስመ፡ <gap reason="ellipsis"/> ቅዱስ፡ ድርሳን፡ ዘበዓለ፡ ፋሲካ፡ ቅድስት፡ ዘደረሰ፡ ርቱዐ፡ ሃይማኖት፡ ለሕዝብ፡ ርቱዓነ፡ ሃይማኖት።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.17">
-<locus from="63v" to="69r"/>
-<title type="complete" xml:lang="en" ref="LIT6589RHFasika">Homily on the suffering of Jesus Christ for Monday in Easter-week</title>
-<note>Indication for reading: <foreign xml:lang="gez">በሰኑየ፡ ፋሲካ፡ ምንባብ፡</foreign></note>
-<note>It is in fact continuation of the preceeding homily</note>
-<textLang mainLang="gez"/>
-</msItem>
-
-<msItem xml:id="ms_i1.18">
-<locus from="69r" to="72v"/>
+<msItem xml:id="p1_i1.16">
+<locus from="69rb" to="72va"/>
 <title type="complete" xml:lang="en" ref="LIT6524Tewoflos">Homily by Theophilus on the apostles and on the thief on the right hand, for Tuesday
 in Easter-week</title>
 <note>Indication for reading: <foreign xml:lang="gez">በ፫ፋሲካ፡ ምንባብ፡</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ ዘሠሉሰ፡ ፋሲካ፡ ዘአባ፡ ቴዎፍሎስ፡ ዘደረሰ፡ በእንተ፡ ሐዋርያት፡ ወበእንተ፡ ፈያታዊ፡ ዘየማን።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.19">
-<locus from="72v" to="77r"/>
+<msItem xml:id="p1_i1.17">
+<locus from="72va" to="77ra"/>
 <title type="complete" xml:lang="en" ref="LIT4865Homily">Homily by Theophilus, bishop of Qarnelos, on Easter, for Wednesday in Easter-week</title>
 <note>Indication for reading: <foreign xml:lang="gez">በረቡዐ፡ ፋሲካ፡</foreign></note>
 <note>This is in fact the same homily, which in <ref type="mss" corresp="EMML1763">EMML 1763</ref> is attributed to Philon, bishop of Carpasia.</note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ ዘቴዎፍሎስ፡ ጳጳስ፡ ዘብሔረ፡ ቀርኔሎስ፡ በእንተ፡ በዓለ፡ ፋሲካ።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.20">
-<locus from="77r" to="83r"/>
+<msItem xml:id="p1_i1.18">
+<locus from="77ra" to="83ra"/>
 <title type="complete" xml:lang="en" ref="LIT2142OntheS">Homily by John, bishop of Constantinople, on the sayings of our Lord Jesus Christ,
    for Thursday in Easter-week</title>
 <note>Indication for reading: <foreign xml:lang="gez">በ፭፡ ፋሲካ፡ ምንባብ፡</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>በኀሙሰ፡ ፋሲካ፡ ድርሳን፡ ዘዮሐንስ፡ ኤጲስ፡ ቆጶስ፡ ዘቈስጠንጢኖስ፡ ጶሊስ፡ በእንተ፡ ዘይቤ፡ እግዚእነ፡ ኢየሱስ፡ ክርስቶስ።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.21">
-<locus from="83r" to="85v"/>
+<msItem xml:id="p1_i1.19">
+<locus from="83ra" to="85va"/>
 <title type="complete" xml:lang="gez" ref="LIT6686ProcPass">Homily by Proclus, patriarch of Constantinople on the Passion of Jesus Christ, his patience,
 and his love for mankind, for Friday in Easter-week</title>
 <note>Indication for reading: <foreign xml:lang="gez">በዓርበ፡ ፋሲካ።</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ ዘጰራቅሊጦሎስ፡ ዘሀገረ፡ ቆዝቆስ፡ ዘደረሰ፡ በቈስጠንጢኖስ፡ ጶሊ፡ በእንተ፡ ሕማማቲሁ፡ ለክርስቶስ፡ ወበእንተ፡ ትዕግስቱ፡ ወአፍቅሮቱ፡ ሰብአ።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.22">
-<locus from="85v" to="89v"/>
+<msItem xml:id="p1_i1.20">
+<locus from="85va" to="89vb"/>
 <title type="complete" xml:lang="gez" ref="LIT6519DersanFasika">Homily by Theophilus, bishop of Aksum, on Easter, for Saturday in Easter-week</title>
 <note>Indication for reading: <foreign xml:lang="gez">በ፯፡ ፋሲካ።</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ ዘብፁዕ፡ ወቅዱስ፡ ኤጲስ፡ ቆጶስ፡ ቴዎፍሎስ። ዘአክሱም፡ በእንተ፡ በዓለ፡ ፋሲካ።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.23">
-<locus from="89v" to="92v"/>
+<msItem xml:id="p1_i1.21">
+<locus from="89vb" to="92vb"/>
 <title type="complete" xml:lang="gez" ref="LIT6520DersanSemuna">Homily by Theophilus, bishop of Aksum, for the first Sunday after Easter</title>
 <note>Indication for reading: <foreign xml:lang="gez">በ፰፡ ፋሲካ።</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ ዘቅዱስ፡ ወብፁዕ፡ ቴዎፍሎስ፡ ኤጲስ፡ ቆጶስ፡ ዘአክሱም፡ ዘ፰፡ ፋሲካ፡</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.24">
-<locus from="92v" to="96v"/>
+<msItem xml:id="p1_i1.22">
+<locus from="92vb" to="96vb"/>
 <title type="complete" xml:lang="gez" ref="LIT6741Rakb">Homily by St Theophilus for the festival of the Meeting of Priests (<foreign xml:lang="grc">μεσοπεντεκοστή</foreign>) on the 18th of Miyāzyā</title>
 <note>Indication for reading: <foreign xml:lang="gez">በረክብ፡ ምንባብ፡</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ ዘቅዱስ፡ ቴዎፍሎስ፡ ዘመንፈቀ፡ ኃምስ።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.25">
-<locus from="96v" to="99r"/>
+<msItem xml:id="p1_i1.23">
+<locus from="96vb" to="99ra"/>
 <title type="complete" xml:lang="gez" ref="LIT6685ChrAsc">Homily by John Chrysostom for Ascension Day</title>
 <note>Indication for reading: <foreign xml:lang="gez">በበዓለ፡ ፵፡ ምንባብ።</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ ዘበዓለ፡ ፵፡ ዘቅድስት፡ ወዓባይ፡ በዓለ፡ ፵።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.26">
-<locus from="99r" to="107v"/>
+<msItem xml:id="p1_i1.24">
+<locus from="99ra" to="107vb"/>
 <title type="complete" xml:lang="gez" ref="LIT6585RHPentecost">Homily by the Orthodox for Whit Sunday</title>
 <note>Indication for reading: <foreign xml:lang="gez">በበዓለ፡ ፶፡ ምንባብ።</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ በበዓለ፡ ፶፡ ዘደረሰ፡ ርቱዐ፡ ሃይማኖት፡ ለርቱዓነ፡ ሃይማኖት።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.27">
-<locus from="107v" to="112v"/>
-<title type="complete" xml:lang="gez" ref="LIT3964Homily">Homily on the miracles of the Archangel Michael by John, Bishop of ʾAksum,
+<msItem xml:id="p1_i1.25">
+<locus from="107vb" to="112vb"/>
+<title type="complete" xml:lang="gez" ref="LIT3964Homily">Homily on the miracles of the Archangel Michael by John, Bishop of Aksum,
 for the festivals of St Michael (the 12th of the month)</title>
 <note>Indication for reading: <foreign xml:lang="gez">በበዓለ፡ ሚካኤል።</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳነ፡ መንክር፡ ዘሚካኤል፡ ሊቀ፡ መላእክት፡ ዘደረሰ፡ ዮሐንስ፡ ጳጳስ፡ ዘአክሱም፡ ቀዳሚሆን፡ ለአብያተ፡ ክርስቲያን፡ ቤተ፡ ሚካኤል፡ 
+        ብ<pb n="108ra"/>ዙኃ፡ ፍቁረ፡ በውእቱ፡ ብሔር።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.28">
-<locus from="113r" to="119v"/>
+<msItem xml:id="p1_i1.26">
+<locus from="113ra" to="119va"/>
 <title type="complete" xml:lang="gez" ref="LIT6585RHPentecost">Homily for the 8th [hour of] Whit Sunday</title>
 <note>Indication for reading: <foreign xml:lang="gez">በ፰፡ በዓለ፡ ፶፡ ምንባብ።</foreign></note>
 <note>This is continuation of <ref target="ms_i1.26"/></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez">ወዘይትፈኖሂ፡ መንፈስ፡ ላዕለ፡ ነቢያት፡ ከመ፡ ኢኮነ፡ ፍጥረተ፡ አለ፡ ዘእምሥላሴ፡</incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.29">
-<locus from="119v" to="120v"/>
-<title type="complete" xml:lang="gez" ref="LIT1286Dersan">Homily by ʾElyās, Bishop of ʾAksum, on the Holy Fathers, for the festival of ʾAbbā
+<msItem xml:id="p1_i1.27">
+<locus from="119vb" to="120vb"/>
+<title type="complete" xml:lang="gez" ref="LIT1286Dersan">Homily by ʾElyās, Bishop of Aksum, on the Holy Fathers, for the festival of ʾAbbā
 Garimā</title>
 <note>Indication for reading: <foreign xml:lang="gez">በአባ፡ ገሪማ፡ ምንባብ።</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ ዘቅዱስ፡ ወብፁዕ፡ ወቅዱስ፡ ኤጲስ፡ ቆጶስ፡ ኤልያስ፡ ዘአክሱም፡ ዘበእንተ፡ አበው፡ ቅዱሳን።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.30">
-<locus from="120v" to="128v"/>
+<msItem xml:id="p1_i1.28">
+<locus from="120vb" to="128va"/>
 <title type="complete" xml:lang="gez" ref="LIT6515DersanApostles">Homily by Minās, bishop of ʾAksum, on the Holy Apostles, for the festival of the Apostles</title>
 <note>Indication for reading: <foreign xml:lang="gez">በሐዋርያት።</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ ዘቅዱስ፡ ወብፁዕ፡ ኤጲስ፡ ቆጶስ፡ ሚናስ፡ ዘ<add resp="PRS8999Strelcyn">አ</add>ክሱም፡ ዘበእንተ፡ ቅዱሳን፡ 
+        ሐዋርያት።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.31">
-<locus from="128v" to="134r"/>
+<msItem xml:id="p1_i1.29">
+<locus from="128va" to="134rb"/>
 <title type="complete" xml:lang="gez" ref="LIT6586RHMahbaromu">Homily by the Orthodox on the disciples of our Lord and on the Assembly of Saints, for the festival
 of the Assembly [of the first born] (on the 1st of Yakkātit)</title>
 <note>Indication for reading: <foreign xml:lang="gez">በማኅበር።</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ ዘርቱዐ፡ ሃይማኖት፡ ዘደረሰ፡ በእንተ፡ አርድእተ፡ እግዚእነ፡ ወበእንተ፡ ማኅበሮሙ፡ ለቅዱሳን።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.32">
-<locus from="134r" to="136r"/>
+<msItem xml:id="p1_i1.30">
+<locus from="134rb" to="136rb"/>
 <title type="complete" xml:lang="gez" ref="LIT1665Homily">Homily by Severus the Orthodox on the Virgin Mary, for the festival of the Virgin Mary during the rainy season</title>
 <note>Indication for reading: <foreign xml:lang="gez">በማርያም፡ ዘክረምት።</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ ዘቅድስት፡ ማርያም፡ ወላዲተ፡ አምላክ፡ ዘበእንቲአሃ፡ ዘደረሰ፡ ርቱዐ፡ ሃይማኖት፡ ሳዊሮስ።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.33">
-<locus from="136r" to="140r"/>
+<msItem xml:id="p1_i1.31">
+<locus from="136rb" to="140rb"/>
 <title type="complete" xml:lang="gez" ref="LIT6583RHMaryam">Homily by the Orthodox on the prayer of the Virgin Mary, for festivals of the Virgin Mary (the 21st of the month)</title>
 <note>Indication for reading: <foreign xml:lang="gez">በማርያም።</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ ዘርቱዐ፡ ሃይማኖት፡ በጸሎታ፡ ለማርያም፡ ወላዲተ፡ አምላክ።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.34">
-<locus from="140r" to="141v"/>
+<msItem xml:id="p1_i1.32">
+<locus from="140rb" to="141vb"/>
 <title type="complete" xml:lang="gez" ref="LIT3323Proclus">Homily by Proclus, Patriarch of Constantinople, on the Incarnation, for the festivals of the Virgin
   Mary (the 21st of the month)</title>
-<note>Indication for reading: <foreign xml:lang="gez">በማኅበር።</foreign></note>
+    <note>Indication for reading: <foreign xml:lang="gez">በማኅበር።</foreign></note><!---This indication is different from what Strelcyn 
+        noted in his catalogue and what fits better to the content: በርቡዐ፡ ማርያም፡ ዘክረምት።. It is either a mistake by Strelcyn or by MKr. I cannot 
+        check, because images are currently not available.-->
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ ዘጵሮቅሎስ፡ ጳጳስ፡ ዘሀገረ፡ <surplus>ዝቆስ፡</surplus> ዘቆስ፡ ዘደረሰ፡ በቈስጠንጢኖስ፡ ጳሊስ፡ በበዓለ፡ 
+        ማርያ<pb n="140va"/>ም፡ በእንተ፡ ተሰግዎቱ፡ ለእግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ እንዘ፡ ሀሎ፡ ንስጥሮስ፡ ዕልው፡ አመ፡ ይስዕርዎ። </title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.35">
-<locus from="141v" to="143r"/>
+<msItem xml:id="p1_i1.33">
+<locus from="141vb" to="143rb"/>
 <title type="complete" xml:lang="gez" ref="LIT6599DersanAbreham">Homily on Abraham the Patriarch and his son Isaac, for the commemoration of Abraham,
   Isaac and Jacob (the 28th of the month)</title>
 <note>Indication for reading: <foreign xml:lang="gez">በአብርሃም፡ ምንባብ።</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ ዘብፁዕ፡ ወቅዱስ፡ አቡነ፡ አብርሃም፡ ወዘንጹሕ፡ ወቅዱስ፡ ይስሐቅ፡ ወልዱ።</title></incipit>
 </msItem>
 
-<msItem xml:id="ms_i1.36">
-<locus from="143v" to="149v"/>
+<msItem xml:id="p1_i1.34">
+<locus from="143va" to="149va"/>
 <title type="complete" xml:lang="gez" ref="LIT1277Dersan">Homily of Theophilus on St John the Baptist, for the commemoration of the beheading of this saint
   (the 2nd of Maskaram)</title>
 <note>Indication for reading: <foreign xml:lang="gez">በምትረተ፡ ርእሱ፡ ለዮሐንስ።</foreign></note>
 <textLang mainLang="gez"/>
+    <incipit xml:lang="gez"><title>ድርሳን፡ ዘብፁዕ፡ ቴዎፍሎስ፡ በእንተ፡ ቅዱስ፡ ወኄር፡ ዮሐንስ፡ ወበዝየኒ፡ ዓቢያተ፡ ሰብእ፡ እለ፡ ኮኑ፡ ውስተ፡ ዝዓለም።</title></incipit>
 </msItem>
 
 <colophon xml:id="coloph1" xml:lang="gez">
-<locus target="#149v"/>
+<locus target="#149vb"/>
 በአኰትተ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ዛቲ፡ መጽሐፍ፡ ዘአጽሐፍክዋ፡ አነ፡ ዮሴፍ፡ ንቡረ፡ እድ፡ ለ<placeName ref="LOC1895BetaMa">ቤተ፡ መስቀል፡</placeName> ዘጕናጕና፡ ከመ፡ ይምሐረኒ፡ እግዚአብሔር፡ በመንግሥቱ።
 <note>According to the colophon the manuscript was commissioned by <persName ref="PRS13835Yosef">Yosef</persName>, nǝbura ʾǝd of Beta Masqal in <placeName ref="LOC7360Gunaguna">Gʷǝnagʷǝna</placeName>.</note>
 </colophon>
@@ -316,59 +399,97 @@ of the Assembly [of the first born] (on the 1st of Yakkātit)</title>
           </support>
           <extent>
               <measure unit="leaf">149</measure>
-              <measure unit="leaf" type="blank">1</measure>
+              <measure unit="page" type="blank">1</measure><locus target="#1v"/>
 <dimensions type="outer" unit="mm">
 <height>303</height>
 <width>190</width>
 </dimensions>
-
             </extent></supportDesc>
-
             <layoutDesc>
                 <layout columns="2" writtenLines="29">
                 </layout>
             </layoutDesc>
-
 </objectDesc>
 
 <handDesc>
     <handNote script="Ethiopic" xml:id="h1">
         <desc>The well-executed archaic writing is dated in the catalogue to the <date>14th Century</date>.
         </desc>
-        <date notBefore="1300" notAfter="1400" resp="PRS8999Strelcyn"/>
+        <date notBefore="1300" notAfter="1400" resp="PRS8999Strelcyn" cert="low"/>
     </handNote>
   </handDesc>
-
-<additions>
-<list>
-
-<item xml:id="e1">
-<desc type="PurchaseNote">A type-written note on the recto of the back guard leaf.</desc>
-<q xml:lang="en">This ms. was brought from Abyssinia after the campaign of 1868 by Sir John Hills, K. C. B., and sold to the
-Trustees of the British Museum in 1918 by his sister, Mrs Lewis Pugh, late of Abermaed, Cardiganshire, for the benefit of
-the British Red Cross Society.</q>
-</item>
-
-</list>
-</additions>
-
+    <decoDesc>
+        <decoNote xml:id="d1" type="other">
+            <desc>In the margins special signs are used to separate chapters; the conventional symbolic signs referring to Christ are used at the
+                beginning of the homilies.</desc>
+        </decoNote>
+    </decoDesc>
+    <additions>
+        <list> 
+            <item xml:id="e2">
+                <locus target="#1r #40v #41r #111r #149v"/>
+                <desc type="Unclear">Pen trials and scribbles.</desc>
+            </item>    
+        </list>
+    </additions>
 </physDesc>
-
-                    <additional>
-                        <adminInfo>
-                            <recordHist>
-                                <source>
-                                    <listBibl type="catalogue">
-                                        <bibl>
-                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
-                                            <citedRange unit="page">89-92</citedRange>
-                                        </bibl>
-                                    </listBibl>
-
-                                </source>
-                            </recordHist>
-                        </adminInfo>
-                    </additional>
+<history>
+    <origin><origDate notBefore="1300" notAfter="1400">Dated to the 14th century on palaeographic grounds by <persName ref="PRS8999Strelcyn"/></origDate></origin>
+</history>
+                    </msPart>
+<msPart xml:id="p2">
+    <msIdentifier></msIdentifier>
+<msContents>
+    <msItem xml:id="p2_i1">
+        <locus target="I"/>
+        <title ref="LIT000000000000000000000">Salām to Mary</title>
+        <incipit xml:lang="gez"><title>ሰላም፡ ለማርያም፡ ታቦት፡</title></incipit>
+    </msItem>
+</msContents>
+    <physDesc>
+        
+        <objectDesc form="Codex">
+            <supportDesc>
+                <support>
+                    <material key="parchment"/>
+                </support>
+                <extent>
+                    <measure unit="leaf">1</measure>
+                    <measure unit="page" type="blank">1</measure><locus target="#Iv"/>
+                    <dimensions type="outer" unit="mm">
+                        <height>130</height>
+                        <width>90</width>
+                    </dimensions>
+                    
+                </extent></supportDesc>
+            
+            <layoutDesc>
+                <layout columns="1" writtenLines="11">
+                </layout>
+            </layoutDesc>
+            
+        </objectDesc>
+        
+        <handDesc>
+            <handNote script="Ethiopic" xml:id="h2">
+                <desc>Good hand of the 18th Century.
+                </desc>
+                <date notBefore="1700" notAfter="1800" resp="PRS8999Strelcyn"/>
+            </handNote>
+        </handDesc>
+        <additions>
+            <list> 
+                <item xml:id="e3">
+                    <desc type="Unclear">Pen trials.</desc>
+                </item>    
+            </list>
+        </additions>
+    </physDesc>
+    <history>
+        <origin><origDate notBefore="1700" notAfter="1800">18th century</origDate></origin>
+        <provenance>A presumed owner is mentioned: <persName role="owner" ref="PRS14473FereMikael">Fǝre Mikāʾel</persName></provenance>
+    </history>
+</msPart>                    
                 </msDesc>
             </sourceDesc>
         </fileDesc>
@@ -394,6 +515,7 @@ the British Red Cross Society.</q>
         <revisionDesc>
             <change who="MKr" when="2022-03-25">Created entity</change>
             <change who="MKr" when="2022-09-27">Added missing ref to work records</change>
+            <change when="2024-06-14" who="CH">Added incipits, updated msContents</change>
         </revisionDesc>
     </teiHeader>
     <facsimile>

--- a/LondonBritishLibrary/orient/BLorient8192.xml
+++ b/LondonBritishLibrary/orient/BLorient8192.xml
@@ -54,8 +54,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <roleName type="title">K. C. B.</roleName></persName>, and sold to the Trustees of the 
                     <placeName ref="INS00001BL">British Museum</placeName> in <date when="1918">1918</date> by his sister, 
                     <persName role="owner" ref="PRS14475VeronicaHills"><roleName type="title">Mrs</roleName> Lewis Pugh</persName>, 
-                    late of Abermaed, Cardiganshire, for the benefit of
-                    the <placeName ref="INS0000000000000000000000000">British Red Cross Society</placeName>.</q>
+                    late of Abermaed, Cardiganshire, for the benefit of the British Red Cross Society.</q>
             </item>    
         </list>
     </additions>
@@ -442,7 +441,7 @@ of the Assembly [of the first born] (on the 1st of Yakkātit)</title>
 <msContents>
     <msItem xml:id="p2_i1">
         <locus target="I"/>
-        <title ref="LIT000000000000000000000">Salām to Mary</title>
+        <title ref="LIT7020SalamMaryTabot">Salām to Mary</title>
         <incipit xml:lang="gez"><title>ሰላም፡ ለማርያም፡ ታቦት፡</title></incipit>
     </msItem>
 </msContents>


### PR DESCRIPTION
I updated BLorient8192. I decided to rework it as a composite manuscript to document the details given for p2 in a searchable and decent way.

I did not find a LIT ID for a salām to Mary beginning with ሰላም፡ ለማርያም፡ ታቦት፡ Probably, I can create a new one. There is no INS ID for the British Red Cross Society, who benefited from the purchase of the manuscript to the British Museum. Do you think, it is appropriate to create a INS or a LOC ID for the British Red Cross Society?