### PR TITLE
Create BLorient5426

### DIFF
--- a/LondonBritishLibrary/orient/BLorient5426.xml
+++ b/LondonBritishLibrary/orient/BLorient5426.xml
@@ -44,8 +44,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                     <textLang mainLang="gez"/>      
                                 </msItem>
                                 <msItem xml:id="ms_i1.1.2">
-                                    <title ref="LIT1758Lefafa#SixthChapter" type="incomplete"/>
-                                    <note>End is missing.</note>
+                                    <title ref="LIT1758Lefafa#SixthChapter"/>
                                     <incipit xml:lang="gez">በስመ፡<gap reason="ellipsis"/> እነግረክሙ፡ አኀውየ፡ እለ፡ ተአምኑ፡ በዝንቱ፡ 
                                        ልፋ<sic resp="PRS8999Strelcyn">ፌ</sic>፡ ጽድቅ፡ ዘወኀባ፡ አብ፡ ለእግዝእትነ፡ ማርያም፡ ዘይከውን፡ መድኃኒተ፡ በደኃሪት፡ እለት፡ ለዛቲ፡ መጽሐፍ፡ 
                                         ዘያጸውራ፡ በአምሳለ፡ እግዝእትነ፡ ማርያም፡</incipit>
@@ -60,7 +59,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                 <msItem xml:id="ms_i1.2.1">
                                     <title>Prayer 1</title>
                                     <incipit xml:lang="gez">በስመ፡<gap reason="ellipsis"/> ጸሎተ፡ መንገደ፡ ሰማይ፡ ሚካኤል፡ ወገብርኤል፡ 
-                                        ሱራፌል፡ ወኪሩቤል፡ ኡራኤል፡ ወፋኑኤል፡ ወአቅናኤል፡ ፱ሊቃነ፡ መላእክት፡</incipit>
+                                        ሱራፌል፡ ወኪሩቤል፡ ኡራኤል፡ ወፋኑኤል፡ ኢያኤል፡ ወአቅናኤል፡ ፱ሊቃነ፡ መላእክት፡</incipit>
                                     <textLang mainLang="gez"/>                            
                                 </msItem>
                                 <msItem xml:id="ms_i1.2.2">
@@ -110,10 +109,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             <title ref="LIT1758Lefafa" type="incomplete">Formula of benediction given to the Archangel Michael</title>
                             <note>Developed formula of benediction given by God to the Archangel Michael for the scribe, the owner, etc. of this
                                 manuscript. The end is missing.</note>
