### PR TITLE
Hand desc rev

### DIFF
--- a/OxfordBodleian/BodNewMSS/BDLaethf35.xml
+++ b/OxfordBodleian/BodNewMSS/BDLaethf35.xml
@@ -234,8 +234,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <layout columns="2" writtenLines="18">
                                     <locus from="1ra" to="107ra"/>
                                     <note>There are 11–12 characters per line per column in the part
-                                        written by <ref target="#h1">hand 1</ref> and 9–11 in the part written by <ref target="#h2">hand 2</ref>.</note>
-                                    <!-- capitalize Hand 1, Hand 2 -->
+                                        written by <ref target="#h1">Hand 1</ref> and 9–11 in the part written by <ref target="#h2">Hand 2</ref>.</note>
                                     <note corresp="#textarea #margin">Data on text area and margin dimensions taken from <locus target="#11r"/>.</note>
                                     <dimensions unit="mm" xml:id="textarea">
                                         <height>101</height>
@@ -260,29 +259,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <locus from="1ra" to="104vb"/>
+                                <date notBefore="1889" notAfter="1926"/>
+                                <persName ref="PRS14003FereS" role="scribe"/> is indicated as the scribe in the the supplication formulas throughout.
                            <seg type="ink">Black, red.</seg>
                                 <seg type="rubrication">Incipits (groups of red lines alternating with black lines) and single words; holy names; the names
-                                    of persons involved in the manuscript production;
-                                    elements of punctuation marks.</seg>
+                                    of persons involved in the manuscript production; elements of punctuation marks.</seg>
                                 <desc>Modern bulky, slightly condensed script. The characters are of somewhat irregular height, but the hand is trained.
-                                The vowel markers for the third and fifth order are hardly distinguishable. The word separator is often omitted at the
-                                end of a line.</desc>
-                                <persName ref="PRS14003FereS" role="scribe"/>
-                                <!--      <persName ref="PRS14003FereS" role="scribe"/> is indicated as the scribe in the the supplication formulas throughout. -->
-                                
-                                <date notBefore="1889" notAfter="1926"/>
-                                <!-- Order is ink, date, desc --> 
+                                The vowel markers of the third and fifth orders are hardly distinguishable. The word separator is often omitted at the
+                                end of a line.</desc>                               
                             </handNote>
 
                             <handNote xml:id="h2" script="Ethiopic">
                                 <locus from="105ra" to="107ra"/>
-                                <seg type="ink">Black.</seg>
-                                <seg type="rubrication">Spaces left for rubrication have been left empty.</seg>
-                                <desc>Hand of the last quire. Modern, slighly cursive script, somewhat irregular. <foreign xml:lang="gez">ሠ</foreign>
-                                has an archaizing form.</desc>
-                                <!-- The letter <foreign xml:lang="gez">ሠ</foreign> has ... --> 
                                 <date notBefore="1889" notAfter="1926"/>
-                                <!-- Order is ink, date, desc --> 
+                                <seg type="ink">Black.</seg>
+                                <desc>Hand of the last quire. Modern, slighly cursive script, somewhat irregular. The letter <foreign xml:lang="gez">ሠ</foreign>
+                                    has an archaizing form.</desc>
+                                <seg type="rubrication">Spaces left for rubrication have been left empty.</seg>                           
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/BodNewMSS/BDLaethf35.xml
+++ b/OxfordBodleian/BodNewMSS/BDLaethf35.xml
@@ -292,7 +292,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <desc>The part written by <ref target="#h1">Hand 1</ref> contains no scribal corrections.
                                     The part written by <ref target="#h2">Hand 2</ref> contains an erasure on <locus target="#105ra"/>
                                         and <locus target="#106va"/>.
-                                        Spaces left for rubrication have been left empty on <locus from="105ra" to="107ra"/>.</desc>
+                                        Spaces intended for rubrication have been left empty on <locus from="105ra" to="107ra"/>.</desc>
                                 </item>
 
                                        <item xml:id="e2">

--- a/OxfordBodleian/BodNewMSS/BDLaethf35.xml
+++ b/OxfordBodleian/BodNewMSS/BDLaethf35.xml
@@ -260,13 +260,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <locus from="1ra" to="104vb"/>
                                 <date notBefore="1889" notAfter="1926"/>
-                                <persName ref="PRS14003FereS" role="scribe"/> is indicated as the scribe in the supplication formulas throughout.
-                           <seg type="ink">Black, red.</seg>
-                                <seg type="rubrication">Incipits (groups of red lines alternating with black lines) and single words; holy names; the names
-                                    of persons involved in the manuscript production; elements of punctuation marks.</seg>
+                                <seg type="ink">Black, red.</seg>
                                 <desc>Modern bulky, slightly condensed script. The characters are of somewhat irregular height, but the hand is trained.
-                                The vowel markers of the third and fifth orders are hardly distinguishable. The word separator is often omitted at the
-                                end of a line.</desc>                               
+                                    The vowel markers of the third and fifth orders are hardly distinguishable. The word separator is often omitted at the
+                                    end of a line.  
+                                <persName ref="PRS14003FereS" role="scribe"/> is indicated as the scribe in the supplication formulas throughout.
+                                </desc> 
+                                <seg type="rubrication">Incipits (groups of red lines alternating with black lines) and single words; holy names; the names
+                                    of persons involved in the manuscript production; elements of the punctuation marks.</seg>                                                            
                             </handNote>
 
                             <handNote xml:id="h2" script="Ethiopic">
@@ -274,8 +275,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <date notBefore="1889" notAfter="1926"/>
                                 <seg type="ink">Black.</seg>
                                 <desc>Hand of the last quire. Modern, slighly cursive script, somewhat irregular. The letter <foreign xml:lang="gez">ሠ</foreign>
-                                    has an archaizing form.</desc>
-                                <seg type="rubrication">Spaces left for rubrication have been left empty.</seg>                           
+                                    has an archaizing form.</desc>                  
                             </handNote>
                         </handDesc>
 
@@ -289,10 +289,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <additions>
                             <list>
                                 <item xml:id="e1">
-                                    <desc>The part written by <ref target="#h1">hand 1</ref> contains no scribal corrections.
-                                    The part written by <ref target="#h2">hand 2</ref> contains an erasure on <locus target="#105ra"/>
-                                        and <locus target="#106va"/>.</desc>
-                                    <!-- capitalize Hand 2 -->
+                                    <desc>The part written by <ref target="#h1">Hand 1</ref> contains no scribal corrections.
+                                    The part written by <ref target="#h2">Hand 2</ref> contains an erasure on <locus target="#105ra"/>
+                                        and <locus target="#106va"/>.
+                                        Spaces left for rubrication have been left empty on <locus from="105ra" to="107ra"/>.</desc>
                                 </item>
 
                                        <item xml:id="e2">

--- a/OxfordBodleian/BodNewMSS/BDLaethf35.xml
+++ b/OxfordBodleian/BodNewMSS/BDLaethf35.xml
@@ -260,7 +260,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <locus from="1ra" to="104vb"/>
                                 <date notBefore="1889" notAfter="1926"/>
-                                <persName ref="PRS14003FereS" role="scribe"/> is indicated as the scribe in the the supplication formulas throughout.
+                                <persName ref="PRS14003FereS" role="scribe"/> is indicated as the scribe in the supplication formulas throughout.
                            <seg type="ink">Black, red.</seg>
                                 <seg type="rubrication">Incipits (groups of red lines alternating with black lines) and single words; holy names; the names
                                     of persons involved in the manuscript production; elements of punctuation marks.</seg>

--- a/OxfordBodleian/BodNewMSS/BDLaethg47.xml
+++ b/OxfordBodleian/BodNewMSS/BDLaethg47.xml
@@ -208,17 +208,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <date notBefore="1800" notAfter="2020"/>
-                                <!-- add date range in letters -->
-                                <desc>Trained hand. Bulky, widely spaced characters.</desc>
-                                <!-- Characters are bulky and widely spaced. -->
-                           <seg type="ink">Black, red.</seg>
-                                <!-- Order -->
-                                <seg type="rubrication">The first two–three lines of prayers; holy names; the complete name of the owner or only the holy name contained in it;
+                                <date notBefore="1800" notAfter="2020">Nineteenth–twentieth century.</date>
+                                <seg type="ink">Black, red.</seg>
+                                <desc>Trained hand. Characters are bulky and widely spaced.</desc>                           
+                                <seg type="rubrication">The first two or three lines of prayers; holy names; the complete name of the owner or only the holy name contained in it;
                                 <foreign xml:lang="gez">ሰላም፡ ለከ፡</foreign>/<foreign xml:lang="gez">ለኪ፡</foreign>; parts of numerals. In the final supplication, the illegible
-                                    name of the owner is followed by <foreign xml:lang="gez">ወእማ፡ ወለተ፡ ሚካኤል፡</foreign>, "and her mother <persName ref="PRS14044WalattaM"/>".</seg>
+                                    name of the owner is followed by <foreign xml:lang="gez">ወእማ፡ ወለተ፡ ሚካኤል፡</foreign>, “and her mother <persName ref="PRS14044WalattaM"/>”.</seg>
                             </handNote>
-                            <!-- "two–three" becomes "two or three"; "and her mother <persName ref="PRS14044WalattaM"/>" becomes “and her mother <persName ref="PRS14044WalattaM"/>” -->
                         </handDesc>
 
                         <!--          <decoDesc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethb3.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethb3.xml
@@ -889,23 +889,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <persName ref="PRS13901Zaparaqlitos" role="scribe"/>
-                                <persName ref="PRS13900WaldaD" role="scribe"/>
-                                <!-- 
-                                 <persName ref="PRS13901Zaparaqlitos" role="scribe"/> is mentioned in red ink in the lower margin of <locus target="#148r"/>.
+                                <date notBefore="1730" notAfter="1755"/>
+                                <persName ref="PRS13901Zaparaqlitos" role="scribe"/> is mentioned in red ink in the lower margin of <locus target="#148r"/>.
                                 <persName ref="PRS13900WaldaD" role="scribe"/> is mentioned in black ink in the lower margin of <locus target="#117r #138v"/>.
                                 The two different names mentioned suggest at least two scribes were involved in the copying,
                                 but no discontinuity in the hand can be observed throughout the manuscript. 
-                                -->
-                                <date notBefore="1730" notAfter="1755"/>
-                                <desc>Regular handwriting, trained hand, <foreign xml:lang="gez">gʷǝlḥ</foreign> script. Big and evenly spaced characters. The two different names indicated in the bottom margins
-                                    of <locus target="#117r #138v"/> and <locus target="#148r"/> indicate that at least two scribes were involved in the copying,
-                                but no differences in the hand can be observed throughout the manuscript. The script of the introductions to the Gospels is smaller than that of the main text.</desc>
                                 <!-- 
-                                Regular handwriting, trained hand, <hi rendition="simple:italic">gʷǝlḥ</hi>-script. Characters are big and evenly spaced.
-                                The script of the Introductions to the Gospels is smaller than that of the main text.
+                                Is this published correctly in the PDF? Should we nest it inside desc or other?
                                 -->
                                 <seg type="ink">Black, red.</seg>
+                                <desc>    Regular handwriting, trained hand, <hi rendition="simple:italic">gʷǝlḥ</hi>-script. Characters are big and evenly spaced.
+                                    The script of the Introductions to the Gospels is smaller than that of the main text.</desc>
                                 <seg type="rubrication">Single lines and groups of lines at the beginning of sections; single lines alternating with black lines
                                     at the beginning of each Gospel; chapter indications; holy names; names mentioned in the supplications;
                                     numerals and elements of numerals and punctuation signs.</seg>

--- a/OxfordBodleian/Juel-Jensen/BDLaethb3.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethb3.xml
@@ -889,20 +889,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <date notBefore="1730" notAfter="1755"/>
-                                <persName ref="PRS13901Zaparaqlitos" role="scribe"/> is mentioned in red ink in the lower margin of <locus target="#148r"/>.
-                                <persName ref="PRS13900WaldaD" role="scribe"/> is mentioned in black ink in the lower margin of <locus target="#117r #138v"/>.
-                                The two different names mentioned suggest at least two scribes were involved in the copying,
-                                but no discontinuity in the hand can be observed throughout the manuscript. 
-                                <!-- 
-                                Is this published correctly in the PDF? Should we nest it inside desc or other?
-                                -->
+                                <date notBefore="1730" notAfter="1755"/> 
                                 <seg type="ink">Black, red.</seg>
-                                <desc>    Regular handwriting, trained hand, <hi rendition="simple:italic">gʷǝlḥ</hi>-script. Characters are big and evenly spaced.
-                                    The script of the Introductions to the Gospels is smaller than that of the main text.</desc>
-                                <seg type="rubrication">Single lines and groups of lines at the beginning of sections; single lines alternating with black lines
-                                    at the beginning of each Gospel; chapter indications; holy names; names mentioned in the supplications;
-                                    numerals and elements of numerals and punctuation signs.</seg>
+                                <desc>                                    
+                                    Regular handwriting, trained hand, <hi rendition="simple:italic">gʷǝlḥ</hi>-script. Characters are big and evenly spaced.
+                                    <persName ref="PRS13901Zaparaqlitos" role="scribe"/> is mentioned in red ink in the lower margin of <locus target="#148r"/>.
+                                    <persName ref="PRS13900WaldaD" role="scribe"/> is mentioned in black ink in the lower margin of <locus target="#117r #138v"/>.
+                                    The two different names mentioned suggest at least two scribes were involved in the copying,
+                                    but no discontinuity in the hand can be observed throughout the manuscript. 
+                                    The script of the Introductions to the Gospels is smaller than that of the main text.
+                                    <seg type="rubrication">Single lines and groups of lines at the beginning of sections; single lines alternating with black lines
+                                        at the beginning of each Gospel; chapter indications; holy names; names mentioned in the supplications;
+                                        numerals and elements of numerals and punctuation signs.</seg>
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethb3.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethb3.xml
@@ -897,7 +897,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <persName ref="PRS13900WaldaD" role="scribe"/> is mentioned in black ink in the lower margin of <locus target="#117r #138v"/>.
                                     The two different names mentioned suggest at least two scribes were involved in the copying,
                                     but no discontinuity in the hand can be observed throughout the manuscript. 
-                                    The script of the Introductions to the Gospels is smaller than that of the main text.
+                                    The script of the <ref target="ms_i1.1">Introductions to the Gospels</ref> is smaller than that of the main text.
                                     <seg type="rubrication">Single lines and groups of lines at the beginning of sections; single lines alternating with black lines
                                         at the beginning of each Gospel; chapter indications; holy names; names mentioned in the supplications;
                                         numerals and elements of numerals and punctuation signs.</seg>

--- a/OxfordBodleian/Juel-Jensen/BDLaethb4.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethb4.xml
@@ -1303,7 +1303,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         ref="PRS4585Georgeo">St George</persName> and 
                                     <persName ref="PRS6819Mary">St Mary</persName>; names of
                                     individuals related to the production of the manuscript;
