### PR TITLE
Create BLorient8819

### DIFF
--- a/LondonBritishLibrary/orient/BLorient8819.xml
+++ b/LondonBritishLibrary/orient/BLorient8819.xml
@@ -126,7 +126,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </support>
                                 <extent>
                                     <measure unit="leaf">1+101</measure>
-                                    <measure unit="page" type="blank">7</measure><locus target="#Ir #Iv #1v #2v #3r #83v #101r"/>
+                                    <measure unit="leaf" type="blank">7</measure><locus target="#Ir #Iv #1v #2v #3r #83v #101r"/>
                                     <dimensions type="outer" unit="mm">
                                         <height>145</height>
                                         <width>85</width>

--- a/LondonBritishLibrary/orient/BLorient8819.xml
+++ b/LondonBritishLibrary/orient/BLorient8819.xml
@@ -49,7 +49,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </msItem>
                             <msItem xml:id="ms_i1.3">
                                 <locus from="17r"/> 
-                                <title ref="LIT0000000000000000000">Homily for Tuesday</title>
+                                <title ref="LIT6193HomiliaryPassions#HomilyTuesdayOther">Homily for Tuesday</title>
                                 <note>According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">92</citedRange>
                                     </bibl>, this part is the homily for Tuesday, but in <ref type="mss" corresp="BNFet116"/> this homily is not attested.</note>
                                 <incipit xml:lang="gez">ወእምድኅረዝ፡ እንዘ፡ ሀሎ፡ በቤተ፡ ስምዖን፡ ዘከመ፡ አቅረቡ፡ ድራረ፡ ወዘከመ፡ ወሀበ፡ ሥጋሁ፡ ወደሞ፡ ለአርዳኢሁ፡ ወዘከመ፡ ሐፀበ፡
@@ -151,7 +151,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <width>85</width>
                                     </dimensions>
                                 </extent>
-                                <collation>Paper endleaves added when the codex was repaired in the <placeName ref="INS00001BL">British Museum</placeName></collation>
                             </supportDesc>
                             <layoutDesc>
                                 <layout writtenLines="13"><locus from="4r" to="77v"/></layout>
@@ -212,11 +211,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </additions>
                         <bindingDesc>
                             <binding xml:id="binding">
-                                <decoNote xml:id="b1" type="Boards"><material key="leather"/>Thick leather boards.</decoNote>
-                                <decoNote xml:id="b2" type="Spine"><material key="leather"/>The leather spine was added added when the 
+                                <decoNote xml:id="b1" type="EndLeaves"><material key="paper"/>Paper endleaves added when the codex was 
+                                    repaired in the <placeName ref="INS00001BL">British Museum</placeName>.</decoNote>
+                                <decoNote xml:id="b2" type="Boards"><material key="leather"/>Thick leather boards.</decoNote>
+                                <decoNote xml:id="b3" type="Spine"><material key="leather"/>The leather spine was added added when the 
                                     manuscript was repaired in the <placeName ref="INS00001BL">British Museum</placeName>.</decoNote>
-                                <decoNote xml:id="b3" type="SlipCase"><material key="leather">Preserved in a leather case.</material></decoNote>
-                                <decoNote xml:id="b6" type="Other"><term key="leafStringMark">Small pieces of blue, yellow and red yarn</term>
+                                <decoNote xml:id="b4" type="SlipCase"><material key="leather">Preserved in a leather case.</material></decoNote>
+                                <decoNote xml:id="b5" type="Other"><term key="leafStringMark">Small pieces of blue, yellow and red yarn</term>
                                     </decoNote>
                             </binding>
                         </bindingDesc>

--- a/LondonBritishLibrary/orient/BLorient8819.xml
+++ b/LondonBritishLibrary/orient/BLorient8819.xml
@@ -37,13 +37,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <locus from="4r"/> 
                                 <title ref="LIT6193HomiliaryPassions#Introduction"/>
                                 <note>Rhyming</note>