-                            <incipit xml:lang="gez">ወይቤሎ፡ ሚካኤል፡ ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ ምንትኑ፡ ድምጸ፡ ነጐድጓድ፡ ዘሰማእኩ፡ ኢይለክፍዎ፡ 
-                                አጋንንት፡ ጸዋጋን፡ <gap reason="ellipsis"/> ወይቤሎ፡ እግዚአብሔር፡ ለሚካኤል፡ ንሣእ፡ ወኃብኩከ፡ ማእኰትየ፡ መፍትው፡ ወለእመኒ፡ ገብረ፡ ተዝካርየ፡ 
-                                ወለ<supplied reason="undefined" resp="PRS8999Strelcyn">እ</supplied>መኒ፡ አምነ፡ በቃለ፡ ዝንቱ፡ መጽሐፍ፡ ዘፆሮ፡ ወአንቆ፡ በክሳዱ፡ 
-                                ወአንበቦ፡ በቃሉ፡ ወአንበሮ፡ ውስተ፡ ቤቱ፡ ወለእመ፡ ተሐጽበ፡ በማየ፡ ጸሎቱ፡ ወእመ፡ ስትየ፡ 
+                            <incipit xml:lang="gez">ወይቤሎ፡ ሚካኤል፡ ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ ምንትኑ፡ ድምጸ፡ ነጐድጓድ፡ ዘሰማእኩ፡ ወይቤሎ፡  
+                                እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ለሚካኤል፡ ደይ፡ ቤተ፡ ውእቱ፡ ምንባሮሙ፡ ኢይለክፍዎ፡ ለኃጥአን፡ እለ፡ ኢይገብሩ፡ ፈቃደ፡ ልቡየ፡ ሐልቀ፡ 
+                                ነፍሶሙ፡ ለእለ፡ ያስተሐቅርዎ፡ ቃሎ፡ ዘይቤሎሙ፡ ለአበዊነ፡ አመ፡ ዕለተ፡ ፍዳ፡ ወደይን፡ ብፁዕ፡ ውእቱ፡ ዘጸሐፎ፡ ወዘአጽሐፎ፡ በንዋዩ፡ ወዘአነቆ፡ በክሳዱ፡ ለዝ፡ መጽሐፍ፡
+                                ኢይለክፍዎ፡ አጋንንት፡ ጸዋጋን፡ <gap reason="ellipsis"/> ወይቤሎ፡ እግዚአብሔር፡ ለሚካኤል፡ ንሣእ፡ ወኃብኩከ፡ ማእኰትየ፡ መፍትው፡ ወለእመኒ፡ 
+                                ገብረ፡ ተዝካርየ፡ ወለ<supplied reason="undefined" resp="PRS8999Strelcyn">እ</supplied>መኒ፡ አምነ፡ በቃለ፡ ዝንቱ፡ መጽሐፍ፡ ዘፆሮ፡ 
+                                ወአነቆ፡ በክሳዱ፡ ወአንበቦ፡ በቃሉ፡ ወአንበሮ፡ ውስተ፡ ቤቱ፡ ወለእመ፡ ተሐጽበ፡ በማየ፡ ጸሎቱ፡ ወእመ፡ ስትየ፡ 
                                 በማ<supplied reason="undefined" resp="PRS8999Strelcyn">ዩ፡</supplied> ተአምኖ፡</incipit>
                             <textLang mainLang="gez"/>                            
                         </msItem>

