### PR TITLE
Create BLorient12996 (Amharic grammar)

### DIFF
--- a/LondonBritishLibrary/orient/BLorient12996.xml
+++ b/LondonBritishLibrary/orient/BLorient12996.xml
@@ -34,7 +34,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <objectDesc form="Codex">
                             <supportDesc>
                                 <extent>
-                                    <measure unit="leaf">59+1</measure>
+                                    <measure unit="leaf" quantity="60">59+1</measure>
                                 </extent> 
                             </supportDesc>
                         </objectDesc> 
@@ -190,7 +190,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title ref="STU0009AmharicGram#Dicere">Conjug. Verbi Affirmativi Dicere in Amahara</title>
                                 </msItem>
                                 <msItem xml:id="p1_i1.19">
-                                    <locus from="0000"/>
+                                    <locus from="37v"/>
                                     <title ref="STU0009AmharicGram#Syntax">Caput ultimum: De Constructione Phrasi</title>
                                     <note>Final chapter on syntax.</note>
                                 </msItem>
@@ -209,7 +209,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <width>105</width>
                                         </dimensions>
                                     </extent> 
-                                    <foliation>With an original pagination from 1 to 70.</foliation>
+                                    <foliation>With a pagination from 1 to 70, probably by the author.</foliation>
                                 </supportDesc>
                                 <layoutDesc>
                                     <layout writtenLines="26"/>                                

--- a/LondonBritishLibrary/orient/BLorient12996.xml
+++ b/LondonBritishLibrary/orient/BLorient12996.xml
@@ -69,7 +69,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <msContents>
                             <msItem xml:id="p1_i1">
                                 <locus from="1r" to="37v"/>
-                                <title ref="LIT000000000000000000000">Amharic grammar</title>
+                                <title ref="STU0009AmharicGram">Amharic grammar</title>
                                 <note>This Amharic grammar is given the Latin title: <foreign xml:lang="la">Theoriam Linguae Aethiopicae dictae: 
                                     Amaharae complectens.</foreign>. It is written by the same hand as <ref target="#p2_i1"/>, which is dated to 
                                     <date when="1742-06-23">23 June 1742</date>. The author is anonymous and appears to be an Italian, as many 
@@ -83,7 +83,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <textLang xml:lang="la"/>
                                 <msItem xml:id="p1_i1.1">
                                     <locus from="1r"/>
