### PR TITLE
Maṣḥafa falāsfā ṭabibān recensions

### DIFF
--- a/Frankfurt/FSUor16.xml
+++ b/Frankfurt/FSUor16.xml
@@ -5,7 +5,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <title>Prayers, <foreign xml:lang="gez">Maṣḥafa falasfā ṭabibān</foreign>, <foreign xml:lang="gez">Hāymānotu la-qǝddus ʿābiyy māri Yāʿqob ʾƎlbarādʿi</foreign></title>
+                <title>Prayers, <foreign xml:lang="gez">Maṣḥafa falāsfā ṭabibān</foreign>, <foreign xml:lang="gez">Hāymānotu la-qǝddus ʿābiyy māri Yāʿqob ʾƎlbarādʿi</foreign></title>
                 <editor key="DR"/>
                 <editor key="AB" role="generalEditor"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/Frankfurt/FSUor16.xml
+++ b/Frankfurt/FSUor16.xml
@@ -5,7 +5,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <title>Prayers, Maṣḥafa falasfā ṭabibān, Hāymānotu la-qǝddus ʿābiyy māri Yāʿqob ʾƎlbarādʿi</title>
+                <title>Prayers, <foreign xml:lang="gez">Maṣḥafa falasfā ṭabibān</foreign>, <foreign xml:lang="gez">Hāymānotu la-qǝddus ʿābiyy māri Yāʿqob ʾƎlbarādʿi</foreign></title>
                 <editor key="DR"/>
                 <editor key="AB" role="generalEditor"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -179,7 +179,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                             
                             <msItem xml:id="p2_i1">
                                 <locus from="7r" to="116v"/>
-                                <title type="complete" ref="LIT1925Mashaf"/>
+                                <title type="complete" ref="LIT7144MFTabiban"/>
                                 <textLang mainLang="gez"/>
                             </msItem>
                         </msContents>

--- a/ParisBNF/abb/BNFabb122.xml
+++ b/ParisBNF/abb/BNFabb122.xml
@@ -5,7 +5,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-           <title>Book of Sirach, Canon of the Doctors of the Church for those who Abjure, <foreign xml:lang="gez">Maṣḥafa falāsfā ṭabibān</foreign>, and other texts</title>
+           <title>Book of Sirach, Canon of the Doctors of the Church for those who renounce, <foreign xml:lang="gez">Maṣḥafa falāsfā ṭabibān</foreign>, and other texts</title>
             <editor role="cataloguer" key="DN"/>
             <editor role="generalEditor" key="AB"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/ParisBNF/abb/BNFabb122.xml
+++ b/ParisBNF/abb/BNFabb122.xml
@@ -5,7 +5,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Book of Sirach, Canon of the Doctors of the Church for those who Abjure, and other texts</title>
+           <title>Book of Sirach, Canon of the Doctors of the Church for those who Abjure, <foreign xml:lang="gez">Maṣḥafa falāsfā ṭabibān</foreign>, and other texts</title>
             <editor role="cataloguer" key="DN"/>
             <editor role="generalEditor" key="AB"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -52,7 +52,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
 
                           <msItem xml:id="ms_i3">
                                 <locus from="69ra" to="148vb"/>
-                                <title type="complete" ref="LIT1925Mashaf"/>
+                            <title type="complete" ref="LIT7145MFTabiban"/>
                                 <textLang mainLang="gez"/>
                                 <incipit xml:lang="gez">
                                   <hi rend="rubric">በስመ፡ እግዚአብሔር፡ መሐሪ፡</hi> ወመስተሣህል፡ ወላዕሌሁ፡

--- a/ParisBNF/et/BNFet157.xml
+++ b/ParisBNF/et/BNFet157.xml
@@ -68,11 +68,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
 
                   <msItem xml:id="ms_i3">
                     <locus from="5r"/>
-                    <title type="complete" ref="LIT1925Mashaf" xml:lang="gez">በስመ፡ እግዚአብሔር፡ መሓሪ፡
-                    ወመስተሣህል፡ ወላዕሌሁ፡ ትውክልትነ፡ ወረድኤትነ፡ ዘውእቱ፡ ይሁብ፡ መክፈልተ፡ ሀብታት፡ በከመ፡ ፈቀደ፤
-                    ውእቱ፡ ይጼጉ፡ ወውእቱ፡ ያስተነቢ፡ ወይሁብ፡ መንፈሶ፡ ለኵሉ፡ <gap reason="omitted" extent="unknown" resp="PRS10747Zotenbe"/>
-                    ንዌጥን፡ በረድኤተ፡ እግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ በጽሒፈ፡ መጽሐፈ፡ ፈላስፋ፡ ጠቢባን፡ ዘተናገሩ፡ ባቲ፡ ለለ፡ ፩፡
-                    እምኔሆሙ፡ በአምጣነ፡ ክሂሎቱ፤</title>
+                     <title type="complete" ref="LIT7144MFTabiban" xml:lang="gez"></title>
                     <textLang mainLang="gez"/>
                     <note>The text is not divided into chapters. It agrees with the excerpts published in
                       <bibl>