-                                <incipit xml:lang="gez">በስመ፡ እግዚአብሔር፡ ሥሉስ፡ ዘእንበለ፡ ቀዲም፡ ወተድኅሮ። በግጻዌሁ፡ ይትረአይ፡ ዘአስተዋሐደ፡ ምክሮ። በጠፈረ፡ በረድ፡ ወነድ፡
-                                    ዘሐነጸ፡ ማኅደሮ። ወበአርእስተ፡ ኪሩቤል፡ ርቱዓ፡ ዘአማዕዘነ፡ መንበሮ። </incipit>
+                                <incipit xml:lang="gez">
+                                    በስመ፡ እግዚአብሔር፡ ሥሉስ፡ ዘእንበለ፡ ቀዲም፡ ወተድኅሮ። 
+                                    በግጻዌሁ፡ ይትረአይ፡ ዘአስተዋሐደ፡ ምክሮ።
+                                    በጠፈረ፡ በረድ፡ ወነድ፡ ዘሐነጸ፡ ማኅደሮ።
+                                    ወበአርእስተ፡ ኪሩቤል፡ ርቱዓ፡ ዘአማዕዘነ፡ መንበሮ።</incipit>
                             </msItem>
                             <msItem xml:id="ms_i1.2">
                                 <locus from="6v"/> 
                                 <title ref="LIT6193HomiliaryPassions#Monday"/>
-                                <note>Indicated by <foreign xml:lang="gez">ዘሰኑይ፡ </foreign> on the upper margin of <locus target="#4r"/>.</note>
                                 <incipit xml:lang="gez">ናንቅሕ፡ ርእሰ፡ ሕሊናነ፡ ወናስተሐውስ፡ አስራወ፡ ልሳንነ፡ ንክሥት፡ አፉነ፡ ወናስተናብብ፡ ከናፍሪነ። ከመ፡ ንንግር፡ ዜና፡ ሕማማቲሁ፡ 
                                     ለመድኅኒነ፡ እንዘ፡ ኃያል፡ ዘኢየሐምም፡</incipit>
                             </msItem>
@@ -58,62 +60,41 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <msItem xml:id="ms_i1.4">
                                 <locus from="24r"/> 
                                 <title ref="LIT6193HomiliaryPassions#HomilyTuesday">Homily for Wednesday</title>
-                                <note>According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">93</citedRange>
-                                    </bibl>, this part the homily for Wednesday, but in <ref type="mss" corresp="BNFet116"/> this homily is attributed to 
-                                    Tuesday.</note>
                                 <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ንግባዕኬ፡ ከመ፡ ንፈጽ<pb n="24v"/>ም፡ ዜና፡ ሕማሙ፡ ለመድኃኒነ፡ ወአንግሁ፡
                                     ይአተ፡ ዕለተ፡ ኵላ፡ ሌሊተ፡ እንዘ፡ ይዘብጥዎ፡ ወይጸፍእዎ። </incipit>
                             </msItem>
                             <msItem xml:id="ms_i1.5">
                                 <locus from="36v"/> 
                                 <title ref="LIT6193HomiliaryPassions#HomilyWednesday">Homily for Thursday</title>
-                                <note>According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">93</citedRange>
-                                    </bibl>, this part is the homily for Thursday, but in <ref type="mss" corresp="BNFet116"/> this homily is attributed to 
-                                    Wednesday.</note>
                                 <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ንግባዕኬ፡ ከመ፡ ንፈጽም፡ ነገረ፡ ወበጊዜ፡ ፱ሰዓት፡ ተከሥተ፡ ፀሐይ፡ በዓውደ፡ ሰማይ።</incipit>
                             </msItem>
                             <msItem xml:id="ms_i1.6">
                                 <locus from="50r"/> 
                                 <title ref="LIT6193HomiliaryPassions#HomilyThursday">Homily for Friday</title>