-                                    the words<foreign xml:lang="gez">ክፍል፡</foreign> and <foreign
+                                    the words <foreign xml:lang="gez">ክፍል፡</foreign> and <foreign
                                         xml:lang="gez">ምዕራፍ፡</foreign> in the <ref target="#ms_i1.2"><hi rendition="simple:italic">Vita</hi> of St George</ref>;
                                     elements of the punctuation marks, text dividers, and numerals
                                     on some folios (e.g. <locus from="19v" to="22r"/> and more

--- a/OxfordBodleian/Juel-Jensen/BDLaethb4.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethb4.xml
@@ -1291,43 +1291,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <locus from="4ra" to="118v"/>
-                                <seg type="ink">Black, red</seg>
-                                <!-- Add dot -->
-                                <date notBefore="1750" notAfter="1850">18th- to 19th-century
-                                    handwriting</date>
-                                <desc>Trained hand. The handwriting is characterised by finely
+                                <date notBefore="1750" notAfter="1850">Mid-eighteenth–mid-nineteenth century.</date>
+                                <seg type="ink">Black, red.</seg>
+                                <desc>Trained handwriting, characterised by finely
                                     shaped, slender, and regularly spaced characters. Presumably due
                                     to the change of nib, the writing appears somewhat irregular
                                     from <locus target="#144v"/> onward.</desc>
-                                <seg type="rubrication">Several groups of lines on the incipit page
-                                    of <ref target="#ms_i1.1 #ms_i1.2 #ms_i1.3"/>, initial two lines
-                                    of the sections of all parts; the name of <persName
-                                        ref="PRS4585Georgeo">St George</persName> and the name of
-                                        <persName ref="PRS6819Mary">St Mary</persName>, names of
-                                    individuals related to the production of the manuscript;
-                                    elements of the punctuation marks, text dividers, and numerals
-                                    on some folios (e.g. <locus from="19v" to="22r"/> and more
-                                    regularly from <locus target="#128r"/> onward) partly executed in
-                                    a darker tone of red (cp. <locus target="#150rb"/>); the words
-                                        <foreign xml:lang="gez">ክፍል፡</foreign> and <foreign
-                                        xml:lang="gez">ምዕራፍ፡</foreign> in <ref target="#ms_i1.2"
-                                    />.</seg>
-                                <!-- 
-                                 <seg type="rubrication">
-                                 Several groups of lines on the incipit pages of all texts; initial two lines
+                                <seg type="rubrication">
+                                    Several groups of lines on the incipit pages of all texts; initial two lines
                                     of the sections of all parts; the names of <persName
                                         ref="PRS4585Georgeo">St George</persName> and 
-                                        <persName ref="PRS6819Mary">St Mary</persName>; names of
+                                    <persName ref="PRS6819Mary">St Mary</persName>; names of
                                     individuals related to the production of the manuscript;
-                                        the words<foreign xml:lang="gez">ክፍል፡</foreign> and <foreign
+                                    the words<foreign xml:lang="gez">ክፍል፡</foreign> and <foreign
                                         xml:lang="gez">ምዕራፍ፡</foreign> in the <ref target="#ms_i1.2"><hi rendition="simple:italic">Vita</hi> of St George</ref>;
                                     elements of the punctuation marks, text dividers, and numerals
                                     on some folios (e.g. <locus from="19v" to="22r"/> and more
                                     regularly from <locus target="#128r"/> onward) partly executed in
                                     a darker tone of red (cp. <locus target="#150rb"/>).                                                                   
-                                   </seg>
-                                -->
+                                </seg>
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethb5.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethb5.xml
@@ -9226,45 +9226,31 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <seg type="ink">Black, red.</seg>
-                                <date notBefore="1711" notAfter="1716"/>
+                                <date notBefore="1711" notAfter="1716"/>        
                                 <persName ref="PRS13094GabraKr" role="scribe"/> is mentioned as scribe in supplications throughout the
                                 manuscript.
                                 <persName ref="PRS13115SelaKr"/> is mentioned as scribe in
                                 supplications on <locus target="#102rc #106vc"/>. It cannot be excluded that more than one scribe were involved in the copying,
                                 but no clear discontinuities in hand can be observed.
+                                <seg type="ink">Black, red.</seg>
                                 <desc>Written by a trained hand, but slightly irregular. The characters are also spaced
                                     irregularly.
                                 </desc>
-                                <seg
-                                    type="rubrication">Incipits (alternating red and black lines at
-                                    the top and bottom of the page for months, two continuous lines
-                                    for days, one to two continuous lines for commemorations),
-                                    elements of punctuation signs, <foreign xml:lang="gez"
-                                        >ሰላም፡</foreign>, the full names of persons involved in the
-                                    production of the manuscript (<locus target="#33ra #78vc"/>),
-                                    or, more often, only the holy names <foreign xml:lang="gez"
-                                        >ማርያም፡</foreign> and <foreign xml:lang="gez"
-                                        >ክርስቶስ፡</foreign> which form part of their name, paratextual
-                                    elements (names of the months, name of the scribe assigned to
-                                    the quires), elements of the quire marks.</seg>
-                            <!-- 
-                            <seg type="rubrication">Incipits (alternating with black lines at
+                                <seg type="rubrication">Incipits (alternating with black lines at
                                     the top and bottom of the page for months, two continuous lines
                                     for days, one to two continuous lines for commemorations);
                                     the word <foreign xml:lang="gez">ሰላም፡</foreign>; 
-                                     the full names of persons involved in the
+                                    the full names of persons involved in the
                                     production of the manuscript (<locus target="#33ra #78vc"/>)
                                     or, more often, only the holy names <foreign xml:lang="gez">ማርያም፡</foreign> and 
                                     <foreign xml:lang="gez">ክርስቶስ፡</foreign> which form part of their name; 
                                     paratextual elements (names of the months and of the scribe);
                                     elements of punctuation signs and quire marks.
-                                    </seg>
-                            -->
+                                </seg>
                                 <list type="abbreviations">
                                     <item>
                                         <abbr>ሰ፡</abbr> for <expan>ሰላም፡</expan> (e.g. <locus
-                                            target="#65ra"/>) </item>
+                                            target="#65ra"/>).</item>
                                 </list>
                             </handNote>
                         </handDesc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethb5.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethb5.xml
@@ -9226,15 +9226,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <date notBefore="1711" notAfter="1716"/>        
-                                <persName ref="PRS13094GabraKr" role="scribe"/> is mentioned as scribe in supplications throughout the
-                                manuscript.
-                                <persName ref="PRS13115SelaKr"/> is mentioned as scribe in
-                                supplications on <locus target="#102rc #106vc"/>. It cannot be excluded that more than one scribe were involved in the copying,
-                                but no clear discontinuities in hand can be observed.
+                                <date notBefore="1711" notAfter="1716"/>                                      
                                 <seg type="ink">Black, red.</seg>
                                 <desc>Written by a trained hand, but slightly irregular. The characters are also spaced
                                     irregularly.
+                                    <persName ref="PRS13094GabraKr" role="scribe"/> is mentioned as scribe in supplications throughout the
+                                    manuscript.
+                                    <persName ref="PRS13115SelaKr"/> is mentioned as scribe in
+                                    supplications on <locus target="#102rc #106vc"/>. It cannot be excluded that more than one scribe were involved in the copying,
+                                    but no clear discontinuities in hand can be observed.
                                 </desc>
                                 <seg type="rubrication">Incipits (alternating with black lines at
                                     the top and bottom of the page for months, two continuous lines

--- a/OxfordBodleian/Juel-Jensen/BDLaethb5.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethb5.xml
@@ -9372,10 +9372,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     </physDesc>
 
                     <history>
-                        <origin> The colophon states that the manuscript was completed during the reign of
+                        <origin><origDate notBefore="1712" notAfter="1714">1712-1714</origDate>
+                            The colophon states that the manuscript was completed during the reign of
                                 King <persName ref="PRS10473Yostos"/> (r. 1711-1716). The weekdays on which
                             the manuscript was begun and completed would point to a production between
-                            <origDate notBefore="1712" notAfter="1714">1712-1714</origDate>.
+                            1712-1714.
                             The colophon mentions <foreign xml:lang="gez">ሰብአ፡ <placeName ref="LOC7348Legat">ልጋት</placeName></foreign> and
                             supplications mention <foreign xml:lang="gez">ደቂቀ፡ ቂርቆስ፡</foreign>
                                 (<locus target="#53vbc #143vc"/>),

--- a/OxfordBodleian/Juel-Jensen/BDLaethb6.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethb6.xml
@@ -87,10 +87,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <handNote xml:id="h2" script="Ethiopic" corresp="#a3 #a4 #a5 #a6">
                                 <locus target="#1r #125rb #186v #187v"/>
                                 <date notBefore="1800" notAfter="1987">Nineteenth–twentieth century.</date>
-                                <persName ref="PRS13549SardaD" role="scribe"/> is indicated as the scribe in the <ref target="#a4">Additional note 4</ref> (or pseudo-colophon, <locus target="#186v"/>).
-                                <seg type="ink">Black, red.</seg>                               
-                                <desc>The hand of the so-called ‘Sǝnkǝssār forger’ who wrote the captions to the miniatures added above the text, the two pseudo-colophons
-                                    on <locus target="#1r"/> and <locus target="#186v"/>, and the name <persName ref="PRS13549SardaD"/> throughout after supplications. Modern hand written with a narrow nib.</desc>
+                               <seg type="ink">Black, red.</seg>                               
+                                <desc>
+                                    <persName ref="PRS13549SardaD" role="scribe"/> is indicated as the scribe in the <ref target="#a4">Additional note 4</ref> (or pseudo-colophon, <locus target="#186v"/>).
+                                    He is the so-called ‘Sǝnkǝssār forger’, who wrote the captions to the miniatures added above the text, the two pseudo-colophons,
+                                    and his own name throughout after supplications. Modern hand written with a narrow nib.
+                                </desc>
+                                <!-- Did I understood correctly the text? -->
                                 <seg type="rubrication">A group of lines at the beginning; the name of <persName ref="PRS13549SardaD"/>; elements of numerals, punctuation marks, and text dividers.</seg>
                             </handNote>
                         </handDesc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethb6.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethb6.xml
@@ -75,31 +75,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
+                                <locus from="1ra" to="187rc"/>
                                 <date notBefore="1632" notAfter="1667"/>
-                                <seg type="ink">Black, red.</seg>
+                                <seg type="ink">Black, red.</seg>                                
+                                <desc>Fine and regular handwriting. The characters are slender and slightly inclined to the right. <foreign xml:lang="gez">ጵ</foreign> has the pre-modern shape
+                                    (e.g. <locus target="#76rc"/>).</desc>
                                 <seg type="rubrication">Groups of two lines at the beginning of months, two lines at the beginning of days,
                                     and one line at the beginning of commemorations; holy names;
                                     the word <foreign xml:lang="gez">ሰላም፡</foreign>; numerals; elements of punctuation marks and text dividers.</seg>
-                                <desc>Fine and regular handwriting. The letters are slender and slightly inclined to the right. ጵ has the pre-modern shape
-                                    (e.g. <locus target="#76rc"/>). No abbreviations are used.</desc>
-                                <!-- 
-                                    The order is: ink, date, <desc/>, rubr.
-                                    Change "The letters" into "Characters"; 
-                                <foreign xml:lang="gez">ጵ</foreign> -->
                             </handNote>
-
                             <handNote xml:id="h2" script="Ethiopic" corresp="#a3 #a4 #a5 #a6">
-                                <date notBefore="1800" notAfter="1987"/>
-                                <persName ref="PRS13549SardaD"/>
-                                <!--      <persName ref="PRS13549SardaD" role="scribe"/> is indicated as the scribe in the <ref target="#a4">Additional note 4</ref> (or pseudo-colophon) on <locus target="#186v"/>. -->
-                                <!-- Order is ink, date, desc, rubr -->
-                                <seg type="ink">Black, red.</seg>
-                               
-                                <seg type="rubrication">Group of lines at the beginning; the name of <persName ref="PRS13549SardaD"/>; elements of numerals; elements of punctuation marks and text dividers.</seg>
-                                <!-- A group of lines at the beginning; the name of <persName ref="PRS13549SardaD"/>; elements of numerals, punctuation marks, and text dividers.-->
+                                <locus target="#1r #125rb #186v #187v"/>
+                                <date notBefore="1800" notAfter="1987">Nineteenth–twentieth century.</date>
+                                <persName ref="PRS13549SardaD" role="scribe"/> is indicated as the scribe in the <ref target="#a4">Additional note 4</ref> (or pseudo-colophon, <locus target="#186v"/>).
+                                <seg type="ink">Black, red.</seg>                               
                                 <desc>The hand of the so-called ‘Sǝnkǝssār forger’ who wrote the captions to the miniatures added above the text, the two pseudo-colophons
                                     on <locus target="#1r"/> and <locus target="#186v"/>, and the name <persName ref="PRS13549SardaD"/> throughout after supplications. Modern hand written with a narrow nib.</desc>
-                                <!-- Add <ref target="#a3">Additional note 3</ref> after <locus target="#1r"/> and <ref target="#a4">Additional note 4</ref> after <locus target="#186v"/> -->
+                                <seg type="rubrication">A group of lines at the beginning; the name of <persName ref="PRS13549SardaD"/>; elements of numerals, punctuation marks, and text dividers.</seg>
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
@@ -454,17 +454,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <dim type="left">15</dim>
                                             <dim type="intercolumn">15</dim>
                                         </dimensions>
-                                        <note>There are 14-17 characters per line.</note>
-                                        <ab type="punctuation" subtype="Dividers">
-                                            Several caesura signs are attested in the manuscript:
-                                            the <foreign xml:lang="la">crux ansata</foreign> is written in the left margin on <locus target="#65va #74vb"/>;
-                                            the <foreign xml:lang="la">coronis</foreign> sign in the left margin, e.g. on <locus target="#3vb #56vb #101va"/>;
-                                            the <foreign xml:lang="la">crux ansata</foreign> and the <foreign xml:lang="la">coronis</foreign> are written together on <locus target="#90va #93rb #98vb"/>.
-                                            The word <foreign xml:lang="gez">ቁም፡</foreign> is written at the end of the line or in the right margin, most often in red ink, e.g. on <locus target="#5rb #97ra #116rb"/>, etc.
-                                            Chains of black and red right-pointing v-shaped marks, indicating quotations from the Old Testament, are in the left margin of e.g. <locus target="#3rb #18rb #93vb"/>, etc.
-                                            Chains of red and black dots separate the chapters are e.g. on <locus target="#4ra #20rb #94rb"/>, etc.
-                                            Chains of red and black dots and double dashes separate the stichometric notes.
-                                        </ab>
+                                        <note>There are 14-17 characters per line.</note>                                      
                                         <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are often visible.</ab>
                                         <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A-1A1A/0-0/0-0/C.</ab>
                                         <ab type="ruling"> The upper line is written above the ruling. The bottom line is written above the ruling.
@@ -476,38 +466,41 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <handDesc>
                                 <handNote xml:id="h1" script="Ethiopic">
                                     <locus from="1ra" to="123vb"/>
-                                    <seg type="ink">Black, red or deep vermilion</seg>
-                                    <!-- Add dot -->
-                                    <date notBefore="1500" notAfter="1600"></date>
-                                    <!-- Add date in letters -->
+                                    <seg type="ink">Black, red or deep vermilion.</seg>
+                                    <date notBefore="1500" notAfter="1600">Sixteenth century.</date>
                                     <desc>
                                         Fine and trained hand. Characters are regularly spaced.
                                     </desc>
                                     <note>
                                         The script displays some relatively archaic features: the numeral <foreign xml:lang="gez">፮</foreign> has a compressed shape and the open loop;
-                                        the letter መ has the loops not completely separated; the letters ፅ and ዕ and numeral ፬ show "cone-forms";
+                                        the letter <foreign xml:lang="gez">መ</foreign> has the loops not completely separated; the letters <foreign xml:lang="gez">ፅ</foreign> and 
+                                        <foreign xml:lang="gez">ዕ</foreign> and numeral <foreign xml:lang="gez">፬</foreign> show “cone-forms”;
                                         the word <foreign xml:lang="gez">እግዚአ፡ ብሔር፡</foreign> is sometimes written as two separate words.
-                                        The graphemes ግ and ዚ are occasionally written with a ligature in the word <foreign xml:lang="gez">እግዚእነ፡</foreign>, e.g. on <locus target="#35va #100vb"/>.
+                                        The graphemes <foreign xml:lang="gez">ግ</foreign> and <foreign xml:lang="gez">ዚ</foreign> are occasionally written with a ligature in the word <foreign xml:lang="gez">እግዚእነ፡</foreign>, e.g. on <locus target="#35va #100vb"/>.
                                         One bottom ruled line has been left unwritten on <locus from="24va" to="25vb"/>.
-                                    </note>
-                                    <!-- All numerals must be marked up with <foreign xml:lang="gez">...</foreign>
-                                        "cone-forms" must become “cone-form”
-                                    -->
+                                    </note>                                   
                                     <seg type="rubrication">
                                         Several groups of lines on the incipit page of each Gospel, alternating with black lines;
                                         the stichometric note at the end of the Gospel of Matthew, on <locus target="#35ra"/>; holy names;
                                         the captions <foreign xml:lang="gez">ማርቆስ፡</foreign> on <locus target="#35vb"/>, <foreign xml:lang="gez">ስዕለ፡ ሉቃስ፡</foreign> (partly illegible)
                                         on <locus target="#61v"/>, and <foreign xml:lang="gez">ዮሐንስ፡</foreign> on <locus target="#100va"/>;
-                                        the numbers of the chapters in the list of the <foreign xml:lang="la">tituli</foreign> at the beginning of each Gospel;
+                                        the numbers of the chapters in the list of the <hi rendition="simple:italic">tituli</hi> at the beginning of each Gospel;
                                         the numbers of the Eusebian Canons to which the Ammonian sections, penned in black ink in the left margins immediately above those numbers, belong;
                                         the numbers and titles of the chapters are written in the upper or lower margin, in correspondence of the beginning of the chapters;
                                         elements of the numerals and of the punctuation signs, including text dividers and caesura signs
-                                        (the <foreign xml:lang="la">crux ansata</foreign> is entirely rubricated on <locus target="#65va"/>; the <foreign xml:lang="la">coronis</foreign> sign is
+                                        (the <hi rendition="simple:italic">crux ansata</hi> is entirely rubricated on <locus target="#65va"/>; the <hi rendition="simple:italic">coronis</hi> sign is
                                         entirely rubricated on <locus target="#62vb #63ra"/>; the word <foreign xml:lang="gez">ቁም፡</foreign> is rubricated on e.g. <locus target="#5rb #56ra #97ra"/>.
-                                    </seg>
-                                    <!-- tituli becomes <hi rendition="simple:italic">tituli</hi>;
-                                        crux ansata becomes <hi rendition="simple:italic">crux ansata</hi>;
-                                        coronis becomes <hi rendition="simple:italic">coronis</hi> -->
+                                    </seg>                        
+                                    <ab type="punctuation" subtype="Dividers">
+                                        Several caesura signs are attested in the manuscript:
+                                        the <hi rendition="simple:italic">crux ansata</hi> is written in the left margin on <locus target="#65va #74vb"/>;
+                                        the <hi rendition="simple:italic">coronis</hi> sign is written in the left margin, e.g. on <locus target="#3vb #56vb #101va"/>;
+                                        the <hi rendition="simple:italic">crux ansata</hi> and the <hi rendition="simple:italic">coronis</hi> are written together on <locus target="#90va #93rb #98vb"/>.
+                                        The word <foreign xml:lang="gez">ቁም፡</foreign> is written at the end of the line or in the right margin, most often in red ink, e.g. on <locus target="#5rb #97ra #116rb"/>.
+                                        Chains of black and red right-pointing v-shaped marks, indicating quotations from the Old Testament, are in the left margin of e.g. <locus target="#3rb #18rb #93vb"/>.
+                                        Chains of red and black dots separate the chapters are e.g. on <locus target="#4ra #20rb #94rb"/>.
+                                        Chains of red and black dots and double dashes separate the stichometric notes.
+                                    </ab>
                                 </handNote>
                             </handDesc>
 
@@ -751,9 +744,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <dim type="intercolumn">16</dim>
                                     </dimensions>
                                     <note> There are 12–13 characters per line.</note>
-                                    <ab type="punctuation" subtype="Dividers">
-                                        The word <foreign xml:lang="gez">ቁም፡</foreign> is written at the end of the line on <locus target="#127vb"/>.
-                                    </ab>
+                                   
                                     <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are visible.</ab>
                                     <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A-1A1A/0-0/0-0/C.</ab>
                                     <ab type="ruling"> The upper line is written above the ruling. The bottom line is written above the ruling.</ab>
@@ -764,22 +755,21 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <handDesc>
                             <handNote xml:id="h2" script="Ethiopic">
                                 <locus from="124ra" to="130va"/>
-                                <persName ref="PRS13184WaldaHe" role="scribe">Walda Ḥǝḍān</persName>
-                                <!--      <persName ref="PRS13184WaldaHe" role="scribe"/> is indicated as the scribe in the <ref target="#coloph1">colophon</ref> on  <locus target="#130va"/>. -->
-                                
-                                <seg type="ink">Black, red</seg>
-                                <!-- Add dot -->
-                                <date notBefore="1650" notAfter="1800"></date>
-                                <!-- Add date in letters, and the hyphen must be – -->
+                                <persName ref="PRS13184WaldaHe" role="scribe"/> is indicated as the scribe in the <ref target="#coloph1">colophon</ref> (<locus target="#130va"/>).                                
+                                <seg type="ink">Black, red.</seg>
+                                <date notBefore="1650" notAfter="1800">Mid-seventeenth–eighteenth century.</date>
                                 <seg type="script"><foreign xml:lang="gez">Gʷǝlḥ</foreign>-script.</seg>
                                 <desc>Fine and trained hand. Characters are regularly spaced.</desc>
                                 <seg type="rubrication">
                                     Incipits of few chapters and of the postscript; holy names; the word <foreign xml:lang="gez">ቁም፡</foreign>, written in a later
                                     hand on <locus target="#127vb"/>; elements of the numerals and of the punctuation signs, including text dividers.
                                 </seg>
+                                <ab type="punctuation" subtype="Dividers">
+                                    The word <foreign xml:lang="gez">ቁም፡</foreign> is written at the end of the line on <locus target="#127vb"/>.
+                                </ab>
                                 <list type="abbreviations">
                                     <item>
-                                        <abbr>ምዕ፡</abbr> for <expan>ምዕራፍ፡</expan> (e.g. on <locus target="#128ra #128va"/>)
+                                        <abbr>ምዕ፡</abbr> for <expan>ምዕራፍ፡</expan> (e.g. on <locus target="#128ra #128va"/>).
                                     </item>
                                 </list>
                             </handNote>

--- a/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
@@ -495,8 +495,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         the <hi rendition="simple:italic">coronis</hi> sign is written in the left margin, e.g. on <locus target="#3vb #56vb #101va"/>;
                                         the <hi rendition="simple:italic">crux ansata</hi> and the <hi rendition="simple:italic">coronis</hi> are written together on <locus target="#90va #93rb #98vb"/>.
                                         The word <foreign xml:lang="gez">ቁም፡</foreign> is written at the end of the line or in the right margin, most often in red ink, e.g. on <locus target="#5rb #97ra #116rb"/>.
-                                        Chains of black and red right-pointing v-shaped marks, indicating quotations from the Old Testament, are in the left margin of e.g. <locus target="#3rb #18rb #93vb"/>.
-                                        Chains of red and black dots separate the chapters are e.g. on <locus target="#4ra #20rb #94rb"/>.
+                                        Chains of black and red right-pointing v-shaped marks, indicating quotations from the Old Testament, are found in the left margin of e.g. <locus target="#3rb #18rb #93vb"/>.
+                                        Chains of red and black dots separate the chapters are found on e.g. <locus target="#4ra #20rb #94rb"/>.
                                         Chains of red and black dots and double dashes separate the stichometric notes.
                                     </ab>
                                 </handNote>

--- a/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethc14.xml
@@ -469,16 +469,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <seg type="ink">Black, red or deep vermilion.</seg>
                                     <date notBefore="1500" notAfter="1600">Sixteenth century.</date>
                                     <desc>
-                                        Fine and trained hand. Characters are regularly spaced.
-                                    </desc>
-                                    <note>
+                                        Fine and trained hand. Characters are regularly spaced.                                  
                                         The script displays some relatively archaic features: the numeral <foreign xml:lang="gez">፮</foreign> has a compressed shape and the open loop;
                                         the letter <foreign xml:lang="gez">መ</foreign> has the loops not completely separated; the letters <foreign xml:lang="gez">ፅ</foreign> and 
                                         <foreign xml:lang="gez">ዕ</foreign> and numeral <foreign xml:lang="gez">፬</foreign> show “cone-forms”;
                                         the word <foreign xml:lang="gez">እግዚአ፡ ብሔር፡</foreign> is sometimes written as two separate words.
                                         The graphemes <foreign xml:lang="gez">ግ</foreign> and <foreign xml:lang="gez">ዚ</foreign> are occasionally written with a ligature in the word <foreign xml:lang="gez">እግዚእነ፡</foreign>, e.g. on <locus target="#35va #100vb"/>.
                                         One bottom ruled line has been left unwritten on <locus from="24va" to="25vb"/>.
-                                    </note>                                   
+                                    </desc>                           
                                     <seg type="rubrication">
                                         Several groups of lines on the incipit page of each Gospel, alternating with black lines;
                                         the stichometric note at the end of the Gospel of Matthew, on <locus target="#35ra"/>; holy names;
@@ -754,12 +752,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h2" script="Ethiopic">
-                                <locus from="124ra" to="130va"/>
-                                <persName ref="PRS13184WaldaHe" role="scribe"/> is indicated as the scribe in the <ref target="#coloph1">colophon</ref> (<locus target="#130va"/>).                                
+                                <locus from="124ra" to="130va"/>                                                              
                                 <seg type="ink">Black, red.</seg>
-                                <date notBefore="1650" notAfter="1800">Mid-seventeenth–eighteenth century.</date>
-                                <seg type="script"><foreign xml:lang="gez">Gʷǝlḥ</foreign>-script.</seg>
-                                <desc>Fine and trained hand. Characters are regularly spaced.</desc>
+                                <date notBefore="1650" notAfter="1800">Mid-seventeenth–eighteenth century.</date>                                
+                                <desc>
+                                    Fine and trained hand, <foreign xml:lang="gez">gʷǝlḥ</foreign>-script. Characters are regularly spaced.
+                                    <persName ref="PRS13184WaldaHe" role="scribe"/> is indicated as the scribe in the <ref target="#coloph1">colophon</ref> (<locus target="#130va"/>).  
+                                </desc>
                                 <seg type="rubrication">
                                     Incipits of few chapters and of the postscript; holy names; the word <foreign xml:lang="gez">ቁም፡</foreign>, written in a later
                                     hand on <locus target="#127vb"/>; elements of the numerals and of the punctuation signs, including text dividers.

--- a/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
@@ -221,9 +221,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <dim type="left">15</dim>
                                         <dim type="intercolumn">15</dim>
                                     </dimensions>
-                                    <note>The characters per line are 16–17</note>
-                                    <ab type="punctuation" subtype="Dividers">The explicit of <ref target="#ms_i2">the ‘Saqoqāwa nafs’</ref> on <locus target="#7rb"/>
-                                        terminates with a chain of red and black dots.</ab>
+                                    <note>The characters per line are 16–17</note>                                  
                                     <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are visible.</ab>
                                     <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A/0-0/0-0/C.</ab>
                                     <ab type="ruling">The upper line is written above the ruling. The bottom line is written above the ruling.</ab>
@@ -266,8 +264,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <dim type="intercolumn">14</dim>
                                     </dimensions>
                                     <note>The characters per line are 12–15. The end of lines is very irregular.</note>
-                                    <ab type="punctuation" subtype="Dividers">The text of the <ref target="#ms_i4">‘<foreign xml:lang="gez">Malkǝʾ</foreign>-hymn to Walatta Ṗeṭros’</ref>
-                                        accommodates a chain of red and black dots on <locus target="#60ra"/>.</ab>
+                                
                                     <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are visible.</ab>
                                     <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A/0-0/0-0/C.</ab>
                                     <ab type="ruling">The upper line is written above the ruling. The bottom line is written above the ruling.</ab>
@@ -278,11 +275,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-
                                 <locus from="1ra" to="1va"/>
-                              <seg type="ink">Black, red</seg>
-                                <!-- add dot. -->
-                                <date notBefore="1700" notAfter="1799">18th century</date>
+                                <date notBefore="1700" notAfter="1799">Eighteenth century.</date>
+                              <seg type="ink">Black, red.</seg>
                                 <desc>Decent handwriting.</desc>
                                 <seg type="rubrication">
                                     Rubrication has not been executed, leading to textual lacunas.
@@ -290,31 +285,26 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </handNote>
                             <handNote xml:id="h2" script="Ethiopic">
                                 <locus from="1vb" to="56vb"/>
-                              <seg type="ink">Black, red</seg>
-                                <!-- add dot. -->
-                                <date notBefore="1700" notAfter="1750">First half of the 18th century</date>
+                                <date notBefore="1700" notAfter="1750">First half of the eighteenth century.</date>
+                              <seg type="ink">Black, red.</seg>                          
                                 <desc>
                                     Elegant and uniform handwriting. Characters are slanted and regularly spaced.
                                 </desc>
                                 <seg type="rubrication">
-                                    Few lines on the incipit pages on <locus target="#2ra #8r"/>, alternating with black lines; holy names; the name of the owner or patron;
-                                    the first word of each stanza of the <ref target="#ms_i2">‘Saqoqāwa nafs’</ref> and of the <ref target="#ms_i3">‘Ṭabiba ṭabibān’</ref>;
-                                    captions of the miniatures on the upper margin of <locus from="8r" to="56v"/> and next to the characters of each miniature;
-                                   elements of the punctuation signs, of the numerals, and of the text dividers.
-                                </seg>
-                                <!-- 
-                                 Few lines on the incipit pages on <locus target="#2ra #8r"/>, alternating with black lines; holy names; the name of the individual involved in the production or
-                                 commissioning of the manuscript;
+                                    Few lines on the incipit pages on <locus target="#2ra #8r"/>, alternating with black lines; holy names; the name of the individual involved in the production or
+                                    commissioning of the manuscript;
                                     the first word of each stanza of the <ref target="#ms_i2">Lamentation of the Soul (<hi rendition="simple:italic">Saqoqāwa nafs</hi>)</ref> and of 
                                     <ref target="#ms_i3">The Wisest among the Wise (<hi rendition="simple:italic">Ṭabiba ṭabibān</hi>)</ref>;
                                     captions of the miniatures on the upper margin of <locus from="8r" to="56v"/> and next to the characters of each miniature;
-                                   elements of the punctuation signs, numerals, and text dividers.                                
-                                -->
+                                    elements of the punctuation signs, numerals, and text dividers.            
+                                </seg>
+                                <ab type="punctuation" subtype="Dividers">The explicit of the <ref target="#ms_i2">Lamentation of the Soul</ref> on <locus target="#7rb"/>
+                                    terminates with a chain of red and black dots.</ab>
                             </handNote>
                             <handNote xml:id="h3" script="Ethiopic">
                                 <locus from="57ra" to="60rb"/>
-                              <seg type="ink">Black, red</seg>
-                                <date notBefore="1700" notAfter="1799">18th century</date>
+                                <date notBefore="1700" notAfter="1799">Eighteenth century.</date>
+                                <seg type="ink">Black, red.</seg>
                                 <desc>
                                     Decent handwriting. Characters are executed with a thin nib and are uniformly spaced.
                                 </desc>
@@ -322,7 +312,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     Few lines on the incipit page, alternating with black lines; holy names, included that of Walatta Ṗeṭros;
                                     the word <foreign xml:lang="gez">salām</foreign>; elements of the punctuation signs, of the numerals, and of the text dividers.
                                 </seg>
-
+                                <ab type="punctuation" subtype="Dividers">The text of the <ref target="#ms_i4"><foreign xml:lang="gez">Malkǝʾ</foreign>-hymn to Walatta Ṗeṭros</ref>
+                                    accommodates a chain of red and black dots on <locus target="#60ra"/>.</ab>
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
@@ -275,13 +275,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <locus from="1ra" to="1va"/>
+                               <locus from="1ra" to="1va"/>
                                 <date notBefore="1700" notAfter="1799">Eighteenth century.</date>
                               <seg type="ink">Black, red.</seg>
-                                <desc>Decent handwriting.</desc>
-                                <seg type="rubrication">
-                                    Rubrication has not been executed, leading to textual lacunas.
-                                </seg>
+                                <desc>Decent handwriting.</desc>                                
                             </handNote>
                             <handNote xml:id="h2" script="Ethiopic">
                                 <locus from="1vb" to="56vb"/>
@@ -658,7 +655,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <item xml:id="e1">
                                     <desc>
                                         The incipits of stanzas 8 and 9 of the <ref target="#ms_i2">Lamentation of the Soul (<hi rendition="simple:italic">Saqoqāwa nafs</hi>)</ref> are indicated with Ethiopic numbers on the left margin
-                                        of <locus target="#1va"/>. Cues for the rubricator are found on the left margin of <locus from="2ra" to="4ra"/>.
+                                        of <locus target="#1va"/>. 
+                                        Rubrication has not been executed on <locus from="1ra" to="1va"/>, leading to textual lacunas.
+                                        Cues for the rubricator are found on the left margin of <locus from="2ra" to="4ra"/>.
                                         Corrections are scarce. They mostly consist of interlineal additions (e.g. <locus target="#12va #12vb #14va"/>), erasures (e.g. <locus target="#11ra"/>),
                                         or are made by encircling the word (<locus target="#26rb"/>).
                                         Pen trial in red and black ink on <locus target="#1vb"/>.

--- a/OxfordBodleian/Juel-Jensen/BDLaethd17.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd17.xml
@@ -407,10 +407,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <date notBefore="1650" notAfter="1750">Mid-seventeenth–mid-eighteenth century.</date>
                                 <seg type="ink">Black, red.</seg>                       
                                 <desc>Trained hand. The handwriting remains uniform throughout the
-                                    Ms. It is characterized by finely shaped, regularly spaced
+                                    manuscript. It is characterized by finely shaped, regularly spaced
                                     characters with a very few archaic features (e.g. the
                                     characters <foreign xml:lang="gez">ፅ</foreign> and <foreign
-                                        xml:lang="gez">ዕ</foreign> are usually cone-shaped, downward
+                                        xml:lang="gez">ዕ</foreign> are usually “cone-shaped” , downward
                                     oriented).</desc>
                                 <seg type="rubrication">Several groups of lines on
                                     the incipit page of the text (<locus target="#4r"/>) as well as

--- a/OxfordBodleian/Juel-Jensen/BDLaethd17.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd17.xml
@@ -401,14 +401,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </layout>
                             </layoutDesc>
                         </objectDesc>
+                        
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <locus from="4ra" to="139ra"/>
-                                <seg type="ink">Black, red</seg>
-                                <!-- Add dot. -->
-                                <date notBefore="1650" notAfter="1750">seventeenth/eighteenth
-                                    century</date>
-                                <!-- In letters or numbers? To be discussed? -->
+                                <date notBefore="1650" notAfter="1750">Mid-eventeenth–mid-eighteenth century.</date>
+                                <seg type="ink">Black, red.</seg>                       
                                 <desc>Trained hand. The handwriting remains uniform throughout the
                                     Ms. It is characterized by finely shaped, regularly spaced
                                     characters with a very few archaic features (e.g. the
@@ -416,19 +413,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         xml:lang="gez">ዕ</foreign> are usually cone-shaped, downward
                                     oriented).</desc>
                                 <seg type="rubrication">Several groups of lines on
-                                    the incipit page (<locus target="#4r"/>) of the text as well as
+                                    the incipit page of the text (<locus target="#4r"/>) as well as
                                     of each section (the other six days); regularly two lines of
                                     subsections; the name of <persName ref="PRS6819Mary"/>; a few
                                     repeatedly occurring words within the reading for Monday (on
-                                        <locus from="13rb" to="15ra"/>: <foreign xml:lang="gez"
-                                            >አመንኩ፡</foreign>, <foreign xml:lang="gez">ስረይ፡</foreign>,
-                                    <foreign xml:lang="gez">መሐረኒ፡</foreign>), the name <persName
-                                        ref="PRS12973Rehr">Rǝḫruḫ Krǝstos</persName>, elements of
-                                    the punctuation marks, text dividers, and of numerals.</seg>
-                                <!-- 
-                                change commas into ; move "(<locus target="#4r"/>)" after "of the text"
-                                -->
-                                
+                                    <locus from="13rb" to="15ra"/>: <foreign xml:lang="gez"
+                                        >አመንኩ፡</foreign>, <foreign xml:lang="gez">ስረይ፡</foreign>,
+                                    <foreign xml:lang="gez">መሐረኒ፡</foreign>); the name <persName
+                                        ref="PRS12973Rehr">Rǝḫruḫ Krǝstos</persName>; elements of
+                                    the punctuation marks, text dividers, and numerals.</seg>
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethd17.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd17.xml
@@ -404,7 +404,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <date notBefore="1650" notAfter="1750">Mid-eventeenth–mid-eighteenth century.</date>
+                                <date notBefore="1650" notAfter="1750">Mid-seventeenth–mid-eighteenth century.</date>
                                 <seg type="ink">Black, red.</seg>                       
                                 <desc>Trained hand. The handwriting remains uniform throughout the
                                     Ms. It is characterized by finely shaped, regularly spaced

--- a/OxfordBodleian/Juel-Jensen/BDLaethd18.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd18.xml
@@ -295,23 +295,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <seg type="ink">Black, red</seg>
-                                <!-- Add dot -->
-                                <date when="1975">20th century</date>
+                                <date when="1975"/>
+                                <seg type="ink">Black, red.</seg>                              
                                 <desc>
                                     Fine handwriting.
                                 </desc>
-                                <seg type="rubrication">
-                                    Holy names; several groups of lines on the incipit page, alternating with black lines;
-                                    the word <foreign xml:lang="gez">ክፍል፡</foreign>;
-                                    first two lines of <ref target="ms_i1.3"/>; incipit of each monthly section of <ref target="ms_i2"/>;
-                                    elements of the punctuation signs, text dividers, and numerals, included quire marks;
-                                    name of the patron and of the scribe in the colophon.
+                                <seg type="rubrication">                                    
+                                    Several groups of lines on the incipit page, alternating with black lines;                                  
+                                    first two lines of the <ref target="ms_i1.3">Book of the Luminaries</ref>; incipit of each monthly section of the <ref target="ms_i2">Book of the Parables</ref>;
+                                    holy names; name of the individuals mentioned in the colophon; the word <foreign xml:lang="gez">ክፍል፡</foreign>;
+                                   elements of the punctuation signs, text dividers, and numerals, included quire marks.
                                 </seg>
-                                <!-- Holy names goes after the incipit lines -->
-                                <!-- <ref target="ms_i1.3"/> becomes <ref target="ms_i1.3">Book of the Luminaries</ref> -->
-                                <!-- <ref target="ms_i2"/> becomes <ref target="ms_i1.2">Book of the Parables</ref> -->
-                                <!-- individuals mentioned in the colophon. -->
                             </handNote>
                         </handDesc>
 
@@ -434,7 +428,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </msIdentifier>
                         <msContents>
                             <msItem xml:id="p2_i1">
-                                <locus from="ir" to="iir"></locus>
+                                <locus from="ir" to="iir"/>
                                 <title>Land record and various documents</title>
                                 <note>
                                     The documents are written in Amharic, with some formulas in Gǝʿǝz.
@@ -551,14 +545,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </layout>
                                 </layoutDesc>
                             </objectDesc>
+                            
                             <handDesc>
                                 <handNote xml:id="h2" script="Ethiopic">
-                                    <date notBefore="1900" notAfter="2006">20th century</date>
-                                    <desc>Uneven and somewhat inaccurate handwriting. Several hands might be involved.
-                                    </desc>
-                                    <!-- and untrained handwriting, possibly executed by several hands.  -->
+                                    <locus from="ir" to="iir"/>
+                                    <date notBefore="1900" notAfter="2006">Twentieth century.</date>
+                                    <seg type="ink">Black.</seg>      
+                                    <desc>Uneven and untrained handwriting, possibly executed by several hands.
+                                    </desc>                   
+                                    <ab type="punctuation" subtype="Dividers">Texts are divided by means of lines in black ink.</ab>          
                                 </handNote>
                             </handDesc>
+                            
                         </physDesc>
                         <history>
                             <origin>

--- a/OxfordBodleian/Juel-Jensen/BDLaethd18.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd18.xml
@@ -299,6 +299,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <seg type="ink">Black, red.</seg>                              
                                 <desc>
                                     Fine handwriting.
+                                    <persName ref="PRS12944AmhaSe" role="scribe"/> is indicated as the scribe in the <ref target="#coloph1">Colophon</ref> (<locus target="#58va"/>).                                    
                                 </desc>
                                 <seg type="rubrication">                                    
                                     Several groups of lines on the incipit page, alternating with black lines;                                  

--- a/OxfordBodleian/Juel-Jensen/BDLaethd20.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd20.xml
@@ -3573,33 +3573,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <date notBefore="1600" notAfter="1799"/>
-                                <desc>Fine and regular handwriting. Regularly spaced characters.</desc>
-                                <!-- Characters are regularly spaced. -->
-                           <seg type="ink">Black, red.</seg>
+                                <date notBefore="1600" notAfter="1799">Seventeenth–eighteenth century.</date>
+                                <seg type="ink">Black, red.</seg>
+                                <desc>Fine and regular handwriting. Characters are regularly spaced.</desc>
                                 <seg type="rubrication">
                                     Incipits (one word to one or several lines, consecutive or alternating with black lines in different groupings);
-                                    captions of miniatures; holy names (<persName ref="PRS6819Mary"/>, <persName ref="PRS4377Gabriel"/>,
-                                    rarely <persName ref="PRS5684JesusCh"/>); the names of individuals related to the production of
-                                    the manuscript (<persName ref="PRS12911KidanaK"/>,
-                                    <persName ref="PRS13031WaldaA"/>, <persName ref="PRS12964Gorgoryos"/>
-                                    <persName ref="PRS13026KenfaM"/>); numerals; text dividers; elements of punctuation signs.
+                                    captions of miniatures; holy names; the names of individuals related to the production of
+                                    the manuscript; elements of the punctuation signs, text dividers, and numerals, included quire marks.
                                 </seg>
-                                <!-- ...; elements of the punctuation signs, text dividers, and numerals, included quire marks. -->
-                                <!-- The specific holy names could be omitted (?) -->
                                 <list type="abbreviations">
                                     <item><abbr>አ</abbr>, <abbr>አሜ</abbr> for <expan>አሜን</expan> (e.g. on <locus target="#9rb #13ra #93ra #96vb"/>);</item>
                                     <item><abbr>ሰ፡ ለ፡</abbr> for <expan>ሰላም፡ ለኪ፡</expan> (e.g. on <locus target="#29rb"/>);</item>
-                                    <item><abbr>ዓለ</abbr> for <expan>ዓለመ</expan>, <expan>ዓለም</expan> (e.g. on <locus target="#103ra"/>).</item>
+                                    <item><abbr>ዓለ</abbr> for <expan>ዓለመ</expan> or <expan>ዓለም</expan> (e.g. on <locus target="#103ra"/>).</item>
                                 </list>
-                            </handNote>
-
-                            <handNote xml:id="h2" script="Ethiopic" corresp="#a1 #a2">
-                                <desc>Hand of additional notes 1 and 2.</desc>
-                                <!-- Desc missing!
-                                Additional notes 1 and 2 should be marked up and capitalized. Short description?-->
-                                <date notAfter="1868"/>
-                                <seg type="ink">Black.</seg>
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethd22.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd22.xml
@@ -108,9 +108,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <date notBefore="1855" notAfter="1868"/>
+                                <seg type="ink">Black.</seg>
                                <desc>Regular hand, bulky script.</desc>
-                           <seg type="ink">Black.</seg>
-                                <!-- Order is ink, date, desc -->
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethe30.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe30.xml
@@ -609,11 +609,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <dim type="right">12</dim>
                                         <dim type="left">10</dim>
                                     </dimensions>
-                                    <note> The characters per line are 10-22.</note>
-                                    <ab type="punctuation" subtype="Dividers">Groups of ten psalms are separated sometimes with one chain of red and black small semicircles
-                                        (e.g. on <locus target="#13v #29v #101v"/>),
-                                        sometimes with two chains of red and black small semicircles (<locus target="#59r #66v #82v"/>),
-                                        or sometimes with one single chain of red semicircles (<locus target="#20v #41v"/>). </ab>
+                                    <note> The characters per line are 10-22.</note>                                
                                     <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are visible.</ab>
                                     <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A/0-0/0-0/C.</ab>
                                     <ab type="ruling"> The upper line is written above the ruling. The bottom line is written above the ruling.
@@ -645,40 +641,36 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <seg type="script"/>
-                                <!-- Delete empty element -->
-                                <seg type="ink">Black, red</seg>
-                                <!-- add dot -->
-                                <date notBefore="1800" notAfter="1850">First half of the 19th century</date>
+                                <date notBefore="1800" notAfter="1850">First half of the nineteenth century.</date>
+                                <seg type="ink">Black, red.</seg>
                                 <desc>
-                                  Fine handwriting, sometimes uneven in size and thickness (e.g. on <locus target="#23r #24r #29r"/>).
-                                </desc>
-                                <!-- Fine hand,  -->
-                                <note>
+                                    Fine handwriting, sometimes uneven in size and thickness (e.g. on <locus target="#23r #24r #29r"/>).
                                     The graphemes ግ and ዚ in the word <foreign xml:lang="gez">እግዚአብሔር፡</foreign> are occasionally
                                     written with ligature (e.g. on <locus target="#14v #31v #113r"/>).
-                              </note>
-                                <!-- <note/> can go inside <desc/>  -->
+                              </desc>
                                 <seg type="rubrication">
                                    Several groups of lines on the incipit pages, alternating with black lines; numbers and titles of the psalms and of the
                                     canticles; incipits and numbers of the songs; holy names; the word <foreign xml:lang="gez">መንፈቁ፡</foreign> indicating the midpoint of the
-                                    Psalms of David; name, number, and traditional interpretation of the Hebrew letters in Ps 118;
+                                    Psalms of David; names, numbers, and traditional interpretation of the Hebrew letters in Ps 118;
                                     some letters, alternating with black letters, of the first word of each line (generally <foreign xml:lang="gez">ይባርክዎ፡</foreign>)
                                     of the Third song of the Three Youths; elements of the punctuation signs, text dividers, and numerals, included quire marks.
                                 </seg>
-                                <!-- mark up texts! "names, numbers and traditional..." -->
+                                <ab type="punctuation" subtype="Dividers">Groups of ten psalms are separated sometimes with one chain of red and black small semicircles
+                                    (e.g. on <locus target="#13v #29v #101v"/>),
+                                    sometimes with two chains of red and black small semicircles (<locus target="#59r #66v #82v"/>),
+                                    or sometimes with one single chain of red semicircles (<locus target="#20v #41v"/>). </ab>
                                 <list type="abbreviations">
                                     <item>
-                                        <abbr>እግ</abbr>, <abbr>እግዚ</abbr> or <abbr>እግዚአ</abbr> for <expan>እግዚአብሔር፡</expan> (e.g. <locus target="#115r"/>)
+                                        <abbr>እግ</abbr>, <abbr>እግዚ</abbr> or <abbr>እግዚአ</abbr> for <expan>እግዚአብሔር፡</expan> (e.g. <locus target="#115r"/>);
                                     </item>
                                     <item>
-                                        <abbr>ስ</abbr> for <expan>ስቡሕ፡</expan> (e.g. <locus target="#115r"/>)
+                                        <abbr>ስ</abbr> for <expan>ስቡሕ፡</expan> (e.g. <locus target="#115r"/>);
                                     </item>
                                     <item>
-                                        <abbr>ሰ፡ ለ፡ ቅድ፡</abbr> or <abbr>ሰ፡ ለ፡ ቅ፡</abbr> for <expan>ሰአሊ፡ ለነ፡ ቅድስት፡</expan> (e.g. <locus target="#126rb #128ra #130ra"/>)
+                                        <abbr>ሰ፡ ለ፡ ቅድ፡</abbr> or <abbr>ሰ፡ ለ፡ ቅ፡</abbr> for <expan>ሰአሊ፡ ለነ፡ ቅድስት፡</expan> (e.g. <locus target="#126rb #128ra #130ra"/>);
                                     </item>
                                     <item>
-                                        <abbr>ወ፡ ሣ፡ ይ፡ ሰ፡ ለ፡ ቅ፡</abbr> for <expan>ወልድኪ፡ ሣህሎ፡ ይክፍለነ፡ ሰአሊ፡ ለነ፡ ቅድስት፡</expan> (e.g. <locus target="#134ra #136va"/>)
+                                        <abbr>ወ፡ ሣ፡ ይ፡ ሰ፡ ለ፡ ቅ፡</abbr> for <expan>ወልድኪ፡ ሣህሎ፡ ይክፍለነ፡ ሰአሊ፡ ለነ፡ ቅድስት፡</expan> (e.g. <locus target="#134ra #136va"/>).
                                     </item>
                                 </list>
                             </handNote>

--- a/OxfordBodleian/Juel-Jensen/BDLaethe32.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe32.xml
@@ -643,7 +643,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     (e.g. on <locus target="#31v #50v #70r"/>), probably added at a later time. </ab>
                                 <list type="abbreviations">
                                     <item>Single letters for the entire refrain in the <ref target="#ms_i1.4">Praise of Mary</ref> and the <ref target="#ms_i1.5">Gate of Light</ref>;</item>
-                                <!-- Add specific abbreviations? -->
                                     <item>
                                         <abbr>ሰ፡ ለ፡ ቅ፡</abbr> for <expan>ሰአሊ፡ ለነ፡ ቅድስት፡</expan> (e.g. <locus target="#109rb #114ra #117ra"/>);
                                     </item>

--- a/OxfordBodleian/Juel-Jensen/BDLaethe32.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe32.xml
@@ -628,7 +628,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <date notBefore="1649" notAfter="1849">Mid-seventeenth–mid-nineteenth century.</date>
                                 <seg type="ink">Black, red.</seg>
-                                <desc>Irregular, but probably trained, hand. Characters are spaced irregularly, and written lines placed also somewhat irregularly
+                                <desc>Irregular, but probably trained, hand. Characters are irregularly spaced, and written lines placed also somewhat irregularly
                                 on the ruled lines.</desc>                           
                                 <seg type="rubrication">
                                     Several groups of lines on the incipit pages, alternating with black lines; titles of the psalms and of the

--- a/OxfordBodleian/Juel-Jensen/BDLaethe32.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe32.xml
@@ -593,11 +593,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <dim type="right">30</dim>
                                         <dim type="left">16</dim>
                                     </dimensions>
-                                    <note> The characters per line are 14-30.</note>
-                                    <ab type="punctuation" subtype="Dividers">Groups of ten psalms are separated by
-                                      text dividers consisting of black and red dots, below which an irregularly executed
-                                      ornamental band consisting of geometric forms, usually covering about half of a line
-                                        (e.g. on <locus target="#31v #50v #70r"/>), probably added secondarily. </ab>
+                                    <note> The characters per line are 14-30.</note>                             
                                     <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are visible.</ab>
                                     <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A/0-0/0-0/C.</ab>
                                     <ab type="ruling">The upper line is written above the ruling. The bottom line is written above the ruling.
@@ -630,32 +626,32 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <date notBefore="1649" notAfter="1849"/>
-                                <desc>Irregular, but probably trained, hand. Letters are spaced irregularly, and written lines placed also somewhat irregularly
-                                on the ruled lines.</desc>
-                               <!-- Characters are ... --> 
-                                <seg type="ink">Black, red</seg>
-                                <!-- Add dot -->
+                                <date notBefore="1649" notAfter="1849">Mid-seventeenth–mid-nineteenth century.</date>
+                                <seg type="ink">Black, red.</seg>
+                                <desc>Irregular, but probably trained, hand. Characters are spaced irregularly, and written lines placed also somewhat irregularly
+                                on the ruled lines.</desc>                           
                                 <seg type="rubrication">
                                     Several groups of lines on the incipit pages, alternating with black lines; titles of the psalms and of the
                                     canticles; incipits of the portions of the Song of Songs; the name <foreign xml:lang="gez">ማርያም፡</foreign> and its abbreviations;
                                     name and traditional interpretation of the Hebrew letters in Ps 118; the abbreviation standing for the refrain
-                                    in <ref target="#ms_i1.4"/> and <ref target="#ms_i1.5"/>;
-                                    <!-- ... in the <ref target="#ms_i1.4">Praise of Mary</ref> and the <ref target="#ms_i1.5">Gate of Light</ref>; -->
+                                    in the <ref target="#ms_i1.4">Praise of Mary</ref> and the <ref target="#ms_i1.5">Gate of Light</ref>;                               
                                  elements of the punctuation signs, text dividers, and numerals.
                                 </seg>
+                                <ab type="punctuation" subtype="Dividers">Groups of ten psalms are separated by
+                                    text dividers consisting of black and red dots, below which an irregularly executed
+                                    ornamental band consisting of geometric forms, usually covering about half of a line
+                                    (e.g. on <locus target="#31v #50v #70r"/>), probably added at a later time. </ab>
                                 <list type="abbreviations">
-                                    <item>Single letters for the entire refrain in <ref target="#ms_i1.4"/> and <ref target="#ms_i1.5"/>;</item>
-                                    <!-- ... in the <ref target="#ms_i1.4">Praise of Mary</ref> and the <ref target="#ms_i1.5">Gate of Light</ref> -->
+                                    <item>Single letters for the entire refrain in the <ref target="#ms_i1.4">Praise of Mary</ref> and the <ref target="#ms_i1.5">Gate of Light</ref>;</item>
+                                <!-- Add specific abbreviations? -->
                                     <item>
-                                        <abbr>ሰ፡ ለ፡ ቅ፡</abbr> for <expan>ሰአሊ፡ ለነ፡ ቅድስት፡</expan> (e.g. <locus target="#109rb #114ra #117ra"/>)
+                                        <abbr>ሰ፡ ለ፡ ቅ፡</abbr> for <expan>ሰአሊ፡ ለነ፡ ቅድስት፡</expan> (e.g. <locus target="#109rb #114ra #117ra"/>);
                                     </item>
                                     <item>
-                                        <abbr>ማርያ፡</abbr> and <abbr>ማር፡</abbr>  for <expan>ማርያም፡</expan> (e.g. <locus target="#112rb #114ra #114va"/>)
-                                        <!-- or -->
+                                        <abbr>ማርያ፡</abbr> or <abbr>ማር፡</abbr>  for <expan>ማርያም፡</expan> (e.g. <locus target="#112rb #114ra #114va"/>);                                   
                                     </item>
                                     <item>
-                                        <abbr>ወ፡ ሣ፡ ይ፡ ሰ፡ ለ፡ ቅ፡</abbr> for <expan>ወልድኪ፡ ሣህሎ፡ ይክፍለነ፡ ሰአሊ፡ ለነ፡ ቅድስት፡</expan> (e.g. <locus target="#120ra #120vb"/>)
+                                        <abbr>ወ፡ ሣ፡ ይ፡ ሰ፡ ለ፡ ቅ፡</abbr> for <expan>ወልድኪ፡ ሣህሎ፡ ይክፍለነ፡ ሰአሊ፡ ለነ፡ ቅድስት፡</expan> (e.g. <locus target="#120ra #120vb"/>).
                                     </item>
                                 </list>
                             </handNote>

--- a/OxfordBodleian/Juel-Jensen/BDLaethe33.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe33.xml
@@ -287,44 +287,37 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </ab>
                                 </layout>
                             </layoutDesc>
-
                         </objectDesc>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <locus target="#1r"/>
-                                <seg type="ink">Black, red</seg>
-                                <!-- Add dot -->
-                                <date notBefore="1700" notAfter="1799">18th century</date>
-                                <!-- 
+                                <date notBefore="1700" notAfter="1799">Eighteenth century.</date>
+                                <seg type="ink">Black, red.</seg>                                                            
                                  <desc>
                                     Decent handwriting.
                                 </desc>
-                                -->
                                 <seg type="rubrication">
                                     The name of <persName ref="PRS4585Georgeo"/>; the word <foreign xml:lang="gez">ሃሌ፡</foreign>; elements of the punctuation signs and numerals.
                                 </seg>
                                 <list type="abbreviations">
                                     <item>
-                                        <abbr>ሃሌ፡</abbr>, for <expan>ሃሌ፡ ሉያ፡</expan> (<locus target="#1r"/>)
+                                        <abbr>ሃሌ፡</abbr>, for <expan>ሃሌ፡ ሉያ፡</expan> (<locus target="#1r"/>).
                                     </item>
                                 </list>
                             </handNote>
                             <handNote xml:id="h2" script="Ethiopic">
-                                <locus from="2r" to="130v"/>
-                                <seg type="script"/>
-                                <seg type="ink">Black, red</seg>
-                                <!-- Add dot -->
-                                <date notBefore="1700" notAfter="1799">18th century</date>
+                                <locus from="2r" to="130v"/>                                
+                                <date notBefore="1700" notAfter="1799">Eighteenth century.</date>
+                                <seg type="ink">Black, red.</seg>           
                                 <desc>
                                     Small and occasionally irregular handwriting.
                                 </desc>
                                 <seg type="rubrication">
                                     Numbers and titles of the psalms; holy names (in particular that of <persName ref="PRS6819Mary"/>);
-                                    name, number, and traditional interpretation of the Hebrew letters in Ps 118;
+                                    names, numbers, and traditional interpretation of the Hebrew letters in Ps 118;
                                     elements of the punctuation signs and numerals.
                                 </seg>
-                                <!-- names, numbers, and ... -->
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethe34.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe34.xml
@@ -111,25 +111,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </objectDesc>
 
                         <handDesc>
-                            <handNote xml:id="h1" script="Ethiopic">
-                            </handNote>
-                        </handDesc>
-                        <!-- 
-                       <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">                             
+                                <date notBefore="1650" notAfter="1750">Mid-seventeenth–mid-eighteenth century.</date>
                                 <seg type="ink">Black.</seg>
-                                   <date notBefore="1650" notAfter="1750"/>
                                 <desc>
-                                  Fine hand, responsible for the captions.
+                                    Fine hand, responsible for the captions.
                                 </desc>
                             </handNote>
                         </handDesc> 
-                        -->
-
-
-
+                      
                        <decoDesc>
-
                          <summary>The illustrations grouped in this volume were first studied by their former
                              owner, Bent Juel-Jensen, who assigned them, with reason, to a period between
                              <date notBefore="1650" notAfter="1750"/> and

--- a/OxfordBodleian/Juel-Jensen/BDLaethe36.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe36.xml
@@ -145,8 +145,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <dim type="left">8</dim>
                                     </dimensions>
                                     <note> The characters per line are 10-23.</note>
-                                    <ab type="punctuation" subtype="Dividers">Groups of ten psalms are separated with a chain of red and black dots, e.g. on
-                                        <locus target="#8r #36r #52r"/>.</ab>
                                     <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are visible.</ab>
                                     <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A/0-0/0-0/C.</ab>
                                     <ab type="ruling"> The upper line is written above the ruling. The bottom line is written above the ruling.</ab>
@@ -157,12 +155,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <locus from="1r" to="60v"/>
-                                <seg type="script"/>
-                                <!-- Delete empty element -->
-                                <seg type="ink">Black, red</seg>
-                                <!-- Add dot -->
-                                <date notBefore="1700" notAfter="1799">18th century</date>
+                                <date notBefore="1700" notAfter="1799">Eighteenth century.</date>
+                                <seg type="ink">Black, red.</seg>
                                 <desc>
                                     Fine and trained hand. Characters are regularly spaced and slighly right-sloping. Vowel orders are clearly distinguished.
                                     The numeral <foreign xml:lang="gez">፮</foreign> has a compressed shape and the open loop.
@@ -171,15 +165,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     Numbers and titles of the psalms; the stichometry, indicated by the word <foreign xml:lang="gez">ቃሉ፡</foreign>
                                     followed by a numeral; elements of the numerals and of the punctuation signs, including text dividers.
                                 </seg>
+                                <ab type="punctuation" subtype="Dividers">Groups of ten psalms are separated with a chain of red and black dots, e.g. on
+                                    <locus target="#8r #36r #52r"/>.</ab>
                                 <list type="abbreviations">
                                     <item>
-                                        <abbr>መ፡</abbr> for <expan>መዝሙር፡</expan> (e.g. <locus target="#18r #22r #24v"/>)
-                                    </item>
+                                        <abbr>መ፡</abbr> for <expan>መዝሙር፡</expan> (e.g. <locus target="#18r #22r #24v"/>);</item>
                                     <item>
-                                        <abbr>ዘ፡</abbr> for <expan>ዘዳዊት፡</expan> (e.g. <locus target="#18r #22r #24v"/>)
-                                    </item>
+                                        <abbr>ዘ፡</abbr> for <expan>ዘዳዊት፡</expan> (e.g. <locus target="#18r #22r #24v"/>);</item>
                                     <item>
-                                        <abbr>ፍ፡</abbr> or  <abbr>ፍጻ፡</abbr> for <expan>ፍጻሜ፡</expan> (e.g. <locus target="#22v #51v #60r"/>)
+                                        <abbr>ፍ፡</abbr> or  <abbr>ፍጻ፡</abbr> for <expan>ፍጻሜ፡</expan> (e.g. <locus target="#22v #51v #60r"/>).
                                     </item>
                                 </list>
                             </handNote>

--- a/OxfordBodleian/Juel-Jensen/BDLaethe38.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe38.xml
@@ -439,34 +439,28 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </objectDesc>
 
                         <handDesc>
-                            <handNote xml:id="h1" script="Ethiopic">
-                                <seg type="script"/>
-                                <!-- Delete empty element -->
-                                <persName ref="PRS12986GabraKr"/>
-                                <!--      <persName ref="PRS12986GabraKr" role="scribe"/> is indicated as the scribe in the <ref target="#coloph1">colophon</ref> on <locus target="#10v"/>. -->
-                                <seg type="ink">Black, red</seg>
-                                <!-- Add dot. -->
+                            <handNote xml:id="h1" script="Ethiopic">                               
                                 <date notBefore="1775" notAfter="1815"></date>
+                                <persName ref="PRS12986GabraKr" role="scribe"/> is indicated as the scribe in the <ref target="#coloph1">colophon</ref> (<locus target="#10v"/>).
+                                <!-- 
+                                Is this published correctly in the PDF? Should we nest it inside desc or other?
+                                -->
+                                <seg type="ink">Black, red.</seg>                                
                                 <desc>Fine and regular handwriting, slightly deteriorating towards the end (e.g. <locus from="76v" to="78v"/>).
                                 </desc>
                                 <seg type="rubrication">
-                                    Several groups of lines on the incipit page of <ref target="#ms_i2"/> and of the opening sections for each weekday, sometimes alternating with black lines;
+                                    Several groups of lines on the incipit page of <ref target="#ms_i2">History of Anne</ref> and of the opening sections for each weekday, sometimes alternating with black lines;
                                     holy names and the names of the individuals involved in the production of the book, both in the colophon and in the supplication formulas throughout the
-                                    manuscript; the words <foreign xml:lang="gez">ሰላም፡</foreign> in the colophon (<ref target="#ms_i1"/>) and
-                                    <foreign xml:lang="gez">ሰላም፡ ለኪ፡</foreign> in <ref target="#ms_i4 #ms_i5"/>;
+                                    manuscript; the words <foreign xml:lang="gez">ሰላም፡</foreign> in the <ref target="#ms_i1">colophon</ref> and
+                                    <foreign xml:lang="gez">ሰላም፡ ለኪ፡</foreign> in <ref target="#ms_i4 #ms_i5"><hi rendition="simple:italic">Malkǝʾ</hi>-hymns to Anne</ref>;
                                     elements of the punctuation, including text dividers, and numerals, including the quire marks.
-                                </seg>
-                                <!-- 
-                                    "the colophon (<ref target="#ms_i1"/>)" must be replaced with "the <ref target="#ms_i1">colophon</ref>" 
-                                <ref target="#ms_i2"/> must be replaced with <ref target="#ms_i2">History of Anne</ref>
-                                <ref target="#ms_i4 #ms_i5"/> must be replaced with  <ref target="#ms_i4 #ms_i5"><hi rendition="simple:italic">Malkǝʾ</hi>-hymns to Anne</ref>
-                                 -->
+                                </seg>                               
                                 <list type="abbreviations">
                                     <item>
-                                        <abbr>ለዓ፡ ዓ፡ አ፡</abbr> for <expan>ለዓለመ፡ ዓለም፡ አሜን፡</expan> (<locus target="#12ra"/>)
+                                        <abbr>ለዓ፡ ዓ፡ አ፡</abbr> for <expan>ለዓለመ፡ ዓለም፡ አሜን፡</expan> (<locus target="#12ra"/>);
                                     </item>
                                     <item>
-                                        <abbr>አ፡</abbr> for <expan>አሜን፡</expan> (<locus target="#60va"/>)
+                                        <abbr>አ፡</abbr> for <expan>አሜን፡</expan> (<locus target="#60va"/>).
                                     </item>
                                 </list>
                             </handNote>

--- a/OxfordBodleian/Juel-Jensen/BDLaethe38.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe38.xml
@@ -440,13 +440,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">                               
-                                <date notBefore="1775" notAfter="1815"></date>
-                                <persName ref="PRS12986GabraKr" role="scribe"/> is indicated as the scribe in the <ref target="#coloph1">colophon</ref> (<locus target="#10v"/>).
-                                <!-- 
-                                Is this published correctly in the PDF? Should we nest it inside desc or other?
-                                -->
+                                <date notBefore="1775" notAfter="1815"/>                               
                                 <seg type="ink">Black, red.</seg>                                
                                 <desc>Fine and regular handwriting, slightly deteriorating towards the end (e.g. <locus from="76v" to="78v"/>).
+                                    <persName ref="PRS12986GabraKr" role="scribe"/> is indicated as the scribe in the <ref target="#coloph1">Colophon</ref> (<locus target="#10v"/>).
                                 </desc>
                                 <seg type="rubrication">
                                     Several groups of lines on the incipit page of <ref target="#ms_i2">History of Anne</ref> and of the opening sections for each weekday, sometimes alternating with black lines;

--- a/OxfordBodleian/Juel-Jensen/BDLaethe39.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethe39.xml
@@ -14,7 +14,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <title xml:lang="gez" xml:id="title1">ገድለ፡ ገብረ፡ መንፈስ፡ ቅዱስ፡, ተአምረ፡ ገብረ፡ መንፈስ፡ ቅዱስ፡, መዝገበ፡ ሃይማኖት፡</title>
                 <title xml:lang="gez" corresp="#title1" type="normalized">Gadla Gabra Manfas Qǝddus, Taʾammǝra Gabra Manfas Qǝddus, Excerpts from Mazgaba hāymānot</title>
                -->
-                <title xml:lang="en" xml:id="title1"><hi rendition="simple:italic">Vita</hi> and Miracles of Gabra Manfas Qǝddus, Excerpts from the Treasure of Faith</title>
+                <title xml:lang="en" xml:id="title1">Vita and Miracles of Gabra Manfas Qǝddus, Excerpts from the Treasure of Faith</title>
                 <editor key="DR"/>
                 <editor key="JG"/>
                 <editor key="MV"/>
@@ -585,13 +585,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <dim type="left">13</dim>
                                             <dim type="intercolumn">15</dim>
                                         </dimensions>
-                                        <note>There are 10–14 characters per line.</note>
-                                        <ab type="punctuation" subtype="Dividers">
-                                            A chain of red and black dots marks the end of <ref target="#p1_i1">the Vita of Gabra Manfas Qǝddus</ref>;
-                                            Two chains of red and black dots mark the end of <ref target="#p1_i2">the Miracles of Gabra Manfas Qǝddus</ref>;
-                                            a chain of black dots separates <ref target="#p1_i4">the enumeration of the Old and New Testament books</ref> from
-                                            <ref target="#p1_i5">the interpretation of the seven alphabetical orders</ref> on <locus target="87vb"/>.
-                                        </ab>
+                                        <note>There are 10–14 characters per line.</note>                                      
                                         <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are often visible.</ab>
                                         <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A-1A1A/0-0/0-0/C.</ab>
                                         <ab type="ruling">The upper line is written above the ruling. The bottom line is written above the ruling.
@@ -603,47 +597,45 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <handDesc>
                                 <handNote xml:id="h1" script="Ethiopic">
                                     <locus from="2ra" to="85vb"/>
-                                    <seg type="script"/>
-                                    <!-- Delete empty element -->
-                                    <seg type="ink">Black, red</seg>
-                                    <!-- Add dot -->
-                                    <date notBefore="1600" notAfter="1700"></date>
+                                    <date notBefore="1600" notAfter="1700">Seventeenth century.</date>                                  
+                                    <seg type="ink">Black, red.</seg>                                    
                                     <desc>
-                                       Fine and trained hand. Characters are relatively tall and regularly spaced.
+                                        Fine and trained hand. Characters are relatively tall and regularly spaced.
                                         The script displays some modern features: e.g. the numeral <foreign xml:lang="gez">፮</foreign> has a compressed shape and the open loop;
                                         the letter <foreign xml:lang="gez">መ</foreign> has the loops completely separated.
                                         One bottom ruled line has been left unwritten on <locus from="51va" to="51vb"/>.
                                     </desc>
                                     <seg type="rubrication">
-                                        Several lines on the incipit pages of <ref target="#p1_i1">the Vita</ref> and <ref target="#p1_i2">the Miracles of Gabra Manfas Qǝddus</ref>,
-                                        alternating with black lines; few words of the incipits of the miracles; holy names, the indication of the patron on <locus target="#82rb"/>;
+                                        Several lines on the incipit pages of the <ref target="#p1_i1">Vita</ref> and the <ref target="#p1_i2">Miracles of Gabra Manfas Qǝddus</ref>,
+                                        alternating with black lines; few words of the incipits of the miracles; holy names;the word <foreign xml:lang="gez">ዘጸሐፎ</foreign> on <locus target="#82rb"/>;
                                         elements of the numerals and of the punctuation signs, including text dividers.
-                                     </seg>
-                                    <!-- holy names; the word <foreign xml:lang="gez">ዘጸሐፎ</foreign> on <locus target="#82rb"/>; elements-->
+                                    </seg>                                 
+                                    <ab type="punctuation" subtype="Dividers">
+                                        A chain of red and black dots marks the end of the <ref target="#p1_i1">Vita of Gabra Manfas Qǝddus</ref>;
+                                        two chains of red and black dots mark the end of the <ref target="#p1_i2">Miracles of Gabra Manfas Qǝddus</ref>;
+                                        a chain of black dots separates the <ref target="#p1_i4">enumeration of the Old and New Testament books</ref> from the
+                                        <ref target="#p1_i5">interpretation of the seven alphabetical orders</ref> on <locus target="87vb"/>.
+                                    </ab>
                                     <list type="abbreviations">
                                         <item>
-                                            <abbr>ቅ</abbr> for <expan>ቅዱስ፡</expan> (e.g. <locus target="#33ra #69ra #76vb"/>)
+                                            <abbr>ቅ</abbr> for <expan>ቅዱስ፡</expan> (e.g. <locus target="#33ra #69ra #76vb"/>).
                                         </item>
                                     </list>
                                 </handNote>
-                                     <handNote xml:id="h2" script="Ethiopic">
+                                <handNote xml:id="h2" script="Ethiopic">
                                     <locus from="86ra" to="87vb"/>
-                                    <seg type="script"/>
-                                         <!-- Delete empty element -->
-                                    <seg type="ink">Black</seg>
-                                         <!-- Add dot -->
-                                    <date notBefore="1600" notAfter="1700"></date>
+                                    <date notBefore="1600" notAfter="1700">Seventeenth century.</date>                    
+                                    <seg type="ink">Black.</seg>                                  
                                     <desc>
-                                        Fine hand. The script displays both modern and archaic features; e.g. the letter <foreign xml:lang="gez">መ</foreign> has the loops regularly separated, but the letters <foreign xml:lang="gez">ፅ</foreign> shows a "cone-form" on <locus target="#86vb"/>.
+                                        Fine hand. The script displays both modern and archaic features; e.g. the letter <foreign xml:lang="gez">መ</foreign> has the loops regularly separated, but the letters <foreign xml:lang="gez">ፅ</foreign> shows a ‘cone-form’ on <locus target="#86vb"/>.
                                         The graphemes <foreign xml:lang="gez">ግ</foreign> and <foreign xml:lang="gez">ዚ</foreign> are written with a ligature in the word <foreign xml:lang="gez">እግዚአብሔር፡</foreign> on <locus target="#86rb"/>.
                                     </desc>
-                                         <!-- Quotation mark -->
-                                         <list type="abbreviations">
-                                             <item>
-                                                 <abbr>ብ</abbr> for <expan>ብሂል፡</expan> (<locus from="86ra" to="86rb"/>)
-                                             </item>
-                                         </list>
-                                    </handNote>
+                                    <list type="abbreviations">
+                                        <item>
+                                            <abbr>ብ</abbr> for <expan>ብሂል፡</expan> (<locus from="86ra" to="86rb"/>).
+                                        </item>
+                                    </list>
+                                </handNote>
                             </handDesc>
 
                               <additions>
@@ -802,11 +794,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <handDesc>
                                 <handNote xml:id="h3" script="Ethiopic">
                                     <locus from="88r" to="90va"/>
-                                    <seg type="script"/>
-                                    <!-- Delete empty element -->
-                                    <seg type="ink">Pale black</seg>
-                                    <!-- add dot -->
-                                    <date notBefore="1500" notAfter="1600"></date>
+                                    <date notBefore="1500" notAfter="1600">Sixteenth century.</date>
+                                    <seg type="ink">Pale black.</seg>
                                     <desc>Mediocre hand. The graphemes ግ and ዚ are written with a ligature on <locus target="#88vb"/>.
                                     </desc>
                                 </handNote>

--- a/OxfordBodleian/Juel-Jensen/BDLaethf23.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf23.xml
@@ -593,19 +593,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <seg type="ink">Blue, black, red</seg>
-                                <!-- Add dot -->
-                                <date notBefore="1950" notAfter="1960">mid-20th century</date>
+                                <date notBefore="1950" notAfter="1960">Mid-twentieth century.</date>
+                                <seg type="ink">Blue, black, red.</seg>
                                 <desc>
-                                    Fine and sometimes hasty handwriting. The text is written in black ink up to <locus target="#36"/>, then in blue ink.
-                                    Occasional corrections are indicated with one or two lines in red or blue ink over the wrong words (e.g. <locus target="#11 #16 #119"/>).
+                                    Fine and sometimes hasty handwriting. The text is written in black ink up to <locus target="#36"/>, then in blue ink.                        
                                 </desc>
                                 <!-- Corrections are not frequent and are indicated with one or two lines in red or blue ink over the words to be removed (e.g...) -->
                                 <seg type="rubrication">
-                                    two initial lines on the incipit page; holy names, included that of the <foreign xml:lang="gez">Fisālgos</foreign>;
+                                    Two initial lines on the incipit page; holy names; the name of the <hi rendition="simple:italic">Fisālgos</hi>;
                                     elements of the numerals and of the punctuation signs.
-                                </seg>
-                                <!-- Capitalize initial letter; "holy names; the name of the <hi rendition="simple:italic">Fisālgos</hi>" -->
+                                </seg>                               
                             </handNote>
                         </handDesc>
 
@@ -638,12 +635,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </item>
                                 
                                 <item xml:id="e1">
-                                    <desc>
-
-                                        Frequent corrections are executed by crossing out single words in black, red or blue ink. The corrections are sometimes accompanied by interlineal additions, 
+                                    <desc>                                        
+                                        Frequent corrections are executed by crossing out single words in black, red or blue ink, or with one or two lines in red or blue ink over the wrong words 
+                                        (e.g. <locus target="#11 #16 #119"/>).
+                                        The corrections are sometimes accompanied by interlineal additions, 
                                         e.g. on <locus target="#3 #16 #45"/>.
                                         A portion of text consisting of six lines has been crossed out and encircled in red ink on <locus target="#38"/>.
-
                                     </desc>
                                 </item>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethf24.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf24.xml
@@ -257,29 +257,22 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                            <locus from="3r" to="26r"/>
-                                <date notBefore="1800" notAfter="1949"/>
-                                <desc>Irregular and untrained hand, cursive script. The scribe often omits the word separator at the end of a line.</desc>
-                                <!-- hand with cursive script -->
+                                <date notBefore="1800" notAfter="1949">Nineteenth–first half of the twentienth century.</date>
                                 <seg type="ink">Black, red.</seg>
-                                <!-- Order is ink, date, desc, rubr -->
-                                <seg type="rubrication">Incipits (single or double red lines); holy names;
-                                    elements of punctuation signs and numerals.</seg>
-                                <!-- Single or double lines on the incipit pages; ...; ... of the punctuation signs and of the -->
-                                <ab type="punctuation" subtype="Dividers">A chain of red and black small semicircles after the first group of ten psalms
-                                    (<locus target="#13r"/>). </ab>
-                                <!-- ... is used as text divider after ... -->
+                                <desc>Irregular and untrained hand with cursive script. The scribe often omits the word separator at the end of a line.</desc>
+                                <seg type="rubrication">Single or double lines on the incipit pages; holy names;
+                                    elements of punctuation signs and of the numerals.</seg>
+                                <ab type="punctuation" subtype="Dividers">A chain of red and black small semicircles is used as text divider after the first group of ten psalms
+                                    (<locus target="#13r"/>). </ab>                              
                             </handNote>
 
                             <handNote xml:id="h2" script="Ethiopic">
                                 <locus from="26r" to="26v"/>
-                                <desc>Hand of <ref target="#a1"/>. More regular hand. Large and very round script, broadly spaced characters.</desc>
-                                <!-- Same hand as <ref target="#a1">the first additional note</ref>. The hand is more regular than that of <ref target="#h1">the first hand</ref>, 
-                                    with a large and a very round script. Characters are broadly spaced. -->
                                 <date when="1911" evidence="internal"/>
                                 <seg type="ink">Black, red.</seg>
-                                <!-- Order is ink, date, desc, rubr -->
-                                <seg type="rubrication">Incipit (double red lines); elements of numerals.</seg>
-                                <!-- Two lines of the incipit; elements of the numerals. -->
+                                <desc>Same hand as <ref target="#a1">Additional note 1</ref>. The hand is more regular than that of <ref target="#h1">the first hand</ref>, 
+                                    with a large and a very round script. Characters are broadly spaced. </desc>                             
+                                <seg type="rubrication">Two lines of the incipit; elements of the numerals.</seg>
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethf26.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf26.xml
@@ -393,10 +393,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <handDesc>
                                 <handNote xml:id="h2" script="Ethiopic">
                                     <locus from="12ra" to="21vb"/>
-                                    <date notBefore="1930" notAfter="1970">Mid-twentieth century.</date>
-                                    <persName ref="PRS13687WaldaA" role="scribe"/> is indicated as the scribe in the <ref target="coloph1">colophon</ref>.
+                                    <date notBefore="1930" notAfter="1970">Mid-twentieth century.</date>                                   
                                    <seg type="ink">Black, red.</seg>
-                                    <desc>Trained and regular hand. Characters are tall and slender.</desc>
+                                    <desc>Trained and regular hand. Characters are tall and slender.
+                                        <persName ref="PRS13687WaldaA" role="scribe"/> is indicated as the scribe in the <ref target="coloph1">Colophon</ref>.</desc>
                                     <seg type="rubrication">Groups of lines on the incipit page, alternating with black lines; the word <foreign xml:lang="gez">ሰላም፡</foreign>;
                                     elements of numerals and of the punctuation signs.</seg>
                                 </handNote>

--- a/OxfordBodleian/Juel-Jensen/BDLaethf26.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf26.xml
@@ -260,30 +260,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                             <handDesc>
                                 <handNote xml:id="h1" script="Ethiopic">
-                                    <!-- add locus!!! -->
-                                    <seg type="ink">Black, red</seg>
-                                    <!-- add dot -->
-                                    <date notBefore="1650" notAfter="1949"/>
-                                    <!-- This range must be narrowed! -->
-                                    <desc>Irregular hand with broadly spaced letters.
+                                    <locus from="2r" to="10r"/>
+                                    <date notBefore="1700" notAfter="1899">Eighteenth–nineteenth century.</date>
+                                    <seg type="ink">Black, red.</seg>
+                                    <desc>Irregular hand with broadly spaced characters.
                                         There are changes of nib on <locus target="#4v #5r #8r"/>, but the hand is probably the same.</desc>
-                                    <seg type="rubrication">Parts of the names of the owner and scribe; holy names;
+                                    <seg type="rubrication">Parts of the names of the individuals involved in the production of the manuscript; holy names;
                                         the words <foreign xml:lang="gez">ሥላሴ፡</foreign>
                                         <foreign xml:lang="gez">ሰላም፡</foreign>; <foreign xml:lang="gez">ይዲ</foreign> <foreign xml:lang="gez">ይካ</foreign>,
                                         <foreign xml:lang="gez">ሕዝ</foreign>; elements
-                                    of punctuation signs.</seg>
-                                    <!-- 
-                                        characters, not letters
-                                        "the" punctuation
-                                    parts of the names of the individuals involved in the production of the manuscript; 
-                                    -->
+                                    of the punctuation signs.</seg>
                                     <list type="abbreviations">
                                         <item>
-                                            <abbr>ሰላ</abbr> and <abbr>ሰ</abbr> for <expan>ሰላም፡</expan> (e.g. <locus target="#3r #6r"/>)
-                                            <abbr>ይዲ</abbr> and  for <expan>ይቤ፡ ዲያቆን፡</expan> (e.g. <locus target="#6v"/>)
-                                            <abbr>ይካ</abbr>  for <expan>ይቤ፡ ካህን፡</expan> (e.g. <locus target="#6v"/>)
-                                            <abbr>ሕዝ</abbr> and for <expan>ሕዝብ፡</expan> (e.g. <locus target="#7r"/>)
-                                            <abbr>ቡራ</abbr> and for <expan>ቡራኬ፡</expan> (<locus target="#9v"/>)
+                                            <abbr>ሰላ</abbr> and <abbr>ሰ</abbr> for <expan>ሰላም፡</expan> (e.g. <locus target="#3r #6r"/>);
+                                            <abbr>ይዲ</abbr> and  for <expan>ይቤ፡ ዲያቆን፡</expan> (e.g. <locus target="#6v"/>);
+                                            <abbr>ይካ</abbr>  for <expan>ይቤ፡ ካህን፡</expan> (e.g. <locus target="#6v"/>);
+                                            <abbr>ሕዝ</abbr> and for <expan>ሕዝብ፡</expan> (e.g. <locus target="#7r"/>);
+                                            <abbr>ቡራ</abbr> and for <expan>ቡራኬ፡</expan> (<locus target="#9v"/>).
                                         </item>
                                     </list>
                                 </handNote>
@@ -316,7 +309,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <history>
                             <origin>
-                                <origDate notBefore="1650" notAfter="1949" evidence="lettering"/>
+                                <origDate notBefore="1700" notAfter="1899" evidence="lettering"/>
                             </origin>
                         </history>
 
@@ -399,18 +392,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                             <handDesc>
                                 <handNote xml:id="h2" script="Ethiopic">
-                                    <!--  <locus from="" to=""/> is missing -->
-                                    <persName ref="PRS13687WaldaA" role="scribe"/>
-                                    <!-- <persName ref="PRS13687WaldaA" role="scribe"/> is indicated as the scribe in the  <ref target="coloph1">colophon</ref> on <locus target="#21vb"/>
-                                    -->
-                                    <seg type="ink">Black, red</seg>
-                                    <!-- Add dot -->
-                                    <date notBefore="1930" notAfter="1970"/>
-                                    <desc>Trained, regular hand. Tall and slender letters.</desc>
-                                    <!-- Trained and regular hand. Characters are tall and slender. -->
-                                    <seg type="rubrication">Groups of lines at the beginning; holy names; the word <foreign xml:lang="gez">ሰላም፡</foreign>;
-                                    elements of numerals and punctuation marks.</seg>
-                                    <!-- Groups of lines on the incipit page, alternating with black lines; ... the numerals and of the ... signs -->
+                                    <locus from="12ra" to="21vb"/>
+                                    <date notBefore="1930" notAfter="1970">Mid-twentieth century.</date>
+                                    <persName ref="PRS13687WaldaA" role="scribe"/> is indicated as the scribe in the <ref target="coloph1">colophon</ref>.
+                                   <seg type="ink">Black, red.</seg>
+                                    <desc>Trained and regular hand. Characters are tall and slender.</desc>
+                                    <seg type="rubrication">Groups of lines on the incipit page, alternating with black lines; the word <foreign xml:lang="gez">ሰላም፡</foreign>;
+                                    elements of numerals and of the punctuation signs.</seg>
                                 </handNote>
                             </handDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethf27.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf27.xml
@@ -350,16 +350,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <date notBefore="1800" notAfter="2006"/>
-                           <desc>Mediocre hand. There are a few changes of nib, but the hand is probably the same one throughout.
-                               Depending on nib, the script alternates between more cursive and bulky shapes.
-                           </desc>
+                                <date notBefore="1800" notAfter="2006">Nineteenth–twentieth century.</date>
                                 <seg type="ink">Black, red.</seg>
-                                <seg type="rubrication">The first three lines of each panel regardless of the beginning of textual units; holy names;
-                                elements of numerals.</seg> 
-                                <!--is panel the best word? section? frame?
-                                "beginning of the textual units"
-                                -->
+                                <desc>Mediocre hand. There are a few changes of nib, but the hand is probably the same one throughout.
+                                    Depending on nib, the script alternates between more cursive and bulky shapes.
+                                </desc>
+                                <seg type="rubrication">The first three lines of each section (regardless of the beginning of the textual units); holy names;
+                                    elements of the numerals.</seg> 
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethf29.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf29.xml
@@ -532,7 +532,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <date notBefore="1800" notAfter="1868">First half of the nineteenth century.</date>
                                 <seg type="ink">Black, red.</seg>
                                 <desc>Trained hand. The handwriting is regular with broadly spaced
-                                    characters. The scribe also copied MS <ref type="mss" corresp="ESqma005"/> (see Provenance).</desc>
+                                    characters. The scribe also copied MS <ref type="mss" corresp="ESqma005"/> (see History).</desc>
                                 <seg type="rubrication">One or more groups of lines on
                                     the incipit pages of the <ref target="#ms_i1">Sword of the Trinity (<hi rendition="simple:italic">Sayfa Śǝllāse</hi>)</ref>, all its
                                     sections and the following texts;                                 

--- a/OxfordBodleian/Juel-Jensen/BDLaethf29.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf29.xml
@@ -529,37 +529,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <handNote xml:id="h1" script="Ethiopic"
                                 corresp="#ms_i1 #ms_i2 #ms_i3 #ms_i4 #ms_i5 #ms_i6">
                                 <locus from="4ra" to="118v"/>
-                                <seg type="ink">Black, red</seg>
-                                <!-- Add dot -->
-                                <date notBefore="1800" notAfter="1868">first half of the 19th
-                                    century</date>
+                                <date notBefore="1800" notAfter="1868">First half of the nineteenth century.</date>
+                                <seg type="ink">Black, red.</seg>
                                 <desc>Trained hand. The handwriting is regular with broadly spaced
-                                    characters. The name of the scribe was erased in all
-                                    supplication formulas he had dedicated to himself (<locus
-                                        target="#15r '#66r #80r"/>), only the first part of his name
-                                    <foreign xml:lang="gez">ገብረ፡</foreign> is preserved. He is
-                                    also the main scribe of <ref type="mss" corresp="ESqma005"
-                                    />.</desc>
-                                <!-- remove space after bracket + one ' within the bracket + reshape sentence after bracket (being preserved?). "of MS <ref type="mss" corresp="ESqma005"/> (see Provenance).
-                                 -->
-                                <seg type="rubrication">Several groups of lines on
-                                    the incipit page of <ref target="#ms_i1"/> as well as all of its
-                                    sections and <ref target="#ms_i2 #ms_i3 #ms_i4"/>; initial
-                                    two lines of subsections of <ref target="#ms_i1.1 #ms_i1.2"/>
-                                    and on the incipit page of <ref target="#ms_i5 #ms_i6"/>; holy
-                                    names (names of the members of the Trinity are written
-                                    alternating with red and black on <locus target="#21v"/>), names
-                                    (mostly erased) of individuals related to the production of the
-                                    manuscript; elements of the punctuation marks, text dividers, and
-                                    numerals. Additional rubricated elements in the texts include:
-                                    name of the letters (<ref target="#ms_i1.1"/>), the word
-                                    <foreign xml:lang="gez">ሰላም፡</foreign> or its first character
-                                    ሰ (<ref target="#ms_i1.2 #ms_i1.7 #ms_i2"/>), the words <foreign
-                                        xml:lang="gez">እኵት፡</foreign> (<ref target="#ms_i1.4"/>) and
-                                    <foreign xml:lang="gez">ስብሐት፡</foreign> or its abbreviated
-                                    form (<ref target="#ms_i1.6"/>), and the first word of each
-                                    verse in <ref target="#ms_i3"/></seg>
-                                <!-- 
+                                    characters. The scribe also copied MS <ref type="mss" corresp="ESqma005"/> (see Provenance).</desc>
                                 <seg type="rubrication">One or more groups of lines on
                                     the incipit pages of the <ref target="#ms_i1">Sword of the Trinity (<hi rendition="simple:italic">Sayfa Śǝllāse</hi>)</ref>, all its
                                     sections and the following texts;                                 
@@ -573,45 +546,33 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <foreign xml:lang="gez">እኵት፡</foreign>; <foreign xml:lang="gez">ስብሐት፡</foreign>; the first word of each
                                     verse in the <ref target="#ms_i3">Lament on the Virgin (<hi rendition="simple:italic">Saqoqāwa dǝngǝl</hi>)</ref>;                                  
                                     elements of the punctuation marks, text dividers, and numerals. 
-                                    </seg>
-                                
-                                -->
+                                </seg>
+                               
                                 <list type="abbreviations">
                                     <item>
                                         <abbr>ለዓለመ፡ ዓ፡ አ፡ ወአ፡ ለይኵ፡ ለይ።</abbr> or <abbr>ለዓለመ፡ ዓለም፡
                                             አሜን፡ ወአሜን፡ ለይ፡ ለ።</abbr> for <expan>ለዓለመ፡ ዓለም፡ አሜን፡
-                                            ወአሜን፡ ለይኵን፡ ለይኩን።</expan> (<ref
-                                            target="#ms_i1.3 #ms_i1.4"/>) </item>
-                                    <!-- <locus from="27r" to="45r"/> -->
+                                                ወአሜን፡ ለይኵን፡ ለይኩን።</expan> (<locus from="27r" to="45r"/>); </item>                            
                                     <item>
                                         <abbr>ስ</abbr> or <abbr>ስብ</abbr> or <abbr>ስብሐ</abbr> for
-                                            <expan>ስብሐት</expan> (<ref target="#ms_i1.6"/>) </item>
-                                    <!-- <locus from="55v" to="66r"/> -->
+                                        <expan>ስብሐት</expan> (<locus from="55v" to="66r"/>);</item>
                                     <item>
                                         <abbr>ሰላ፡ ለፍቅ</abbr> or <abbr>ሰላለፍ</abbr> or
-                                            <abbr>ሰለፍ</abbr>or <abbr>ሰ፡ ለፍ</abbr> for <expan>ሰላም፡
-                                            ለፍቅረ</expan> (<ref target="#ms_i1.7"/>) </item>
-                                    <!--  <abbr>ሰላ፡ ለፍቅ</abbr> or <abbr>ሰላለፍ</abbr> or
-                                          <abbr>ሰ፡ ለፍ</abbr> for <expan>ሰላም፡
-                                            ለፍቅረ</expan> <locus from="66v" to="73v"/> -->
+                                        <abbr>ሰ፡ ለፍ</abbr> for <expan>ሰላም፡
+                                            ለፍቅረ</expan> (<locus from="66v" to="73v"/>);</item>
                                     <item>
                                         <abbr>ሰ</abbr> or <abbr>ሰላ</abbr> for <expan>ሰላም </expan>
-                                            (<ref target="#ms_i2"/>) </item>
-                                    <!-- <locus from="80v" to="95r"/> -->
+                                        (<locus from="80v" to="95r"/>).</item>
                                 </list>
                             </handNote>
 
                             <handNote xml:id="h2" script="Ethiopic" corresp="#a1 #a2">
                                 <locus from="119r" to="120v"/>
-                                <seg type="ink">Black</seg>
-                                <!-- Add dot -->
-                                <!--     <date notBefore="1841" notAfter="1868">first half of the 19th century</date>-->
-                                <desc>Poor handwriting. Unexperienced scribe who tends to scribal
+                                <date notBefore="1841" notAfter="1868">Mid-nineteenth century</date>
+                                <seg type="ink">Black.</seg>
+                                <desc>Poor hand, executed by an unexperienced scribe who tends to scribal
                                     errors and to a rushed script.</desc>
-                                <!-- Poor hand, executed by an unexperienced scribe who tends to scribal
-                                    errors and to a rushed script. -->
                             </handNote>
-
                         </handDesc>
 
                                      <decoDesc>
@@ -691,14 +652,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         were filled with an interlaced band on <locus
                                             target="#50r #72r"/> and with several thin lines on
                                         <locus target="#66v #79v"/>. The scribe wrote the last
-                                        two lines of <ref target="#ms_i1.3">reading for Tuesday</ref> in small script in
+                                        two lines of the <ref target="#ms_i1.3">reading for Tuesday</ref> in small script in
                                         order to complete the section on the same folio (<locus
                                             target="#35v"/>). Writing exercises were executed on
                                         <locus target="#123r"/> and upside down on <locus
                                             target="#121v #122v"/>. The name <persName
                                                 ref="PRS13017GabraMar"/> is written on <locus
                                                     target="#3r"/> (the rest of the entire folio is
-                                        blank).</desc>
+                                        blank).
+                                        The name of the scribe was erased in all
+                                        supplication formulas he had dedicated to himself (<locus
+                                            target="#15r #66r #80r"/>), only the first part of his name
+                                        <foreign xml:lang="gez">ገብረ፡</foreign> being preserved.</desc>
                                 </item>
 
                                 <item xml:id="e2">

--- a/OxfordBodleian/Juel-Jensen/BDLaethf30.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf30.xml
@@ -169,8 +169,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                  <date notBefore="1800" notAfter="1950">Nineteenth–first half of the twentienth century.</date>
                                  <seg type="ink">Black, red.</seg>
                                  <desc>Trained, but mediocre hand, with some irregularities in the size of characters. Change of nib on <locus target="#77r"/>.
-                                     Very probably the hand is the same throughout the entire manuscript, in both <ref target="#p1">Part 1</ref> 
-                                     and <ref target="#p2">Part 2</ref>.
+                                     Very probably the hand is the same throughout the entire manuscript, in both <ref target="#p1">Unit 1</ref> 
+                                     and <ref target="#p2">Unit 2</ref>.
                                  </desc>
                                  <seg type="rubrication">Several lines on the incipit pages, alternating with black lines;
                                      numbers and titles of the psalms and of the

--- a/OxfordBodleian/Juel-Jensen/BDLaethf30.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf30.xml
@@ -169,8 +169,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                  <date notBefore="1800" notAfter="1950">Nineteenth–first half of the twentienth century.</date>
                                  <seg type="ink">Black, red.</seg>
                                  <desc>Trained, but mediocre hand, with some irregularities in the size of characters. Change of nib on <locus target="#77r"/>.
-                                     Very probably the hand is the same throughout the entire manuscript, in both <ref target="#p1"/>Part 1</ref> 
-                                     and <ref target="#p2"/>Part 2</ref>.
+                                     Very probably the hand is the same throughout the entire manuscript, in both <ref target="#p1">Part 1</ref> 
+                                     and <ref target="#p2">Part 2</ref>.
                                  </desc>
                                  <seg type="rubrication">Several lines on the incipit pages, alternating with black lines;
                                      numbers and titles of the psalms and of the

--- a/OxfordBodleian/Juel-Jensen/BDLaethf30.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf30.xml
@@ -166,36 +166,32 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                          <handDesc>
                              <handNote xml:id="h1" script="Ethiopic" corresp="#p1 #p2">
-                                 <date notBefore="1800" notAfter="1950"/>
-                                 <desc>Trained, but mediocre hand, with some irregularities in the size of characters. Change of nib on <locus target="#77r"/>.
-                                     Very probably the hand is the same of <ref target="#p1"/> and <ref target="#p2"/>.
-                                 </desc>
-                                 <!-- ..is the same throughout the entire manuscript, in both the first and second codicological units, or <ref target="#p1"/>Part 1</ref> and <ref target="#p2"/>Part 2</ref>. -->
+                                 <date notBefore="1800" notAfter="1950">Nineteenth–first half of the twentienth century.</date>
                                  <seg type="ink">Black, red.</seg>
-                                 <!-- Order is ink, date, desc, rubr -->
+                                 <desc>Trained, but mediocre hand, with some irregularities in the size of characters. Change of nib on <locus target="#77r"/>.
+                                     Very probably the hand is the same throughout the entire manuscript, in both <ref target="#p1"/>Part 1</ref> 
+                                     and <ref target="#p2"/>Part 2</ref>.
+                                 </desc>
                                  <seg type="rubrication">Several lines on the incipit pages, alternating with black lines;
                                      numbers and titles of the psalms and of the
                                      canticles (spaces left for the titles of psalms have been left unfilled on <locus from="98" to="100v"/>); incipits of the songs;
-                                     the first refrain of each day of <ref target="#p1_i1.4"/> and the abbreviation standing for the refrain after the subsequential
-                                     stanzas;
-                                     holy names;
-                                     name of the Hebrew letters in Ps. 118;
+                                     the first refrain of each day of the <ref target="#p1_i1.4">Praise of Mary</ref> and the abbreviation standing for the refrain after the subsequential
+                                     stanzas; holy names; names of the Hebrew letters in Ps. 118;
                                      the letters <foreign xml:lang="get">ስ</foreign> and <foreign xml:lang="get">ብ</foreign> in the word
                                      <foreign xml:lang="get">ስብሕዎ፡</foreign> at the beginning of each verse of Ps. 150;
                                      the letters <foreign xml:lang="gez">ይ</foreign> and <foreign xml:lang="gez">ር</foreign> in the word
-                                     <foreign xml:lang="gez">ይባርክዎ፡</foreign> at the beginning of each verse of the Third song of the Three Youths;
-                                     elements of punctuation marks.
+                                     <foreign xml:lang="gez">ይባርክዎ፡</foreign> at the beginning of each line of the Third song of the Three Youths;
+                                     elements of punctuation signs.
                                  </seg>
-                                 <!-- Is "(spaces left for the titles of psalms have been left unfilled on <locus from="98" to="100v"/>)" to be kept here? -->
-                                 <!-- Open <ref target="#p1_i1.4"/> and add "the Praise of Mary" -->
-                                 <!-- names of the Hebrew letters
-                                  each line of ... 
-                          of the punctuation signs -->
+                                 <ab type="punctuation" subtype="Dividers">One chain of red and black small semicircles after
+                                     Ps 100 and Ps 150, at the end of the Psalms of David, and after
+                                     the <ref type="work" corresp="LIT2509Weddas#Thursday">reading of the Praise of Mary for Thursday</ref> (<locus target="#76v #117v #138r #146rb"/>).
+                                 </ab>
                                  <list type="abbreviations">
                                      <item>single letters for the entire refrain in <ref target="#p1_i1.4"/>;</item>
                                      <!-- Too simplified as compared to the other Psalters! -->
                                      <item>
-                                         <abbr>ሰ፡</abbr>, <abbr>ሰአ፡</abbr> or <abbr>ሰአሊ፡</abbr> for <expan>ሰአሊ፡ ለነ፡ ቅድስት፡</expan> (e.g. <locus target="#140vb #142rb #144vb"/>)
+                                         <abbr>ሰ፡</abbr>, <abbr>ሰአ፡</abbr> or <abbr>ሰአሊ፡</abbr> for <expan>ሰአሊ፡ ለነ፡ ቅድስት፡</expan> (e.g. <locus target="#140vb #142rb #144vb"/>).
                                      </item>
                                  </list>
                              </handNote>
@@ -744,10 +740,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <ab type="ruling"> The upper line is written above the ruling. The bottom line is written above the ruling.
                                     </ab>
                                     <!--double pricking f. 66, 82, 84-->
-                                    <ab type="punctuation" subtype="Dividers">One chain of red and black small semicircles after
-                                        Ps. 100 and Ps. 150, at the end of the Psalms of David, and after
-                                        the <ref type="work" corresp="LIT2509Weddas#Thursday"/> (<locus target="#76v #117v #138r #146rb"/>).
-                             </ab>
+                                   
                                 </layout>
 
                                 <layout columns="2" writtenLines="22">

--- a/OxfordBodleian/Juel-Jensen/BDLaethf30.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf30.xml
@@ -178,7 +178,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                      the first refrain of each day of the <ref target="#p1_i1.4">Praise of Mary</ref> and the abbreviation standing for the refrain after the subsequential
                                      stanzas; holy names; names of the Hebrew letters in Ps. 118;
                                      the letters <foreign xml:lang="get">ስ</foreign> and <foreign xml:lang="get">ብ</foreign> in the word
-                                     <foreign xml:lang="get">ስብሕዎ፡</foreign> at the beginning of each verse of Ps. 150;
+                                     <foreign xml:lang="get">ስብሕዎ፡</foreign> at the beginning of each verse of Ps 150;
                                      the letters <foreign xml:lang="gez">ይ</foreign> and <foreign xml:lang="gez">ር</foreign> in the word
                                      <foreign xml:lang="gez">ይባርክዎ፡</foreign> at the beginning of each line of the Third song of the Three Youths;
                                      elements of punctuation signs.
@@ -188,8 +188,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                      the <ref type="work" corresp="LIT2509Weddas#Thursday">reading of the Praise of Mary for Thursday</ref> (<locus target="#76v #117v #138r #146rb"/>).
                                  </ab>
                                  <list type="abbreviations">
-                                     <item>single letters for the entire refrain in <ref target="#p1_i1.4"/>;</item>
-                                     <!-- Too simplified as compared to the other Psalters! -->
+                                     <item>Single letters for the entire refrain in the <ref target="#p1_i1.4">Praise of Mary</ref>;</item>
                                      <item>
                                          <abbr>ሰ፡</abbr>, <abbr>ሰአ፡</abbr> or <abbr>ሰአሊ፡</abbr> for <expan>ሰአሊ፡ ለነ፡ ቅድስት፡</expan> (e.g. <locus target="#140vb #142rb #144vb"/>).
                                      </item>

--- a/OxfordBodleian/Juel-Jensen/BDLaethf31.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf31.xml
@@ -242,60 +242,46 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </layout>
                             </layoutDesc>
                         </objectDesc>
-
+                        
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">/
                                 <locus from="3ra" to="75rb"/>
-                                <seg type="ink">Black, red</seg>
-                                <!-- Add dot -->
-                                <date notBefore="1700" notAfter="1799">18th-century handwriting</date>
-                                <desc>Mediocre handwriting.
-                                    The handwriting becomes less accurate towards the end (e.g. on <locus target="#74ra"/>).
+                                <date notBefore="1700" notAfter="1799">Eighteenth-century.</date>
+                                <seg type="ink">Black, red.</seg>
+                                <desc>Mediocre handwriting. It becomes less accurate towards the end (e.g. on <locus target="#74ra"/>).
                                     The scribe does not always follow the vertical ruling (e.g. on <locus target="#40r #57v"/>).
                                     The last ruled line has not been written on <locus target="#13vb"/>.
                                 </desc>
                                 <seg type="rubrication">
-                                    Few lines on the incipit page of <ref target="#ms_i1">the Gospel of John</ref>, alternating with black lines;
+                                    Few lines on the incipit page of the <ref target="#ms_i1">Gospel of John</ref>, alternating with black lines;
                                     the chapters, indicated with the term <foreign xml:lang="gez">ምዕራፍ፡</foreign>, and the first two or three lines of each chapter;
                                     elements of the numerals and of the punctuation signs, including the text dividers.
-                                </seg>
-                                <!-- better: "the <ref target="#ms_i1">Gospel of John</ref>" -->
+                                </seg>                           
                                 <list type="abbreviations">
-                                   <item>
-                                     <abbr>ም፡</abbr> or <abbr>ምዕ፡</abbr> for <expan>ምዕራፍ፡</expan> (e.g. on <locus target="#7ra #16vb #45vb"/>)
-                                  </item>
+                                    <item>
+                                        <abbr>ም፡</abbr> or <abbr>ምዕ፡</abbr> for <expan>ምዕራፍ፡</expan> (e.g. on <locus target="#7ra #16vb #45vb"/>).
+                                    </item>
                                 </list>
                             </handNote>
-
-                                <handNote xml:id="h2" script="Ethiopic">
+                            
+                            <handNote xml:id="h2" script="Ethiopic">
                                 <locus from="75va" to="82vb"/>
-                                <seg type="ink">Black, red</seg>
-                                    <!-- Add dot -->
-                                <date notBefore="1700" notAfter="1799">18th-century handwriting</date>
-                                    <desc>The handwriting is mediocre, uneven and somewhat irregular in spacing the letters.
-                                        It is not clear whether it is the same hand as <ref target="#h1"/>.
-                                        <!-- <ref target="#h1">Hand 1</ref> capitalized -->
+                                <date notBefore="1700" notAfter="1799">Eighteenth century.</date>
+                                <seg type="ink">Black, red.</seg>
+                                <desc>The handwriting is mediocre, uneven and somewhat irregular in spacing the letters.
+                                    It is not clear whether it is the same hand as <ref target="#h1">Hand 1</ref>.
                                 </desc>
                                 <seg type="rubrication">
-                                   The first two lines of the incipit page of <ref target="#ms_i2"/>; the first two words of <ref target="#ms_i3 #ms_i4"/>; the first letter or word of each
-                                    stanza of <ref target="#ms_i3 #ms_i4"/>; holy names (those of <persName ref="PRS6819Mary">Mary</persName> and of <persName ref="PRS4585Georgeo">George</persName>);
-                                    elements of the numerals and of the punctuation signs.
-                                </seg>
-                                    <!-- 
-                                    
-                                     <seg type="rubrication">
-                                   The first two lines of the incipit page of the <hi rendition="simple:italic">Malkǝʾ</hi>-hymn known as 
-                                   <ref target="#ms_i2"><hi rendition="simple:italic">Tafaśśəḥi Māryām la-ʾAddām fāsikāhu</hi></ref>; 
-                                   the first two words and the first letter or word of each
-                                   stanza of <ref target="#ms_i3 #ms_i4"/>the two <hi rendition="simple:italic">Malkǝʾ</hi>-hymns</ref>; 
+                                    The first two lines of the incipit page of the <hi rendition="simple:italic">Malkǝʾ</hi>-hymn known as 
+                                    <ref target="#ms_i2"><hi rendition="simple:italic">Tafaśśəḥi Māryām la-ʾAddām fāsikāhu</hi></ref>; 
+                                    the first two words and the first letter or word of each
+                                    stanza of <ref target="#ms_i3 #ms_i4"/>the two <hi rendition="simple:italic">Malkǝʾ</hi>-hymns</ref>; 
                                     holy names (those of <persName ref="PRS6819Mary">Mary</persName> and of <persName ref="PRS4585Georgeo">George</persName>);
                                     elements of the numerals and of the punctuation signs.
                                 </seg>
-                                    
-                                    -->
-                                 <list type="abbreviations">
-                                   <item>
-                                       <abbr>ጊዮር፡</abbr> or <abbr>ጊዮርጊ፡</abbr> for <expan>ጊዮርጊስ፡</expan> (e.g. on <locus target="#79va #79vb"/>)
+                                <list type="abbreviations">
+                                    <item>
+                                        <abbr>ጊዮር፡</abbr> or <abbr>ጊዮርጊ፡</abbr> for <expan>ጊዮርጊስ፡</expan> (e.g. on <locus target="#79va #79vb"/>).
                                     </item>
                                 </list>
                             </handNote>

--- a/OxfordBodleian/Juel-Jensen/BDLaethf31.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf31.xml
@@ -244,9 +244,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </objectDesc>
                         
                         <handDesc>
-                            <handNote xml:id="h1" script="Ethiopic">/
+                            <handNote xml:id="h1" script="Ethiopic">
                                 <locus from="3ra" to="75rb"/>
-                                <date notBefore="1700" notAfter="1799">Eighteenth-century.</date>
+                                <date notBefore="1700" notAfter="1799">Eighteenth century.</date>
                                 <seg type="ink">Black, red.</seg>
                                 <desc>Mediocre handwriting. It becomes less accurate towards the end (e.g. on <locus target="#74ra"/>).
                                     The scribe does not always follow the vertical ruling (e.g. on <locus target="#40r #57v"/>).

--- a/OxfordBodleian/Juel-Jensen/BDLaethf31.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf31.xml
@@ -275,7 +275,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     The first two lines of the incipit page of the <hi rendition="simple:italic">Malkǝʾ</hi>-hymn known as 
                                     <ref target="#ms_i2"><hi rendition="simple:italic">Tafaśśəḥi Māryām la-ʾAddām fāsikāhu</hi></ref>; 
                                     the first two words and the first letter or word of each
-                                    stanza of <ref target="#ms_i3 #ms_i4"/>the two <hi rendition="simple:italic">Malkǝʾ</hi>-hymns</ref>; 
+                                    stanza of <ref target="#ms_i3 #ms_i4">the two <hi rendition="simple:italic">Malkǝʾ</hi>-hymns</ref>; 
                                     holy names (those of <persName ref="PRS6819Mary">Mary</persName> and of <persName ref="PRS4585Georgeo">George</persName>);
                                     elements of the numerals and of the punctuation signs.
                                 </seg>

--- a/OxfordBodleian/Juel-Jensen/BDLaethf32.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf32.xml
@@ -171,36 +171,29 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <seg type="ink">Black, red</seg>
-                                <!-- Add dot -->
-                                <date notBefore="1700" notAfter="1799">18th century</date>
+                                <date notBefore="1700" notAfter="1799">Eighteenth century</date>
+                                <seg type="ink">Black, red.</seg>
                                 <desc>
                                     Mediocre handwriting. Slant and spacing of the characters vary throughout the manuscript.
                                 </desc>
                                 <seg type="rubrication">
-                                    Holy names; some lines on the incipit page, alternating with black lines; few lines on <locus target="#62v"/>;
-                                    the title of the <foreign xml:lang="gez">Ṣalota fattǝto</foreign> on <locus target="#64v"/>;
-                                    liturgical directives in abbreviation; few letters, alternating with black lines, of single words or groups of words on <ref target="#63v #71v"/>;
-                                    elements of the punctuation signs and numerals.
-                                </seg>
-                                <!-- 
                                     Some lines on the incipit page, alternating with black lines; few lines on <locus target="#62v"/>;
                                     the title of the the Prayer of the breaking of the bread on <locus target="#64v"/>; holy names;                                 
                                     liturgical directives in abbreviation; few letters, alternating with black lines, of single words or groups of words on <ref target="#63v #71v"/>;
                                     elements of the punctuation signs and numerals.
-                                -->
+                                </seg>
                                 <list type="abbreviations">
                                     <item>
-                                        <abbr>ይዲ</abbr> for <expan>ይበል፡ ዲያቆን፡</expan> (e.g. <locus target="#15r #17v #18v"/>)
+                                        <abbr>ይዲ</abbr> for <expan>ይበል፡ ዲያቆን፡</expan> (e.g. <locus target="#15r #17v #18v"/>);
                                     </item>
                                     <item>
-                                        <abbr>ይካ</abbr> or <abbr>ይ፡ ካህ፡</abbr> for <expan>ይበል፡ ካህን፡</expan> (e.g. <locus target="#17v #20r #68v"/>)
+                                        <abbr>ይካ</abbr> or <abbr>ይ፡ ካህ፡</abbr> for <expan>ይበል፡ ካህን፡</expan> (e.g. <locus target="#17v #20r #68v"/>);
                                     </item>
                                     <item>
-                                        <abbr>ይሕ</abbr> for <expan>ይበል፡ ሕዝብ፡</expan> (e.g. <locus target="#47v #71v #73r"/>)
+                                        <abbr>ይሕ</abbr> for <expan>ይበል፡ ሕዝብ፡</expan> (e.g. <locus target="#47v #71v #73r"/>);
                                     </item>
                                     <item>
-                                        <abbr>ቅ</abbr> for <expan>ቅዱስ፡</expan> (e.g. <locus target="#53v"/>)
+                                        <abbr>ቅ</abbr> for <expan>ቅዱስ፡</expan> (e.g. <locus target="#53v"/>).
                                     </item>
                                    </list>
                             </handNote>

--- a/OxfordBodleian/Juel-Jensen/BDLaethf33.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf33.xml
@@ -620,12 +620,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <dim type="left">11</dim>
                                         <dim type="intercolumn">11</dim>
                                     </dimensions>
-                                    <note> The characters per line are 7-10.</note>
-                                    <ab type="punctuation" subtype="Dividers">
-                                        Single chains of red and black dots are e.g. on <locus target="#15vb #39va #54rb"/>.
-                                        Double chains of red and black dots, often interspersed with sequences of red and black nine-dot asterisks, are e.g on <locus target="#25vb #34rb #44vb"/>.
-                                        Single lines are sometimes used as dividers, either in black ink (<locus target="#4ra #17va"/>) or in red ink (<locus target="#11ra"/>), or both (<locus target="#40rb"/>).
-                                    </ab>
+                                    <note> The characters per line are 7-10.</note>                                  
                                     <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are visible.</ab>
                                     <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A-1A1A/0-0/0-0/C.</ab>
                                     <ab type="ruling"> The upper line is written above the ruling. The bottom line is written above the ruling.
@@ -646,11 +641,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <dim type="left">11</dim>
                                         <dim type="intercolumn">8</dim>
                                     </dimensions>
-                                        <note> The characters per line are 9-11.</note>
-                                    <ab type="punctuation" subtype="Dividers">
-                                        Single chains of red and black dots are e.g. on <locus target="#68rb #74ra #81vb"/>.
-                                        Single lines in red and black ink are on <locus target="#68rb #76vb #85ra"/>.
-                                    </ab>
+                                        <note> The characters per line are 9-11.</note>                               
                                     <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are visible.</ab>
                                     <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A-1A1A/0-0/0-0/C.</ab>
                                     <ab type="ruling"> The upper line is written above the ruling. The bottom line is written above the ruling.
@@ -662,76 +653,65 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-
-                                <locus from="2ra" to="65v"/>
-                                <seg type="script"/>
-                                <!-- Delete empty element -->
-                                <seg type="ink">Black, red</seg>
-                                <!-- Add dot -->
-                                <date notBefore="1750" notAfter="1850">18th-19th century handwriting</date>
-                                <!-- If we keep it, the hyphen must be – -->
+                                <locus from="2ra" to="65v"/>                                
+                                <date notBefore="1750" notAfter="1850">Mid-eighteenth–mid-nineteenth century.</date>
+                                <seg type="ink">Black, red.</seg>
                                <desc>
-                                 Decent and mostly uniform handwriting.
-                                 Characters are broadly spaced. Sometimes the lower part of the characters are written below the ruled line.
+                                 Decent and mostly uniform handwriting; characters are broadly spaced; sometimes the lower part of the characters is written below the ruled line.
                                  The scribe wrote the last line of <locus target="#63va"/> under the last ruled line.
                                 </desc>
-                                <!-- ... the lower part IS written ... -->
                                 <seg type="rubrication">
                                     Two lines on the incipit pages, alternating with black lines; first lines and incipit formulas of the individual sections (sometimes alternating with a black line);
                                     the titles of the biblical passages and of the prayers; liturgical exhortations (e.g. <foreign xml:lang="gez">ንስእለከ፡</foreign>, <foreign xml:lang="gez">ጸልዩ፡</foreign>)
-                                    and directives (e.g. <foreign xml:lang="gez">ይበል፡ ዲያቆን</foreign>); the name of Mary and of the Archangels; the word <foreign xml:lang="gez">እገሌ፡</foreign> ;
-                                    elements of the punctuation signs, text dividers, and numerals (in full or in part).
+                                    and directives (e.g. <foreign xml:lang="gez">ይበል፡ ዲያቆን</foreign>); the name of <persName ref="PRS6819Mary"/> and of the Archangels; the word <foreign xml:lang="gez">እገሌ፡</foreign> ;
+                                    numerals in full or in part; elements of the punctuation signs and of the text dividers.
                                     The rubrication has not been executed on the last lines of <locus target="#34rb"/>.
-                                </seg>
-                                <!-- encode Mary as such: <persName ref="PRS6819Mary"/>
-                                numerals in full or in part; elements of the punctuation signs and of the text dividers.
-                                -->
+                                    <ab type="punctuation" subtype="Dividers">
+                                        Single chains of red and black dots are e.g. on <locus target="#15vb #39va #54rb"/>.
+                                        Double chains of red and black dots, often interspersed with sequences of red and black nine-dot asterisks, are e.g on <locus target="#25vb #34rb #44vb"/>.
+                                        Single lines are sometimes used as dividers, either in black ink (<locus target="#4ra #17va"/>) or in red ink (<locus target="#11ra"/>), or both (<locus target="#40rb"/>).
+                                    </ab>
+                                </seg>                                
                                 <list type="abbreviations">
                                     <item>
-                                        <abbr>አ</abbr> for <expan>አሜን፡</expan> (<locus from="65rb" to="67va"/>)
+                                        <abbr>አ</abbr> for <expan>አሜን፡</expan> (<locus from="65rb" to="67va"/>).
                                     </item>
                                 </list>
                             </handNote>
                             <handNote xml:id="h2" script="Ethiopic">
-                                <locus from="66r" to="91vb"/>
-                                <seg type="script"/>
-                                <!-- remove empty element -->
-                                <seg type="ink">Black, red</seg>
-                                <!-- Add dot -->
-                                <date notBefore="1750" notAfter="1850">18th-19th century handwriting</date>
-                                <!-- If we keep it, the hyphen must be – -->
+                                <locus from="66r" to="91vb"/>                                
+                                <date notBefore="1750" notAfter="1850">Mid-eighteenth–mid-nineteenth century.</date>
+                                <seg type="ink">Black, red.</seg>
                                 <desc>
-                                   Mediocre handwriting.
-                                   Characters are relatively thick, perhaps due to a change of nib
-                                    The last ruled line has not been written on <locus target="#86ra"/>.
+                                    Mediocre handwriting; characters are relatively thick, perhaps due to a change of nib.
+                                    The grapheme <foreign xml:lang="gez">ጵ</foreign> has the pre-modern shape, with the vowel marker of the sixth order placed on the top of the letter, towards the left
+                                    (e.g. on <locus target="#80va"/>).    
+                                    The last ruled line has not been written on <locus target="#86ra"/>.                            
                                 </desc>
-                                <!-- Add dot after nib. -->
-                                <note>
-                                    The grapheme <foreign xml:lang="gez">ጵ</foreign> has the ancient shape, with the vowel marker of the sixth order placed on the top of the letter, towards the left
-                                    (e.g. on <locus target="#80va"/>).
-                                </note>
-                                <!-- This part can go within <desc/>; use the word "pre-modern" instead of "ancient" -->
-                              <seg type="rubrication">
-                                   First lines and incipit formulas of the individual sections, sometimes alternating with a black line;
+                                <seg type="rubrication">
+                                    First lines and incipit formulas of the individual sections, sometimes alternating with a black line;
                                     the titles of the single prayers; liturgical directives in full or in abbreviation (e.g. <foreign xml:lang="gez">ይካ</foreign>, <foreign xml:lang="gez">ይዲ</foreign>);
-                                    the name of Mary; elements of the punctuation signs, text dividers, and numerals.
+                                    the name of <persName ref="PRS6819Mary"/>; elements of the punctuation signs, text dividers, and numerals.
                                 </seg>
-                                <!-- encode Mary as such: <persName ref="PRS6819Mary"/> -->
+                                <ab type="punctuation" subtype="Dividers">
+                                    Single chains of red and black dots are e.g. on <locus target="#68rb #74ra #81vb"/>.
+                                    Single lines in red and black ink are on <locus target="#68rb #76vb #85ra"/>.
+                                </ab>
                                 <list type="abbreviations">
                                     <item>
-                                        <abbr>ይካ</abbr> or <abbr>ካ</abbr> for <expan>ይበል፡ ካህን፡</expan> (e.g. <locus target="#73rb #75rb #83rb"/>)
+                                        <abbr>ይካ</abbr> or <abbr>ካ</abbr> for <expan>ይበል፡ ካህን፡</expan> (e.g. <locus target="#73rb #75rb #83rb"/>);
                                     </item>
                                     <item>
-                                        <abbr>ይዲ</abbr> or <abbr>ዲ</abbr> for <expan>ይበል፡ ዲያቆን፡</expan> (e.g. <locus target="#73rb #73vb #87rb"/>)
+                                        <abbr>ይዲ</abbr> or <abbr>ዲ</abbr> for <expan>ይበል፡ ዲያቆን፡</expan> (e.g. <locus target="#73rb #73vb #87rb"/>);
                                     </item>
                                     <item>
-                                        <abbr>ጸ</abbr> for <expan>ጸልዩ፡</expan> (e.g. <locus target="#73vb"/>)
+                                        <abbr>ጸ</abbr> for <expan>ጸልዩ፡</expan> (e.g. <locus target="#73vb"/>);
                                     </item>
-                                       <item>
-                                        <abbr>ሕ</abbr> for <expan>ይበል፡ ሕዝብ፡</expan> (e.g. <locus target="#86ra"/>)
+                                    <item>
+                                        <abbr>ሕ</abbr> for <expan>ይበል፡ ሕዝብ፡</expan> (e.g. <locus target="#86ra"/>);
                                     </item>
-                                       <item>
-                                        <abbr>ቅ</abbr> for <expan>ቅዱስ፡</expan> (e.g. <locus target="#86ra"/>)
+                                    <item>
+                                        <abbr>ቅ</abbr> for <expan>ቅዱስ፡</expan> (e.g. <locus target="#86ra"/>).
                                     </item>
                                 </list>
                             </handNote>

--- a/OxfordBodleian/Juel-Jensen/BDLaethf33.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf33.xml
@@ -663,15 +663,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <seg type="rubrication">
                                     Two lines on the incipit pages, alternating with black lines; first lines and incipit formulas of the individual sections (sometimes alternating with a black line);
                                     the titles of the biblical passages and of the prayers; liturgical exhortations (e.g. <foreign xml:lang="gez">ንስእለከ፡</foreign>, <foreign xml:lang="gez">ጸልዩ፡</foreign>)
-                                    and directives (e.g. <foreign xml:lang="gez">ይበል፡ ዲያቆን</foreign>); the name of <persName ref="PRS6819Mary"/> and of the Archangels; the word <foreign xml:lang="gez">እገሌ፡</foreign> ;
+                                    and directives (e.g. <foreign xml:lang="gez">ይበል፡ ዲያቆን</foreign>); the name of <persName ref="PRS6819Mary"/> and of the Archangels; the word <foreign xml:lang="gez">እገሌ፡</foreign>;
                                     numerals in full or in part; elements of the punctuation signs and of the text dividers.
                                     The rubrication has not been executed on the last lines of <locus target="#34rb"/>.
-                                    <ab type="punctuation" subtype="Dividers">
-                                        Single chains of red and black dots are e.g. on <locus target="#15vb #39va #54rb"/>.
-                                        Double chains of red and black dots, often interspersed with sequences of red and black nine-dot asterisks, are e.g on <locus target="#25vb #34rb #44vb"/>.
-                                        Single lines are sometimes used as dividers, either in black ink (<locus target="#4ra #17va"/>) or in red ink (<locus target="#11ra"/>), or both (<locus target="#40rb"/>).
-                                    </ab>
-                                </seg>                                
+                                 </seg>        
+                                <ab type="punctuation" subtype="Dividers">
+                                    Single chains of red and black dots are e.g. on <locus target="#15vb #39va #54rb"/>.
+                                    Double chains of red and black dots, often interspersed with sequences of red and black nine-dot asterisks, are e.g on <locus target="#25vb #34rb #44vb"/>.
+                                    Single lines are sometimes used as dividers, either in black ink (<locus target="#4ra #17va"/>) or in red ink (<locus target="#11ra"/>), or both (<locus target="#40rb"/>).
+                                </ab>
                                 <list type="abbreviations">
                                     <item>
                                         <abbr>አ</abbr> for <expan>አሜን፡</expan> (<locus from="65rb" to="67va"/>).

--- a/OxfordBodleian/Juel-Jensen/BDLaethf34.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethf34.xml
@@ -682,9 +682,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <dim type="left">13</dim>
                                         <dim type="intercolumn">10</dim>
                                     </dimensions>
-                                    <note> The characters per line are 8-12.</note>
-                                    <ab type="punctuation" subtype="Dividers">Subsections of text are separated with one or two chains of red and black dots
-                                        (e.g. <locus target="#5vb #6va #43vab"/>).</ab>
+                                    <note> The characters per line are 8-12.</note>                  
                                     <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are mostly visible.</ab>
                                     <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A-1A1A/0-0/0-0/C.</ab>
                                     <ab type="ruling"> The upper line is written above the ruling. The bottom line is written above the ruling.</ab>
@@ -715,51 +713,46 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                               <locus from="2ra" to="85vb"/>
-                                <seg type="ink">Black, red</seg>
-                                <!-- Add dot. -->
-                                <date notBefore="1700" notAfter="1799">18th-century handwriting</date>
+                                <date notBefore="1700" notAfter="1799">Eighteenth century.</date>
+                                <seg type="ink">Black, red.</seg>                                
                                 <desc>Fine handwriting.
                                 It is possible that several hands were involved in the writing.
-                                Changes of nib are sporadically discernable, e.g. on <locus target="#26ra #57va"/>.
-                                    <!-- Changes of nib can be identified on <locus target="#26ra #57va"/> -->
+                                Changes of nib can be identified on <locus target="#26ra #57va"/>.
                                 </desc>
                                 <seg type="rubrication">
-                                    Few lines on the incipit page of <ref target="#ms_i1"/>, alternating with black lines; first words of texts and sections of texts; titles of the New Testament excerpts
-                                    holy names; directives and refrains in full or in abbreviated form (e.g. <foreign xml:lang="gez">ቅ፡ ቅ፡ ቅ፡</foreign> or <foreign xml:lang="gez">ሰላም፡ ለኪ፡</foreign>)
+                                    Few lines on the incipit page of <ref target="#ms_i1">Textual unit I</ref>, alternating with black lines; first words of texts and sections of texts; titles of the New Testament excerpts;
+                                    holy names; directives and refrains in full or in abbreviated form (e.g. <foreign xml:lang="gez">ቅ፡ ቅ፡ ቅ፡</foreign> or <foreign xml:lang="gez">ሰላም፡ ለኪ፡</foreign>);
                                     elements of the punctuation signs, text dividers, and numerals.
                                     Rubrication was possibly executed in a different hand.
-                                </seg>
-                                <!-- 
-                                <ref target="#ms_i1">textul unit I</ref> + add ; after excerpts + 
-                                -->                                
+                                </seg>                           
+                                <ab type="punctuation" subtype="Dividers">Subsections of text are separated with one or two chains of red and black dots
+                                    (e.g. <locus target="#5vb #6va #43vab"/>).</ab>
                                 <list type="abbreviations">
                                     <item>
-                                        <abbr>ቅ፡</abbr> for <expan>ቅዱስ፡</expan> (e.g. on <locus target="#2va #9rb #31ra"/>)
+                                        <abbr>ቅ፡</abbr> for <expan>ቅዱስ፡</expan> (e.g. on <locus target="#2va #9rb #31ra"/>);
                                     </item>
                                     <item>
-                                        <abbr>ገ፡ ለ፡</abbr> for <expan> ገነይነ፡ ለኪ፡</expan> (e.g. on <locus target="#10ra"/>)
+                                        <abbr>ገ፡ ለ፡</abbr> for <expan> ገነይነ፡ ለኪ፡</expan> (e.g. on <locus target="#10ra"/>);
                                     </item>
                                     <item>
-                                        <abbr>ቅ፡ እ፡ ጸ፡ አ፡</abbr> for <expan>ቅዱስ፡ እግዚአብሔር፡ ጸባዖት፡ አምላክነ፡</expan> (<locus from="31ra" to="31va"/>)
+                                        <abbr>ቅ፡ እ፡ ጸ፡ አ፡</abbr> for <expan>ቅዱስ፡ እግዚአብሔር፡ ጸባዖት፡ አምላክነ፡</expan> (<locus from="31ra" to="31va"/>);
                                     </item>
                                     <item>
-                                        <abbr>ሃ፡ ሉ፡</abbr> for <expan>ሃሌ፡ ሉያ፡</expan> (<locus from="32va" to="33ra"/>)
+                                        <abbr>ሃ፡ ሉ፡</abbr> for <expan>ሃሌ፡ ሉያ፡</expan> (<locus from="32va" to="33ra"/>);
                                     </item>
                                     <item>
-                                        <abbr>ይ፡ ሕ፡</abbr> for <expan>ይቤ፡ ሕዝብ፡</expan> (e.g. on <locus target="#33ra #37ra"/>)
+                                        <abbr>ይ፡ ሕ፡</abbr> for <expan>ይቤ፡ ሕዝብ፡</expan> (e.g. on <locus target="#33ra #37ra"/>);
                                     </item>
                                    <item>
-                                       <abbr>ይ፡ ካ፡</abbr> for <expan>ይቤ፡ ካህን፡</expan> (e.g. on <locus target="#33vb #36vb"/>)
+                                       <abbr>ይ፡ ካ፡</abbr> for <expan>ይቤ፡ ካህን፡</expan> (e.g. on <locus target="#33vb #36vb"/>);
                                     </item>
                                        <item>
-                                           <abbr>ይ፡ ዲ፡</abbr> for <expan>ይቤ፡ ዲያቆን፡</expan> (e.g. on <locus target="#33vb #36vb"/>)
+                                           <abbr>ይ፡ ዲ፡</abbr> for <expan>ይቤ፡ ዲያቆን፡</expan> (e.g. on <locus target="#33vb #36vb"/>);
                                     </item>
                                     <item>
-                                        <abbr>በ፡ ሰ፡</abbr> or <abbr>በሰ፡ ሰ፡</abbr> for <expan>በሰጊድ፡ ሰላም፡</expan> (<locus from="37vb" to="41vb"/>)
+                                        <abbr>በ፡ ሰ፡</abbr> or <abbr>በሰ፡ ሰ፡</abbr> for <expan>በሰጊድ፡ ሰላም፡</expan> (<locus from="37vb" to="41vb"/>).
                                     </item>
                                 </list>
-
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethg28.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg28.xml
@@ -156,22 +156,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <locus from="2r" to="15v"/>
-                                <seg type="ink">Black, red</seg>
-                                <!-- Add dot -->
-                                <date notBefore="1800" notAfter="1950">19th or 20th century</date>
-                                <!-- Discuss how to give this info: 19th or 20th / 19th–20th /omit simply -->
-                                <desc>Mediocre hand with angular script. Word dividers are also
-                                    placed at the beginning of a line (e.g. <locus
-                                        target="#5v #6r #10v"/>.</desc>
-                                <!-- add comma after e.g. -->
+                                 <date notBefore="1800" notAfter="1950">Nineteenth–twentieth century.</date>
+                                <seg type="ink">Black, red.</seg>                               
+                                <desc>Mediocre hand with angular script.</desc>
                                 <seg type="rubrication">Initial two lines on the incipit page of
-                                        <ref target="#ms_i1"/>; the first word of each stanza; the name
+                                    <ref target="#ms_i1"><hi rendition="simple:italic">Malkǝʾ</hi>-hymn to St Michael</ref>; the first word of each stanza; the name
                                     of St Michael, erased names of individuals related
                                     to the production or ownership of the manuscript; elements of
-                                    the punctuation marks, and numerals.</seg>
-                                <!-- Open <ref target="#ms_i1"/> adding <hi rendition="simple:italic">Malkǝʾ</hi>-hymn to St Michael -->
-                                <!-- punctuation signs -->
+                                    the punctuation signs, and numerals.</seg>
+                                <ab type="punctuation" subtype="Dividers">Word dividers are sometimes placed at the beginning of the line (e.g. <locus target="#5v #6r #10v"/>.</ab>         
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethg29.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg29.xml
@@ -174,16 +174,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <date notBefore="1900" notAfter="1973"/>
+                                <seg type="ink">Black, red.</seg>
                                 <desc>Trained hand.</desc>
-                           <seg type="ink">Black, red.</seg>
-                                <!-- Order is ink, date, desc, rubr -->
-                                <seg type="rubrication">Lines and groups of lines, alternating with black lines, on incipit pages; holy names;
-                                    the list of the names of God on <locus from="14v" to="15r"/>; elements of numerals.</seg>
-                                <!-- Add "the" twice -->
+                                <seg type="rubrication">Lines and groups of lines on incipit pages, alternating with black lines; holy names;
+                                    the list of the names of God on <locus from="14v" to="15r"/>; elements of the numerals.</seg>                          
                                 <list type="abbreviations">
                                     <item>
                                         <abbr>ለዓለ፡ ዓለ፡</abbr> or <abbr>ለዓ፡ ዓለ፡</abbr> for <expan>ለዓለመ፡ ዓለም፡</expan> (e.g. <locus
-                                            target="#20r #24v"/>).
+                                            target="#20r #24v"/>);
                                     </item>
                                     <item>
                                         <abbr>አሜ፡</abbr> for <expan>አሜን፡</expan> (e.g. <locus

--- a/OxfordBodleian/Juel-Jensen/BDLaethg30.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg30.xml
@@ -153,27 +153,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-
-                                <seg type="script"/>
-                                <!-- Delete empty element -->
-
-                                <seg type="ink">Black, red</seg>
-                                <!-- Add dot -->
-                                <date notBefore="1800" notAfter="1950">from 19th to mid-20th century</date>
+                                <date notBefore="1800" notAfter="1950">Nineteenth–first half of the twentieth century.</date>
+                                <seg type="ink">Black, red.</seg>
                                 <desc>
                                     Mediocre handwriting. Characters are unevenly spaced and sometimes irregular in size.
-                                </desc>
-                                <!-- Mediocre hand. ... -->
-                                <note>
                                     The graphemes ግ and ዚ in the word <foreign xml:lang="gez">እግዚአብሔር፡</foreign> are occasionally written with ligature
                                     (e.g. on <locus target="#14r #24r #29r"/>).
-                                </note>
+                                </desc>   
                                 <seg type="rubrication">
                                     Very few rubricated words are still legible, e.g. the name of <persName ref="PRS7840Phanuel"/> on <locus target="#24r #24v"/> and
                                     part of the word <foreign xml:lang="gez">ሰላም፡</foreign>.
-                                    The elements of the punctuation signs were possibly rubricated (cp. on <locus target="#23v"/>).
+                                    The elements of the punctuation signs were possibly rubricated (e.g. <locus target="#23v"/>).
                                 </seg>
-                                <!-- e.g. on -->
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethg31.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg31.xml
@@ -202,9 +202,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <dim type="right">7</dim>
                                         <dim type="left">7</dim>
                                     </dimensions>
-                                    <note> The characters per line are 8-11.</note>
-                                    <ab type="punctuation" subtype="Dividers">The explicits of <ref target="#i1"/> (<locus target="#31r"/>) and of <ref target="#i2"/> (<locus target="#46v"/>)
-                                        terminate with two chains of red and black small semicircles.</ab>
+                                    <note> The characters per line are 8-11.</note>                               
                                     <ab type="pricking">Ruling and pricking are barely visible. Primary and ruling pricks are rarely visible (e.g. <locus target="#40"/>).</ab>
                                     <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A/0-0/0-0/C.</ab>
                                     <ab type="ruling"> The upper line is written above the ruling. The bottom line is written above the ruling.</ab>
@@ -214,29 +212,27 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <seg type="ink">Black, red</seg>
-                                <!-- Add dot -->
-                                <date notBefore="1700" notAfter="1799">18th century</date>
+                                <date notBefore="1700" notAfter="1799">Eighteenth century.</date>
+                                <seg type="ink">Black, red.</seg>
                                 <desc>
-                                    Mediocre handwriting.
-                                    <!-- hand -->
+                                    Mediocre handwriting.                                  
                                 </desc>
                                 <seg type="rubrication">
                                     One or two lines on the incipit pages, sometimes alternating with black lines;
-                                    refrains in full or in abbreviated form (e.g. <foreign xml:lang="gez">ተዘከር፡</foreign>, <foreign xml:lang="gez">አምህለከ፡</foreign>, <foreign xml:lang="gez">መሐልኩ፡</foreign>)
-                                    <!-- add ; -->
-                                    holy names; the name of the owner; elements of the punctuation signs, text dividers, and numerals.
-                                    <!-- names of the individuals who commissioned or owned the manuscript;-->
+                                    refrains in full or in abbreviated form (e.g. <foreign xml:lang="gez">ተዘከር፡</foreign>, <foreign xml:lang="gez">አምህለከ፡</foreign>, <foreign xml:lang="gez">መሐልኩ፡</foreign>);
+                                    holy names; names of the individuals who commissioned or owned the manuscript; elements of the punctuation signs, text dividers, and numerals.
                                 </seg>
+                                <ab type="punctuation" subtype="Dividers">The explicits of the first two texts (<locus target="#31r #46v"/>)
+                                    terminate with two chains of red and black small semicircles.</ab>
                                 <list type="abbreviations">
                                     <item>
-                                        <abbr>አ፡ ኦ፡ ወ፡</abbr> or <abbr>አ፡ ኦወል፡ ወፍ፡</abbr> for <expan>አምህለከ፡ ኦወልድየ፡ ወፍቁርየ፡</expan> (<locus from="5r" to="9r"/>)
+                                        <abbr>አ፡ ኦ፡ ወ፡</abbr> or <abbr>አ፡ ኦወል፡ ወፍ፡</abbr> for <expan>አምህለከ፡ ኦወልድየ፡ ወፍቁርየ፡</expan> (<locus from="5r" to="9r"/>);
                                     </item>
                                     <item>
-                                        <abbr>ዘ፡ እ፡</abbr> for <expan>ዘይትሜሰል፡ እመሂ፡</expan> (<locus from="19v" to="20v"/>)
+                                        <abbr>ዘ፡ እ፡</abbr> for <expan>ዘይትሜሰል፡ እመሂ፡</expan> (<locus from="19v" to="20v"/>);
                                     </item>
                                     <item>
-                                        <abbr>መ፡</abbr> or <abbr>መሐ፡</abbr> for <expan>መሐልኩ፡</expan> (<locus from="25r" to="29r"/>)
+                                        <abbr>መ፡</abbr> or <abbr>መሐ፡</abbr> for <expan>መሐልኩ፡</expan> (<locus from="25r" to="29r"/>).
                                     </item>
                                 </list>
                             </handNote>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg32.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg32.xml
@@ -262,40 +262,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <date notBefore="1800" notAfter="2006"/>
-                                <!-- Add date range in letters -->
-                           <desc>Regular hand, bulky characters.</desc>
-                                <!-- Regular hand. The characters are bulky. -->
+                                <date notBefore="1800" notAfter="2006">Nineteenth–twentieth century.</date>
                                 <seg type="ink">Black, red.</seg>
-                                <!-- Order is ink, date, desc -->
+                                <desc>Regular hand. The characters are bulky. </desc>
                                 <seg type="rubrication">Groups of lines or single words at the beginning of sections;
                                     elements of numerals and punctuation signs.</seg>
                                 <list type="abbreviations">
                                     <item>
-                                        <abbr>ጊ፡</abbr> for <expan>ጊዜ፡</expan> <locus target="#6v"/>;
-                                        <abbr>ምዕ፡</abbr> for <expan>ምዕራብ፡</expan> on <locus target="#7r"/>;
-                                        <abbr>ደቡ፡</abbr> for <expan>ደቡብ፡</expan>  on <locus target="#7r"/>;
-                                        <abbr>ሰ፡</abbr> for <expan>ሰሜን፡</expan> on <locus target="#7r"/>.
-                                    </item>
-                                </list>
-                                <!-- 
-                                
-                                 <list type="abbreviations">
-                                    <item>
-                                         <abbr>ጊ፡</abbr> for <expan>ጊዜ፡</expan> (<locus target="#6v"/>)
+                                        <abbr>ጊ፡</abbr> for <expan>ጊዜ፡</expan> (<locus target="#6v"/>);
                                     </item>
                                     <item>
-                                        <abbr>ምዕ፡</abbr> for <expan>ምዕራብ፡</expan> (<locus target="#7r"/>)
+                                        <abbr>ምዕ፡</abbr> for <expan>ምዕራብ፡</expan> (<locus target="#7r"/>);
                                     </item>
                                     <item>
-                                       <abbr>ደቡ፡</abbr> for <expan>ደቡብ፡</expan> (<locus target="#7r"/>)
+                                        <abbr>ደቡ፡</abbr> for <expan>ደቡብ፡</expan> (<locus target="#7r"/>);
                                     </item>
-                                       <item>
-                                       <abbr>ሰ፡</abbr> for <expan>ሰሜን፡</expan> (<locus target="#7r"/>)
+                                    <item>
+                                        <abbr>ሰ፡</abbr> for <expan>ሰሜን፡</expan> (<locus target="#7r"/>).
                                     </item>                                     
                                 </list>
-                                
-                                -->
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethg33.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg33.xml
@@ -406,8 +406,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <seg type="ink">Black, red</seg>
-                                <date notBefore="1700" notAfter="1799">18th century</date>
+                                <date notBefore="1700" notAfter="1799">Eighteenth century.</date>
+                                <seg type="ink">Black, red.</seg>                       
                                 <desc>
                                     Mediocre handwriting. Characters are slender.
                                     A change of hand or more probably of nib occurred from <locus target="#49r"/> onwards: characters are larger in size and thicker.
@@ -420,25 +420,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </seg>
                                 <list type="abbreviations">
                                     <item>
-                                        <abbr>ይዲ</abbr> or <abbr>ዲ</abbr> for <expan>ይቤ፡ ዲያቆን፡</expan> (e.g. on <locus target="#26r #27v #29v"/>)
+                                        <abbr>ይዲ</abbr> or <abbr>ዲ</abbr> for <expan>ይቤ፡ ዲያቆን፡</expan> (e.g. on <locus target="#26r #27v #29v"/>);
                                     </item>
                                     <item>
-                                        <abbr>ይካ</abbr> or <abbr>ይካሕ</abbr> for <expan>ይቤ፡ ካህን፡</expan> (e.g. on <locus target="#27v #29v #31r"/>)
+                                        <abbr>ይካ</abbr> or <abbr>ይካሕ</abbr> for <expan>ይቤ፡ ካህን፡</expan> (e.g. on <locus target="#27v #29v #31r"/>);
                                     </item>
                                     <item>
-                                        <abbr>ሕ</abbr> or <abbr>ይሕ</abbr> for <expan>ይቤ፡ ሕዝብ፡</expan> (e.g. on <locus target="#40v #53r #55r"/>)
+                                        <abbr>ሕ</abbr> or <abbr>ይሕ</abbr> for <expan>ይቤ፡ ሕዝብ፡</expan> (e.g. on <locus target="#40v #53r #55r"/>);
                                     </item>
                                     <item>
-                                        <abbr>ቅ</abbr> for <expan>ቅዱስ፡</expan> (on <locus target="#80v #84r"/>)
+                                        <abbr>ቅ</abbr> for <expan>ቅዱስ፡</expan> (on <locus target="#80v #84r"/>);
                                     </item>
                                     <item>
-                                        <abbr>ዘማር</abbr> for <expan>ዘማርቆስ፡</expan> (on <locus target="#80v"/>)
+                                        <abbr>ዘማር</abbr> for <expan>ዘማርቆስ፡</expan> (on <locus target="#80v"/>);
                                     </item>
                                     <item>
-                                        <abbr>ዘሉቃ</abbr> for <expan>ዘሉቃስ፡</expan> (on <locus target="#80v"/>)
+                                        <abbr>ዘሉቃ</abbr> for <expan>ዘሉቃስ፡</expan> (on <locus target="#80v"/>);
                                     </item>
                                     <item>
-                                        <abbr>ዘዮሐን</abbr> for <expan>ዘዮሐንስ፡</expan> (on <locus target="#81v"/>)
+                                        <abbr>ዘዮሐን</abbr> for <expan>ዘዮሐንስ፡</expan> (on <locus target="#81v"/>).
                                     </item>
                                 </list>
                             </handNote>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg34.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg34.xml
@@ -350,12 +350,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                             <handDesc>
                                 <handNote xml:id="h2" script="Ethiopic">
-                                    <date notBefore="1700" notAfter="1899"/>
+                                    <date notBefore="1700" notAfter="1899">Eighteenth–nineteenth century.</date>
                                     <seg type="ink">Black, red.</seg>
+                                    <desc>Slightly irregular hand. Characters are broad.</desc>
                                     <seg type="rubrication">Incipit (alternating red and black lines); the beginning of a new section on <locus target="#18r"/>;
                                         the name of <persName ref="PRS6819Mary"/>;
-                                        elements of numerals, punctuation marks, and the text divider on <locus target="#36v"/>.</seg>
-                                    <desc>Slightly irregular hand. Broad characters.</desc>
+                                        elements of numerals, punctuation marks, and the text divider on <locus target="#36v"/>.</seg>                               
                                 </handNote>
                             </handDesc>
 
@@ -394,6 +394,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <msItem xml:id="p3_i1">
                             <locus from="37r" to="41r"/>
                             <title ref="LIT6467Heresies" type="complete"/>
+                            <!-- Check correctness of the title in the work record: "Tract on heresies" or perhaps "Treatise on heresies" ? -->
                             <note>The order in which the heresies are listed here and their wording
                                 differs slightly from the other witnesses of this treatise.</note>
 
@@ -514,6 +515,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <msItem xml:id="p3_i5">
                             <locus from="49r" to="54r"/>
                             <title ref="LIT6556SalastuEdaw" type="complete"/>
+                            <!-- English translation of the title is missing in the work record -->
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez">
                                 <locus from="49r" to="49v"/>
@@ -537,7 +539,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <msItem xml:id="p3_i6">
                             <locus from="54v" to="56v"/>
-                             <title ref="LIT6558Salam" type="complete"/>
+                            <title ref="LIT6558Salam" type="complete"/>
+                            <!-- English translation of the title is missing in the work record -->
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez">
                                 <locus target="#54v"/>
@@ -752,27 +755,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <handNote xml:id="h3" script="Ethiopic">
                                     <date notBefore="1700" notAfter="1716"/>
                                     <seg type="ink">Black, red.</seg>
+                                    <desc>Mediocre and irregular hand, with cursive script.</desc>
                                     <seg type="rubrication">Incipit;  the first word of sentences and stanzas;  the name of <persName ref="PRS6819Mary"/> and saints; <foreign xml:lang="gez">ንሕነሰ፡</foreign> or
-                                        <foreign xml:lang="gez">ንሕነሰ፡ ንቤ፡</foreign> in <ref target="#p3_i1"/>; the word <foreign xml:lang="gez">ሠረቀ፡</foreign> in <ref target="#p3_i2"/>;
-             elements of numerals, punctuation marks and text dividers.</seg>
-                                    <!-- Open  <ref target="#p3_i1"/> and  <ref target="#p3_i2"/> and add the title of the work -->
+                                        <foreign xml:lang="gez">ንሕነሰ፡ ንቤ፡</foreign> in the <ref target="#p3_i1">Treatise on the heresies</ref>; 
+                                        the word <foreign xml:lang="gez">ሠረቀ፡</foreign> in the <ref target="#p3_i2">Calendar of saint commemorations</ref>;
+                                        elements of numerals, punctuation marks and text dividers.</seg>
                                     <list type="abbreviations">
                                         <item>
-                                            <abbr>ስ፡</abbr> for <expan>ስብሐት፡</expan> in <ref target="#p3_i5"/>.
+                                            <abbr>ስ፡</abbr> for <expan>ስብሐት፡</expan> in <locus from="49r" to="54r"/>;
                                         </item>
                                         <item>
-                                            <abbr>ስብ፡</abbr> for <expan>ስብሐት፡</expan> in <ref target="#p3_i6"/>.
+                                            <abbr>ስብ፡</abbr> for <expan>ስብሐት፡</expan> in <locus from="54v" to="56r"/>;
                                         </item>
                                         <item><abbr>ሰኪ፡</abbr> for <expan>ሰላም፡ ለኪ፡</expan> and
-                                            <abbr>ሰላ፡</abbr> for <expan>ሰላም፡</expan> in <ref target="#p3_i6"/>.
+                                            <abbr>ሰላ፡</abbr> for <expan>ሰላም፡</expan> in <locus from="54v" to="56r"/>;
                                         </item>
                                         <item>
-                                            <abbr>ማር፡</abbr> and <abbr>ማርያ፡</abbr> for <expan>ማርያም፡</expan> in <ref target="#p3_i6"/>.
+                                            <abbr>ማር፡</abbr> and <abbr>ማርያ፡</abbr> for <expan>ማርያም፡</expan> in <locus from="54v" to="56r"/>.
                                         </item>
-                                        <!-- References to p3_i should be replaced with single pages -->
                                     </list>
-                                    <desc>Mediocre and irregular hand, cursive script.</desc>
-                                    <!-- , hand with. (The general order is: ink /date /desc) -->
                                 </handNote>
                             </handDesc>
 
@@ -822,7 +823,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <origin>
                                 <origDate notBefore="1700" notAfter="1716" evidence="prosopography"/>
                                  <persName ref="PRS3430DawitII"/> and <persName ref="PRS6777Marqos"/>,
-                                who were active simultaneously in <date when="1716"/>, are mentioned in <ref target="#a2"/>.
+                                who were active simultaneously in <date when="1716"/>, are mentioned in <ref target="#a2">Additional note 2</ref>.
                             </origin>
 
                         </history>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg35.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg35.xml
@@ -243,24 +243,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <date notBefore="1650" notAfter="1849"/>
+                                <date notBefore="1650" notAfter="1849">Mid-seventeenth–mid-nineteenth century.</date>
+                                <seg type="ink">Black, red.</seg>
                                 <desc>Mediocre hand. Change of nib on <locus target="#24v"/>.</desc>
-                           <seg type="ink">Black, red.</seg>
-                                <seg type="rubrication">Beginnings of texts; holy names; the abbreviations <foreign xml:lang="gez">ሰ</foreign>/<foreign xml:lang="gez">ሰላ</foreign>
-                                    and <foreign xml:lang="gez">ጊ</foreign>/<foreign xml:lang="gez">ጊዮ</foreign>; numerals
-                                    and elements of
-                                numerals; elements of punctuation signs.</seg>
-                                <!-- 
-                                    Incipits of the texts (two lines alternating with a black line on <locus target="#1r"/>;
-                               holy names; the words <foreign xml:lang="gez">ሰላም</foreign> and <foreign xml:lang="gez">ጊዮርጊስ</foreign> in abbreviated form;                     
-                                    numerals and elements of the numerals and of the punctuation signs.
-                                -->
+                                <seg type="rubrication">Incipits of the texts (two lines alternating with a black line on <locus target="#1r"/>;
+                                    holy names; the words <foreign xml:lang="gez">ሰላም</foreign> and <foreign xml:lang="gez">ጊዮርጊስ</foreign> in abbreviated form;                     
+                                    numerals and elements of the numerals and of the punctuation signs.</seg>
                                 <list type="abbreviations">
                                     <item>
-                                        <abbr>ሰ፡</abbr> or <abbr>ሰላ</abbr> for <expan>ሰላም፡</expan> (e.g. <locus target="#14r #26r #45r"/>)
+                                        <abbr>ሰ፡</abbr> or <abbr>ሰላ</abbr> for <expan>ሰላም፡</expan> (e.g. <locus target="#14r #26r #45r"/>);
                                     </item>
                                     <item>
-                                        <abbr>ጊ</abbr> or <abbr>ጊዮ፡</abbr> for <expan>ጊዮርጊስ፡</expan> (e.g. <locus target="#5v #14r #18r"/>)
+                                        <abbr>ጊ</abbr> or <abbr>ጊዮ፡</abbr> for <expan>ጊዮርጊስ፡</expan> (e.g. <locus target="#5v #14r #18r"/>).
                                     </item>
                                 </list>
                             </handNote>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg37.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg37.xml
@@ -498,7 +498,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <foreign xml:lang="gez">፮</foreign> and <foreign xml:lang="gez">ጵ</foreign> have
                                     the modern form (e.g. <locus target="#23ra #36vb"/>).</desc>
                                 <seg type="rubrication">The title and numeral at the beginning of each canticle; elements of punctuation signs.</seg>
-                            </handNote>                            
+                            </handNote>                  
+                        </handDesc>
 
                         <decoDesc>
                           <summary>The prayers in the manuscript are prefaced by a portrait of

--- a/OxfordBodleian/Juel-Jensen/BDLaethg37.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg37.xml
@@ -492,48 +492,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <date notBefore="1550" notAfter="1799"/>
-                                <!-- Want to reconsider this in light of comment about images? -->
-                           <seg type="ink">Black, red.</seg>
-                                <seg type="rubrication">The title and numeral at the beginning of each canticle; elements of punctuation signs.</seg>
-                                <!-- Order is ink, date, desc, rubr -->
-                                <desc>Fine and regular handwriting. The letters are slightly slanted towards the right, broad spaces between characters. ፮ and ጵ have
+                                <!-- Want to reconsider or narrow this time range in light of the images (First Gondarine Style)? -->
+                           <seg type="ink">Black, red.</seg>                   
+                                <desc>Fine and regular handwriting. The letters are slightly slanted towards the right, broad spaces between characters. 
+                                    <foreign xml:lang="gez">፮</foreign> and <foreign xml:lang="gez">ጵ</foreign> have
                                     the modern form (e.g. <locus target="#23ra #36vb"/>).</desc>
-                                <!-- All numerals must be marked up with <foreign xml:lang="gez">...</foreign> -->
-                            </handNote>
-
-                            <handNote xml:id="h2" script="Ethiopic" corresp="#a1">
-                                <locus from="1r" to="2v"/>
-                                <date notBefore="1800" notAfter="2006"/>
-                                <seg type="ink">Black.</seg>
-                            </handNote>
-                            <!-- This is quite normal: all additional notes are written in a different hand (moslty untrained, like here h4, h5) and could be omitted for the sake of space. If needed,
-                                a comment might be added to the respective additional notes, without redoubling the information.
-                                If so, add a remind in the respective additional notes to delete corresp="#h2", corresp="#h3" etc.
-                              -->
-
-                            <handNote xml:id="h3" script="Ethiopic" corresp="#a2">
-                                <locus from="3r" to="4r"/>
-                                <date notBefore="1800" notAfter="2006"/>
-                                <seg type="ink">Black.</seg>
-                            </handNote>
-                            <!-- To remove -->
-
-                            <handNote xml:id="h4" script="Ethiopic" corresp="#a3">
-                                <locus target="#4v"/>
-                                <date notBefore="1800" notAfter="1974"/>
-                                <seg type="ink">Black.</seg>
-                                <desc>An untrained hand.</desc>
-                            </handNote>
-                            <!-- To remove -->
-
-                            <handNote xml:id="h5" script="Ethiopic" corresp="#a6">
-                                <locus from="47r" to="51v"/>
-                                <date notBefore="1800" notAfter="2006"/>
-                                <seg type="ink">Black.</seg>
-                                <desc>An untrained, irregular hand.</desc>
-                            </handNote>
-                        </handDesc>
-                        <!-- To remove -->
+                                <seg type="rubrication">The title and numeral at the beginning of each canticle; elements of punctuation signs.</seg>
+                            </handNote>                            
 
                         <decoDesc>
                           <summary>The prayers in the manuscript are prefaced by a portrait of
@@ -624,7 +589,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <additions>
                             <list>
-                                <item xml:id="a1" corresp="#h2">
+                                <item xml:id="a1">
                                     <locus from="1r" to="2v"/>
                                     <desc type="MagicText">Protective prayer containing excerpts from the Psalms of David. The name or names mentioned at the end of the text have
                                         been erased, and that of <persName ref="PRS13177HaylG"/>, hardly legible, has been added in a crude hand above the erasure.</desc>
@@ -642,7 +607,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </q>
                                 </item>
 
-                                <item xml:id="a2" corresp="#h3">
+                                <item xml:id="a2">
                                     <locus from="3r" to="4r"/>
                                     <desc type="MagicText">Protective prayer against criminals, containing <foreign xml:lang="gez">ʾasmāt</foreign> and Amharic words.</desc>
                                     <q xml:lang="gez">
@@ -708,7 +673,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             ፀሐይቱ፡</persName></hi></q>
                                 </item>
 
-                                <item xml:id="a6" corresp="#h5">
+                                <item xml:id="a6">
                                     <locus target="#46rb"/>
                                     <desc type="GuestText">The beginning of <title ref="LIT1828Mahale#Simeon" type="incomplete"/> is copied in a later hand next to <ref target="#ms_i1.15"/>.</desc>
                                     <q xml:lang="gez"/>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg38.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg38.xml
@@ -188,21 +188,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <date notBefore="1800" notAfter="2006"/>
+                                <date notBefore="1800" notAfter="2006">Nineteenth–twentieth century.</date>
+                                <seg type="ink">Black, red.</seg>
                                 <desc>Fine handwriting. Characters are uniformly spaced.
                                     The scribe has used modified letters which are not usually found in the <hi rendition="simple:italic">fidal</hi> syllabary, like
                                     <foreign xml:lang="gez">ሐ</foreign> or <foreign xml:lang="gez">ሑ</foreign> with a horizontal stroke on the top of the letter (e.g. <locus target="#1r56 #1r57"/>).
                                     Some letters are provided with loops at their ends, like <foreign xml:lang="gez">ፓ</foreign>
-                                        (<locus target="#1r30"/>),
-                                        <foreign xml:lang="gez">ሐ</foreign>/<foreign xml:lang="gez">ሑ</foreign> (e.g. <locus target="#1r56 #1r57"/>), and
-                                            <foreign xml:lang="gez">ዎ</foreign> (<locus target="#2r4"/>).
+                                    (<locus target="#1r30"/>),
+                                    <foreign xml:lang="gez">ሐ</foreign>/<foreign xml:lang="gez">ሑ</foreign> (e.g. <locus target="#1r56 #1r57"/>), and
+                                    <foreign xml:lang="gez">ዎ</foreign> (<locus target="#2r4"/>).
                                     These letters resemble <hi rendition="simple:italic">Brillenbuchstaben</hi>, but they are used within words in the body of the text.</desc>
-                      
-                                <seg type="ink">Black, red.</seg>
-                                <!-- Order is ink, date, desc, rubr -->
-                                <seg type="rubrication">Few lines of the incipits and other lines within the text, the name of Mary, some of the 
+                                <seg type="rubrication">Few lines of the incipits and other lines within the text; the name of Mary; some of the 
                                     <hi rendition="simple:italic">Brillenbuchstaben</hi>.</seg>
-                                <!-- ; instead of ,-->
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethg39.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg39.xml
@@ -295,13 +295,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <date notBefore="1800" notAfter="2006"/>
-                                <desc>Untrained hand, bulky and broadly spaced characters.</desc>
-                                <!-- Untrained hand. Characters are bulky and broadly spaced. -->
-                           <seg type="ink">Black, red.</seg>
+                                <date notBefore="1800" notAfter="2006">Nineteenth–twentieth century.</date>
+                                <seg type="ink">Black, red.</seg>
+                                <desc>Untrained hand. Characters are bulky and broadly spaced.</desc>                               
                                 <seg type="rubrication">Groups of lines at the beginning of textual units, alternating with black lines; the name of the owner;
-                                    holy names;
-                                    elements of numerals and punctuation marks. Traces of rubrication are also visible on the verso.</seg>
+                                    holy names; elements of numerals and punctuation marks. Traces of rubrication are also visible on the verso.</seg>
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethg40.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg40.xml
@@ -191,18 +191,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <date notBefore="1650" notAfter="1849"/>
-                           <desc>Probably a trained hand, but slightly irregular. Broad and cursive script. The characters are widely spaced.</desc>
+                                <date notBefore="1650" notAfter="1849">Mid-seventeenth–mid-nineteenth century.</date>
                                 <seg type="ink">Black, red.</seg>
-                                <!-- Order is: ink, date, desc -->
+                                <desc>Probably a trained hand, but slightly irregular. Broad and cursive script. The characters are widely spaced.</desc>
                                 <seg type="rubrication">Incipits (groups of rubricated lines alterating with groups of black lines or
-                                    pairs of rubricated lines); several groups of lines within the main body of
-                                    <ref target="#ms_i1"/> and <ref target="#ms_i2"/>; holy name; names of owners; elements of numerals and punctuation signs.</seg>
-                                <!-- alterNating
-                                "the <ref target="#ms_i1">Legend of St Susǝnyos and Wǝrzǝlyā</ref> and <ref target="#ms_i2">textual unit II [this work record is missing in the work repo,
-                                it must be added and the title inserted here]</ref>; 
-                                the name of <persName ref="PRS5684JesusCh">Jesus</persName>; names of the owners"
-                                -->
+                                    pairs of rubricated lines); several groups of lines within the main body ofthe <ref target="#ms_i1">Legend of St Susǝnyos and Wǝrzǝlyā</ref> and 
+                                    <ref target="#ms_i2">textual unit II <!-- this work record is missing in the work repo, it must be added and the title inserted here] --></ref>; 
+                                    the name of <persName ref="PRS5684JesusCh">Jesus</persName>; names of the owners; elements of numerals and punctuation signs.</seg>
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethg40.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg40.xml
@@ -73,8 +73,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <msItem xml:id="ms_i2">
                             <locus from="1r122" to="1r219"/>
-                            <title type="complete" ref="LIT4703MagicPr"/>
-                            <!-- This work record is apparently missing in the repo -->
+                            <title type="complete" ref="LIT5690MagicPrayer"/>
                             <textLang mainLang="gez"/>
                             <incipit xml:lang="gez"><hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩ አምላክ፡ ጸሎተ፡ ነዲራ፡ ዝውእቱ፡ ሕ</hi>ማመ፡
                                 ዓይነት፡ እኪት፡ ወእንዘ፡ የኃውር፡ እግዚእነ፡ ውስተ<supplied reason="omitted">፡</supplied> ባሕረ፡ ጥብርያዶስ፡

--- a/OxfordBodleian/Juel-Jensen/BDLaethg40.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg40.xml
@@ -194,7 +194,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <seg type="ink">Black, red.</seg>
                                 <desc>Probably a trained hand, but slightly irregular. Broad and cursive script. The characters are widely spaced.</desc>
                                 <seg type="rubrication">Incipits (groups of rubricated lines alterating with groups of black lines or
-                                    pairs of rubricated lines); several groups of lines within the main body ofthe <ref target="#ms_i1">Legend of St Susǝnyos and Wǝrzǝlyā</ref> and 
+                                    pairs of rubricated lines); several groups of lines within the main body of the <ref target="#ms_i1">Legend of St Susǝnyos and Wǝrzǝlyā</ref> and 
                                     <ref target="#ms_i2">textual unit II <!-- this work record is missing in the work repo, it must be added and the title inserted here] --></ref>; 
                                     the name of <persName ref="PRS5684JesusCh">Jesus</persName>; names of the owners; elements of numerals and punctuation signs.</seg>
                             </handNote>

--- a/OxfordBodleian/Juel-Jensen/BDLaethg41.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg41.xml
@@ -242,14 +242,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <date notBefore="1777" notAfter="1800"/>
-                                <!-- Add date range in letter -->
-                                <desc>Relatively regular hand, bulky script with broadly spaced characters.
-                                    The word separator is often placed at the beginning of the next line.</desc>
-                                <!-- Relatively regular hand. The script is bulky, characters are broadly spaced. .... -->
-                           <seg type="ink">Black, red.</seg>
-                                <!-- Order is ink, date, desc, rubr -->
-                                <seg type="rubrication">Beginnings of texts and sections, holy name, some of the names of the owners.</seg>
-                                <!-- Incipits of texts and sections; holy names; occasionally the name of the owners. -->
+                                <seg type="ink">Black, red.</seg>
+                                <desc>Relatively regular hand. The script is bulky, characters are broadly spaced.
+                                    The word separator is often placed at the beginning of the next line.</desc>                          
+                                <seg type="rubrication">Incipits of texts and sections; holy names; occasionally the name of the owners.</seg>                                
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethg43.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg43.xml
@@ -238,21 +238,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <date notBefore="1800" notAfter="2006"/>
-                                <desc>Relatively regular hand. Broad and slightly cursive characters. The word separator at the end of a line is
-                                occasionally omitted or placed at the beginning of the next line. The ligature
-                                <foreign xml:lang="gez"><hi rend="ligature">ግዚ</hi></foreign> is used.</desc>
-                                <!-- The characters are broad and slightly cursive.  -->
+                                <date notBefore="1800" notAfter="2006">Nineteenth–twentieth century.</date>
                                 <seg type="ink">Black, red.</seg>
-                                <!-- Order is ink, date, desc, rubr -->
-                                <seg type="rubrication">Incipits (one or two rubricated lines), name of the owner, one numeral,
-                                    the words <foreign xml:lang="gez">ወይርኃቁ፡</foreign>
-                                    in <ref target="#ms_i4">textual unit IV</ref> and
-                                    <foreign xml:lang="gez">ሰላም፡ ለከ፡</foreign> in <ref target="#ms_i5">textual unit V</ref>.</seg>
-                                <!-- 
-                                    replace commas with ;
-                                    ; the numeral <foreign xml:lang="gez">፲ወ፪</foreign> in <ref target="#ms_i3">textual unit III</ref> -->
-                                <!-- Textual units should be capitalized -->
+                                <desc>Relatively regular hand. The characters are broad and slightly cursive. The word separator at the end of a line is
+                                occasionally omitted or placed at the beginning of the next line. The ligature
+                                <foreign xml:lang="gez"><hi rend="ligature">ግዚ</hi></foreign> is used.</desc>                            
+                                <seg type="rubrication">Incipits (one or two rubricated lines); name of the owner; the numeral <foreign xml:lang="gez">፲ወ፪</foreign> in 
+                                    <ref target="#ms_i3">Textual unit III</ref>; the words <foreign xml:lang="gez">ወይርኃቁ፡</foreign>
+                                    in <ref target="#ms_i4">Textual unit IV</ref> and
+                                    <foreign xml:lang="gez">ሰላም፡ ለከ፡</foreign> in <ref target="#ms_i5">Textual unit V</ref>.</seg>                               
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethg45.xml
@@ -183,12 +183,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <date notBefore="1800" notAfter="2006"/>
-                                <!--19th c., Tigray, given in the handlist. [Tigray goes to the provenance?] -->
-                                <desc>Mediocre but regular hand, cursive script.</desc>
+                                <date notBefore="1800" notAfter="2006">Nineteenth–twentieth century.</date>
                                 <seg type="ink">Black, red.</seg>
-                                <seg type="rubrication">Incipits, holy name as part of the name of the owner.</seg>
-                                <!-- Incipits of the texts; part of the name of the owner. -->
+                                <desc>Mediocre but regular hand, cursive script.</desc>                            
+                                <seg type="rubrication">Incipits of the texts; part of the name of the owner.</seg>
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Juel-Jensen/BDLjj29.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLjj29.xml
@@ -116,18 +116,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <date notBefore="1650" notAfter="1775"/>
-                                <seg type="script"><foreign xml:lang="gez">Gʷǝlḥ</foreign>-script.</seg>
-                                <!-- delete -->
-                                <desc>Fine and regular hand, broad spaces between the characters. The characters are very large, with a height of more than
-                                    one centimetre.</desc>
-                                <!-- 
+                                <date notBefore="1650" notAfter="1775">Mid-seventeenth–eighteenth century</date>
+                                <seg type="ink">Black, red.</seg>
+                                <desc>    
                                     Fine and regular hand, <hi rendition="simple:italic">gʷǝlḥ</hi>-script. Characters are broadly spaced and very large, with a height of more than
                                     one centimetre.
-                                -->
-                                <seg type="ink">Black, red.</seg>
-                                <seg type="rubrication">The name of <persName ref="PRS6819Mary"/>; a numeral; elements of punctuation signs.</seg>
-                                <!-- the numeral <foreign xml:lang="gez">፶</foreign> -->
+                                </desc>
+                                <seg type="rubrication">The name of <persName ref="PRS6819Mary"/>; the numeral <foreign xml:lang="gez">፶</foreign>; elements of punctuation signs.</seg>
                             </handNote>
                         </handDesc>
                         

--- a/OxfordBodleian/Ullendorff/BDLeu1.xml
+++ b/OxfordBodleian/Ullendorff/BDLeu1.xml
@@ -446,10 +446,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <dim type="right">16</dim>
                                         <dim type="left">8</dim>
                                     </dimensions>
-                                    <note>The characters per line are 16–31.</note>
-                                    <ab type="punctuation" subtype="Dividers">Groups of ten psalms are separated sometimes
-                                        with one chain of red and black dots
-                                        (e.g. on <locus target="#7v"/>).<!--The only photographed occurence--></ab>
+                                    <note>The characters per line are 16–31.</note>                              
                                     <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are visible.</ab>
                                     <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A/0-0/0-0/C.</ab>
                                     <ab type="ruling"> The upper line is written above the ruling. The bottom line is written above the ruling.
@@ -461,15 +458,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <date notBefore="1650" notAfter="1849"/>
-                                <!-- Order is ink, date, desc -->
-                                <!-- Date range in letters -->
-                                <desc>Slightly irregular hand. Broadly spaced characters. The vowel markers of <foreign xml:lang="gez">ን</foreign> and <foreign xml:lang="gez">ግ</foreign>
-                                    are extended; the vowel marker of the 5th order is always closed. The ligature <foreign xml:lang="gez">ግዚ</foreign> is not used.</desc>
-                                <!-- Characters are broadly spaced. Rimuovere l'ultima frase sulla legatura, è ridondante -->
+                                <date notBefore="1650" notAfter="1849">Mid-seventeenth mid-nineteenth century.</date>
+                                <seg type="ink">Black, red.</seg>
+                                <desc>Slightly irregular hand. Characters are broadly spaced. 
+                                    The vowel markers of <foreign xml:lang="gez">ን</foreign> and <foreign xml:lang="gez">ግ</foreign>
+                                    are extended; the vowel marker of the 5th order is always closed.</desc>
                            <seg type="ink">Black, red.</seg>
                                 <seg type="rubrication">One red line, alternating with black lines, at the beginning of the Psalms of David and the Canticles;
                                     titles and numbers of Psalms; elements of punctuation marks and text dividers.</seg>
+                                <ab type="punctuation" subtype="Dividers">Groups of ten psalms are separated sometimes
+                                    with one chain of red and black dots
+                                    (e.g. on <locus target="#7v"/>).<!--The only photographed occurence--></ab>
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Ullendorff/BDLeu10.xml
+++ b/OxfordBodleian/Ullendorff/BDLeu10.xml
@@ -135,18 +135,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <date notBefore="1900" notAfter="2006"/>
-                                <!-- date range in letters -->
-                                <desc>
-                                    The script is hasty. Characters have been executed with a thin nib.
-                                </desc>
-                                <!-- Valutare se sostituire "script" con "handwriting" -->
+                                <date notBefore="1900" notAfter="2006">Twentieth century.</date>
                                 <seg type="ink">Black, red.</seg>
-                                <!-- ordine  -->
-                                <seg type="rubrication">Few incipit lines of each text, the name of the Trinity, the words <foreign xml:lang="gez">ዘአሠሮ፡</foreign> and
-                                    <foreign xml:lang="gez">ዘአሠርኮ፡</foreign> (in full or in part), the name of the owner, some elements of the punctuation signs.</seg>
+                                <desc>
+                                    The handwriting is hasty. Characters have been executed with a thin nib.
+                                </desc>                              
+                                <seg type="rubrication">Few incipit lines of each text; the name of the Trinity; the words <foreign xml:lang="gez">ዘአሠሮ፡</foreign> and
+                                    <foreign xml:lang="gez">ዘአሠርኮ፡</foreign> (in full or in part); the name of the owner; some elements of the punctuation signs.</seg>
                             </handNote>
-                            <!-- usare punto e virgola tra le parti -->
                         </handDesc>
 
                        <!-- <decoDesc>

--- a/OxfordBodleian/Ullendorff/BDLeu2.xml
+++ b/OxfordBodleian/Ullendorff/BDLeu2.xml
@@ -155,17 +155,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <date notBefore="1954" notAfter="1955"/>
-                                <persName ref="PRS14000WaldaA" role="scribe"/>
-                                <!--      <persName ref="PRS14000WaldaA" role="scribe"/> is indicated as the scribe in the final supplication on <locus target="#39v"/>. -->
-                                
+                              <persName ref="PRS14000WaldaA" role="scribe"/> is indicated as the scribe in the final supplication on <locus target="#39v"/>.                                
                                 <seg type="ink">Black, red.</seg>
+                                <desc>Modern bulky script, somewhat irregular.</desc>
                                 <seg type="rubrication">Incipit (two times two red lines alternating with black lines); holy names; names of the persons involved in
                                     the manuscript production;
                                     the words <foreign xml:lang="gez">ተዘከር፡</foreign> and <foreign xml:lang="gez">አምሕለከ፡</foreign>
                                     and <foreign xml:lang="gez">መሐልኩ፡ ለኪ፡</foreign> in the main text;
-                                    elements of numerals and punctuation marks.</seg>
-                                <desc>Modern bulky script, somewhat irregular.</desc>
-                                <!-- Order is ink, date, desc, rubr -->
+                                    elements of numerals and punctuation marks.</seg>                          
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Ullendorff/BDLeu3.xml
+++ b/OxfordBodleian/Ullendorff/BDLeu3.xml
@@ -216,7 +216,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <date notBefore="1750" notAfter="1900">Mid-eighteenth–twentieth century.</date>
                                 <seg type="ink">Black, red.</seg>
                                 <desc>Mediocre handwriting.
-                                    Characters were occasionally carelessly executed; spacing between characters is also irregular.
+                                    Characters were occasionally carelessly executed; spacing between characters is  irregular.
                                     The graphemes <foreign xml:lang="gez">ግ</foreign> and <foreign xml:lang="gez">ዚ</foreign> in the word <foreign xml:lang="gez">እግዚአብሔር፡</foreign> are often written with ligature.
                                 </desc>
                                 <seg type="rubrication">

--- a/OxfordBodleian/Ullendorff/BDLeu3.xml
+++ b/OxfordBodleian/Ullendorff/BDLeu3.xml
@@ -212,46 +212,39 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </objectDesc>
 
                         <handDesc>
-                            <handNote xml:id="h1" script="Ethiopic">/
-                                <locus from="3ra" to="50vb"/>
-                                <!-- locus useless if there's only h1 -->
-                                <seg type="ink">Black, red</seg>
-                                <!-- Add dot -->
-                                <date notBefore="1750" notAfter="1900">18th- or 19th-century handwriting</date>
+                            <handNote xml:id="h1" script="Ethiopic">
+                                <date notBefore="1750" notAfter="1900">Mid-eighteenth–twentieth century.</date>
+                                <seg type="ink">Black, red.</seg>
                                 <desc>Mediocre handwriting.
-                                    Characters were occasionally carelessly executed. Spacing between characters is also irregular.
-                                </desc>
-                                <!-- punto e virgola invece del punto tra le due ultime frasi -->
-                                <note>
+                                    Characters were occasionally carelessly executed; spacing between characters is also irregular.
                                     The graphemes <foreign xml:lang="gez">ግ</foreign> and <foreign xml:lang="gez">ዚ</foreign> in the word <foreign xml:lang="gez">እግዚአብሔር፡</foreign> are often written with ligature.
-                                </note>
+                                </desc>
                                 <seg type="rubrication">
                                     The name of Mary and some words, in full or in abbreviated form;
                                     elements of the numerals and of the punctuation signs, including the text dividers.
-                                    The rubrication has not been executed on some folios (e.g. on <locus target="#20va #34rb #35va"/>) and <locus from="36vb" to="50vb"/>), with lacunae in the body of the text.
+                                    The rubrication has not been executed on some folios (e.g. on <locus target="#20va #34rb #35va"/>) and <locus from="36vb" to="50vb"/>), which gave rise to textual lacunas.
                                 </seg>