@@ -82,7 +78,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <ptr target="bm:Dillmann1866Chrestomathia"/>
                            <citedRange unit="page">40–45</citedRange>
                         </bibl>,
-                       its readings  agree partly with <ref type="mss" corresp="FSUor16"/> and partly with <ref type="mss" corresp="UBTaeth6"/>.
+                       its readings agree partly with <ref type="mss" corresp="FSUor16"/> and partly with <ref type="mss" corresp="UBTaeth6"/>.
                       However, in the introduction this manuscript, <ref type="mss" corresp="BNFet158#ms_i1"/> and <ref type="mss" corresp="BNFet159#ms_i1"/> have
                       <foreign xml:lang="gez">ምስጢራተ፡</foreign> instead of   <foreign xml:lang="gez">ምስጢራቲሃ፡</foreign>, see  <bibl>
                            <ptr target="bm:Cornill1875Falasfa"/>
@@ -90,9 +86,16 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <citedRange unit="line">9</citedRange>
                         </bibl>.</note>
                     <note>On <locus target="#12ra"/>, there is a sentence attributed to the author of the work.</note>
-                     <!--To work record?-->
 
-                    <incipit xml:lang="gez">
+                    <incipit xml:lang="gez" type="incipit">
+                       በስመ፡ እግዚአብሔር፡ መሓሪ፡
+                       ወመስተሣህል፡ ወላዕሌሁ፡ ትውክልትነ፡ ወረድኤትነ፡ ዘውእቱ፡ ይሁብ፡ መክፈልተ፡ ሀብታት፡ በከመ፡ ፈቀደ፤
+                       ውእቱ፡ ይጼጉ፡ ወውእቱ፡ ያስተነቢ፡ ወይሁብ፡ መንፈሶ፡ ለኵሉ፡ <gap reason="omitted" extent="unknown" resp="PRS10747Zotenbe"/>
+                       ንዌጥን፡ በረድኤተ፡ እግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ በጽሒፈ፡ መጽሐፈ፡ ፈላስፋ፡ ጠቢባን፡ ዘተናገሩ፡ ባቲ፡ ለለ፡ ፩፡
+                       እምኔሆሙ፡ በአምጣነ፡ ክሂሎቱ፤
+                    </incipit>
+                     
+                     <incipit xml:lang="gez" type="sentence1">
                         <locus from="5v"/>
                       ይቤ፡ ጠቢብ፡ ወሬዛ፡ ጠቢብ፡ ይኄይስ፡ እምነ፡ አረጋዊ፡ አብድ። <hi rend="rubric">ተብህለ፡</hi> እስመ፡ ተግሣጽሰ፡ ይከብር፡ እምነ፡ አዕናቍ፡ ክቡራት፡
                       ወያከብር፡ ዘመደ፡ ኅሡራን፡ ወያቀውሞሙ፡ ውስተ፡ ምቅዋመ፡ ክቡራን፡ ወያከብር፡ እንበለ፡ ተባይጾ፡ ወያብዝኅ፡ ረድኤተ፡ እንዘ፡ አልቦቱ፡ ዘርእ። <hi rend="rubric">ተብህለ፡</hi>
@@ -101,7 +104,6 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                       ፍኖት፡ ይእቲ፡ ወዓርክ፡ ይእቲ፡ በውስተ፡ ተአንግዶ፡ ወሞገስ፡ ይእቲ፡ በውስተ፡ ጉባኤ። <hi rend="rubric">ተብህለ፡</hi> መቅድመ፡ ኵሉ፡ ዘይፈቅድ፡ ባቲ፡
                       ሰብእ፡ ልቡና፡ ወተግሣጽ፡ ወጽድቅ፡ ወትዕግሥት፡ ወጥበብ፡ ወንጽሕና፡ ወተገድሎ፡ ወአእኵቶ፡ ወጸልዮ፡ ጸሎታት፡ እንተ፡ ይእቲ፡ መሠረተ፡ ሃይማኖት፡ ዘታበጽሕ፡ ኀበ፡
                       ፈጣሪ፡ ሎቱ፡ ስብሐት። ወጽድቀ፡ ቃል፡ ወዜና፡ ወርኂቅ፡ እመሐላ፡ በሐሰት፡ ወተቀብሎ፡ በገጽ፡ ፍሡሕ፤ ወአክብሮ፡ አናግድ፡ ወአሠንዮ፡ ለኵሉ፡ ወዓዊበ፡ ጎር፡</incipit>