--- a/LondonBritishLibrary/orient/BLorient5426.xml
+++ b/LondonBritishLibrary/orient/BLorient5426.xml
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" type="mss" xml:lang="en" xml:id="BLorient5426">
+    <teiHeader xml:base="https://betamasaheft.eu/">
+        <fileDesc>
+            <titleStmt>
+                <title>Magic Scroll</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS00001BL"/>
+                        <idno>BL Oriental 5426</idno>
+                        <altIdentifier><idno>Or. 5426</idno></altIdentifier>
+                        <altIdentifier><idno>Strelcyn 73</idno></altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                        <summary/>
+                        <msItem xml:id="ms_i1">
+                            <title ref="LIT1758Lefafa" type="incomplete"/>
+                            <note>The beginning is missing. With considerable differences to 
+                                <bibl><ptr target="bm:Euringer1940Rechtfertigung"/><citedRange>91-99</citedRange></bibl>.</note>
+                            <msItem xml:id="ms_i1.1">
+                                <title ref="LIT1758Lefafa#FirstPart"/>
+                                <msItem xml:id="ms_i1.1.1">
+                                    <title>Undefined section</title>
+                                    <incipit xml:lang="gez"><gap reason="lost"/>
+                                        <supplied reason="undefined" resp="PRS8999Strelcyn">በኀይለ፡ ዝንቱ፡ አስ</supplied>ማቲከ፡ ኢሀለው፡ ውስተ፡ ልበ፡ ሰብእ፡ መዋቲ፡ 
+                                        እለ፡ ዘወጽኡ፡ እምአፉሆሙ፡ ለአብ፡ ወወልድ፡ <supplied reason="undefined" resp="PRS8999Strelcyn">ወ</supplied>መንፈስ፡ ቅዱስ፡
+                                        ፩ስሙ፡ አግዮስ፡ ፩ስሙ፡ አቅደሴ፡ ፩ስሙ፡ አርኅኖን፡ <gap reason="ellipsis"/> እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ይምኃሮ፡ ለገብሩ፡ 
+                                        <persName ref="PRS14534GabraMikael">ገብረ፡ ሚካኤል።</persName></incipit>
+                                    <textLang mainLang="gez"/>      
+                                </msItem>
+                                <msItem xml:id="ms_i1.1.2">
+                                    <title ref="LIT1758Lefafa#SixthChapter" type="incomplete"/>
+                                    <note>End is missing.</note>
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> እነግረክሙ፡ አኀውየ፡ እለ፡ ተአምኑ፡ በዝንቱ፡ 
+                                       ልፋ<sic resp="PRS8999Strelcyn">ፌ</sic>፡ ጽድቅ፡ ዘወኀባ፡ አብ፡ ለእግዝእትነ፡ ማርያም፡ ዘይከውን፡ መድኃኒተ፡ በደኃሪት፡ እለት፡ ለዛቲ፡ መጽሐፍ፡ 
+                                        ዘያጸውራ፡ በአምሳለ፡ እግዝእትነ፡ ማርያም፡</incipit>
+                                    <textLang mainLang="gez"/>                            
+                                </msItem>
+                            </msItem>
+                            <msItem xml:id="ms_i1.2">
+                                <title ref="LIT1758Lefafa#MangadaSamay" type="incomplete">Six sections of Ṣalota mangada samāy</title>
+                                <note>Six out of seven prayers, in another order as in 
+                                    <bibl><ptr target="bm:Euringer1940Rechtfertigung"/><citedRange>96-99</citedRange></bibl> and with
+                                    considerably deviating incipits that makes it impossible to identify the prayers.</note>
+                                <msItem xml:id="ms_i1.2.1">
+                                    <title>Prayer 1</title>
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎተ፡ መንገደ፡ ሰማይ፡ ሚካኤል፡ ወገብርኤል፡ 
+                                        ሱራፌል፡ ወኪሩቤል፡ ኡራኤል፡ ወፋኑኤል፡ ወአቅናኤል፡ ፱ሊቃነ፡ መላእክት፡</incipit>
+                                    <textLang mainLang="gez"/>                            
+                                </msItem>
+                                <msItem xml:id="ms_i1.2.2">
+                                    <title>Prayer 2</title>
+                                    <note>Judged from the incipit given in 
+                                        <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">117</citedRange></bibl>, 
+                                        it is either <ref type="work" corresp="LIT1758Lefafa#FirstPrayer"/> or 
+                                        <ref type="work" corresp="LIT1758Lefafa#SecondPrayer"/>.</note>
+                                    <incipit xml:lang="gez">ጸሎተ፡ መንገደ፡ ሰማይ፡ ዕቀበኒ፡ ክርስቶስ፡ ከመ፡ ኢያዕቅፍዋ፡ መላእክተ፡ ጽልመት፡ <gap reason="ellipsis"/> 
+                                        ለነፍ<corr resp="PRS8999Strelcyn">ስ</corr>የ፡ </incipit>
+                                    <textLang mainLang="gez"/>                            
+                                </msItem>
+                                <msItem xml:id="ms_i1.2.3">
+                                    <title>Prayer 3</title>
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ መንገደ፡ ሰማይ፡ ዕቀበኒ፡ ክርስቶስ፡ ከመ፡ ኢያእቅፍዋ፡ ለነፍስየ፡ መላእክተ፡ 
+                                        ጽልመት፡ ፈኑ፡ ሊተ፡ ሚካኤል፡</incipit>
+                                    <textLang mainLang="gez"/>                            
+                                </msItem>
+                                <msItem xml:id="ms_i1.2.4">
+                                    <title>Prayer 4</title>
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎተ፡ መንገደ፡ ሰማይ፡ እቀበኒ፡ ክርስቶስ፡ ከመ፡ ኢያእቅፍዎ፡ መላእክተ፡ ጽልመት፡
+                                        ዘሐነፀ፡ ጽርኃ፡ ኀበ፡ አልቦ፡ ዘየአምሮ፡</incipit>
+                                    <textLang mainLang="gez"/>                            
+                                </msItem>
+                                <msItem xml:id="ms_i1.2.5">
+                                    <title>Prayer 5</title>
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎተ፡ መንገደ፡ ሰማይ፡ አሜሃ፡ 
+                                        በደኃ<supplied reason="undefined" resp="PRS8999Strelcyn">ሪ፡</supplied> መዋዕል፡</incipit>
+                                    <textLang mainLang="gez"/>                            
+                                </msItem>
+                                <msItem xml:id="ms_i1.2.6">
+                                    <title>Prayer 6</title>
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎተ፡ መንገደ፡ ሰማይ፡ ዕቀበኒ፡ ክርስቶስ፡ ከመ፡ ኢያእቅፍዋ፡ ለነፍስየ፡ መላእክተ፡
+                                        ጽልመት፡ ወሶቤሃ፡ ነገሮሙ፡ ለ፲ወ፪ሐዋርያት፡</incipit>
+                                    <textLang mainLang="gez"/>                            
+                                </msItem>
+                            </msItem>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <title ref="LIT2765RepCh49"/>
+                            <incipit xml:lang="gez">ሰላም፡ ለከ፡ ሰዳዴ፡ ሰይጣናት፡ ፋኑኤል፡ ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ 
+                                እምጽ<supplied reason="undefined" resp="PRS8999Strelcyn">ር</supplied>ሁ፡ ከመ፡ ኢይስክዩ፡ ሰብዓ፡ ወኢይኔሥሁ፡ ለጌጋይ፡ 
+                                ዘዘዚአሁ።</incipit>
+                            <textLang mainLang="gez"/>                            
+                        </msItem>
+                        <msItem xml:id="ms_i3">
+                            <title ref="LIT1758Lefafa" type="incomplete">Formula of benediction given to the Archangel Michael</title>
+                            <note>Developed formula of benediction given by God to the Archangel Michael for the scribe, the owner, etc. of this
+                                manuscript. The end is missing.</note>
+                            <incipit xml:lang="gez">ወይቤሎ፡ ሚካኤል፡ ለእ<hi rend="ligature">ግዚ</hi>አብሔር፡ ምንትኑ፡ ድምጸ፡ ነጐድጓድ፡ ዘሰማእኩ፡ ኢይለክፍዎ፡ 
+                                አጋንንት፡ ጸዋጋን፡ <gap reason="ellipsis"/> ወይቤሎ፡ እግዚአብሔር፡ ለሚካኤል፡ ንሣእ፡ ወኃብኩከ፡ ማእኰትየ፡ መፍትው፡ ወለእመኒ፡ ገብረ፡ ተዝካርየ፡ 
+                                ወለ<supplied reason="undefined" resp="PRS8999Strelcyn">እ</supplied>መኒ፡ አምነ፡ በቃለ፡ ዝንቱ፡ መጽሐፍ፡ ዘፆሮ፡ ወአንቆ፡ በክሳዱ፡ 
+                                ወአንበቦ፡ በቃሉ፡ ወአንበሮ፡ ውስተ፡ ቤቱ፡ ወለእመ፡ ተሐጽበ፡ በማየ፡ ጸሎቱ፡ ወእመ፡ ስትየ፡ 
+                                በማ<supplied reason="undefined" resp="PRS8999Strelcyn">ዩ፡</supplied> ተአምኖ፡</incipit>
+                            <textLang mainLang="gez"/>                            
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Scroll">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf">1</measure>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>1020</height>
+                                        <width>85</width>
+                                    </dimensions>
+                                    <note>Scroll originally composed of at least four strips of which two are preserved with at least one is missing before and after.</note>
+                                </extent>
+                            </supportDesc> 
+                        </objectDesc>
+                        <handDesc>
+                            <handNote xml:id="h1" script="Ethiopic">
+                                <desc>Small, trained, but not very careful handwriting.</desc>
+                                <date notBefore="1700" notAfter="1799" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                        </handDesc>
+                        <decoDesc>
+                            <decoNote xml:id="d1" type="miniature">
+                                <desc>A magical picture.</desc>
+                            </decoNote>
+                        </decoDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1700" notAfter="1799">18th century</origDate>
+                        </origin>
+                        <provenance>The name of the owner was <persName role="owner" ref="PRS14534GabraMikael">Gabra Mikāʾel</persName>.</provenance>
+                        <acquisition>Bought of <persName role="owner" ref="PRS14433Shapland">C. Shapland</persName>. 
+                            <date when="1898-06-12">12 July 1898</date>.</acquisition>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                            <citedRange unit="page">117-118</citedRange>
+                                        </bibl>
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+                <xi:fallback>
+                    <p>Definitions of prefixes used.</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage><language ident="en">English</language><language ident="gez">Gǝʿǝz</language></langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-07-30">Created record.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text xml:base="https://betamasaheft.eu/">
+        <body>
+            <ab/>
+        </body>
+    </text>
+</TEI>