-                                <!-- Replace lacunae with lacunas -->
                                 <list type="abbreviations">
                                     <item>
-                                        <abbr>ቅ፡ እ፡</abbr> for <expan>ቅዱስ፡ እግዚአብሔር፡</expan> (e.g. on <locus target="#3va #4ra"/>)
+                                        <abbr>ቅ፡ እ፡</abbr> for <expan>ቅዱስ፡ እግዚአብሔር፡</expan> (e.g. on <locus target="#3va #4ra"/>);
                                     </item>
                                     <item>
-                                        <abbr>ግ</abbr> or <abbr>ግነ</abbr> for <expan>ግነይ፡</expan> (e.g. on <locus target="#4vb #5ra #5rb"/>)
+                                        <abbr>ግ</abbr> or <abbr>ግነ</abbr> for <expan>ግነይ፡</expan> (e.g. on <locus target="#4vb #5ra #5rb"/>);
                                     </item>
                                     <item>
-                                        <abbr>እዌ</abbr> for <expan>እዌድሰኪ፡</expan> (e.g. on <locus target="#6ra #8vb"/>)
+                                        <abbr>እዌ</abbr> for <expan>እዌድሰኪ፡</expan> (e.g. on <locus target="#6ra #8vb"/>);
                                     </item>
                                     <item>