-                     <!--added from Zotenberg p. 260-->
                   </msItem>
 
                   <msItem xml:id="ms_i4">

--- a/ParisBNF/et/BNFet158.xml
+++ b/ParisBNF/et/BNFet158.xml
@@ -37,7 +37,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   <summary/>
               
                   <msItem xml:id="ms_i1">
-                    <title type="complete" ref="LIT1925Mashaf" xml:lang="gez">በስመ፡ እግዚአብሔር፡
+                     <title type="complete" ref="LIT7144MFTabiban" xml:lang="gez">በስመ፡ እግዚአብሔር፡
                     መሐሪ፡ ወመስተሣህል፡ ወላዕሌሁ፡ ትውክልት፡ ወረድኤትነ። ንወጥን፡ በረድኤተ፡ እግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡
                     በጽሒፈ፡ መጽሐፈ፡ ፈላስፋ፡ ጠቢባን፡ ዘተናገሩ፡ ባቲ፡ ለለ፩፩፡ እምኔሆሙ፡</title>
                     <textLang mainLang="gez"/>
@@ -46,8 +46,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                       The text of the introduction agrees more often with <ref type="mss" corresp="UBTaeth6"/> than with <ref type="mss" corresp="FSUor16"/>. Otherwise,
                       this manuscript as well as <ref type="mss" corresp="BNFet158"/> mostly have the same mistakes as <ref type="mss" corresp="UBTaeth6"/> 
                        and <ref type="mss" corresp="FSUor16"/>.
-                    </note>
-                    <note>A sentence  at the end, <ref target="#Sentence"/>, is not present in <ref type="mss" corresp="BNFet157#ms_i3"/>.</note>
+                       A sentence at the end is not present in <ref type="mss" corresp="BNFet157#ms_i3"/>.</note>
                   </msItem>
               
                   <msItem xml:id="ms_i2">

--- a/ParisBNF/et/BNFet159.xml
+++ b/ParisBNF/et/BNFet159.xml
@@ -37,31 +37,51 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   <summary/>
               
                   <msItem xml:id="ms_i1">
-                    <title type="complete" ref="LIT1925Mashaf" xml:lang="gez"> 
-                      በስመ፡ እግዚአብሔር፡ መሓሪ፡ ወመስተሣህል፡ ወውእቱ፡ ረዳኢነ፡ ወተስፋነ፡ ላዕለ፡ ኵሉ፡ ግብር። ንዌጥን፡ በረድኤተ፡ 
-                      እግዚአብሔር፡ በጽሒፈ፡ አንጋረ፡ ፈላስፋ፡ ዘውእቶሙ፡ ጠቢባን፡ ብሂል፡ ዘተናገሩ፡ ባቲ፡ ውስተ፡ ዛቲ፡ መጽሐፍ፡ ለለ፩፡
-                      እምኔሆሙ፡ ከመ፡ ትኩን፡ በቍዔተ፡ ለዘያነብባ፡ ወለዘይሰምዓ፡ ወይገብር፡ ባቲ።
-                    </title>
+                     <locus from="1r"/>
+                     <title type="complete" ref="LIT7145MFTabiban"/> 
                     <textLang mainLang="gez"/>
-                    <note>This recension is different from <ref type="mss" corresp="BNFet157#ms_i3"/> and <ref type="mss" corresp="BNFet158#ms_i1"/>,
+                     <note>This recension is different from <ref type="work" corresp="LIT7144MFTabiban"/> 
+                        (preserved in <ref type="mss" corresp="BNFet157#ms_i3"/> and <ref type="mss" corresp="BNFet158#ms_i1"/>),
                       especially in the second part of the work.
                     Several sentences are missing, others are more developed or followed by a commentary. 
-                    The sentences preceding and following <ref target="#SentencePlato"/> are arranged in
+                    The sentences preceding and following Plato's section are arranged in
                     a different order.
                     The three paragraphs with the three anachoretes' sentences
-                      <ref target="#SentencesAnachoretes"/> are included here at the end of the work together
+                      are included here at the end of the work together
                       with other sentences by anachoretes, which in the other recension are included throughout the work.</note>
-                    <!--Information belongs to work record-->
                
                      <msItem xml:id="ms_i1.1">