--- a/LondonBritishLibrary/orient/BLorient5426.xml
+++ b/LondonBritishLibrary/orient/BLorient5426.xml
@@ -143,7 +143,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </handDesc>
                         <decoDesc>
                             <decoNote xml:id="d1" type="miniature">
-                                <desc>A magical picture.</desc>
+                                <desc>A magic picture.</desc>
                             </decoNote>
                         </decoDesc>
                     </physDesc>

--- a/LondonBritishLibrary/orient/BLorient5426.xml
+++ b/LondonBritishLibrary/orient/BLorient5426.xml
@@ -114,7 +114,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                 ነፍሶሙ፡ ለእለ፡ ያስተሐቅርዎ፡ ቃሎ፡ ዘይቤሎሙ፡ ለአበዊነ፡ አመ፡ ዕለተ፡ ፍዳ፡ ወደይን፡ ብፁዕ፡ ውእቱ፡ ዘጸሐፎ፡ ወዘአጽሐፎ፡ በንዋዩ፡ ወዘአነቆ፡ በክሳዱ፡ ለዝ፡ መጽሐፍ፡
                                 ኢይለክፍዎ፡ አጋንንት፡ ጸዋጋን፡ <gap reason="ellipsis"/> ወይቤሎ፡ እግዚአብሔር፡ ለሚካኤል፡ ንሣእ፡ ወኃብኩከ፡ ማእኰትየ፡ መፍትው፡ ወለእመኒ፡ 
                                 ገብረ፡ ተዝካርየ፡ ወለ<supplied reason="undefined" resp="PRS8999Strelcyn">እ</supplied>መኒ፡ አምነ፡ በቃለ፡ ዝንቱ፡ መጽሐፍ፡ ዘፆሮ፡ 
