### PR TITLE
Create BLorient11764.xml

### DIFF
--- a/LondonBritishLibrary/orient/BLorient11764.xml
+++ b/LondonBritishLibrary/orient/BLorient11764.xml
@@ -84,20 +84,20 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             </handNote>
                         </handDesc>
                         <decoDesc>
-                            <decoNote xml:id="d1" type="miniature">
-                                <desc>Coloured magic picture.</desc>
+                            <decoNote xml:id="d1" type="drawing">
+                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
                             </decoNote>
-                            <decoNote xml:id="d2" type="miniature">
-                                <desc>Coloured magic picture.</desc>
+                            <decoNote xml:id="d2" type="drawing">
+                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
                             </decoNote>
-                            <decoNote xml:id="d3" type="miniature">
-                                <desc>Coloured magic picture.</desc>
+                            <decoNote xml:id="d3" type="drawing">
+                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
                             </decoNote>
-                            <decoNote xml:id="d4" type="miniature">
-                                <desc>Coloured magic picture.</desc>
+                            <decoNote xml:id="d4" type="drawing">
+                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
                             </decoNote>
-                            <decoNote xml:id="d5" type="miniature">
-                                <desc>Coloured magic picture.</desc>
+                            <decoNote xml:id="d5" type="drawing">
+                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
                             </decoNote>
                         </decoDesc>
                     </physDesc>
@@ -139,10 +139,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                     <p>Definitions of prefixes used.</p>
                 </xi:fallback>
             </xi:include>
-        </encodingDesc>
+        </encodingDesc> 
         <profileDesc>
+            <textClass>
+                <keywords>
+                    <term key="ChristianContent"/>
+                    <term key="Magic"/>
+                </keywords>
+            </textClass>
             <langUsage><language ident="en">English</language><language ident="gez">Gǝʿǝz</language></langUsage>
-        </profileDesc>
+        </profileDesc> 
         <revisionDesc>
             <change who="CH" when="2024-07-25">Created record.</change>
         </revisionDesc>