+                        <locus from="1r" to="2r"/>
                         <title type="complete">Introduction</title>
                         <textLang mainLang="gez"/>
+                        <incipit xml:lang="gez">
+                           በስመ፡ እግዚአብሔር፡ መሓሪ፡ ወመስተሣህል፡ ወውእቱ፡ ረዳኢነ፡ ወተስፋነ፡ ላዕለ፡ ኵሉ፡ ግብር። ንዌጥን፡ በረድኤተ፡ 
+                           እግዚአብሔር፡ በጽሒፈ፡ አንጋረ፡ ፈላስፋ፡ ዘውእቶሙ፡ ጠቢባን፡ ብሂል፡ ዘተናገሩ፡ ባቲ፡ ውስተ፡ ዛቲ፡ መጽሐፍ፡ ለለ፩፡
+                           እምኔሆሙ፡ ከመ፡ ትኩን፡ በቍዔተ፡ ለዘያነብባ፡ ወለዘይሰምዓ፡ ወይገብር፡ ባቲ።
+                        </incipit>
+                     </msItem>  
+                     <msItem xml:id="ms_i1.2">
+                        <locus from="1r" to="2r"/>
+                        <title type="complete" ref="LIT7145MFTabiban#Preamble">Preamble</title>
+                        <textLang mainLang="gez"/>
+                        <incipit xml:lang="gez">
+                           ወናሁ፡ አስተጋብኡ፡ ውስቴታ፡ ብዙኀ፡ ነገረ፡ ምዕዳን፡ ወተግሣጽ፡ ሠናይ፡ ወዜና፡ ቅሱም፡ ከመ፡ ፄው። 
+                          ዘጽይሕት፡ ፍናዊሃ፡ ለዘየዓቅባ፡ ወቀሊል፡ ሰሚዖታ፡ ወያስተፌሥሕ፡ አልባበ፡ ወትሁብ፡ ልቡና፡ ለለባዊ። ዘከሩ፡
+                          ውስቴታ፡ ዝክረ፡ ሠናየ፡ ዘይረክብ፡ ባቲ፡ ኵሉ፡ መፍቅዶ። እንተ፡ ይእቲ፡ ጥበቦሙ፡ ለጠቢባን፡ ወንባቦሙ፡
+                          ለማእምራን፡ ወይእቲ፡ ትኄይስ፡ ወትትበደር፡ እምነ፡ ወርቅ፡ ወምብሩር፡ ወእምዕንቍ፡ ክቡር። ወዓዲ፡ 
+                          ትኆእይስ፡ እምጽጌ፡ ገነታት፡ ዘዘዚአሁ፡ ኅበሪሆሙ። ወዛቲሰ፡ ገነት፡ ቀሊል፡ ይእቲ፡ ጸራ። ለእመ፡ አንበብከ፡ 
+                          ውስቴታ፡ ትሁበከ፡ ኵሎ፡ መፍቅደከ፡ ወትጼግወከ፡ ልቡና፡ ፍጹመ። ወታሠምረከ፡ ወታኅረኅርኅ፡ እከይ።
+                          ወትቀስም፡ ልሳነከ፡ በፄወ፡ ጥበብ፡ ወአእምሮ፡ ወየውሃት፡ ወልቡና፡ ወትዕግሥት። ወትሬሲ፡ ግዕዘከ፡ ሠናየ፡
+                          ወኅሩየ። ወንባበከሂ፡ ጥዑመ፡ ውስተ፡ እዝነ፡ እለ፡ <locus target="#1v"/> ይሰምዕዋ። ወትሴርሕ፡ ኵሉ፡ ፍናዊከ። ተአምር፡ በአሐቲ፡
+                          ወርኅ፡ ዘኢተአምሮ፡ በኵሉ፡ መዋዕሊከ፡ እምአፈ፡ ኵሉ፡ ዕደው፡ ጠቢባን፡ ሶበ፡ ተኀሥሣ፡ ምስለ፡ ዕረፍት፡
+                          ወኅድዓት፡ ወተቃወመከ፡ በአንቀጸ፡ ረባሕ፡ ወበቍዔት። ወዛቲ፡ ትኄይስ፡ እምኵሎን፡ መዛግብት። ወትፄኑ፡
+                          እምኵሎን፡ አፈዋት። ትትኤዘዝ፡ ለከ፡ በሌሊት፡ ከመ፡ መዓልት። ወበውስተ፡ ፍኖትከሂ፡ ትሄሉ፡ ምስሌከ።                           
+                        </incipit>
                      </msItem>
                     