-                                ወአነቆ፡ በክሳዱ፡ ወአንበቦ፡ በቃሉ፡ ወአንበሮ፡ ውስተ፡ ቤቱ፡ ወለእመ፡ ተሐጽበ፡ በማየ፡ ጸሎቱ፡ ወእመ፡ ስትየ፡ 
+                                ወአነቆ፡ በክሳዱ፡ ወአንበቦ፡ በቃሉ፡ ወአንበሮ፡ ውስተ፡ ቤቱ፡ ወለእመ፡ ተሐጽበ፡ በማየ፡ ጸሎቱ፡ ወእመ፡ ሰትየ፡ 
                                 በማ<supplied reason="undefined" resp="PRS8999Strelcyn">ዩ፡</supplied> ተአምኖ፡</incipit>
                             <textLang mainLang="gez"/>                            
                         </msItem>

--- a/LondonBritishLibrary/orient/BLorient5426.xml
+++ b/LondonBritishLibrary/orient/BLorient5426.xml
@@ -39,14 +39,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                     <incipit xml:lang="gez"><gap reason="lost"/>
                                         <supplied reason="undefined" resp="PRS8999Strelcyn">በኀይለ፡ ዝንቱ፡ አስ</supplied>ማቲከ፡ ኢሀለው፡ ውስተ፡ ልበ፡ ሰብእ፡ መዋቲ፡ 
                                         እለ፡ ዘወጽኡ፡ እምአፉሆሙ፡ ለአብ፡ ወወልድ፡ <supplied reason="undefined" resp="PRS8999Strelcyn">ወ</supplied>መንፈስ፡ ቅዱስ፡
