### PR TITLE
Create BLorient11763.xml

### DIFF
--- a/LondonBritishLibrary/orient/BLorient11763.xml
+++ b/LondonBritishLibrary/orient/BLorient11763.xml
@@ -40,7 +40,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             <textLang mainLang="gez"/>
                         </msItem>
                         <msItem xml:id="ms_i3">
-                            <title>Prayer against ʿaynat</title>
+                            <title ref="LIT00000000000000000000000">Prayer against ʿaynat šumdān</title>
                             <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ ሕማመ፡ ዓይነት፡ ሺምዳን፡ ተክለ፡ ሽርታን፡</incipit>
                             <textLang mainLang="gez"/>
                         </msItem>

--- a/LondonBritishLibrary/orient/BLorient11763.xml
+++ b/LondonBritishLibrary/orient/BLorient11763.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" type="mss" xml:lang="en" xml:id="BLorient11763">
+    <teiHeader xml:base="https://betamasaheft.eu/">
+        <fileDesc>
+            <titleStmt>
+                <title>Magical Scroll</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS00001BL"/>
+                        <idno>BL Oriental 11763</idno>
+                        <altIdentifier><idno>Or. 11763</idno></altIdentifier>
+                        <altIdentifier><idno>Strelcyn 69</idno></altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                        <summary/>
+                        <msItem xml:id="ms_i1">
+                            <title ref="LIT5196MagicPrayer"/>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎተ፡ ግርማ፡ ሞገስ፡ ዘወረደ፡ ላዕለ፡ ሐዋርያት፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <title ref="LIT7057Fever"/>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎተ፡ ፌራ፡ ወንዳድ፡ ዘቅዱስ፡ ሚካኤል፡ ሊቀ፡ መላእክት፡ <gap reason="ellipsis"/>
+                                ሌኬ፡ ኤንካ፡ ጌሌ፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i3">
+                            <title>Prayer against ʿaynat</title>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ ሕማመ፡ ዓይነት፡ ሺምዳን፡ ተክለ፡ ሽርታን፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Scroll">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="panel">1</measure>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>715</height>
+                                        <width>97</width>
+                                    </dimensions>
+                                </extent>
+                            </supportDesc> 
+                        </objectDesc>
+                        <handDesc>
+                            <handNote xml:id="h1" script="Ethiopic">
+                                <desc>Mediocre, square handwriting.</desc>
+                                <date notBefore="1600" notAfter="1699" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                        </handDesc>
+                        <decoDesc>
+                            <decoNote xml:id="d1" type="miniature">
+                                <desc>One coloured magical picture.</desc>
+                            </decoNote>
+                        </decoDesc>
+                        <bindingDesc>
+                            <binding xml:id="binding" contemporary="true">
+                                <decoNote xml:id="b1" type="SlipCase"><material key="leather"/>Contained in a cylindrical leather case.</decoNote>
+                            </binding>
+                        </bindingDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1600" notAfter="1699">17th century</origDate>
+                        </origin>
+                        <provenance>Two owners are named: <persName role="owner" ref="PRS14519WaldaSamuel">Walda Sāmuʾel</persName>
+                            and <persName role="owner" ref="PRS14520BakweraSeyon">Bakʷǝra Ṣǝyon</persName></provenance>
+                        <acquisition>Presented by Miss <persName role="bequeather" ref="PRS14518Gresley">M. Gresley</persName>.
+                            <date when="1944-03-28">28 March 1944</date>.</acquisition>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                            <citedRange unit="page">113</citedRange>
+                                        </bibl>
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+                <xi:fallback>
+                    <p>Definitions of prefixes used.</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage><language ident="en">English</language><language ident="gez">Gǝʿǝz</language></langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-07-25">Created record.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text xml:base="https://betamasaheft.eu/">
+        <body>
+            <ab/>
+        </body>
+    </text>
+</TEI>

--- a/LondonBritishLibrary/orient/BLorient11763.xml
+++ b/LondonBritishLibrary/orient/BLorient11763.xml
@@ -40,7 +40,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             <textLang mainLang="gez"/>
                         </msItem>
                         <msItem xml:id="ms_i3">
-                            <title ref="LIT00000000000000000000000">Prayer against ʿaynat šumdān</title>
+                            <title ref="LIT00000000000000000000000">Prayer against ʿaynat šimdān</title>
                             <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ ሕማመ፡ ዓይነት፡ ሺምዳን፡ ተክለ፡ ሽርታን፡</incipit>
                             <textLang mainLang="gez"/>
                         </msItem>


### PR DESCRIPTION
I created a record for BLorient11763 according to the catalogue description in Strelcyn 1978. Images are still not available as far as I know.

I created a new LIT ID for ms_i2 according to our discussion in https://github.com/BetaMasaheft/Documentation/issues/2591.

I refrained from creating an ID for ms_i3 according to our discussion in https://github.com/BetaMasaheft/Documentation/issues/2592.