-                                        <abbr>ማ</abbr> or <abbr>ማር</abbr> for <expan>ማርያም፡</expan> (e.g. on <locus target="#6rb #11ra #19ra"/>)
+                                        <abbr>ማ</abbr> or <abbr>ማር</abbr> for <expan>ማርያም፡</expan> (e.g. on <locus target="#6rb #11ra #19ra"/>);
                                     </item>
                                     <item>
-                                        <abbr>ተ</abbr> for <expan>ተዘከር፡</expan> (e.g. on <locus target="#7ra"/>)
+                                        <abbr>ተ</abbr> for <expan>ተዘከር፡</expan> (e.g. on <locus target="#7ra"/>);
                                     </item>
                                     <item>
-                                        <abbr>ሰ</abbr> or <abbr>ሰአ</abbr> for <expan>ሰአሊ፡</expan> (e.g. on <locus target="#11ra #12rb #34va"/>)
+                                        <abbr>ሰ</abbr> or <abbr>ሰአ</abbr> for <expan>ሰአሊ፡</expan> (e.g. on <locus target="#11ra #12rb #34va"/>);
                                     </item>
                                     <item>
-                                        <abbr>ቅ</abbr> for <expan>ቅዱስ፡</expan> (e.g. on <locus target="#19va"/>)
+                                        <abbr>ቅ</abbr> for <expan>ቅዱስ፡</expan> (e.g. on <locus target="#19va"/>).
                                     </item>
                                 </list>
                             </handNote>