-                                        ፩ስሙ፡ አግዮስ፡ ፩ስሙ፡ አቅደሴ፡ ፩ስሙ፡ አርኅኖን፡ <gap reason="ellipsis"/> እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ይምኃሮ፡ ለገብሩ፡ 
+                                        ፩ስሙ፡ አግዮስ፡ ፩ስሙ፡ አቅደሴ፡ ፩ስሙ፡ አርኅኖን፡<gap reason="ellipsis"/> እ<hi rend="ligature">ግዚ</hi>አብሔር፡ ይምኃሮ፡ ለገብሩ፡ 
                                         <persName ref="PRS14534GabraMikael">ገብረ፡ ሚካኤል።</persName></incipit>
                                     <textLang mainLang="gez"/>      
                                 </msItem>
                                 <msItem xml:id="ms_i1.1.2">
                                     <title ref="LIT1758Lefafa#SixthChapter" type="incomplete"/>
                                     <note>End is missing.</note>
-                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> እነግረክሙ፡ አኀውየ፡ እለ፡ ተአምኑ፡ በዝንቱ፡ 
+                                    <incipit xml:lang="gez">በስመ፡<gap reason="ellipsis"/> እነግረክሙ፡ አኀውየ፡ እለ፡ ተአምኑ፡ በዝንቱ፡ 
                                        ልፋ<sic resp="PRS8999Strelcyn">ፌ</sic>፡ ጽድቅ፡ ዘወኀባ፡ አብ፡ ለእግዝእትነ፡ ማርያም፡ ዘይከውን፡ መድኃኒተ፡ በደኃሪት፡ እለት፡ ለዛቲ፡ መጽሐፍ፡ 
                                         ዘያጸውራ፡ በአምሳለ፡ እግዝእትነ፡ ማርያም፡</incipit>
                                     <textLang mainLang="gez"/>                            
@@ -59,7 +59,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                     considerably deviating incipits that makes it impossible to identify the prayers.</note>
                                 <msItem xml:id="ms_i1.2.1">
                                     <title>Prayer 1</title>
-                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎተ፡ መንገደ፡ ሰማይ፡ ሚካኤል፡ ወገብርኤል፡ 
+                                    <incipit xml:lang="gez">በስመ፡<gap reason="ellipsis"/> ጸሎተ፡ መንገደ፡ ሰማይ፡ ሚካኤል፡ ወገብርኤል፡ 
                                         ሱራፌል፡ ወኪሩቤል፡ ኡራኤል፡ ወፋኑኤል፡ ወአቅናኤል፡ ፱ሊቃነ፡ መላእክት፡</incipit>
                                     <textLang mainLang="gez"/>                            
                                 </msItem>
@@ -75,25 +75,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                 </msItem>
                                 <msItem xml:id="ms_i1.2.3">
                                     <title>Prayer 3</title>