-                                <note>According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">93</citedRange>
-                                    </bibl>, this part is the homily for Friday, but in <ref type="mss" corresp="BNFet116"/> this homily is attributed to
-                                    Thursday.</note>
                                 <incipit xml:lang="gez">ንግባዕኬ፡ ከመ፡ ንፈጽም፡ ነገረ፡ ዘ፱ሰዓት። ወይእተ፡ ጊዜ፡ ሶበ፡ ርእዩ፡ ነቢያት፡ ቀደምት፡ ወአበው፡ ቀደምት፡ ሞቶ፡ ለመድኃኒነ፡ ጸርሑ፡
                                     ኀቤሁ፡ </incipit>
                             </msItem>
                             <msItem xml:id="ms_i1.7">
                                 <locus from="62r"/> 
                                 <title ref="LIT6193HomiliaryPassions#HomilyFriday">Homily for Saturday</title>
-                                <note>According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">93</citedRange>
-                                    </bibl>, this part is the homily for Saturday, but in <ref type="mss" corresp="BNFet116"/> this homily is attributed to 
-                                    Friday.</note>
                                 <incipit xml:lang="gez">ንግባዕኬ፡ ከመ፡ ንፈጽም፡ ነገረ፡ ዘምሴተ፡ ዓርብ። እስመ፡ ይቤ፡ ዘካርያስ፡ ይእቲ፡ ዕለ<pb n="62v"/>ት፡ እምርት፡ ይእቲ፡ በኀበ፡
                                     እግዚአብሔር፡ ኢኮነት፡ መዓልተ፡ ወሌሊተ፡ ወፍና፡ ሠርከ፡ ይበርህ፡ ብርሃን፡ </incipit>
                             </msItem>
                             <msItem xml:id="ms_i1.8">
                                 <locus from="70r"/> 
-                                <title ref="LIT6193HomiliaryPassions#HomilySaturday">Homily for Sunday</title>
-                                <note>According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">93</citedRange>
-                                    </bibl>, this part is the homily for Sunday, but in <ref type="mss" corresp="BNFet116"/> this homily is attributed to 
-                                    Saturday.</note>
+                                <title ref="LIT6193HomiliaryPassions#HomilySaturday">Homily for Sunday</title> 
                                 <incipit xml:lang="gez">ንንግርኬ፡ ኅዳጠ፡ ዜናሁ፡ ለፀልቦ፡ መድኃኒነ፡ መስቀል፡ ዘከመ፡ ሀሎ፡ ምስለ፡ እግዚአብሔር፡ እምቅድመ፡ ኵሉ፡ ፍጡር፤ ወእምቅድመ፡
                                     ኵሉ፡ ግቡር፤ ትእምርተ፡ መስቀል፡ ክቡር፤ እምቅድመ፡ ነገር፤ ትእምርተ፡ መስቀል፡ አርአያሁ፡ ለእግዚአብሔር። </incipit>  
                             </msItem>
                             <msItem xml:id="ms_i1.9">
                                 <locus from="75r"/> 
                                 <title ref="LIT6193HomiliaryPassions#HomilySunday">Final chapter</title>
-                                <note>According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">93</citedRange>
-                                    </bibl>, this part is designated the 'final chapter', but in <ref type="mss" corresp="BNFet116"/> this homily is 
-                                    attributed to Sunday.</note>
                                 <incipit xml:lang="gez">ንግባዕኬ፡ ከመ፡ ንስብሖ፡ ለእግዚአብሔር፡ ወንወድሶ፡ እንዘ፡ ንብል፡ ጥዑመ፡ ስም፡ መድኀኒነ፡ ለሊሁ፡ ንጉሥ፡ ወእሙ፡ መቅደስ፤ 
                                     ወመስቀሉ፡ አትሮንስ። </incipit>
                             </msItem>
                             <msItem xml:id="ms_i1.10">
                                 <locus from="77v"/> 