-                    <msItem xml:id="ms_i1.2">
+                    <msItem xml:id="ms_i1.3">
                         <title type="complete">Main Part</title>
                         <textLang mainLang="gez"/>
-                      
                         <incipit xml:lang="gez">
                            <locus from="2r"/>
                         ይቤ፡ ጠቢብ፡ ወሬዛ፡ ጠቢብ፡ ይኄይስ፡ እምነ፡ አረጋዊ፡ ዓብድ። ተግሣጽ፡ ወጥበብ፡ ያሌዕሉ፡ ዘመደ፡ ኅውራን፡ ወያበጽሑ፡ ኀበ፡ ምቅዋመ፡ ክቡራን። 
@@ -72,14 +92,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         ወዓዲ፡ ነገረ፡ ጽድቅ፡ ወርኂቅ፡ እመሐላ፡ በሐሰት፡ ወተቀብሎ፡ ሰብእ፡ በብሩህ፡ ገጽ። ወአክብሮ፡ አንጋድ፡ ወዓቂበ፡ ጎር፡ ወገቢረ፡ ሠናያት።
                       </incipit>
                       
-                        <msItem xml:id="ms_i1.3">
-                           <title type="complete"/>
-                           <textLang mainLang="gez"/>
-                        </msItem>
-                      
-                        <msItem xml:id="ms_i1.4">
+                       <msItem xml:id="ms_i1.4">
                            <locus from="66r" to="72v"/>
-                           <title type="complete">Discourse of the philosophers in presence of the body of Alexander</title>
+                          <title type="complete" ref="LIT7145MFTabiban#Alexander">Discourse of the philosophers in presence of the body of Alexander</title>
                            <textLang mainLang="gez"/>
                           <note>The content of these sentences generally has no connection to their title. 
                             They are not the same as those transmitted by Arabic authors under the same title. </note>
@@ -90,7 +105,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                       
                         <msItem xml:id="ms_i1.5">
                            <locus from="72v"/>
-                           <title type="complete">Sentences and anecdotes of the Arabic "Precious Pearls of the Wise"</title> 
+                           <title type="complete" ref="LIT7145MFTabiban#PreciousPearl">Sentences and anecdotes of the Arabic "Precious Pearls of the Wise"</title> 
                            <!--Which work is this?-->
                            <textLang mainLang="gez"/>
                            <incipit xml:lang="gez">በስመ፡ እግዚአብሔር፡ መርሕ፡ ኀበ፡ ጽድቅ፤ ወውእቱ፡ መጋቤ፡ ረድኤት። ቃል፡ እምባሕርየ፡ ዕንቆሙ፡ ለጠቢባን። ንንግር፡

--- a/ParisBNF/et/BNFet205.xml
+++ b/ParisBNF/et/BNFet205.xml
@@ -5,8 +5,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-             <title>Maṣḥafa Falāsfā Ṭabibān, Physiologus, Excerpts of Ethiopian history, Ṭǝbāba Sābelā, Sentences of the wise philosophers, 
-                 Fǝkkāre ʾIyasus, Biblical chronology, Baralām wa-Yǝwāsǝf</title>
+             <title><foreign xml:lang="gez">Maṣḥafa falāsfā ṭabibān</foreign>, Physiologus, Excerpts of Ethiopian history, <foreign xml:lang="gez">Ṭǝbāba Sābelā</foreign>,
+                 Sentences of the wise philosophers, 
+                 <foreign xml:lang="gez">Fǝkkāre ʾIyasus</foreign>, Biblical chronology, <foreign xml:lang="gez">Baralām wa-Yǝwāsǝf</foreign></title>
             <editor key="MV"/>
             <editor key="AB" role="generalEditor"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -37,7 +38,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                     <summary/>
                     <msItem xml:id="ms_i1">
                         <locus from="3r" to="16r"/>
-                        <title type="complete" ref="LIT1925Mashaf">መጽሐፈ፡ ፈላስፋ፡ ጠቢባን፡</title>
+                        <title type="complete" ref="LIT7144MFTabiban"/>
                         <textLang mainLang="gez"/>
                     </msItem>
                     


### PR DESCRIPTION
I have specified the IDs of the recension of the _Maṣḥafa falāsfā ṭabibān_ to which the msItems so far attributed to the general record LIT1925Mashaf belong.
Some msItems could not be identified due to missing incipits (e.g. DHAS007), so they still have LIT1925Mashaf.

Cp. [Maṣḥafa falāsfā ṭabibān #2686](https://github.com/BetaMasaheft/Documentation/issues/2686#event-15281654086)