-                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ መንገደ፡ ሰማይ፡ ዕቀበኒ፡ ክርስቶስ፡ ከመ፡ ኢያእቅፍዋ፡ ለነፍስየ፡ መላእክተ፡ 
+                                    <incipit xml:lang="gez">በስመ፡<gap reason="ellipsis"/> ጸሎት፡ መንገደ፡ ሰማይ፡ ዕቀበኒ፡ ክርስቶስ፡ ከመ፡ ኢያእቅፍዋ፡ ለነፍስየ፡ መላእክተ፡ 
                                         ጽልመት፡ ፈኑ፡ ሊተ፡ ሚካኤል፡</incipit>
                                     <textLang mainLang="gez"/>                            
                                 </msItem>
                                 <msItem xml:id="ms_i1.2.4">
                                     <title>Prayer 4</title>
-                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎተ፡ መንገደ፡ ሰማይ፡ እቀበኒ፡ ክርስቶስ፡ ከመ፡ ኢያእቅፍዎ፡ መላእክተ፡ ጽልመት፡
+                                    <incipit xml:lang="gez">በስመ፡<gap reason="ellipsis"/> ጸሎተ፡ መንገደ፡ ሰማይ፡ እቀበኒ፡ ክርስቶስ፡ ከመ፡ ኢያእቅፍዎ፡ መላእክተ፡ ጽልመት፡
                                         ዘሐነፀ፡ ጽርኃ፡ ኀበ፡ አልቦ፡ ዘየአምሮ፡</incipit>
                                     <textLang mainLang="gez"/>                            
                                 </msItem>
                                 <msItem xml:id="ms_i1.2.5">
                                     <title>Prayer 5</title>
-                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎተ፡ መንገደ፡ ሰማይ፡ አሜሃ፡ 
+                                    <incipit xml:lang="gez">በስመ፡<gap reason="ellipsis"/> ጸሎተ፡ መንገደ፡ ሰማይ፡ አሜሃ፡ 
                                         በደኃ<supplied reason="undefined" resp="PRS8999Strelcyn">ሪ፡</supplied> መዋዕል፡</incipit>
                                     <textLang mainLang="gez"/>                            
                                 </msItem>
                                 <msItem xml:id="ms_i1.2.6">
                                     <title>Prayer 6</title>
-                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎተ፡ መንገደ፡ ሰማይ፡ ዕቀበኒ፡ ክርስቶስ፡ ከመ፡ ኢያእቅፍዋ፡ ለነፍስየ፡ መላእክተ፡
+                                    <incipit xml:lang="gez">በስመ፡<gap reason="ellipsis"/> ጸሎተ፡ መንገደ፡ ሰማይ፡ ዕቀበኒ፡ ክርስቶስ፡ ከመ፡ ኢያእቅፍዋ፡ ለነፍስየ፡ መላእክተ፡
                                         ጽልመት፡ ወሶቤሃ፡ ነገሮሙ፡ ለ፲ወ፪ሐዋርያት፡</incipit>
                                     <textLang mainLang="gez"/>                            
                                 </msItem>
@@ -149,8 +149,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                     <history>
                         <origin>
                             <origDate notBefore="1700" notAfter="1799">18th century</origDate>
+                            The name of the owner was <persName role="owner" ref="PRS14534GabraMikael">Gabra Mikāʾel</persName>.
                         </origin>
-                        <provenance>The name of the owner was <persName role="owner" ref="PRS14534GabraMikael">Gabra Mikāʾel</persName>.</provenance>
                         <acquisition>Bought of <persName role="owner" ref="PRS14433Shapland">C. Shapland</persName>. 
                             <date when="1898-06-12">12 July 1898</date>.</acquisition>
                     </history>


### PR DESCRIPTION
I have not been able to mark up the prayers in LIT1758Lefafa#MangadaSamay individually. The order does not correspond to the order in Euringer, and the incipits are too short and have too many variations to stick them into the existing sub-ID (i.e. LIT1758Lefafa#FirstPrayer, etc.).
The last msItem (ms_i3) was described by S. Strelcyn as "Developed formula of blessing given by God to Archangel Michael for the scribe, owner etc of this manuscript". I think he did not realise that it is also part of LIT1758Lefafa, as can be seen by comparing it with the transcribed text of BMLacq384 (on f. 9).