-                                <title>Final benediction</title>
-                                <note>According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">93</citedRange>
-                                </bibl>, this part is designated the 'final benediction', but in <ref type="work" corresp="LIT6193HomiliaryPassions"/> 
-                                    this part is included to the homily attributed to Sunday.</note>
+                                <title>Final benediction</title> 
                                 <incipit xml:lang="gez">ዘጸሐፎ፡ ወለዘአጽሐፎ፡ ለዝንቱ፡ ድርሳን፡ እግዚአብሔር፡ ይጽሐፍ፡ ስሞሙ፡ በዓምደ፡ ብርሃን፡ ወያርፍቆሙ፡ በደብረ፡ ጽዮን፡ መካን፤
                                     በሥላሴሁ፡ አመ፡ ይመጽእ፡ መድኅ<pb n="78r"/>ን፡ ምስለ፡ መላእክቲሁ፡ ትጉሃን፤ ለዓለመ፡ ዓለም። ለዘጸሐፋ፡ ለዛቲ፡ ተውዳስ፤ ወትረ፡ የሃሉ፡ በሞገስ፤ በሥጋ፡
                                     ወነፍስ፤ እንበለ፡ ንዴት፡ ወተጽናፍስ፤ ወዘእንበለ፡ ሐተታ፡ ወሙቃስ፤፡ ኅዙነ፡ ለቡና፡ ወለተ፡ ጊጋር፡ ለዓለመ፡ ዓለም፡ አሜን፡ ወአሜን፡ ለይኩን፤ ለይኩን። </incipit>
@@ -121,7 +102,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </msItem>
                         <msItem xml:id="ms_i2">
                             <locus from="78v" to="83r"/> 
-                            <title ref="LIT7017Crucifixion"/>
+                            <title ref="LIT4035SenkessarDL#Mask27SalEwostatewos"/>
                             <incipit xml:lang="gez">
                                 ሰላም፡ ለሥቃይከ፡ ለለ፩፩፤
                                 እምሴተ፡ ሐሙስ፡ ዘኮነ፡ እስከ፡ ምሴተ፡ ዓርብ፡ የዓዱ።
@@ -206,6 +187,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <locus target="24r"/>
                                     <desc type="OwnershipNote"><persName role="owner" ref="PRS14481WalattaGigar">Walatta Gigār</persName>
                                         is named as an owner on several places in the codex.</desc>
+                                </item>
+                                <item xml:id="e3">
+                                    <locus target="#4r"/>
+                                    <desc type="findingAid">On the upper margin</desc>
+                                    <q xml:lang="gez">ዘሰኑይ፡ </q>
                                 </item>
                             </list>
                         </additions>