--- a/OxfordBodleian/Ullendorff/BDLeu3.xml
+++ b/OxfordBodleian/Ullendorff/BDLeu3.xml
@@ -221,8 +221,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </desc>
                                 <seg type="rubrication">
                                     The name of Mary and some words, in full or in abbreviated form;
-                                    elements of the numerals and of the punctuation signs, including the text dividers.
-                                    The rubrication has not been executed on some folios (e.g. on <locus target="#20va #34rb #35va"/>) and <locus from="36vb" to="50vb"/>), which gave rise to textual lacunas.
+                                    elements of the numerals and of the punctuation signs, including the text dividers.                                
                                 </seg>
                                 <list type="abbreviations">
                                     <item>
@@ -283,6 +282,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <item xml:id="e1">
                                     <desc>Scribal corrections or interventions are not uncommon. They consist of interlineal additions (e.g. on <locus target="#8rb #11va #38vb"/>),
                                         additions in the upper margins (e.g. on <locus from="41va" to="43vb"/>), and erasures (e.g. on <locus target="#45vb"/>).
+                                        The rubrication has not been executed on some folios (e.g. on <locus target="#20va #34rb #35va"/> and <locus from="36vb" to="50vb"/>), leading to textual lacunas.
                                     </desc>
                                 </item>
                                 