--- a/LondonBritishLibrary/orient/BLorient11764.xml
+++ b/LondonBritishLibrary/orient/BLorient11764.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" type="mss" xml:lang="en" xml:id="BLorient11764">
+    <teiHeader xml:base="https://betamasaheft.eu/">
+        <fileDesc>
+            <titleStmt>
+                <title>Magical Scroll</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS00001BL"/>
+                        <idno>BL Oriental 11764</idno>
+                        <altIdentifier><idno>Or. 11764</idno></altIdentifier>
+                        <altIdentifier><idno>Strelcyn 70</idno></altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                        <summary/>
+                        <msItem xml:id="ms_i1">
+                            <title ref="LIT1824Mafteh"/>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> አስማተ፡ ሥራይ፡ ጁር፡ ጁር፡ ዓቅጁር፡ </incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <title ref="LIT4007Salotb"/>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/>ጸሎት፡ በእንተ፡ መፍትሔ፡ ሥራይ፡ ዘተቀድሐ፡ እም፹ወ፩መጻሕፍት፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i3">
+                            <title ref="LIT7042PrayerMichael"/>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/>ጸሎት፡ በእንተ፡ ሌጌዎን፡ ርኩስ፡ ዘይሰልብ፡ ልበ፡ ሰብእ፡ ወያጸልም፡ አዕይንተ፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i4">
+                            <title ref="LIT7063Devils">Prayer catching devils</title>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/>አላሁማ፡ ወያኑራ፡ ሐሽም፡ <gap reason="ellipsis"/> ዘነበቦሙ፡ 
+                                ለአጋ<surplus>ጋ</surplus>ንንት፡ ሎፍሐም፡ ከማሁ፡ እስሮሙ፡ ለቡዳ፡ መሰርይ፡ ወሌጌዎን፡ ዕኩይ፡ ለእመ፡ አኀዞ፡ እደ፡ ሰብእ፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i5">
+                            <title ref="LIT7064PrayerChest">Prayer against bāryā, chest pain (wǝgʿat), diseases, and charms</title>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ዕልመይከክን፡ ረቢ፡ ታኦስ፡ ባኦስ፡ <gap reason="ellipsis"/> ከማሁ፡ ዓፅርዕ፡ ወአዕትት፡ 
+                                ሕማመ፡ ባርያ፡ ወውግዓት፡ ወደዌ፡ ወሥራይ፡ እምላዕለ፡ ነፍሱ፡ ወሥጋሁ፡ ለገብረ፡ እግዚአብሔር፡ </incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i6">
+                            <title ref="LIT7045Colic"/>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎተ፡ ቍረፀት፡ ኄር፡ ኪሳ፡ ኪሳ፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Scroll">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf">1</measure>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>1730</height>
+                                        <width>70</width>
+                                    </dimensions>
+                                    <note>Composed of three strips.</note>
+                                </extent>
+                            </supportDesc> 
+                        </objectDesc>
+                        <handDesc>
+                            <handNote xml:id="h1" script="Ethiopic">
+                                <desc>Square, rather careful script.</desc>
+                                <date notBefore="1600" notAfter="1799" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                        </handDesc>
+                        <decoDesc>
+                            <decoNote xml:id="d1" type="miniature">
+                                <desc>Coloured magical picture.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d2" type="miniature">
+                                <desc>Coloured magical picture.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d3" type="miniature">
+                                <desc>Coloured magical picture.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d4" type="miniature">
+                                <desc>Coloured magical picture.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d5" type="miniature">
+                                <desc>Coloured magical picture.</desc>
+                            </decoNote>
+                        </decoDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1600" notAfter="1799">17th/18th century</origDate>
+                        </origin>
+                        <provenance>The manuscript had several owners. 
+                            It was written for a man, called <persName role="owner" ref="PRS14521TasfaMikael"/>. 
+                            Later it passed successively to <persName role="owner" ref="PRS14522WaldaKrestos"/>,
+                            <persName role="owner" ref="PRS14523Agapis">ʾAgāṗis (?)</persName>,
+                            <persName role="owner" ref="PRS14524BakweraSeyon"/>, <persName role="owner" ref="PRS14525TabotaSeyon"/>,
+                            <persName role="owner" ref="PRS14526Abisha"/>, <persName role="owner" ref="PRS14527WalattaLewi"/>,
+                            <persName role="owner" ref="PRS14528WalattaLibanos"/> and 
+                            <persName role="owner" ref="PRS14529WalattaKrestos"/>.</provenance>
+                        <acquisition>Presented by Miss <persName role="bequeather" ref="PRS14518Gresley">M. Gresley</persName>.
+                            <date when="1944-03-28">28 March 1944</date>.</acquisition>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                            <citedRange unit="page">114</citedRange>
+                                        </bibl>
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+                <xi:fallback>
+                    <p>Definitions of prefixes used.</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage><language ident="en">English</language><language ident="gez">Gǝʿǝz</language></langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-07-25">Created record.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text xml:base="https://betamasaheft.eu/">
+        <body>
+            <ab/>
+        </body>
+    </text>
+</TEI>

--- a/LondonBritishLibrary/orient/BLorient11764.xml
+++ b/LondonBritishLibrary/orient/BLorient11764.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <title>Magical Scroll</title>
+                <title>Magic Scroll</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
             </titleStmt>
@@ -85,19 +85,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </handDesc>
                         <decoDesc>
                             <decoNote xml:id="d1" type="miniature">
-                                <desc>Coloured magical picture.</desc>
+                                <desc>Coloured magic picture.</desc>
                             </decoNote>
                             <decoNote xml:id="d2" type="miniature">
-                                <desc>Coloured magical picture.</desc>
+                                <desc>Coloured magic picture.</desc>
                             </decoNote>
                             <decoNote xml:id="d3" type="miniature">
-                                <desc>Coloured magical picture.</desc>
+                                <desc>Coloured magic picture.</desc>
                             </decoNote>
                             <decoNote xml:id="d4" type="miniature">
-                                <desc>Coloured magical picture.</desc>
+                                <desc>Coloured magic picture.</desc>
                             </decoNote>
                             <decoNote xml:id="d5" type="miniature">
-                                <desc>Coloured magical picture.</desc>
+                                <desc>Coloured magic picture.</desc>
                             </decoNote>
                         </decoDesc>
                     </physDesc>


### PR DESCRIPTION
New LIT IDs for ms_i3, ms_i4, ms_i5 and ms_i6 have been created after discussion in https://github.com/BetaMasaheft/Documentation/issues/2594, https://github.com/BetaMasaheft/Documentation/issues/2596, https://github.com/BetaMasaheft/Documentation/issues/2597 and https://github.com/BetaMasaheft/Documentation/issues/2598.

It would be nice to have an art theme for magic pictures, but I assume, that there is none. So I marked them up simply as "miniatures".