--- a/LondonBritishLibrary/orient/BLorient8819.xml
+++ b/LondonBritishLibrary/orient/BLorient8819.xml
@@ -1,0 +1,278 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="BLorient8819" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Discourses on the Passion for Holy Week, Salām to Jesus Christ, Salām to the Virgin Mary</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS00001BL"/>
+                        <collection>Oriental</collection>
+                        <idno>BL Oriental 8819</idno>
+                        <altIdentifier><idno>Or. 8819</idno></altIdentifier>
+                        <altIdentifier><idno>Strelcyn 57</idno></altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                        <msItem xml:id="ms_i1">
+                            <locus from="4r" to="78r"/> 
+                            <title ref="LIT6193HomiliaryPassions">Discourses on the Passion of our Lord Jesus Christ for Holy Week</title>  
+                            <msItem xml:id="ms_i1.1">
+                                <locus from="4r"/> 
+                                <title ref="LIT6193HomiliaryPassions#Introduction"/>
+                                <note>Rhyming</note>
+                                <incipit xml:lang="gez">በስመ፡ እግዚአብሔር፡ ሥሉስ፡ ዘእንበለ፡ ቀዲም፡ ወተድኅሮ። በግጻዌሁ፡ ይትረአይ፡ ዘአስተዋሐደ፡ ምክሮ። በጠፈረ፡ በረድ፡ ወነድ፡
+                                    ዘሐነጸ፡ ማኅደሮ። ወበአርእስተ፡ ኪሩቤል፡ ርቱዓ፡ ዘአማዕዘነ፡ መንበሮ። </incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.2">
+                                <locus from="6v"/> 
+                                <title ref="LIT6193HomiliaryPassions#Monday"/>
+                                <note>Indicated by <foreign xml:lang="gez">ዘሰኑይ፡ </foreign> on the upper margin of <locus target="#4r"/>.</note>
+                                <incipit xml:lang="gez">ናንቅሕ፡ ርእሰ፡ ሕሊናነ፡ ወናስተሐውስ፡ አስራወ፡ ልሳንነ፡ ንክሥት፡ አፉነ፡ ወናስተናብብ፡ ከናፍሪነ። ከመ፡ ንንግር፡ ዜና፡ ሕማማቲሁ፡ 
+                                    ለመድኅኒነ፡ እንዘ፡ ኃያል፡ ዘኢየሐምም፡</incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.3">
+                                <locus from="17r"/> 
+                                <title ref="LIT0000000000000000000">Homily for Tuesday</title>
+                                <note>According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">92</citedRange>
+                                    </bibl>, this part is the homily for Tuesday, but in <ref type="mss" corresp="BNFet116"/> this homily is not attested.</note>
+                                <incipit xml:lang="gez">ወእምድኅረዝ፡ እንዘ፡ ሀሎ፡ በቤተ፡ ስምዖን፡ ዘከመ፡ አቅረቡ፡ ድራረ፡ ወዘከመ፡ ወሀበ፡ ሥጋሁ፡ ወደሞ፡ ለአርዳኢሁ፡ ወዘከመ፡ ሐፀበ፡
+                                    እገሪሆሙ፡ ወዘከመ፡ አውተረ፡ ጸልዮ፡ ኵሉ፡ ጽሑፍ፡ ሀሎ፡ ውስተ፡ ወንጌል።</incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.4">
+                                <locus from="24r"/> 
+                                <title ref="LIT6193HomiliaryPassions#HomilyTuesday">Homily for Wednesday</title>
+                                <note>According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">93</citedRange>
+                                    </bibl>, this part the homily for Wednesday, but in <ref type="mss" corresp="BNFet116"/> this homily is attributed to 
+                                    Tuesday.</note>
+                                <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ንግባዕኬ፡ ከመ፡ ንፈጽ<pb n="24v"/>ም፡ ዜና፡ ሕማሙ፡ ለመድኃኒነ፡ ወአንግሁ፡
+                                    ይአተ፡ ዕለተ፡ ኵላ፡ ሌሊተ፡ እንዘ፡ ይዘብጥዎ፡ ወይጸፍእዎ። </incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.5">
+                                <locus from="36v"/> 
+                                <title ref="LIT6193HomiliaryPassions#HomilyWednesday">Homily for Thursday</title>
+                                <note>According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">93</citedRange>
+                                    </bibl>, this part is the homily for Thursday, but in <ref type="mss" corresp="BNFet116"/> this homily is attributed to 
+                                    Wednesday.</note>
+                                <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ንግባዕኬ፡ ከመ፡ ንፈጽም፡ ነገረ፡ ወበጊዜ፡ ፱ሰዓት፡ ተከሥተ፡ ፀሐይ፡ በዓውደ፡ ሰማይ።</incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.6">
+                                <locus from="50r"/> 
+                                <title ref="LIT6193HomiliaryPassions#HomilyThursday">Homily for Friday</title>
+                                <note>According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">93</citedRange>
+                                    </bibl>, this part is the homily for Friday, but in <ref type="mss" corresp="BNFet116"/> this homily is attributed to
+                                    Thursday.</note>
+                                <incipit xml:lang="gez">ንግባዕኬ፡ ከመ፡ ንፈጽም፡ ነገረ፡ ዘ፱ሰዓት። ወይእተ፡ ጊዜ፡ ሶበ፡ ርእዩ፡ ነቢያት፡ ቀደምት፡ ወአበው፡ ቀደምት፡ ሞቶ፡ ለመድኃኒነ፡ ጸርሑ፡
+                                    ኀቤሁ፡ </incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.7">
+                                <locus from="62r"/> 
+                                <title ref="LIT6193HomiliaryPassions#HomilyFriday">Homily for Saturday</title>
+                                <note>According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">93</citedRange>
+                                    </bibl>, this part is the homily for Saturday, but in <ref type="mss" corresp="BNFet116"/> this homily is attributed to 
+                                    Friday.</note>
+                                <incipit xml:lang="gez">ንግባዕኬ፡ ከመ፡ ንፈጽም፡ ነገረ፡ ዘምሴተ፡ ዓርብ። እስመ፡ ይቤ፡ ዘካርያስ፡ ይእቲ፡ ዕለ<pb n="62v"/>ት፡ እምርት፡ ይእቲ፡ በኀበ፡
+                                    እግዚአብሔር፡ ኢኮነት፡ መዓልተ፡ ወሌሊተ፡ ወፍና፡ ሠርከ፡ ይበርህ፡ ብርሃን፡ </incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.8">
+                                <locus from="70r"/> 
+                                <title ref="LIT6193HomiliaryPassions#HomilySaturday">Homily for Sunday</title>
+                                <note>According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">93</citedRange>
+                                    </bibl>, this part is the homily for Sunday, but in <ref type="mss" corresp="BNFet116"/> this homily is attributed to 
+                                    Saturday.</note>
+                                <incipit xml:lang="gez">ንንግርኬ፡ ኅዳጠ፡ ዜናሁ፡ ለፀልቦ፡ መድኃኒነ፡ መስቀል፡ ዘከመ፡ ሀሎ፡ ምስለ፡ እግዚአብሔር፡ እምቅድመ፡ ኵሉ፡ ፍጡር፤ ወእምቅድመ፡
+                                    ኵሉ፡ ግቡር፤ ትእምርተ፡ መስቀል፡ ክቡር፤ እምቅድመ፡ ነገር፤ ትእምርተ፡ መስቀል፡ አርአያሁ፡ ለእግዚአብሔር። </incipit>  
+                            </msItem>
+                            <msItem xml:id="ms_i1.9">
+                                <locus from="75r"/> 
+                                <title ref="LIT6193HomiliaryPassions#HomilySunday">Final chapter</title>
+                                <note>According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">93</citedRange>
+                                    </bibl>, this part is designated the 'final chapter', but in <ref type="mss" corresp="BNFet116"/> this homily is 
+                                    attributed to Sunday.</note>
+                                <incipit xml:lang="gez">ንግባዕኬ፡ ከመ፡ ንስብሖ፡ ለእግዚአብሔር፡ ወንወድሶ፡ እንዘ፡ ንብል፡ ጥዑመ፡ ስም፡ መድኀኒነ፡ ለሊሁ፡ ንጉሥ፡ ወእሙ፡ መቅደስ፤ 
+                                    ወመስቀሉ፡ አትሮንስ። </incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.10">
+                                <locus from="77v"/> 
+                                <title>Final benediction</title>
+                                <note>According to <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">93</citedRange>
+                                </bibl>, this part is designated the 'final benediction', but in <ref type="work" corresp="LIT6193HomiliaryPassions"/> 
+                                    this part is included to the homily attributed to Sunday.</note>
+                                <incipit xml:lang="gez">ዘጸሐፎ፡ ወለዘአጽሐፎ፡ ለዝንቱ፡ ድርሳን፡ እግዚአብሔር፡ ይጽሐፍ፡ ስሞሙ፡ በዓምደ፡ ብርሃን፡ ወያርፍቆሙ፡ በደብረ፡ ጽዮን፡ መካን፤
+                                    በሥላሴሁ፡ አመ፡ ይመጽእ፡ መድኅ<pb n="78r"/>ን፡ ምስለ፡ መላእክቲሁ፡ ትጉሃን፤ ለዓለመ፡ ዓለም። ለዘጸሐፋ፡ ለዛቲ፡ ተውዳስ፤ ወትረ፡ የሃሉ፡ በሞገስ፤ በሥጋ፡
+                                    ወነፍስ፤ እንበለ፡ ንዴት፡ ወተጽናፍስ፤ ወዘእንበለ፡ ሐተታ፡ ወሙቃስ፤፡ ኅዙነ፡ ለቡና፡ ወለተ፡ ጊጋር፡ ለዓለመ፡ ዓለም፡ አሜን፡ ወአሜን፡ ለይኩን፤ ለይኩን። </incipit>
+                            </msItem>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <locus from="78v" to="83r"/> 
+                            <title ref="LIT7017Crucifixion"/>
+                            <incipit xml:lang="gez">
+                                ሰላም፡ ለሥቃይከ፡ ለለ፩፩፤
+                                እምሴተ፡ ሐሙስ፡ ዘኮነ፡ እስከ፡ ምሴተ፡ ዓርብ፡ የዓዱ።
+                                ኢየሱስ፡ ክርስቶስ፡ ተስፋ፡ ኤዎስጣቴዎስ፡ ወውሉዱ።
+                                ዘበእንቲአሁ፡ ሶበ፡ በውስቴቱ፡ ወረዱ፤
+                                ለእሳተ፡ ጤገን፡ ዘብርት፡ አብሰሎሙ፡ ነዱ።
+                            </incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i3">
+                            <locus from="84r" to="98r"/> 
+                            <title ref="LIT2807RepCh91"/>
+                            <note>With interspersed stanzas containing praises to Jesus Christ.</note>
+                            <incipit xml:lang="gez">ሰላም፡ ለኪ፡ ማርያም፡ ድንግል፡</incipit>
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Codex">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf">1+101</measure>
+                                    <measure unit="page" type="blank">7</measure><locus target="#Ir #Iv #1v #2v #3r #83v #101r"/>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>145</height>
+                                        <width>85</width>
+                                    </dimensions>
+                                </extent>
+                                <collation>Paper endleaves added when the codex was repaired in the <placeName ref="INS00001BL">British Museum</placeName></collation>
+                            </supportDesc>
+                            <layoutDesc>
+                                <layout writtenLines="13"><locus from="4r" to="77v"/></layout>
+                                <layout writtenLines="14"><locus from="78r" to="83r"/></layout>
+                                <layout writtenLines="17"><locus from="84r" to="98r"/></layout>                                
+                            </layoutDesc>   
+                        </objectDesc> 
+                        <handDesc>
+                            <handNote script="Ethiopic" xml:id="h1">
+                                <locus from="1" to="83r"/>
+                                <desc>Careful handwriting, larger than the following hand.</desc>
+                                <date notBefore="1600" notAfter="1800" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                            <handNote script="Ethiopic" xml:id="h2">
+                                <locus from="84r" to="98r"/>
+                                <desc>Careful handwriting, smaller than the previous hand.</desc>
+                                <date notBefore="1600" notAfter="1800" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                        </handDesc> 
+                        <additions>
+                            <list>
+                                <item xml:id="a1">
+                                    <locus target="#1r"/>
+                                    <desc type="GuestText">Prayer to Jesus Christ, written by the same hand as <ref target="#a2"/> below.</desc>
+                                </item>
+                                <item xml:id="a2">
+                                    <locus target="#2r"/>
+                                    <desc type="GuestText">Prayer to Jesus Christ, written by the same hand as <ref target="#a1"/> above.</desc>
+                                </item>
+                                <item xml:id="a3">
+                                    <locus target="#3v"/>
+                                    <desc type="GuestText">One stanza of a <foreign xml:lang="gez">salām</foreign> to the Virgin Mary, written in
+                                        the same very poor hand as <ref target="#a4"/> below.</desc>
+                                </item>
+                                <item xml:id="a4">
+                                    <locus target="#3v"/>
+                                    <desc type="GuestText">A fragment of a prayer, written in the same very poor hand as <ref target="#a3"/> above.</desc>
+                                </item>
+                                <item xml:id="a5">
+                                    <locus from="99r" to="100r"/>
+                                    <desc type="GuestText">Magical prayer for expelling devils, written in another hand.</desc>
+                                    <q xml:lang="gez">በስሙ፡ ለእግዚአብሔር፡ አብ፡ <gap reason="ellipsis"/> ታኦስ፡ አዝዮስ፡ ማስያስ፡ <gap reason="ellipsis"/></q>
+                                </item>
+                                <item xml:id="e1">
+                                    <locus target="#83r"/>
+                                    <desc type="OwnershipNote">The owners 
+                                        <persName role="owner" ref="PRS14478WaldaTaklaHay">Walda Takla Hāymānot</persName>,
+                                        his son <persName role="owner" ref="PRS14479SahlaSellase">Śāhla Śǝllāse</persName> 
+                                        and his wife <persName role="owner" ref="PRS14480TsotaMikael">Ṣota Mikāʾel</persName> are named
+                                        in a note.</desc>
+                                </item>
+                                <item xml:id="e2">
+                                    <locus target="24r"/>
+                                    <desc type="OwnershipNote"><persName role="owner" ref="PRS14481WalattaGigar">Walatta Gigār</persName>
+                                        is named as an owner on several places in the codex.</desc>
+                                </item>
+                            </list>
+                        </additions>
+                        <bindingDesc>
+                            <binding xml:id="binding">
+                                <decoNote xml:id="b1" type="Boards"><material key="leather"/>Thick leather boards.</decoNote>
+                                <decoNote xml:id="b2" type="Spine"><material key="leather"/>The leather spine was added added when the 
+                                    manuscript was repaired in the <placeName ref="INS00001BL">British Museum</placeName>.</decoNote>
+                                <decoNote xml:id="b3" type="SlipCase"><material key="leather">Preserved in a leather case.</material></decoNote>
+                                <decoNote xml:id="b6" type="Other"><term key="leafStringMark">Small pieces of blue, yellow and red yarn</term>
+                                    </decoNote>
+                            </binding>
+                        </bindingDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1600" notAfter="1800">17th/18th century</origDate>    
+                        </origin>
+                        <acquisition>Bequeathed by <persName role="bequeather" ref="PRS14320DareaCurzon">Darea
+                            <roleName type="title">Baroness</roleName> Zouche</persName>. <date when="1917-10-13">13 October 1917</date>.
+                                </acquisition>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                            <citedRange unit="page">92-94</citedRange>
+                                        </bibl> 
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="Hagiography"/>
+                    <term key="Prayers"/>
+                    <term key="ChristianLiterature"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-06-17">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I created a record for BLorient8819 according to the description of St. Strelcyn.

Strelcyn subdivided the main text different to what was encoded by Denis to LIT6193HomiliaryPassions. The subdivision in LIT6193HomiliaryPassions is based on the witness BNFet116. However, either in BNFet116 nor in the incipits given by Strelcyn for BLorient8819, I found evidence to verify or falsify this subdivision. Probably the subdivision was based on the printed editions. In the end, I do not know, whether the two manuscripts are different in their attribution of textparts to the days of the week. Yet alone the existence of ms_i1.3 seems to be unique to BLorient8819. I suggest to create a new sub-ID or LIT-ID for it.

For ms_i2, see our discussion in https://github.com/BetaMasaheft/Documentation/issues/2562#issuecomment-2174464848.