--- a/OxfordBodleian/Ullendorff/BDLeu5.xml
+++ b/OxfordBodleian/Ullendorff/BDLeu5.xml
@@ -241,16 +241,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <seg type="ink">Black, red</seg>
-                                <!-- Add dot -->
-                                <date notBefore="1700" notAfter="1750"></date>
-                                <!-- Add date range in letters -->
+                                <seg type="ink">Black, red.</seg>
+                                <date notBefore="1700" notAfter="1750">First half of the eighteenth century.</date>
                                 <desc>Fine and regular handwriting. Characters are uniformly spaced.
                                 </desc>
                                 <seg type="rubrication">
                                     Several groups of lines on the incipit page, alternating with black lines; the titles and incipits of the single chapters; holy names;
                                     elements of the punctuation signs, text dividers, and numerals, included quire marks.
                                 </seg>
+                                <ab type="punctuation" subtype="Dividers">Single chains of red and black small semicircles are used as dividers after the title
+                                    (<locus target="#1r"/>) and before and after the subscription (<locus target="#66vc"/>).
+                                </ab>
                               </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Ullendorff/BDLeu5.xml
+++ b/OxfordBodleian/Ullendorff/BDLeu5.xml
@@ -241,8 +241,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <seg type="ink">Black, red.</seg>
                                 <date notBefore="1700" notAfter="1750">First half of the eighteenth century.</date>
