### PR TITLE
created minirecord BNFabb60

### DIFF
--- a/ParisBNF/abb/BNFabb60.xml
+++ b/ParisBNF/abb/BNFabb60.xml
@@ -1,0 +1,79 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="BNFabb60" xml:lang="en" type="mss">
+    <!-- This is a stub with minimal information (MV 2024-11-14) -->
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Lives of saints</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS0303BNF"/>
+                        <collection>Manuscrits orientaux</collection>
+                        <collection>Fonds éthiopien</collection>
+                        <collection>d'Abbadie</collection>
+                        <idno>BnF Éthiopien d'Abbadie 60</idno>
+                    </msIdentifier>
+                    <msContents>
+                        <msItem xml:id="ms_i1">
+                            <locus from="1r"/>
+                            <title type="complete" ref="LIT1803Lifeof"/>
+                            <note>The text is edited in <bibl>
+                                <ptr target="bm:Pereira1903PauloThebasT"/></bibl> and translated in <bibl>
+                                    <ptr target="bm:Pereira1904PauloThebasV"/></bibl>.
+                            </note>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <locus from="16r" to="76v"/>
+                            <title type="complete" ref="LIT4857LifeofA"/>
+                        </msItem>
+                    </msContents>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <t:profileDesc xmlns:t="http://www.tei-c.org/ns/1.0">
+            <creation/>
+            <t:abstract>
+                <p/>
+            </t:abstract>
+            <textClass>
+                <t:keywords>
+                    <t:term key="ChristianLiterature"/>
+                    <t:term key="Hagiography"/>
+                    <t:term key="Translation"/>
+                </t:keywords>
+            </textClass>
+            <t:langUsage>
+                <t:language ident="en">English</t:language>
+                <t:language ident="gez">Gǝʿǝz</t:language>
+            </t:langUsage>
+        </t:profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2024-11-14">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/>
+        </body>
+    </text>
+</TEI>

--- a/ParisBNF/abb/BNFabb60.xml
+++ b/ParisBNF/abb/BNFabb60.xml
@@ -28,11 +28,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <collection>Manuscrits orientaux</collection>
                         <collection>Fonds éthiopien</collection>
                         <collection>d'Abbadie</collection>
-                        <idno>BnF Éthiopien d'Abbadie 60</idno>
+                        <idno facs="https://gallica.bnf.fr/ark:/12148/btv1b10087386p">BnF Éthiopien d'Abbadie 60</idno>
                     </msIdentifier>
                     <msContents>
                         <msItem xml:id="ms_i1">
-                            <locus from="1r"/>
+                            <locus from="1ra" to="16rb"/>
                             <title type="complete" ref="LIT1803Lifeof"/>
                             <note>The text is edited in <bibl>
                                 <ptr target="bm:Pereira1903PauloThebasT"/></bibl> and translated in <bibl>
@@ -40,7 +40,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </note>
                         </msItem>
                         <msItem xml:id="ms_i2">
-                            <locus from="16r" to="76v"/>
+                            <locus from="16va" to="76rb"/>
                             <title type="complete" ref="LIT4857LifeofA"/>
                         </msItem>
                     </msContents>


### PR DESCRIPTION
Following https://github.com/BetaMasaheft/Works/pull/1315/files, I have created this minimal record for BNFabb60, so that `<listWit>` in LIT1803Lifeof (Life of Paul the first hermit) can work.
Btw also LIT4857LifeofA (Life of Antony) had in `<listWit>` a reference to BNFabb60 which pointed to nowhere.