-                                    <title ref="LIT000000000000000000000#Script">Script and Phonetics</title>
+                                    <title ref="STU0009AmharicGram#Script">Script and Phonetics</title>
                                     <note>Introduction to the Ethiopic alphasyllabary and the phonetics of the language. The author gives the Arabic letters
                                         corresponding to the Amharic characters and also indicates the pronunciation with reference to German (indicated as 
                                         <foreign xml:lang="la">Germ.</foreign>), Czech (indicated as <foreign xml:lang="la">Boem.</foreign>, Italian 
@@ -103,12 +103,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </msItem>
                                 <msItem xml:id="p1_i1.2">
                                     <locus target="#6r"/>
-                                    <title ref="LIT00000000000000000000000#Oration1">De partibus Orationis</title>
+                                    <title ref="STU0009AmharicGram#Oration1">De partibus Orationis</title>
                                     <note>Some orations as language samples.</note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.3">
                                     <locus from="6r"/>
-                                    <title ref="LIT00000000000000000000000#Declination">De Nomine et sua Declinatione</title>
+                                    <title ref="STU0009AmharicGram#Declination">De Nomine et sua Declinatione</title>
                                     <note>On the declension of the noun. The author distinguishes six cases: 'nom.', 'gen.', 'dat.', 'acc.', 'voc.', and 'abl.' 
                                         (i.e. <foreign xml:lang="am">ባርያ፡</foreign>, <foreign xml:lang="am">የባርያ፡</foreign>, 
                                         <foreign xml:lang="am">ለባርያ፡</foreign>, <foreign xml:lang="am">ለባርያ፡</foreign>, 
@@ -116,85 +116,81 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </msItem>
                                 <msItem xml:id="p1_i1.4">
                                     <locus from="8r"/>
-                                    <title ref="LIT00000000000000000000000#Pronouns">De Pronominibus</title>
+                                    <title ref="STU0009AmharicGram#Pronouns">De Pronominibus</title>
                                     <note>On pronouns.</note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.5">
                                     <locus from="10r"/>
-                                    <title ref="LIT00000000000000000000000#VerbalAffixes">De Affixis Verborum</title>
+                                    <title ref="STU0009AmharicGram#VerbalAffixes">De Affixis Verborum</title>
                                     <note>On verbal affixes.</note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.6">
                                     <locus from="11r"/>
-                                    <title ref="LIT00000000000000000000000#Oration2">De alijs Orationis partibus</title>
-                                    <note>Second part of orations as language samples.</note>
+                                    <title ref="STU0009AmharicGram#Oration2">De alijs Orationis partibus</title>
+                                    <note>On other parts of speech.</note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.7">
                                     <locus target="#12r"/>
-                                    <title ref="LIT00000000000000000000000#Numbers">De Numero</title>
+                                    <title ref="STU0009AmharicGram#Numbers">De Numero</title>
                                     <note>On the numbers (i.e. <foreign xml:lang="am">፩</foreign>, <foreign xml:lang="am">፪</foreign>, 
                                         <foreign xml:lang="am">፫</foreign>, etc.), which do not have the conventional two horizontal dashes.</note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.8">
                                     <locus from="12r"/>
-                                    <title ref="LIT00000000000000000000000#Conjugation">De Verbo, et ejus Conjugatione</title>
+                                    <title ref="STU0009AmharicGram#Conjugation">De Verbo, et ejus Conjugatione</title>
                                     <note>On the verb and its conjugation.</note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.9">
                                     <locus from="14v"/>
-                                    <title ref="LIT00000000000000000000000#AffirmativeVerbs">Conjugatio Verbi Affirmativi</title>
+                                    <title ref="STU0009AmharicGram#AffirmativeVerbs">Conjugatio Verbi Affirmativi</title>
                                     <note>Conjugation of affirmative verbs, that are described here as <foreign xml:lang="it">Ingiuriare</foreign> 
                                         (i.e. verbs 'to offend').</note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.10">
                                     <locus from="15v"/>
-                                    <title ref="LIT00000000000000000000000#Particles">Modus et forma struendi reliquos Modos</title>
-                                    <note>Description containing twenty-four noteson the different particles used with the verb.</note>
+                                    <title ref="STU0009AmharicGram#Particles">Modus et forma struendi reliquos Modos</title>
+                                    <note>Description containing twenty-four notes on the different particles used with the verb.</note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.11">
                                     <locus from="21r"/>
-                                    <title ref="LIT00000000000000000000000#Participle">De Participio sive Supino in Rus</title>
-                                    <note>On participles (sic) of the pattern <foreign xml:lang="am">supino</foreign> (i.e. converb/gerund) in Rus (?)</note>
+                                    <title ref="STU0009AmharicGram#Participle">De Participio sive Supino in Rus.</title>
+                                    <note>On participles (sic) of the pattern 'supino' (i.e. 'supine') in Rus. (i.e. in Russian?)</note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.12">
                                     <locus from="22v"/>
-                                    <title ref="LIT00000000000000000000000#ParticipleAgentis">De Participijs Agentibus et Patientibus</title>
-                                    <note>Presumably on participles that name the actor and those that name the person affected by an action (i.e. active 
-                                        and passive participles).</note>
+                                    <title ref="STU0009AmharicGram#ParticipleAgentis">De Participijs Agentibus et Patientibus</title>
                                 </msItem>
                                 <msItem xml:id="p1_i1.13">
                                     <locus from="26r"/>
-                                    <title ref="LIT00000000000000000000000#DeclensionParticiples">Declinatio supradictorum duorum Participii</title>
-                                    <note>Declension of the two participles above.</note>
+                                    <title ref="STU0009AmharicGram#DeclensionParticiples">Declinatio supradictorum duorum Participii</title>
                                 </msItem>
                                 <msItem xml:id="p1_i1.14">
                                     <locus from="28v"/>
-                                    <title ref="LIT00000000000000000000000#VerbalNoun">De Abstracto seu Nomine Verbali</title>
+                                    <title ref="STU0009AmharicGram#VerbalNoun">De Abstracto seu Nomine Verbali</title>
                                     <note>On the verbal noun e.g. the gerund.</note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.15">
                                     <locus from="32r"/>
-                                    <title ref="LIT00000000000000000000000#TablePronounAffixes">Tabula Pronominum Verbis affixorum</title>
+                                    <title ref="STU0009AmharicGram#TablePronounAffixes">Tabula Pronominum Verbis affixorum</title>
                                     <note>Table showing the pronominal affixes as they appear on the verb.</note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.16">
                                     <locus from="32v"/>
-                                    <title ref="LIT00000000000000000000000#TablePresent">Seconda Tabula pro Tempore Praesenti</title>
+                                    <title ref="STU0009AmharicGram#TablePresent">Secunda Tabula pro Tempore Praesenti</title>
                                     <note>Second table shows the verbal forms of the present tense.</note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.17">
                                     <locus from="34r"/>
-                                    <title ref="LIT00000000000000000000000#Negative">Conjugazio Verbi Negativi, Modo Arabico</title>
-                                    <note>Conjugation (sic) of negated verbs in the Arabic mode (sic).</note>
+                                    <title ref="STU0009AmharicGram#Negative">Conjugazio Verbi Negativi, Modo Arabico</title>
+                                    <note>Conjugation of negated verbs in the Arabic mode (sic).</note>
                                 </msItem>
                                 <msItem xml:id="p1_i1.18">
                                     <locus from="35v"/>
-                                    <title ref="LIT00000000000000000000000#Dicere">Conjug. Verbi Affirmativi Dicere in Amahara</title>
-                                    <note>On the conjugation of affirmative verbs with a form of 'to say' (<foreign xml:lang="am">በል፡</foreign>).</note>
+                                    <title ref="STU0009AmharicGram#Dicere">Conjug. Verbi Affirmativi Dicere in Amahara</title>
                                 </msItem>
                                 <msItem xml:id="p1_i1.19">
                                     <locus from="0000"/>
-                                    <title ref="LIT00000000000000000000000#Syntax">Caput ultimum: De Constructione Phrasi</title>
+                                    <title ref="STU0009AmharicGram#Syntax">Caput ultimum: De Constructione Phrasi</title>
                                     <note>Final chapter on syntax.</note>
                                 </msItem>
                             </msItem>
@@ -207,7 +203,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </support>
                                     <extent>
                                         <measure unit="leaf">37</measure>
-                                        <dimensions type="leaf" unit="mm" xml:id="leafdim">
+                                        <dimensions type="leaf" unit="mm">
                                             <height>165</height>
                                             <width>105</width>
                                         </dimensions>

--- a/LondonBritishLibrary/orient/BLorient12996.xml
+++ b/LondonBritishLibrary/orient/BLorient12996.xml
@@ -94,7 +94,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <foreign xml:lang="am">ጸ</foreign> and <foreign xml:lang="am">ፀ</foreign> are both transliterated as 'za',
                                         <foreign xml:lang="am">ጀ</foreign> is transliterated as 'gia'. The series of ž is noted by 
                                         <foreign xml:lang="am">ዠ</foreign>etc. (a character with a mark on the lower left side, which signifies the sixth 
-                                        order).
+                                        order <figure><graphic url="https://betamasaheft.eu/resources/images/snippets/BLorient12996/sign1.png" height="30px">
+                                        </graphic></figure>).
                                         The pronunciation of <foreign xml:lang="am">ቸ</foreign> is indicated as 'cia' (but on <locus target="#5r"/>:
                                         <foreign xml:lang="cs">cža</foreign> <foreign xml:lang="la">Boem.</foreign>) and that of
                                         <foreign xml:lang="am">ጨ</foreign> as 'cca' (but  <foreign xml:lang="cs">cža</foreign> (sic!) 

--- a/LondonBritishLibrary/orient/BLorient12996.xml
+++ b/LondonBritishLibrary/orient/BLorient12996.xml
@@ -1,0 +1,292 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="BLorient12996" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Amharic Grammar; Arabic Grammar</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS00001BL"/>
+                        <collection>Oriental</collection>
+                        <idno>BL Oriental 12996</idno>
+                        <altIdentifier><idno>Or. 12996</idno></altIdentifier>
+                        <altIdentifier><idno>Strelcyn 62</idno></altIdentifier>
+                    </msIdentifier>
+                    <msContents><summary/></msContents>
+                    <physDesc>
+                        <objectDesc form="Codex">
+                            <supportDesc>
+                                <extent>
+                                    <measure unit="leaf">59+1</measure>
+                                </extent> 
+                            </supportDesc>
+                        </objectDesc> 
+                        <bindingDesc>
+                            <binding xml:id="binding">
+                                <decoNote xml:id="b1" type="Boards"><material key="wood"/>Modern binding, supplied by the 
+                                    <placeName ref="INS00001BL">British Museum</placeName>.</decoNote>
+                            </binding>
+                        </bindingDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1700" notAfter="1799">18th century</origDate>    
+                        </origin>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                            <citedRange unit="page">103-104</citedRange>
+                                        </bibl> 
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                    <msPart xml:id="p1">
+                        <msIdentifier/>
+                        <msContents>
+                            <msItem xml:id="p1_i1">
+                                <locus from="1r" to="37v"/>
+                                <title ref="LIT000000000000000000000">Amharic grammar</title>
+                                <note>This Amharic grammar is given the Latin title: <foreign xml:lang="la">Theoriam Linguae Aethiopicae dictae: 
+                                    Amaharae complectens.</foreign>. It is written by the same hand as <ref target="#p2_i1"/>, which is dated to 
+                                    <date when="1742-06-23">23 June 1742</date>. The author is anonymous and appears to be an Italian, as many 
+                                    Amharic words and expressions are translated into Italian or the Italian terms are used instead of Latin. Gemination is 
+                                    sometimes, but probably only in the perfect form (cf. <locus target="#26v #30r #30v"/>), indicated by a wavy line (~) 
+                                    on top of the character. The author probably learnt Amharic from an Ethiopian, because he probably did not know 
+                                    <bibl><ptr target="bm:Ludolf1698Grammatica"/></bibl> and he emphasises the importance of learning the 
+                                    pronunciation from a native speaker: <foreign xml:lang="la">Quod concernit pronuntiationem linguae Amaharae, 
+                                    optime aqviritur viva M<supplied reason="omitted">a</supplied>gistri voce; et qui eam praetendit adiscere absque 
+                                    Magistro fallit</foreign>.</note>
+                                <textLang xml:lang="la"/>
+                                <msItem xml:id="p1_i1.1">
+                                    <locus from="1r"/>
+                                    <title ref="LIT000000000000000000000#Script">Script and Phonetics</title>
+                                    <note>Introduction to the Ethiopic alphasyllabary and the phonetics of the language. The author gives the Arabic letters
+                                        corresponding to the Amharic characters and also indicates the pronunciation with reference to German (indicated as 
+                                        <foreign xml:lang="la">Germ.</foreign>), Czech (indicated as <foreign xml:lang="la">Boem.</foreign>, Italian 
+                                        (indicated as <foreign xml:lang="la">Ital.</foreign>, and French <foreign xml:lang="la">Gall.</foreign>. There 
+                                        are also references to Persian. The author notes the letters <foreign xml:lang="am">ፙ</foreign>, transliterated as 
+                                        'moa', a form similar to <foreign xml:lang="am">ፙ</foreign>, but with a mark of the second order on the right side 
+                                        and transliterated as 'mha' (sic) as well as <foreign xml:lang="am">ኸ</foreign>, transliterated as 'chha', etc.
+                                        <foreign xml:lang="am">ጸ</foreign> and <foreign xml:lang="am">ፀ</foreign> are both transliterated as 'za',
+                                        <foreign xml:lang="am">ጀ</foreign> is transliterated as 'gia'. The series of ž is noted by 
+                                        <foreign xml:lang="am">ዠ</foreign>etc. (a character with a mark on the lower left side, which signifies the sixth 
+                                        order).
+                                        The pronunciation of <foreign xml:lang="am">ቸ</foreign> is indicated as 'cia' (but on <locus target="#5r"/>:
+                                        <foreign xml:lang="cs">cža</foreign> <foreign xml:lang="la">Boem.</foreign>) and that of
+                                        <foreign xml:lang="am">ጨ</foreign> as 'cca' (but  <foreign xml:lang="cs">cža</foreign> (sic!) 
+                                        <foreign xml:lang="la">Boemice</foreign>). The author notes the difference between the first and the fourth orders
+                                        only as a difference in length but indicates the two functions of the sixth.</note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.2">
+                                    <locus target="#6r"/>
+                                    <title ref="LIT00000000000000000000000#Oration1">De partibus Orationis</title>
+                                    <note>Some orations as language samples.</note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.3">
+                                    <locus from="6r"/>
+                                    <title ref="LIT00000000000000000000000#Declination">De Nomine et sua Declinatione</title>
+                                    <note>On the declension of the noun. The author distinguishes six cases: 'nom.', 'gen.', 'dat.', 'acc.', 'voc.', and 'abl.' 
+                                        (i.e. <foreign xml:lang="am">ባርያ፡</foreign>, <foreign xml:lang="am">የባርያ፡</foreign>, 
+                                        <foreign xml:lang="am">ለባርያ፡</foreign>, <foreign xml:lang="am">ለባርያ፡</foreign>, 
+                                        <foreign xml:lang="am">ባርያ፡</foreign> and <foreign xml:lang="am">ከባርያ፡</foreign>).</note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.4">
+                                    <locus from="8r"/>
+                                    <title ref="LIT00000000000000000000000#Pronouns">De Pronominibus</title>
+                                    <note>On pronouns.</note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.5">
+                                    <locus from="10r"/>
+                                    <title ref="LIT00000000000000000000000#VerbalAffixes">De Affixis Verborum</title>
+                                    <note>On verbal affixes.</note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.6">
+                                    <locus from="11r"/>
+                                    <title ref="LIT00000000000000000000000#Oration2">De alijs Orationis partibus</title>
+                                    <note>Second part of orations as language samples.</note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.7">
+                                    <locus target="#12r"/>
+                                    <title ref="LIT00000000000000000000000#Numbers">De Numero</title>
+                                    <note>On the numbers (i.e. <foreign xml:lang="am">፩</foreign>, <foreign xml:lang="am">፪</foreign>, 
+                                        <foreign xml:lang="am">፫</foreign>, etc.), which do not have the conventional two horizontal dashes.</note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.8">
+                                    <locus from="12r"/>
+                                    <title ref="LIT00000000000000000000000#Conjugation">De Verbo, et ejus Conjugatione</title>
+                                    <note>On the verb and its conjugation.</note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.9">
+                                    <locus from="14v"/>
+                                    <title ref="LIT00000000000000000000000#AffirmativeVerbs">Conjugatio Verbi Affirmativi</title>
+                                    <note>Conjugation of affirmative verbs, that are described here as <foreign xml:lang="it">Ingiuriare</foreign> 
+                                        (i.e. verbs 'to offend').</note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.10">
+                                    <locus from="15v"/>
+                                    <title ref="LIT00000000000000000000000#Particles">Modus et forma struendi reliquos Modos</title>
+                                    <note>Description containing twenty-four noteson the different particles used with the verb.</note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.11">
+                                    <locus from="21r"/>
+                                    <title ref="LIT00000000000000000000000#Participle">De Participio sive Supino in Rus</title>
+                                    <note>On participles (sic) of the pattern <foreign xml:lang="am">supino</foreign> (i.e. converb/gerund) in Rus (?)</note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.12">
+                                    <locus from="22v"/>
+                                    <title ref="LIT00000000000000000000000#ParticipleAgentis">De Participijs Agentibus et Patientibus</title>
+                                    <note>Presumably on participles that name the actor and those that name the person affected by an action (i.e. active 
+                                        and passive participles).</note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.13">
+                                    <locus from="26r"/>
+                                    <title ref="LIT00000000000000000000000#DeclensionParticiples">Declinatio supradictorum duorum Participii</title>
+                                    <note>Declension of the two participles above.</note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.14">
+                                    <locus from="28v"/>
+                                    <title ref="LIT00000000000000000000000#VerbalNoun">De Abstracto seu Nomine Verbali</title>
+                                    <note>On the verbal noun e.g. the gerund.</note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.15">
+                                    <locus from="32r"/>
+                                    <title ref="LIT00000000000000000000000#TablePronounAffixes">Tabula Pronominum Verbis affixorum</title>
+                                    <note>Table showing the pronominal affixes as they appear on the verb.</note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.16">
+                                    <locus from="32v"/>
+                                    <title ref="LIT00000000000000000000000#TablePresent">Seconda Tabula pro Tempore Praesenti</title>
+                                    <note>Second table shows the verbal forms of the present tense.</note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.17">
+                                    <locus from="34r"/>
+                                    <title ref="LIT00000000000000000000000#Negative">Conjugazio Verbi Negativi, Modo Arabico</title>
+                                    <note>Conjugation (sic) of negated verbs in the Arabic mode (sic).</note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.18">
+                                    <locus from="35v"/>
+                                    <title ref="LIT00000000000000000000000#Dicere">Conjug. Verbi Affirmativi Dicere in Amahara</title>
+                                    <note>On the conjugation of affirmative verbs with a form of 'to say' (<foreign xml:lang="am">በል፡</foreign>).</note>
+                                </msItem>
+                                <msItem xml:id="p1_i1.19">
+                                    <locus from="0000"/>
+                                    <title ref="LIT00000000000000000000000#Syntax">Caput ultimum: De Constructione Phrasi</title>
+                                    <note>Final chapter on syntax.</note>
+                                </msItem>
+                            </msItem>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Codex">
+                                <supportDesc>
+                                    <support>
+                                        <material key="paper"/>
+                                    </support>
+                                    <extent>
+                                        <measure unit="leaf">37</measure>
+                                        <dimensions type="leaf" unit="mm" xml:id="leafdim">
+                                            <height>165</height>
+                                            <width>105</width>
+                                        </dimensions>
+                                    </extent> 
+                                    <foliation>With an original pagination from 1 to 70.</foliation>
+                                </supportDesc>
+                                <layoutDesc>
+                                    <layout writtenLines="26"/>                                
+                                </layoutDesc>
+                            </objectDesc>  
+                        </physDesc>
+                    </msPart>
+                    <msPart xml:id="p2">
+                        <msIdentifier/>
+                        <msContents>
+                            <msItem xml:id="p2_i1">
+                                <locus from="38r" to="59r"/>
+                                <title>Arabic grammar</title>
+                                <textLang xml:lang="la"/>
+                                <colophon xml:id="coloph1">
+                                    <locus target="#55v"/>
+                                    <q xml:lang="la">Die 23 Junii 1742.</q>
+                                </colophon>
+                            </msItem>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Codex">
+                                <supportDesc>
+                                    <support>
+                                        <material key="paper"/>
+                                    </support>
+                                    <extent>
+                                        <measure unit="leaf">22+1</measure>
+                                        <dimensions type="leaf" unit="mm">
+                                            <height>170</height>
+                                            <width>110</width>
+                                        </dimensions>
+                                    </extent> 
+                                    <foliation>With an original pagination from 1 (on <locus target="#39r"/>) to 35 (on <locus target="#56r"/>, the 
+                                        remaining pages being unnumbered.</foliation>
+                                </supportDesc>
+                                <layoutDesc>
+                                    <layout writtenLines="30"/>                                
+                                </layoutDesc>
+                            </objectDesc>  
+                        </physDesc>
+                    </msPart>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="Vocabulary"/>
+                    <term key="AmharicLiterature"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="am">Amharic</language>
+                <language ident="it">Italian</language>
+                <language ident="la">Latin</language>
+                <language ident="cs">Czech</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-07-11">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I encoded BLorient12996 according to the description of St. Strelcyn. However, Strelcyn was not interested in the second part, containing an Arabic grammar, but gave detailed information only on the first part with an Amharic grammar. I would like to create a new STUD ID for this latter text, as recommended by Eugenia in https://github.com/BetaMasaheft/Documentation/issues/2575 and eventually replace the place holders before merging. 

For the representation of some irregular and not standartized letter, it was proposed to insert some images in a [recent issue on graphemes](https://github.com/BetaMasaheft/Documentation/issues/2569). Can you explain, how to insert images to a record?

I wanted to define the dimensions of the two text parts, that are slightly different as dimension of the leaves. I got the advice by Denis for [another record](https://github.com/BetaMasaheft/Manuscripts/pull/2493) to use `<dimensions type="leaf" unit="mm" xml:id="leafdim">` for that. However, leafdim in xml:id works only once in a record. For p2, I was able to code not more than `<dimensions type="leaf" unit="mm">`. Is this the correct way to indicate the dimension of the leaves or should I better alter it again and indicate it explicitly in a note?