+                                <seg type="ink">Black, red.</seg>                                
                                 <desc>Fine and regular handwriting. Characters are uniformly spaced.
                                 </desc>
                                 <seg type="rubrication">

--- a/OxfordBodleian/Ullendorff/BDLeu6.xml
+++ b/OxfordBodleian/Ullendorff/BDLeu6.xml
@@ -155,10 +155,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <dim type="intercolumn">8</dim>
                                     </dimensions>
                                    <note>The characters per line are 8–9.</note>
-                                         <ab type="punctuation" subtype="Dividers">
-                                        A single chain of red and black dots is used on <locus target="#68ra"/> to separate the two main texts.
-                                             A double chain of red and black dots is used on <locus target="#68vb"/> at the end of <ref target="#ms_i2">the second text</ref>.
-                                        </ab>
                                     <ab type="pricking">Ruling and pricking are visible. Both primary and ruling pricks are visible.</ab>
                                     <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A-1A1A/0-0/0-0/C.</ab>
                                     <ab type="ruling"> The upper line is written above the ruling. The bottom line is written above the ruling.</ab>
@@ -177,8 +173,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <dim type="right">11</dim>
                                         <dim type="left">8</dim>
                                     </dimensions>
-                                   <note>The characters per line are 12–18.</note>
-                                    <ab type="punctuation" subtype="Dividers">One black lines separates the stanzas on <locus target="#7r"/>.</ab>
+                                   <note>The characters per line are 12–18.</note>                          
                                     <ab type="pricking">The quire is unruled.</ab>
                                 </layout>
                             </layoutDesc>
