### PR TITLE
Create BLorient11602

### DIFF
--- a/LondonBritishLibrary/orient/BLorient11602.xml
+++ b/LondonBritishLibrary/orient/BLorient11602.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" type="mss" xml:lang="en" xml:id="BLorient11602">
+    <teiHeader xml:base="https://betamasaheft.eu/">
+        <fileDesc>
+            <titleStmt>
+                <title>Magic Scroll</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS00001BL"/>
+                        <idno>BL Oriental 11602</idno>
+                        <altIdentifier><idno>Or. 11602</idno></altIdentifier>
+                        <altIdentifier><idno>Strelcyn 75</idno></altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                        <summary/>
+                        <msItem xml:id="ms_i1">
+                            <title ref="LIT7074AynatTsella" type="incomplete"/>
+                            <note>The first two lines written in red containing probably magic characters are mostly illegible.</note>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="illegible"/> በዝ፡ ጠልሰም፡ ወበዝ፡ ክታብ፡ 
+                                አድኅ<supplied reason="undefined" resp="PRS8999Strelcyn">ነ</supplied>ኒ፡ እምሕማመ፡ ዓይነ፡ ጽላ፡ አድኅኖ፡ ለገብረ፡ እግዚአብሔር፡ 
+                                ኪዳነ፡ ማርያም፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <title ref="LIT1763Legend">Magic prayer to Susenyos to protect suckling infants</title>
+                            <incipit xml:lang="gez">በስመ፡<gap reason="ellipsis"/> በስመ፡ እግዚአብሔር፡ ሕያው፡ ነባቢ፡ ወተናጋሪ፡ ለቅዱስ፡ ሱስንዮስ፡ በእንተ፡ አሰስሎ፡
+                                ደዌ፡ እምሕፃናት፡ እለ፡ ይጠብው፡ ጥበ፡ እሞሙ፡ </incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i3">
+                            <title ref="LIT7081NamesGod" type="incomplete"/>
+                            <note>The end is missing.</note>
+                            <incipit xml:lang="gez">በስመ፡<gap reason="ellipsis"/> ዝውእቱ፡ አስማቲሁ፡ ለእግዚአብሔር፡ ዘየአምር፡ አልኤና፡ እግዚአብሔር፡ ኵሎ፡ አሚረ፡ 
+                                ሕልው፡ እግዚአብሔር፡ ዘይጼሉ፡ ሀልዮሙ፡ ወመስተሣህል፡ ልዑል፡ ኀያል፡ ባዕል፡ ኄር፡ ክቡር፡ ወመንክር፡ ማዕምር፡ ወመምህር፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i4">
+                            <title ref="LIT7127Manso"/>
+                            <incipit xml:lang="gez">በስመ፡<gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ ሕማመ፡ ዓይነት፡ ወመንሶ፡ ወማዕሠረ፡ አጋንንት፡ ኢትቅረቡ፡ በሌሊት፡
+                                ዕቀበኒ፡ መስቀል፡ መድኃኒተ፡ ኵሉ፡ ዓለም። መስቀል፡ መግረሬ፡ ፀር፡ መስቀል፡ መዋዔ፡ ፀር፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i5">
+                            <title ref="LIT7085Papur">Magic prayer for binding demons</title>
+                            <incipit xml:lang="gez">በስመ፡<gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ ማዕሠረ፡ አጋንንት፡ ጰጱር፡ ጵውያካኤል፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i6">
+                            <title ref="LIT7093BlackBarya"/>
+                            <incipit xml:lang="gez">በስመ፡<gap reason="ellipsis"/> ተሰደድ፡ አንተ፡ ባርያ፡ ጸሊም፡ አጽመ፡ ዘትሰብር፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Scroll">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf">1</measure>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>1620</height>
+                                        <width>115</width>
+                                    </dimensions>
+                                    <note>Scroll composed of three strips.</note>
+                                </extent>
+                            </supportDesc> 
+                        </objectDesc>
+                        <handDesc>
+                            <handNote xml:id="h1" script="Ethiopic">
+                                <desc>Rather careful handwriting.</desc>
+                                <date notBefore="1700" notAfter="1799" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                        </handDesc>
+                        <decoDesc>
+                            <decoNote xml:id="d1" type="miniature">
+                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d2" type="miniature">
+                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d3" type="miniature">
+                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
+                            </decoNote>
+                        </decoDesc>
+                        <additions>
+                            <list>
+                                <item xml:id="e1">
+                                    <desc type="Unclear">Magic characters</desc>
+                                </item>
+                            </list>
+                        </additions>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1700" notAfter="1799">18th century</origDate>
+                        </origin>
+                        <provenance>The owner was <persName role="owner" ref="PRS14537KidanaMaryam">Kidāna Māryām</persName>.</provenance>
+                        <acquisition>On a slip stuck on the verso: 
+                            'Bought of Mr. <persName role="owner" ref="PRS14536JLowe">J. St. Lowe</persName>.
+                            <date when="1936-08-15">15 Aug. 1936</date>.</acquisition>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                            <citedRange unit="page">119</citedRange>
+                                        </bibl>
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+                <xi:fallback>
+                    <p>Definitions of prefixes used.</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage><language ident="en">English</language><language ident="gez">Gǝʿǝz</language></langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-07-30">Created record.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text xml:base="https://betamasaheft.eu/">
+        <body>
+            <ab/>
+        </body>
+    </text>
+</TEI>

--- a/LondonBritishLibrary/orient/BLorient11602.xml
+++ b/LondonBritishLibrary/orient/BLorient11602.xml
@@ -37,7 +37,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             <textLang mainLang="gez"/>
                         </msItem>
                         <msItem xml:id="ms_i2">
-                            <title ref="LIT1763Legend">Magic prayer to Susenyos to protect suckling infants</title>
+                            <title ref="LIT1763Legend">Magic prayer to Susǝnyos to protect suckling infants</title>
                             <incipit xml:lang="gez">በስመ፡<gap reason="ellipsis"/> በስመ፡ እግዚአብሔር፡ ሕያው፡ ነባቢ፡ ወተናጋሪ፡ ለቅዱስ፡ ሱስንዮስ፡ በእንተ፡ አሰስሎ፡
                                 ደዌ፡ እምሕፃናት፡ እለ፡ ይጠብው፡ ጥበ፡ እሞሙ፡ </incipit>
                             <textLang mainLang="gez"/>


### PR DESCRIPTION
Some new LIT IDs have been created according to our discussions in https://github.com/BetaMasaheft/Documentation/issues/2619, https://github.com/BetaMasaheft/Documentation/issues/2620, https://github.com/BetaMasaheft/Documentation/issues/2621, https://github.com/BetaMasaheft/Documentation/issues/2618. However, the latter ID (LIT7081NamesGod) is still not visible in the app (cf. https://github.com/BetaMasaheft/Works/pull/1222).