@@ -187,43 +182,41 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <locus from="9ra" to="68vb"/>
-                                <date notBefore="1700" notAfter="1800"/>
-                                <!-- Date range in letters -->
-                                <!-- Order is ink, date, desc, rubr -->
-                              <desc>Fine and regular handwriting. The ligature <foreign xml:lang="gez">ግዚ</foreign> is used e.g. on <locus target="#1r"/>.
-                                    </desc>
-                           <seg type="ink">Black, red.</seg>
+                                <date notBefore="1700" notAfter="1800">Eighteenth century.</date>
+                                <seg type="ink">Black, red.</seg>
+                                <desc>Fine and regular handwriting. The ligature <foreign xml:lang="gez">ግዚ</foreign> is used e.g. on <locus target="#1r"/>.
+                                </desc>                                
                                 <seg type="rubrication">
-                                    Few lines on the incipit page of <ref target="#ms_i1">the first text</ref>, alternating with black lines;
-                                    the incipits of the sections of <ref target="#ms_i1">the first text</ref>; the first word of <ref target="#ms_i2">the second text</ref>;
-                                    holy names, included that of the saint; elements of the punctuation, including text dividers, and numerals.
-                                </seg>
-                                <!-- "the first text" becomes <hi rendition="simple:italic">Vita</hi> of Zamikāʾel ʾAragāwi (Vita might be not italicized)
-                                "the second text" becomes Monastic genealogy of Dabra Dāmmo
-                                -->
-
+                                    Few lines on the incipit page of the <ref target="#ms_i1">Vita of Zamikāʾel ʾAragāwi</ref>, alternating with black lines;
+                                    the incipits of the sections of the <ref target="#ms_i1">Vita of Zamikāʾel ʾAragāwi</ref>; the first word of the <ref target="#ms_i2">Monastic genealogy of 
+                                        Dabra Dāmmo</ref>; holy names, included that of the saint; elements of the punctuation, including text dividers, and numerals.
+                                </seg>                                                               
+                                <ab type="punctuation" subtype="Dividers">
+                                    A single chain of red and black dots is used on <locus target="#68ra"/> to separate the two main texts;
+                                    a double chain of red and black dots is used on <locus target="#68vb"/> at the end of the <ref target="#ms_i2">Monastic genealogy of 
+                                        Dabra Dāmmo</ref>.
+                                </ab>
                             </handNote>
                             <handNote xml:id="h2" script="Ethiopic" corresp="#a1">
                                 <locus from="1v" to="7v"/>
-                                <date notBefore="1700" notAfter="1900"/>
-                                <!-- Date range in letters -->
+                                <date notBefore="1700" notAfter="1900">Eighteenth–nineteenth century.</date>
+                                <seg type="ink">Black, red.</seg>
                                 <desc>
-                                    This hand wrote <title ref="LIT2849RepCh131"/> <!-- <hi rendition="simple:italic">Malkǝʾ</hi>-hymn to the Archangel Raphael -->.
+                                    This hand wrote the <title ref="LIT2849RepCh131"><hi rendition="simple:italic">Malkǝʾ</hi>-hymn to the Archangel Raphael</title>.
                                     The handwriting is irregular due to the lack of ruling. Characters are executed in a very angular manner.
-                                The ligature <foreign xml:lang="gez">ግዚ</foreign> is used e.g. on <locus target="#2r"/>.</desc>
-                              <seg type="ink">Black, red.</seg>
-                                <seg type="rubrication">The incipit of the text, the name of Rufāʾel, the word <foreign xml:lang="gez">ሰላም፡</foreign> (in full or in abbreviated
-                                    form), and elements of the numerals and of the punctuation</seg>
-                                <!-- Usare punto e virgola; aggiungere punto finale -->
+                                    The ligature <foreign xml:lang="gez">ግዚ</foreign> is used e.g. on <locus target="#2r"/>.</desc>                       
+                                <seg type="rubrication">The incipit of the text; the name of Rufāʾel; the word <foreign xml:lang="gez">ሰላም፡</foreign> (in full or in abbreviated
+                                    form); elements of the numerals and of the punctuation.</seg>
+                                <ab type="punctuation" subtype="Dividers">One black lines separates the stanzas on <locus target="#7r"/>.</ab>
                                 <list type="abbreviations">
                                     <item>
-                                        <abbr>ሰላ</abbr> for <expan>ሰላም፡</expan> (<locus from="1v" to="6r"/>)
+                                        <abbr>ሰላ</abbr> for <expan>ሰላም፡</expan> (<locus from="1v" to="6r"/>);
                                     </item>
                                     <item>
-                                        <abbr>ሩፋ</abbr> or <abbr>ሩፋኤ</abbr> for <expan>ሩፋኤል፡</expan> (<locus from="3r" to="6r"/>)
+                                        <abbr>ሩፋ</abbr> or <abbr>ሩፋኤ</abbr> for <expan>ሩፋኤል፡</expan> (<locus from="3r" to="6r"/>).
                                     </item>
                                 </list>
-                       </handNote>
+                            </handNote>
                         </handDesc>
 
                        <!-- <decoDesc>

--- a/OxfordBodleian/Ullendorff/BDLeu7.xml
+++ b/OxfordBodleian/Ullendorff/BDLeu7.xml
@@ -195,15 +195,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <date notBefore="1800" notAfter="2006"/>
+                                <date notBefore="1800" notAfter="2006">Nineteenth–twentieth century.</date>
+                                <seg type="ink">Black, red.</seg>
                                 <desc>Fine handwriting. Characters are regular.
                                     The ligature <foreign xml:lang="gez">ግዚ</foreign> is occasionally used e.g. on <locus target="#1r18"/>.
-                                  </desc>
-                                <seg type="ink">Black, red.</seg>
-                                <!-- Order is ink, date, desc, rubr -->
-                                <seg type="rubrication">Few lines of the incipits and other lines within the text, the name of Mary and of the owner in the supplications,
-                                    the refrain <foreign xml:lang="gez">ሰላም፡ ለኪ፡</foreign>, captions of the miniatures.</seg>
-                                <!-- Usare punto e virgola -->
+                                  </desc>                            
+                                <seg type="rubrication">Few lines of the incipits and other lines within the text; the name of Mary and of the owner in the supplications;
+                                    the refrain <foreign xml:lang="gez">ሰላም፡ ለኪ፡</foreign>; captions of the miniatures.</seg>
                             </handNote>
                         </handDesc>
 

--- a/OxfordBodleian/Ullendorff/BDLeu9.xml
+++ b/OxfordBodleian/Ullendorff/BDLeu9.xml
@@ -192,7 +192,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <date notBefore="1800" notAfter="2002">Nineteenth–twentieth century.</date>
                                 <seg type="ink">Black, red.</seg>
-                                <desc>Modern bulky script, somewhat irregular. The nine-dotted asterisk is used often as word separator, and the word separator is often omitted when the end of a word
+                                <desc>Modern bulky script, somewhat irregular. The nine-dot asterisk is used often as word separator, and the word separator is often omitted when the end of a word
                                     coincides with the end of the line.</desc>                              
                                 <seg type="rubrication">Beginnings of prayers; holy names; elements of numerals and punctuation marks. Towards the end of the scroll, rubrication in
                                     punctuation marks is omitted.</seg>

--- a/OxfordBodleian/Ullendorff/BDLeu9.xml
+++ b/OxfordBodleian/Ullendorff/BDLeu9.xml
@@ -186,18 +186,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <ab type="pricking">Pricking and ruling are not visible.</ab>
                                 </layout>
                             </layoutDesc>
-
                         </objectDesc>
 
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                           <desc>Modern bulky script, somewhat irregular. The nine-dotted asterisk is used often as word separator, and the word separator is often omitted when the end of a word
-                               coincides with the end of the line.</desc>
-                                <date notBefore="1800" notAfter="2002"/>
+                                <date notBefore="1800" notAfter="2002">Nineteenth–twentieth century.</date>
                                 <seg type="ink">Black, red.</seg>
-                                <!-- Order is ink, date, desc, rubr -->
+                                <desc>Modern bulky script, somewhat irregular. The nine-dotted asterisk is used often as word separator, and the word separator is often omitted when the end of a word
+                                    coincides with the end of the line.</desc>                              
                                 <seg type="rubrication">Beginnings of prayers; holy names; elements of numerals and punctuation marks. Towards the end of the scroll, rubrication in
-                                punctuation marks is omitted.</seg>
+                                    punctuation marks is omitted.</seg>
                             </handNote>
                         </handDesc>
 


### PR DESCRIPTION
Dear all,

this branch contains the revision of the HandDesc section. The main changes have been on order of the single parts (fols in more than one hand; date; scribes; ink; rubrication; punctuation; abbreviations); syntax; use of semicolon; etc.
`<ab type="punctuation" subtype="Dividers"/>` has been moved here from Layout, as agreed in the last meeting with Dorothea an Jonas.
Two issues:
- MS g.37: can current dating (1550-1799) be further narrowed on the basis of the style of the miniatures? They are executed in the First Gondarine Style. @gnizla 
- There might be problems in the PDF with information on the scribes. For instance MS b.3 has the following text: 
 `<persName ref="PRS13901Zaparaqlitos" role="scribe"/> is mentioned in red ink in the lower margin of <locus target="#148r"/>. <persName ref="PRS13900WaldaD" role="scribe"/> is mentioned in black ink in the lower margin of <locus target="#117r #138v"/>. The two different names mentioned suggest at least two scribes were involved in the copying, but no discontinuity in the hand can be observed throughout the manuscript. `
What can I do to avoid problems in the generation of the PDF?
- Other minor problems will be solved down the line; for instance MS g.40 contains a text, LIT4703MagicPr, whose work record is missing in the repo (been deleted?), so the title of that work can't be provided in the handNote.