### PR TITLE
2024 12 06 jk uub o etiop 45

### DIFF
--- a/EMIP/1-1000/EMIP00382.xml
+++ b/EMIP/1-1000/EMIP00382.xml
@@ -222,10 +222,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <list>
                     <item xml:id="a1">
                     <locus target="#ir(ecto) #iv(erso) #iir(ecto) #iiv(erso) #iiir(ecto) #iiiv(erso)" facs="001 002 003 004"/>
-                    <desc type="Asmat">
-                    Asmat Prayer of Saint Mary against Unclean Spirits.
-                    Incipit: <foreign xml:lang="gez">ወትቤ፡ ዮሳምር፡ አርምዕድክኤል፡ አዶናኤል፡ ሮስ፡ ኬራስኮኤል፡ ርድአኒ፡ በዛቲ፡ (ለ)ሰዓት፡ <gap reason="omitted"/></foreign>
-                    </desc>
+                      <desc type="Asmat"><title type="complete" ref="LIT7219PPYosomer"/></desc>
+                      <q xml:lang="gez">
+                        ወትቤ፡ ዮሳምር፡ አርምዕድክኤል፡ አዶናኤል፡ ሮስ፡ 
+                        ኬራስኮኤል፡ ርድአኒ፡ በዛቲ፡ <surplus resp="JK">ሰ</surplus>ሰዓት፡ <gap reason="ellipsis"/>
+                      </q>
                     </item>
                     <item xml:id="a2">
                     <locus target="#181r" facs="185"/>
@@ -335,6 +336,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
           <change when="2020-04-17" who="RL">corrected ǝ character</change>
           <change when="2020-05-15" who="ABe">Added facs statements</change>
           <change when="2020-07-22" who="RL">Added linkg to spiritual meaning of Hebrew letters in Ps118, and minor format edits</change>
+        <change when="2024-12-20" who="JK">Added work, corrected transcription from ms</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">

--- a/Uppsala/UppEt45.xml
+++ b/Uppsala/UppEt45.xml
@@ -186,19 +186,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                     </msContents>
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
                     <physDesc>
                         <objectDesc form="Scroll">
                             <supportDesc>
@@ -284,28 +271,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             </list>
                         </additions>
                         
-                        <bindingDesc>
-                            <binding contemporary="true" xml:id="binding">
-                                <decoNote xml:id="b1" type="Boards">Wooden boards.
-                                </decoNote>
-                                <decoNote xml:id="b2" type="SewingStations">4
-                                </decoNote>
-                                <decoNote xml:id="b3" type="bindingMaterial"><material key="wood"></material>
-                                </decoNote>
-                            </binding>
-                        </bindingDesc>
                         
                     </physDesc>
-                    
-                    
-                    
-                    
-                    
-                    
-                    
-                    
-                    
-                    
                     
                     <history>
                         <origin>
@@ -337,14 +304,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </acquisition>
                     </history>
                     
-                    
-                    
-                    
-                    
-                    
-                    
-                    
-                    
+
                     <additional>
                         <adminInfo>
                             <recordHist>
@@ -352,8 +312,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                     <listBibl type="catalogue">
                                         <bibl> 
                                             <ptr target="bm:Loefgren1974Katalog"/>
-                                            <citedRange unit="page">39–40</citedRange>
-                                            <citedRange unit="number">10</citedRange>
+                                            <citedRange unit="page">136–137</citedRange>
+                                            <citedRange unit="number">44</citedRange>
                                         </bibl>
                                         <bibl> 
                                             <ptr target="bm:Zettersteen1899Upsala"/>
@@ -367,6 +327,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                             <ptr target="bm:BmWebsite"/>
                                         </bibl>
                                     </listBibl>
+                                    <listBibl type="secondary">
+                                        <bibl> 
+                                            <ptr target="bm:Loefgren1962Wandamulette"/>
+                                        </bibl>
+                                        <bibl> 
+                                            <ptr target="bm:Lundin2023Osamlingen"/>
+                                            <citedRange unit="page">64–65</citedRange>
+                                        </bibl>
+                                        <bibl> 
+                                            <ptr target="bm:Lundin2023Ocollection"/>
+                                            <citedRange unit="page">64–65</citedRange>
+                                        </bibl>
+                                    </listBibl>
                                 </source>
                             </recordHist>
                         </adminInfo>
@@ -374,28 +347,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                     
                 </msDesc>
                 
-                <bibl> 
-                    <ptr target="bm:Loefgren1974Katalog"/>
-                    <citedRange unit="page">43–45</citedRange>
-                    <citedRange unit="number">14</citedRange>
-                </bibl>
-                <bibl> 
-                    <ptr target="bm:Loefgren1929Evangeliska"/>
-                    <citedRange unit="page">16–17</citedRange>
-                    <citedRange unit="number">10</citedRange>
-                </bibl>
             </sourceDesc>
-
-
-
-
-
-
-
-
-
-
-
 
         </fileDesc>
         <encodingDesc>

--- a/Uppsala/UppEt45.xml
+++ b/Uppsala/UppEt45.xml
@@ -52,7 +52,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             
                             <msItem xml:id="ms_i2">
                                 <locus target="#1ra"/>
-                                <title type="complete" ref=""></title>
+                                <title type="complete" ref="LIT7212PPTaosAzyos"></title>
                                 <incipit xml:lang="gez">
                                     <hi rend="rubric">በስሙ፡ ለአብ<supplied reason="omitted">፡</supplied> 
                                         በስሙ፡ ለወልድ፡ በስሙ፡ ለመንፈስ፡ ቅዱስ፡ ታኦስ፡ አ</hi>ዝዮስ፡ ማሲ፡ ማስዮስ፡ 

--- a/Uppsala/UppEt45.xml
+++ b/Uppsala/UppEt45.xml
@@ -232,7 +232,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                     a man with round eyes showing the onlooker the palms of his hands.
                                     From the top of his head, two snakes emerges, one reaching towards the left
                                     and the other to the right.
-                                    The picture is placed in a field of 42 cm height, which it almost fills.</desc>
+                                    The picture is placed in a field of 42 cm height, which it almost fills. 
+                                    <bibl><ptr target="bm:Loefgren1929Evangeliska"/><citedRange unit="page">16</citedRange></bibl>
+                                hesitantly identifies the person as demon, whereas 
+                                <bibl><ptr target="bm:Loefgren1962Wandamulette"/><citedRange unit="page">105</citedRange></bibl>
+                                    rejects this and suggests that it rather represents a saint or a priest.
+                                </desc>
                             </decoNote>
                         </decoDesc>
 
@@ -304,23 +309,28 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             <origDate notBefore="1800" notAfter="1899">19th century.</origDate>
                         </origin>
                         <provenance>
-                            The name of the original owner, as present in supplications, has regularly been erased and substituted by the name
+                            The latter part of the name of the original owner, as present in supplications, has regularly been erased 
+                            and substituted, producing the name of a secondary owner
                             <persName></persName>. 
-                            
-                            Names in a later layer include
-                            <foreign xml:lang="gez-tr"><persName ref="PRS14557WaldaMikael">Walda Mikāʾel</persName></foreign>
-                            (e.g. on <locus target="#16vb #20vb #30va #50rb"/>),
-                            <foreign xml:lang="gez-tr"><persName ref="PRS14559IyasuWaldaAbiyaEgz">ʾIyāsu Walda ʾAbiya ʾƎgziʾ</persName></foreign>
-                            (e.g. on <locus target="#32ra #46va #50rb #55vb"/>),
-                            <foreign xml:lang="gez-tr"><persName ref="PRS14560Abamelek">ʾAbamelek</persName></foreign>
-                            (e.g. on <locus target="#39ra #72vb #142vb"/>), and
-                            <foreign xml:lang="gez-tr"><persName ref="PRS14558WalattaMikael">Walatta Mikāʾel</persName></foreign>
-                            (e.g. on <locus target="#43vb #55va #64vb"/>).
+                            The manuscript was acquired by an unknown missionary of
+                            Evangeliska fosterlandsstiftelsen and brought to Sweden at some point between <date when="1866">1866</date>
+                            (when the first missionaries connected to Evangeliska fosterlandsstiftelsen arrived in Ethiopia) and
+                            <date when="1928">1928</date>, when it was catalogued in Sweden. During a period, 
+                            the manuscript was kept at <placeName ref="INS1020EFSmissionsmuseum"/> in 
+                            Johannelund (Ulvsunda, <placeName ref="LOC7456Stockholm"/>).
                         </provenance>
-                        <acquisition>According to <ref target="#e3"/>, the manuscript reached its current repository
-                            in <date when="1894"/>. It was a gift from <persName ref="PRS2680Bergman">August Bergman</persName>, 
-                            who had been active as a missionary in <placeName ref="LOC1741Balaza"/>.</acquisition>
+                        <acquisition>
+                            According to <ref target="e4"/>, manuscript reached its current repository in <date when="1968"/>.
+                        </acquisition>
                     </history>
+                    
+                    
+                    
+                    
+                    
+                    
+                    
+                    
                     
                     <additional>
                         <adminInfo>
@@ -357,8 +367,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                     <citedRange unit="number">14</citedRange>
                 </bibl>
                 <bibl> 
-                    <ptr target="bm:Zettersteen1899Upsala"/>
-                    <citedRange unit="page">519</citedRange>
+                    <ptr target="bm:Loefgren1929Evangeliska"/>
+                    <citedRange unit="page">16–17</citedRange>
                     <citedRange unit="number">10</citedRange>
                 </bibl>
             </sourceDesc>

--- a/Uppsala/UppEt45.xml
+++ b/Uppsala/UppEt45.xml
@@ -35,7 +35,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             <title type="complete" ref="LIT5920JohnBeg"/>
                             <note>As noted by <bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">136</citedRange></bibl>,
                                 John 1:1–5 is reproduced. After this follows an elaboration on how, similarly, demons will not prevail over the owner of
-                                the scroll, <persName></persName>.
+                                the scroll, <persName ref="PRS14625WalattaMaryam" role="owner"/>.
                             </note>
                             <incipit xml:lang="gez">
                                 <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ<supplied reason="omitted">፡</supplied></hi>
@@ -45,8 +45,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             <explicit>
                                 ወጽልመትኒ<supplied reason="omitted">፡</supplied> ኢይረክቦ፡ ወኢይቀርቦ፡ ከማሁ፡ ኢይቅረብዋ፡ 
                                 መናፍስ<surplus>ስ</surplus><sic resp="JK">ተ</sic>፡ ርኩሳን፡ ወሰብእ፡ መሠርያን፡ ወአጋንንት፡ 
-                                ፀዋጋን፡ ወሰብእ፡ ነሀቢ፡ ኢትቅረቡ፡ በላዕለ፡ አመትከ፡ <hi rend="rubric">ወለተ፡</hi>
-                                <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst>
+                                ፀዋጋን፡ ወሰብእ፡ ነሀቢ፡ ኢትቅረቡ፡ በላዕለ፡ አመትከ፡ <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
+                                    <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst></persName>
                             </explicit>
                         </msItem>
                             
@@ -67,8 +67,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                     ዝንቱ፡ ቤት፡ አሜን፡ አልፋ፡ አልፋ፡ አልፋ፡ አልፋ፡ ፃዕ፡ ፃዕ፡ ወወጺአከ፡ ኢትግ<del rend="effaced">ባ</del>ባዕ፡ 
                                     አልፋአ፡ አልፋአ<supplied reason="omitted">፡</supplied> ፃዕ፡ ይቤለከ፡ ኢየሱስ፡ ክርስቶስ፡ 
                                     ወዝክረ፡ ስምከ፡ ይደምሰስ፡ ለዓለመ፡ ዓለም፡ አሜን፡ ይሰደድ፡ ጋኔን፡ ላዕለ፡ አመትከ፡ 
-                                    <hi rend="rubric">ወለተ፡</hi>
-                                    <subst><del rend="effaced" unit="chars" quantity="5"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst>
+                                    <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
+                                        <subst><del rend="effaced" unit="chars" quantity="5"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst></persName>
                                 </explicit>
                             </msItem>
                             
@@ -90,8 +90,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                 አርዮ፡ ኃይለ፡ ግርማ፡ ንጉሠ፡ ስብሐት፡ ፌማ፡ ኢይርአዩ፡ ገጻ፡ 
                                 ወኢ<supplied resp="JK" reason="omitted">ይ</supplied>ስምዑ፡ ድምፃ፡ 
                                 ወኢይልክፉ፡ ኀበ<supplied reason="omitted">፡</supplied> ነፍሳ፡ ወሥጋሃ፡ 
-                                ለዓመትከ፡ <hi rend="rubric">ወለተ፡</hi>
-                                <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም፡</add></subst>
+                                ለዓመትከ፡ <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
+                                    <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም፡</add></subst></persName>
                             </explicit>
                         </msItem>
                         
@@ -101,14 +101,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             <incipit xml:lang="gez">
                                 <hi rend="rubric">ጸሎት፡ በእንተ፡ ሕማመ፡ ቍርጥማት፡ በሸበል፡ ሽሩምያል፡ ግርሙ</hi>ያል፡ 
                                 ሳምአም፡ ስያል፡ በዝንቱ፡ አስማቲከ፡ አድኅና፡ ለአመትከ<supplied reason="omitted">፡</supplied>
-                                እምሕማመ፡ ቍርጥማት፡ ወዓይነት፡ ወውግዓት፡ አድኅና፡ ለአመትከ፡ <hi rend="rubric">ወለተ፡</hi>
-                                <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም፡</add></subst>
+                                እምሕማመ፡ ቍርጥማት፡ ወዓይነት፡ ወውግዓት፡ አድኅና፡ ለአመትከ፡ 
+                                <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
+                                <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም፡</add></subst></persName>
                             </incipit>
                             <explicit>
                                 <hi rend="rubric">ወገጹ፡ ዘፍጹም፡ በጽልመት<supplied reason="omitted">፡</supplied></hi>
                                 ፈርሃ፡ ወደንገጸ፡ ዲያብሎስ፡ ርእዮ፡ ብሁተ፡ ልደት፡ በሥጋ፡ አምላክ፡ በሲኦል፡ በዝ፡ ቃለ፡ 
-                                መለኮትከ፡ ዕቀባ፡ ለአመትከ፡ <hi rend="rubric">ወለተ፡</hi>
-                                <subst><del rend="effaced" unit="chars" quantity="8"/><add>ማርያም፡</add></subst>
+                                መለኮትከ፡ ዕቀባ፡ ለአመትከ፡ <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
+                                    <subst><del rend="effaced" unit="chars" quantity="8"/><add>ማርያም፡</add></subst></persName>
                             </explicit>
                         </msItem>
                         
@@ -121,8 +122,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                 እለ፡ ይ<surplus>ጠ</surplus>ጠብዉ፡ ጥበ፡ እሞሙ፡ ዓዲ፡ ይበቍዓ፡ ለብእሲት፡ ትጽሐፍ፡ 
                                 ወትስቅሎ፡ ላዕሌሃ፡ በረድኤተ፡ እግዚአብሔር፡ ልዑል፡ ወክቡር፡ እስከ፡ ለዓለ<sic resp="JK">ም</sic>፡ 
                                 ዓለም፡ አሜን፡ ዕቀባ፡ ወአድኅና፡ እምአይነተ፡ ባርያ፡ ወሌጌዎን<supplied reason="omitted">፡</supplied>
-                                እምሹተላይ፡ ወመጋኛ፡ ለአመትከ፡ <hi rend="rubric">ወለተ፡</hi>
-                                <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም፡</add></subst>
+                                እምሹተላይ፡ ወመጋኛ፡ ለአመትከ፡ <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
+                                    <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም፡</add></subst></persName>
                             </incipit>
                             <incipit xml:lang="gez">
                                 <hi rend="rubric">ወሀሎ፡ ፩ብእሲ፡ ዘስሙ፡ ሱስንዮስ፡ ወአውሰበ፡ ብእሲተ፡ ወወ</hi>ለደ፡ 
@@ -139,14 +140,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                 <subst><del rend="effaced" unit="chars" quantity="7"/><add place="inline">ማርያም</add></subst>
                                    ወገጹ፡ ዘፍጹም፡ በጽልመት፡ ፈርሃ፡ ወደንገ</hi>ጸ፡ ዲያብሎስ፡ ርእዮ፡ 
                                 ብሁተ፡ ልደት፡ በሥጋ፡ አምላክ፡ በሲኦል፡ በዝ፡ ቃለመለኮት፡ ዕቀባ፡ ለአመትከ፡ 
-                                <hi rend="rubric">ወለተ፡</hi>
-                                <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst>
+                                <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
+                                    <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst></persName>
                             </explicit>
                         </msItem>
 
                         <msItem xml:id="ms_i6">
                             <locus from="" to=""/>
-                            <title type="complete" ref=""></title>
+                            <title type="complete" ref="LIT7063Devils"></title>
                             <incipit xml:lang="gez">
                                 <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ<supplied reason="omitted">፡</supplied></hi>
                                 ጸሎተ፡ አላሁማ፡ ወያኑራ፡ ሐሸምራ፡ ለሐቅረጅ፡ ለቅመግኑን፡ ዕልዋቁን፡ መሸሾንጠበሽበሾን፡ ዘረበቦሙ፡ 
@@ -157,8 +158,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             <explicit>
                                 እለ<supplied reason="omitted">፡</supplied> ገብሩ፡ እለ፡ ሴዘ፡ እለ፡ ጥልፍልፍ፡ እለ፡ ሌጌዎን፡ 
                                 ይስዓር፡ ሥራያቲክሙ፡ እለ፡ ሀሎክሙ፡ በስዕርተ፡ ር<add place="above">እ</add>ስየ፡ በቅድሜየ፡ 
-                                ወበድሜየ፡ ወበድኅሬየ፡ በየማንየ፡ ወበፀጋምየ፡ ዕቀበኒ፡ ለዓመትከ፡ <hi rend="rubric">ወለተ፡</hi>
-                                <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም፡</add></subst><hi rend="rubric">እ</hi>
+                                ወበድሜየ፡ ወበድኅሬየ፡ በየማንየ፡ ወበፀጋምየ፡ ዕቀበኒ፡ ለዓመትከ፡ 
+                                <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
+                                    <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም፡</add></subst></persName><hi rend="rubric">እ</hi>
                             </explicit>
                         </msItem>
                         
@@ -175,7 +177,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                 ወእምዝ፡ ጸለየት፡ በነገረ፡ ዕብራይስጢ፡ ወትቤ<supplied reason="omitted">፡</supplied>
                                 ኪርምያል፡ አፍዳኮዳዮዳ፡ ሕልማና፡ ያሰርስ፡ ብንያክኤል፡ ሶርስሳብ፡ ሮስሳብ፡ እርዳድ፡ 
                                 ለምንያም፡ አልሚስ፡ ጢራጢብንዮስ፡ ስምዓኒ፡ ለአመትከ፡ 
-                                <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም፡</add></subst>
+                                <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
+                                <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም፡</add></subst></persName>
                                 ወትቤ፡ እግዝእትነ፡ በነገረ፡ ዕብራይስጢ፡ ሶፎሶሮያሮስቦ፡ ወክርሜል<supplied reason="omitted">፡</supplied>
                             </explicit>
                         </msItem>

--- a/Uppsala/UppEt45.xml
+++ b/Uppsala/UppEt45.xml
@@ -74,7 +74,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             
                         <msItem xml:id="ms_i3">
                             <locus target="#1ra"/>
-                            <title type="complete" ref=""></title>
+                            <title type="complete" ref="LIT7217PPYaqi"></title>
                             <incipit xml:lang="gez">
                                 <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ<supplied reason="omitted">፡</supplied></hi>
                                 ያቂ፡ ወያቂ፡ አንተ፡ ሰይጣን፡ ወአንተ፡ ባርያ፡ ወአንተ፡ ሌጌዎን፡ ወአን፡ ጋኔን፡ ወአንተ፡ ደስክ፡ 
@@ -97,7 +97,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         
                         <msItem xml:id="ms_i4">
                             <locus target="#1ra"/>
-                            <title type="complete" ref=""></title>
+                            <title type="complete" ref="LIT7213PPQwertemat"></title>
                             <incipit xml:lang="gez">
                                 <hi rend="rubric">ጸሎት፡ በእንተ፡ ሕማመ፡ ቍርጥማት፡ በሸበል፡ ሽሩምያል፡ ግርሙ</hi>ያል፡ 
                                 ሳምአም፡ ስያል፡ በዝንቱ፡ አስማቲከ፡ አድኅና፡ ለአመትከ<supplied reason="omitted">፡</supplied>
@@ -166,7 +166,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         
                         <msItem xml:id="ms_i7">
                             <locus target="#1rc"/>
-                            <title type="complete" ref=""></title>
+                            <title type="complete" ref="LIT7218PPYosomer"></title>
                             <incipit xml:lang="gez">
                                 <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡</hi>
                                 ወመጽኡ፡ እሉ፡ አጋንንት፡ <sic resp="JK">ወእግዝትነ፡</sic> <hi rend="rubric">ማርያምሰ፡</hi>
@@ -184,7 +184,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </msItem>
                       
                     </msContents>
-
 
                     <physDesc>
                         <objectDesc form="Scroll">
@@ -271,7 +270,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             </list>
                         </additions>
                         
-                        
                     </physDesc>
                     
                     <history>
@@ -303,7 +301,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             According to <ref target="e4"/>, manuscript reached its current repository in <date when="1968"/>.
                         </acquisition>
                     </history>
-                    
 
                     <additional>
                         <adminInfo>

--- a/Uppsala/UppEt45.xml
+++ b/Uppsala/UppEt45.xml
@@ -146,7 +146,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </msItem>
 
                         <msItem xml:id="ms_i6">
-                            <locus from="" to=""/>
+                            <locus target="#1rc"/>
                             <title type="complete" ref="LIT7063Devils"></title>
                             <incipit xml:lang="gez">
                                 <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ<supplied reason="omitted">፡</supplied></hi>
@@ -165,7 +165,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </msItem>
                         
                         <msItem xml:id="ms_i7">
-                            <locus from="" to=""/>
+                            <locus target="#1rc"/>
                             <title type="complete" ref=""></title>
                             <incipit xml:lang="gez">
                                 <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡</hi>
@@ -314,12 +314,22 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <provenance>
                             The latter part of the name of the original owner, as present in supplications, has regularly been erased 
                             and substituted, producing the name of a secondary owner
-                            <persName></persName>. 
-                            The manuscript was acquired by an unknown missionary of
-                            Evangeliska fosterlandsstiftelsen and brought to Sweden at some point between <date when="1866">1866</date>
+                            <persName ref="PRS14625WalattaMaryam" role="owner"/>. According to 
+                            <bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">138</citedRange></bibl>,
+                            this manuscript shares the same history as <ref type="mss" corresp="#UppEt46"/> and
+                            <ref type="mss" corresp="#UppEt47"/>: they were all owned by the same original owner and later
+                            all passed into the ownership <persName ref="PRS14625WalattaMaryam" role="owner"/>. Based on
+                            <ref type="mss" corresp="#UppEt46"/>, the original owner can be
+                            identified as <persName ref="PRS14626WalattaAbiyaEgzi" role="owner"/> (contrary to
+                            the suggestion by <bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">138</citedRange></bibl>,
+                            reproduced in <bibl><ptr target="bm:alvin"/></bibl>, that the original owner was called
+                            <foreign xml:lang="gez">Walatta Dəngəl</foreign>).
+                            At some point between <date when="1866">1866</date>
                             (when the first missionaries connected to Evangeliska fosterlandsstiftelsen arrived in Ethiopia) and
-                            <date when="1928">1928</date>, when it was catalogued in Sweden. During a period, 
-                            the manuscript was kept at <placeName ref="INS1020EFSmissionsmuseum"/> in 
+                            <date when="1928">1928</date> (when the manuscript was catalogued for the first time in Sweden),
+                            the manuscript was acquired by an unknown missionary of
+                            Evangeliska fosterlandsstiftelsen and brought to Sweden. During a period, 
+                            it was kept at <placeName ref="INS1020EFSmissionsmuseum"/> in 
                             Johannelund (Ulvsunda, <placeName ref="LOC7456Stockholm"/>).
                         </provenance>
                         <acquisition>

--- a/Uppsala/UppEt45.xml
+++ b/Uppsala/UppEt45.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
         <fileDesc>
             <titleStmt>
                 <title xml:id="t1">
-                    Magic scroll
+                    Protective prayers
                 </title>
             </titleStmt>
             <publicationStmt>
@@ -42,7 +42,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                 ቀዳሚሁ፡ ቃል፡ <del rend="effaced" unit="chars" quantity="1"/>ውእቱ፡ ቃል፡ ወውእቱ፡ ቃል፡ ኀበ፡ እግዚአብሔር፡ 
                                 ውእቱ፡ 
                             </incipit>
-                            <explicit>
+                            <explicit xml:lang="gez">
                                 ወጽልመትኒ<supplied reason="omitted">፡</supplied> ኢይረክቦ፡ ወኢይቀርቦ፡ ከማሁ፡ ኢይቅረብዋ፡ 
                                 መናፍስ<surplus>ስ</surplus><sic resp="JK">ተ</sic>፡ ርኩሳን፡ ወሰብእ፡ መሠርያን፡ ወአጋንንት፡ 
                                 ፀዋጋን፡ ወሰብእ፡ ነሀቢ፡ ኢትቅረቡ፡ በላዕለ፡ አመትከ፡ <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
@@ -61,7 +61,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                     ጮሕ፡ ዋረቅ፡ ሐሩርቃኤል፡ በዝንቱ፡ አስማተ፡ ቃልከ፡ ስሑል፡ እሳተ፡ መለኮት፡ 
                                     መግዝም፡ ምን<supplied reason="omitted">፡</supplied> እንዳለህ፡ አሞር፡ ኤሴር፡
                                 </incipit>
-                                <explicit>
+                                <explicit xml:lang="gez">
                                     ወይፃዕ<supplied reason="omitted">፡</supplied> መንፈስ፡ ርኩስ፡ ወለዘአሐዞ፡ ሰብእ፡ 
                                     ወተግባረ፡ ሰብእ፡ ወኀበ፡ ቦአ፡ ዝንቱ፡ ጸሎት፡ ይሰደድ፡ <sic resp="JK">እምላለ፡</sic> 
                                     ዝንቱ፡ ቤት፡ አሜን፡ አልፋ፡ አልፋ፡ አልፋ፡ አልፋ፡ ፃዕ፡ ፃዕ፡ ወወጺአከ፡ ኢትግ<del rend="effaced">ባ</del>ባዕ፡ 
@@ -83,7 +83,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                 ወልደ<supplied reason="omitted">፡</supplied> ወልደ፡ ክርስቶስ፡ ነገርኩክሙ፡
                                 በሎፍሐም፡ 
                             </incipit>
-                            <explicit>
+                            <explicit xml:lang="gez">
                                 ፒልፒልማኤል፡ ያሽኩት፡ አምደ፡ ብርሃን፡ ልብርሃን፡ ይበርቅ፡ በቅ<surplus>ድ</surplus>ድመ፡ 
                                 ገጹ፡ ወለኃይለ፡ ጸላኢ፡ ባርያ፡ ወለኃይለ፡ ፀላኢ፡ ዓይነት፡ ወሥራይ፡ ወለኃይለ፡ ፀላኢ፡ ሌጌዎን፡ 
                                 ወለኃይለ፡ ጸላኢ፡ ጋኔን፡ ወጉዳሌ፡ ውግዓት፡ ወቍርጥማት፡ ፍልፀት፡ ወቍርፀት፡ ፓንዋማ፡ 
@@ -105,7 +105,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                 <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
                                 <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም፡</add></subst></persName>
                             </incipit>
-                            <explicit>
+                            <explicit xml:lang="gez">
                                 <hi rend="rubric">ወገጹ፡ ዘፍጹም፡ በጽልመት<supplied reason="omitted">፡</supplied></hi>
                                 ፈርሃ፡ ወደንገጸ፡ ዲያብሎስ፡ ርእዮ፡ ብሁተ፡ ልደት፡ በሥጋ፡ አምላክ፡ በሲኦል፡ በዝ፡ ቃለ፡ 
                                 መለኮትከ፡ ዕቀባ፡ ለአመትከ፡ <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
@@ -132,7 +132,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                 ወነገረቶ፡ ወሶበ<supplied reason="omitted">፡</supplied> ሰምዓ፡ ቅዱስ፡ 
                                 ሱስንዮስ፡ ወተፅዕነ፡ ዲበ፡ ፈረሱ፡
                             </incipit>
-                            <explicit>
+                            <explicit xml:lang="gez">
                                 ወሖረ፡ ወኮነ፡ <unclear resp="JK">ሰ</unclear>ማተ፡ በእንተ፡ እግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ ዘሎቱ፡ 
                                 ስ<surplus>ት</surplus>ብሐት፡ እስከ፡ ለዓለመ፡ ዓለም፡ አሜን፡ ጸሎቱ፡ ወበረከቱ፡ ለቅዱስ፡ ሱስንዮስ፡ የሐሉ፡ 
                                 <add place="above">ዓ</add>መቱ፡ 
@@ -155,7 +155,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                 <hi rend="rubric">በዝንቱ፡ አስማት፡ ወበዝንቱ፡ ቃላት፡ አስተናግሮ፡ ለቡዳ<supplied reason="omitted">፡</supplied></hi>
                                 መሠርይ፡ ወለሌጌዎን፡ ዕከይ፡ ወለእመ፡ አሐዞ፡ እደ፡ ሰብእ፡ ይትናገር፡ ሕሙም፡ ፌራ፡ በቀቢ፡ ስሙ፡ ለእግዚአብሔር፡ 
                             </incipit>
-                            <explicit>
+                            <explicit xml:lang="gez">
                                 እለ<supplied reason="omitted">፡</supplied> ገብሩ፡ እለ፡ ሴዘ፡ እለ፡ ጥልፍልፍ፡ እለ፡ ሌጌዎን፡ 
                                 ይስዓር፡ ሥራያቲክሙ፡ እለ፡ ሀሎክሙ፡ በስዕርተ፡ ር<add place="above">እ</add>ስየ፡ በቅድሜየ፡ 
                                 ወበድሜየ፡ ወበድኅሬየ፡ በየማንየ፡ ወበፀጋምየ፡ ዕቀበኒ፡ ለዓመትከ፡ 
@@ -173,7 +173,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                 አእመረት፡ ወ፡ ምክሮሙ፡ ወትቤ፡ ዮሳምር፡ አርሞሳድክኤል፡ አዶናኤል፡ ሮሳ፡ ኪራክስክኤል፡ ርድአኒ፡ 
                                 በዛቲ፡ ሰዓት፡
                             </incipit>
-                            <explicit>
+                            <explicit xml:lang="gez">
                                 ወእምዝ፡ ጸለየት፡ በነገረ፡ ዕብራይስጢ፡ ወትቤ<supplied reason="omitted">፡</supplied>
                                 ኪርምያል፡ አፍዳኮዳዮዳ፡ ሕልማና፡ ያሰርስ፡ ብንያክኤል፡ ሶርስሳብ፡ ሮስሳብ፡ እርዳድ፡ 
                                 ለምንያም፡ አልሚስ፡ ጢራጢብንዮስ፡ ስምዓኒ፡ ለአመትከ፡ 
@@ -197,7 +197,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                         <height>940</height>
                                         <width>240</width>
                                     </dimensions>
-                                    <note>Composed of one strip.</note>
+                                    <note>Consists of <measure unit="strips">1</measure> strip.</note>
                                 </extent>
                             </supportDesc>
                             <layoutDesc>
@@ -208,7 +208,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <desc>Able hand of the 19th century (<foreign xml:lang="de">von einer habilen Hand des 19. Jahrhunderts</foreign>, 
+                                <desc>Skilled hand of the 19th century (<foreign xml:lang="de">von einer habilen Hand des 19. Jahrhunderts</foreign>, 
                                     <bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">137</citedRange></bibl>).
                                     </desc>
                                 <date notBefore="1800" notAfter="1899">19th century.</date>
@@ -219,13 +219,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             <decoNote xml:id="d1" type="miniature">
                                 <desc>Coloured <term key="Magic">magic picture</term> of 
                                     a man with round eyes showing the onlooker the palms of his hands.
-                                    From the top of his head, two snakes emerges, one reaching towards the left
+                                    From the top of his head, two snakes emerge, one reaching towards the left
                                     and the other to the right.
-                                    The picture is placed in a field of 42 cm height, which it almost fills. 
-                                    <bibl><ptr target="bm:Loefgren1929Evangeliska"/><citedRange unit="page">16</citedRange></bibl>
-                                hesitantly identifies the person as demon, whereas 
-                                <bibl><ptr target="bm:Loefgren1962Wandamulette"/><citedRange unit="page">105</citedRange></bibl>
-                                    rejects this and suggests that it rather represents a saint or a priest.
+                                    The picture is placed at the top of the scroll in a field of 42 cm height, which it almost fills. 
+                                    Initially, <persName ref="PRS6337Lofgren"/>
+                                    hesitantly identified the person as demon 
+                                    (<bibl><ptr target="bm:Loefgren1929Evangeliska"/><citedRange unit="page">16</citedRange></bibl>), but later 
+                                he rejected this and suggested that it might rather represent a saint or a priest
+                                    (<bibl><ptr target="bm:Loefgren1962Wandamulette"/><citedRange unit="page">105</citedRange></bibl>).
                                 </desc>
                             </decoNote>
                         </decoDesc>
@@ -293,12 +294,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             (when the first missionaries connected to Evangeliska fosterlandsstiftelsen arrived in Ethiopia) and
                             <date when="1928">1928</date> (when the manuscript was catalogued for the first time in Sweden),
                             the manuscript was acquired by an unknown missionary of
-                            Evangeliska fosterlandsstiftelsen and brought to Sweden. During a period, 
+                            Evangeliska fosterlandsstiftelsen and brought to Sweden. For a while, 
                             it was kept at <placeName ref="INS1020EFSmissionsmuseum"/> in 
                             Johannelund (Ulvsunda, <placeName ref="LOC7456Stockholm"/>).
                         </provenance>
                         <acquisition>
-                            According to <ref target="e4"/>, manuscript reached its current repository in <date when="1968"/>.
+                            According to <ref target="#e4"/>, the manuscript reached its current repository in <date when="1968"/>.
                         </acquisition>
                     </history>
 

--- a/Uppsala/UppEt45.xml
+++ b/Uppsala/UppEt45.xml
@@ -40,102 +40,82 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                     
                     <msContents>
                         <msItem xml:id="ms_i1">
-                            <locus from="1ra" to="151rb"/>
-                            <title type="complete" ref="LIT1146Argano"/>
-                            <note><bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">43–44</citedRange></bibl>
-                                provides a general introduction to the work, discussing the number of manuscripts available in Europe.
+                            <title type="complete" ref="LIT5920JohnBeg"/>
+                            <note>As noted by <bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">136</citedRange></bibl>,
+                                John 1:1–5 is reproduced. After this follows an elaboration on how, similarly, demons will not prevail over the owner of
+                                the scroll, <persName></persName>.
                             </note>
-                            
                             <incipit xml:lang="gez">
-                                <locus from="1ra" to="1rb"/>
-                                <hi rend="rubric">በስመ፡ እግዚአብሔር፡፡ ሥሉስ፡ ዘእን</hi>በለ፡ 
-                                ፍልጠት፡ ወአሐዱ፡ በጽምረት፡ ኅቡረ፡ 
-                                <hi rend="rubric">ህላዌ፡ ዕሩየ፡ መለኮት፡ ዘአሐተ፡ ይሰገድ፡</hi>
-                                እምኀበ፡ ሰብእ፡ ወመ<sic resp="JK">ለ</sic>እክት<hi rend="partialRubric">፨</hi>
-                                ንጽሐፍ፡ እን<hi rend="rubric">ከ፡ ዘንተ፡ መጽሐፈ፡ <del rend="effaced">ዘ</del>ይሠመይ፡ አርጋኖ</hi>
-                                <del rend="effaced" unit="lines" quantity="3"/><cb n="rb"/>
-                                <hi rend="rubric">ት፡ ዘአስተብጽዖ፡ ድንግልናሃ፡ ወነጊ</hi>ረ፡ 
-                                ዕበያ፡ ወአክብሮ፡ ስማ፡ ወሰብሖ፡
-                                ቅድ<hi rend="rubric">ስናሃ፡ ወግናይ፡ ለንግሣ፡ ለቅድስት፡ ወ</hi>ንጽሕት፡ 
-                                ወቡርክት፡ ማርያም፡ ዘበዕብራ<hi rend="rubric">ይስጢ፡ ማሪሃም፡ ድንግል፡ ወላዲተ፡</hi> 
-                                ኣምላክ፡ እንተ፡ ይእቲ፡ ሐመረ፡ ወርቅ፡ እሞገደ፡ ኣስራም፡
+                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ<supplied reason="omitted">፡</supplied></hi>
+                                ቀዳሚሁ፡ ቃል፡ <del rend="effaced" unit="chars" quantity="1"/>ውእቱ፡ ቃል፡ ወውእቱ፡ ቃል፡ ኀበ፡ እግዚአብሔር፡ 
+                                ውእቱ፡ 
                             </incipit>
                             <explicit>
-                                <locus from="151ra" to="151rb"/>
-                                በረከተ፡ ክልኤ<cb n="rb"/>ሆን፡ ሰንበታት<hi rend="partialRubric">፨</hi> 
-                                ወበረከተ፡ ቤተ፡ ክርስቲያን<hi rend="partialRubric">፨</hi> 
-                                ቅድስት<hi rend="partialRubric">፨</hi> 
-                                ወበረከተ፡ ሥጋሁ፡ ወደሙ፡ ለወልድኪ<hi rend="partialRubric">፨</hi> 
-                                ወበረከተ፡ ዚአኪ<hi rend="partialRubric">፨</hi> 
-                                ወበረከተ፡ <hi rend="rubric">አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ።</hi> 
-                                ይኩን፡ ምስለ፡ ኃጥእ፡ 
-                                            <subst>
-                                                <del rend="erasure" unit="lines" quantity="2"/>
-                                                    <add place="overstrike">
-                                                        ለገብርኪ፡ 
-                                                        <persName ref="PRS14555EdaKrestos"><del rend="effaced"/>እ<gap reason="illegible"/>ክርስቶስ፡</persName>
-                                                        <add place="above"><persName ref="PRS14557WaldaMikael">ወልደ፡ ሚካኤል</persName></add>
-                                                        ለዓለመ፡ ዓለም፡ አሜን።
-                                                    </add>
-                                            </subst>
-                                ወኢትርሐቂ፡ ወትረ፡ እምኔሆሙ<hi rend="partialRubric">፨</hi> 
-                                በኵሉ፡ መዋዕሊሆሙ<hi rend="partialRubric">፨</hi> 
-                                ዘምስለ፡ ደቂቆሙ፡ ወአዋልዲሆሙ<hi rend="partialRubric">፨</hi> 
-                                ይእዜኒ<hi rend="partialRubric">፨</hi> 
-                                ወዘልፈኒ<hi rend="partialRubric">፨</hi> 
-                                ወለዓለመ፡ ዓለም<hi rend="partialRubric">፨</hi> 
-                                ኣሜን<hi rend="partialRubric">፨</hi> 
-                                ወኣሜን<hi rend="partialRubric">፨</hi> 
+                                ወጽልመትኒ<supplied reason="omitted">፡</supplied> ኢይረክቦ፡ ወኢይቀርቦ፡ ከማሁ፡ ኢይቅረብዋ፡ 
+                                መናፍስ<surplus>ስ</surplus><sic resp="JK">ተ</sic>፡ ርኩሳን፡ ወሰብእ፡ መሠርያን፡ ወአጋንንት፡ 
+                                ፀዋጋን፡ ወሰብእ፡ ነሀቢ፡ ኢትቅረቡ፡ በላዕለ፡ አመትከ፡ <hi rend="rubric">ወለተ፡</hi>
+                                <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst>
                             </explicit>
+                        </msItem>
+                        
+                        
                             
-                            <msItem xml:id="ms_i1.1">
-                                <locus from="1ra" to="30va"/>
-                                <title type="complete" ref="LIT1146Argano#Monday"></title>
-                                <note><bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">39</citedRange></bibl>
-                                    notes that folios are in the wrong order, correcting it to: 
-                                    <locus target="#1"/>, <locus target="#3"/>, <locus target="#4"/>, 
-                                    <locus target="#7"/>, <locus target="#16"/>, <locus target="#5"/>, 
-                                    <locus target="#6"/>, <locus target="#2"/>, <locus from="8" to="15"/>,
-                                    <locus from="17" to="30"/>.
-                                </note>
+                            <msItem xml:id="ms_i2">
+                                <locus from="" to=""/>
+                                <title type="complete" ref=""></title>
+
                             </msItem>
                             
-                            <msItem xml:id="ms_i1.2">
-                                <locus from="30vb" to="55va"/>
-                                <title type="complete" ref="LIT1146Argano#Tuesday"></title>
-                            </msItem>
+                        <msItem xml:id="ms_i3">
+                            <locus from="" to=""/>
+                            <title type="complete" ref=""></title>
                             
-                            <msItem xml:id="ms_i1.3">
-                                <locus from="55va" to="79vb"/>
-                                <title type="complete" ref="LIT1146Argano#Wednesday"></title>
-                            </msItem>
+                        </msItem>
+                        
+                        <msItem xml:id="ms_i4">
+                            <locus from="" to=""/>
+                            <title type="complete" ref=""></title>
                             
-                            <msItem xml:id="ms_i1.4">
-                                <locus from="80ra" to="86rb"/>
-                                <locus from="87ra" to="104vb"/>
-                                <title type="complete" ref="LIT1146Argano#Thursday"></title>
-                                <note>The text on <locus target="#86r"/> is written by a different hand.</note>
-                            </msItem>
+                        </msItem>
+                        
+                        <msItem xml:id="ms_i5">
+                            <locus from="" to=""/>
+                            <title type="complete" ref=""></title>
                             
-                            <msItem xml:id="ms_i1.5.">
-                                <locus from="105ra" to="127va"/>
-                                <title type="complete" ref="LIT1146Argano#Friday"></title>
-                            </msItem>
+                        </msItem>
+                        
+                        <msItem xml:id="ms_i6">
+                            <title type="complete" ref="LIT1763Legend"></title>
+                            <incipit xml:lang="gez">
+                                <hi rend="rubric">ወሀሎ፡ ፩ብእሲ፡ ዘስሙ፡ ሱስንዮስ፡ ወአውሰበ፡ ብእሲተ፡ ወወ</hi>ለደ፡ 
+                                ወልደ፡ ተባዕተ፡ ወበቀዳሚ<supplied reason="omitted">፡</supplied>
+                                ወልዱ፡ ቦአት፡ ውርዝልያ፡ ወቀተለቶ፡ ወሖረት፡ ወከልሐት፡ ወበከየት፡ እሙ፡ 
+                                ወነገረቶ፡ ወሶበ<supplied reason="omitted">፡</supplied> ሰምዓ፡ ቅዱስ፡ 
+                                ሱስንዮስ፡ ወተፅዕነ፡ ዲበ፡ ፈረሱ፡
+                            </incipit>
+                            <explicit>
+                                ወሖረ፡ ወኮነ፡ <unclear resp="JK">ሰ</unclear>ማተ፡ በእንተ፡ እግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ ዘሎቱ፡ 
+                                ስ<surplus>ት</surplus>ብሐት፡ እስከ፡ ለዓለመ፡ ዓለም፡ አሜን፡ ጸሎቱ፡ ወበረከቱ፡ ለቅዱስ፡ ሱስንዮስ፡ የሐሉ፡ 
+                                <add place="above">ዓ</add>መቱ፡ 
+                                <hi rend="rubric">ወለተ፡ 
+                                <subst><del rend="effaced" unit="chars" quantity="7"/><add place="inline">ማርያም</add></subst>
+                                   ወገጹ፡ ዘፍጹም፡ በጽልመት፡ ፈርሃ፡ ወደንገ</hi>ጸ፡ ዲያብሎስ፡ ርእዮ፡ 
+                                ብሁተ፡ ልደት፡ በሥጋ፡ አምላክ፡ በሲኦል፡ በዝ፡ ቃለመለኮት፡ ዕቀባ፡ ለአመትከ፡ 
+                                <hi rend="rubric">ወለተ፡</hi>
+                                <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst>
+                            </explicit>
+                        </msItem>
+
+                        <msItem xml:id="ms_i7">
+                            <locus from="" to=""/>
+                            <title type="complete" ref=""></title>
                             
-                            <msItem xml:id="ms_i1.6">
-                                <locus from="127vb" to="139vb"/>
-                                <title type="complete" ref="LIT1146Argano#Saturday"></title>
-                            </msItem>
+                        </msItem>
+                        
+                        <msItem xml:id="ms_i8">
+                            <locus from="" to=""/>
+                            <title type="complete" ref=""></title>
                             
-                            <msItem xml:id="ms_i1.7">
-                                <locus from="139vb" to="151rb"/>
-                                <title type="complete" ref="LIT1146Argano#Sunday"></title>
-                                <note>According to <bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">39</citedRange></bibl>,
-                                    for the original redactor of the text version attested in this manuscript,
-                                    the reading for Sunday began only on <locus target="143ra"/>.
-                                    (This is clear from the presence of <foreign xml:lang="gez">ḥarag</foreign> only there.)
-                                </note>
-                            </msItem>
                         </msItem>
                       
                     </msContents>
@@ -247,9 +227,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         
                     </physDesc>
                     
+                    
+                    
+                    
+                    
+                    
+                    
+                    
+                    
+                    
+                    
                     <history>
                         <origin>
-                            <origDate notBefore="1400" notAfter="1499">15th century</origDate>
+                            <origDate notBefore="1800" notAfter="1899">19th century.</origDate>
                         </origin>
                         <provenance>
                             The name of the original owner, as present in supplications, has regularly been erased.
@@ -338,6 +328,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <langUsage><language ident="sv">Swedish</language></langUsage>
             <langUsage><language ident="am">Amharic</language></langUsage>
         </profileDesc>
+        
+        
+        
         
         
         

--- a/Uppsala/UppEt45.xml
+++ b/Uppsala/UppEt45.xml
@@ -29,17 +29,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <altIdentifier><idno>Löfgren X</idno></altIdentifier>
                     </msIdentifier>
                     
-                    
-                    
-                    
-                    
-                    
-                    
-                    
-                    
-                    
                     <msContents>
                         <msItem xml:id="ms_i1">
+                            <locus target="#1ra"/>
                             <title type="complete" ref="LIT5920JohnBeg"/>
                             <note>As noted by <bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">136</citedRange></bibl>,
                                 John 1:1–5 is reproduced. After this follows an elaboration on how, similarly, demons will not prevail over the owner of
@@ -57,35 +49,81 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                 <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst>
                             </explicit>
                         </msItem>
-                        
-                        
                             
                             <msItem xml:id="ms_i2">
-                                <locus from="" to=""/>
+                                <locus target="#1ra"/>
                                 <title type="complete" ref=""></title>
-
+                                <incipit xml:lang="gez">
+                                    <hi rend="rubric">በስሙ፡ ለአብ<supplied reason="omitted">፡</supplied> 
+                                        በስሙ፡ ለወልድ፡ በስሙ፡ ለመንፈስ፡ ቅዱስ፡ ታኦስ፡ አ</hi>ዝዮስ፡ ማሲ፡ ማስዮስ፡ 
+                                    አቅዴፌር፡ በስሙ፡ በሐራዋን፡ ሐሪ፡ ፌኬር፡ በጠጁን፡ ዘሐጁን፡ ፌልፌልማኤል፡ 
+                                    በስመ፡ አልዶር፡ አዳናትፌዳ፡ ታኦስ፡ አብሽቱር፡ ፀባዖት<supplied reason="omitted">፡</supplied>
+                                    ጮሕ፡ ዋረቅ፡ ሐሩርቃኤል፡ በዝንቱ፡ አስማተ፡ ቃልከ፡ ስሑል፡ እሳተ፡ መለኮት፡ 
+                                    መግዝም፡ ምን<supplied reason="omitted">፡</supplied> እንዳለህ፡ አሞር፡ ኤሴር፡
+                                </incipit>
+                                <explicit>
+                                    ወይፃዕ<supplied reason="omitted">፡</supplied> መንፈስ፡ ርኩስ፡ ወለዘአሐዞ፡ ሰብእ፡ 
+                                    ወተግባረ፡ ሰብእ፡ ወኀበ፡ ቦአ፡ ዝንቱ፡ ጸሎት፡ ይሰደድ፡ <sic resp="JK">እምላለ፡</sic> 
+                                    ዝንቱ፡ ቤት፡ አሜን፡ አልፋ፡ አልፋ፡ አልፋ፡ አልፋ፡ ፃዕ፡ ፃዕ፡ ወወጺአከ፡ ኢትግ<del rend="effaced">ባ</del>ባዕ፡ 
+                                    አልፋአ፡ አልፋአ<supplied reason="omitted">፡</supplied> ፃዕ፡ ይቤለከ፡ ኢየሱስ፡ ክርስቶስ፡ 
+                                    ወዝክረ፡ ስምከ፡ ይደምሰስ፡ ለዓለመ፡ ዓለም፡ አሜን፡ ይሰደድ፡ ጋኔን፡ ላዕለ፡ አመትከ፡ 
+                                    <hi rend="rubric">ወለተ፡</hi>
+                                    <subst><del rend="effaced" unit="chars" quantity="5"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst>
+                                </explicit>
                             </msItem>
                             
                         <msItem xml:id="ms_i3">
-                            <locus from="" to=""/>
+                            <locus target="#1ra"/>
                             <title type="complete" ref=""></title>
-                            
+                            <incipit xml:lang="gez">
+                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ<supplied reason="omitted">፡</supplied></hi>
+                                ያቂ፡ ወያቂ፡ አንተ፡ ሰይጣን፡ ወአንተ፡ ባርያ፡ ወአንተ፡ ሌጌዎን፡ ወአን፡ ጋኔን፡ ወአንተ፡ ደስክ፡ 
+                                ወጉዳሌ፡ አንተ፡ ሥራይ፡ ወአንተ፡ ዓይነት፡ አንተ፡ ውግዓት፡ ወቍርጥማን፡ ዘትትሜሰል፡ 
+                                በብዙኅ፡ ጾታ፡ አራህድራህያ፡ ምራኤል፡ ኃያል፡ እግዚአብሔር፡ አዶናይ፡ ቅዱስ፡
+                                ወልደ<supplied reason="omitted">፡</supplied> ወልደ፡ ክርስቶስ፡ ነገርኩክሙ፡
+                                በሎፍሐም፡ 
+                            </incipit>
+                            <explicit>
+                                ፒልፒልማኤል፡ ያሽኩት፡ አምደ፡ ብርሃን፡ ልብርሃን፡ ይበርቅ፡ በቅ<surplus>ድ</surplus>ድመ፡ 
+                                ገጹ፡ ወለኃይለ፡ ጸላኢ፡ ባርያ፡ ወለኃይለ፡ ፀላኢ፡ ዓይነት፡ ወሥራይ፡ ወለኃይለ፡ ፀላኢ፡ ሌጌዎን፡ 
+                                ወለኃይለ፡ ጸላኢ፡ ጋኔን፡ ወጉዳሌ፡ ውግዓት፡ ወቍርጥማት፡ ፍልፀት፡ ወቍርፀት፡ ፓንዋማ፡ 
+                                አርዮ፡ ኃይለ፡ ግርማ፡ ንጉሠ፡ ስብሐት፡ ፌማ፡ ኢይርአዩ፡ ገጻ፡ 
+                                ወኢ<supplied resp="JK" reason="omitted">ይ</supplied>ስምዑ፡ ድምፃ፡ 
+                                ወኢይልክፉ፡ ኀበ<supplied reason="omitted">፡</supplied> ነፍሳ፡ ወሥጋሃ፡ 
+                                ለዓመትከ፡ <hi rend="rubric">ወለተ፡</hi>
+                                <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም፡</add></subst>
+                            </explicit>
                         </msItem>
                         
                         <msItem xml:id="ms_i4">
-                            <locus from="" to=""/>
+                            <locus target="#1ra"/>
                             <title type="complete" ref=""></title>
-                            
+                            <incipit xml:lang="gez">
+                                <hi rend="rubric">ጸሎት፡ በእንተ፡ ሕማመ፡ ቍርጥማት፡ በሸበል፡ ሽሩምያል፡ ግርሙ</hi>ያል፡ 
+                                ሳምአም፡ ስያል፡ በዝንቱ፡ አስማቲከ፡ አድኅና፡ ለአመትከ<supplied reason="omitted">፡</supplied>
+                                እምሕማመ፡ ቍርጥማት፡ ወዓይነት፡ ወውግዓት፡ አድኅና፡ ለአመትከ፡ <hi rend="rubric">ወለተ፡</hi>
+                                <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም፡</add></subst>
+                            </incipit>
+                            <explicit>
+                                <hi rend="rubric">ወገጹ፡ ዘፍጹም፡ በጽልመት<supplied reason="omitted">፡</supplied></hi>
+                                ፈርሃ፡ ወደንገጸ፡ ዲያብሎስ፡ ርእዮ፡ ብሁተ፡ ልደት፡ በሥጋ፡ አምላክ፡ በሲኦል፡ በዝ፡ ቃለ፡ 
+                                መለኮትከ፡ ዕቀባ፡ ለአመትከ፡ <hi rend="rubric">ወለተ፡</hi>
+                                <subst><del rend="effaced" unit="chars" quantity="8"/><add>ማርያም፡</add></subst>
+                            </explicit>
                         </msItem>
                         
                         <msItem xml:id="ms_i5">
-                            <locus from="" to=""/>
-                            <title type="complete" ref=""></title>
-                            
-                        </msItem>
-                        
-                        <msItem xml:id="ms_i6">
+                            <locus target="#1rb"/>
                             <title type="complete" ref="LIT1763Legend"></title>
+                            <incipit xml:lang="gez">
+                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ፩አምላክ፡ በስመ፡ እግዚአብሔር፡ ሕያው፡ 
+                                    ፈጣሪ፡ ነባ</hi>ቢ፡ ወተናጋዊ፡ ጸሎት፡ ዘቅዱስ፡ ሱስንዮስ፡ በእንተ፡ አሰስሎ፡ ደዌ፡ እምሕፃናት፡ 
+                                እለ፡ ይ<surplus>ጠ</surplus>ጠብዉ፡ ጥበ፡ እሞሙ፡ ዓዲ፡ ይበቍዓ፡ ለብእሲት፡ ትጽሐፍ፡ 
+                                ወትስቅሎ፡ ላዕሌሃ፡ በረድኤተ፡ እግዚአብሔር፡ ልዑል፡ ወክቡር፡ እስከ፡ ለዓለ<sic resp="JK">ም</sic>፡ 
+                                ዓለም፡ አሜን፡ ዕቀባ፡ ወአድኅና፡ እምአይነተ፡ ባርያ፡ ወሌጌዎን<supplied reason="omitted">፡</supplied>
+                                እምሹተላይ፡ ወመጋኛ፡ ለአመትከ፡ <hi rend="rubric">ወለተ፡</hi>
+                                <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም፡</add></subst>
+                            </incipit>
                             <incipit xml:lang="gez">
                                 <hi rend="rubric">ወሀሎ፡ ፩ብእሲ፡ ዘስሙ፡ ሱስንዮስ፡ ወአውሰበ፡ ብእሲተ፡ ወወ</hi>ለደ፡ 
                                 ወልደ፡ ተባዕተ፡ ወበቀዳሚ<supplied reason="omitted">፡</supplied>
@@ -106,16 +144,40 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             </explicit>
                         </msItem>
 
+                        <msItem xml:id="ms_i6">
+                            <locus from="" to=""/>
+                            <title type="complete" ref=""></title>
+                            <incipit xml:lang="gez">
+                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ<supplied reason="omitted">፡</supplied></hi>
+                                ጸሎተ፡ አላሁማ፡ ወያኑራ፡ ሐሸምራ፡ ለሐቅረጅ፡ ለቅመግኑን፡ ዕልዋቁን፡ መሸሾንጠበሽበሾን፡ ዘረበቦሙ፡ 
+                                ለአጋንንት፡ ሎፍሐም፡ እስሮሙ፡ 
+                                <hi rend="rubric">በዝንቱ፡ አስማት፡ ወበዝንቱ፡ ቃላት፡ አስተናግሮ፡ ለቡዳ<supplied reason="omitted">፡</supplied></hi>
+                                መሠርይ፡ ወለሌጌዎን፡ ዕከይ፡ ወለእመ፡ አሐዞ፡ እደ፡ ሰብእ፡ ይትናገር፡ ሕሙም፡ ፌራ፡ በቀቢ፡ ስሙ፡ ለእግዚአብሔር፡ 
+                            </incipit>
+                            <explicit>
+                                እለ<supplied reason="omitted">፡</supplied> ገብሩ፡ እለ፡ ሴዘ፡ እለ፡ ጥልፍልፍ፡ እለ፡ ሌጌዎን፡ 
+                                ይስዓር፡ ሥራያቲክሙ፡ እለ፡ ሀሎክሙ፡ በስዕርተ፡ ር<add place="above">እ</add>ስየ፡ በቅድሜየ፡ 
+                                ወበድሜየ፡ ወበድኅሬየ፡ በየማንየ፡ ወበፀጋምየ፡ ዕቀበኒ፡ ለዓመትከ፡ <hi rend="rubric">ወለተ፡</hi>
+                                <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም፡</add></subst><hi rend="rubric">እ</hi>
+                            </explicit>
+                        </msItem>
+                        
                         <msItem xml:id="ms_i7">
                             <locus from="" to=""/>
                             <title type="complete" ref=""></title>
-                            
-                        </msItem>
-                        
-                        <msItem xml:id="ms_i8">
-                            <locus from="" to=""/>
-                            <title type="complete" ref=""></title>
-                            
+                            <incipit xml:lang="gez">
+                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡</hi>
+                                ወመጽኡ፡ እሉ፡ አጋንንት፡ <sic resp="JK">ወእግዝትነ፡</sic> <hi rend="rubric">ማርያምሰ፡</hi>
+                                አእመረት፡ ወ፡ ምክሮሙ፡ ወትቤ፡ ዮሳምር፡ አርሞሳድክኤል፡ አዶናኤል፡ ሮሳ፡ ኪራክስክኤል፡ ርድአኒ፡ 
+                                በዛቲ፡ ሰዓት፡
+                            </incipit>
+                            <explicit>
+                                ወእምዝ፡ ጸለየት፡ በነገረ፡ ዕብራይስጢ፡ ወትቤ<supplied reason="omitted">፡</supplied>
+                                ኪርምያል፡ አፍዳኮዳዮዳ፡ ሕልማና፡ ያሰርስ፡ ብንያክኤል፡ ሶርስሳብ፡ ሮስሳብ፡ እርዳድ፡ 
+                                ለምንያም፡ አልሚስ፡ ጢራጢብንዮስ፡ ስምዓኒ፡ ለአመትከ፡ 
+                                <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም፡</add></subst>
+                                ወትቤ፡ እግዝእትነ፡ በነገረ፡ ዕብራይስጢ፡ ሶፎሶሮያሮስቦ፡ ወክርሜል<supplied reason="omitted">፡</supplied>
+                            </explicit>
                         </msItem>
                       
                     </msContents>
@@ -186,7 +248,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                 </item>
                                 
                                 <item xml:id="e2">
-                                    <desc type="StampExlibris">Paper sticker attached sidewayson the unwritten back of the scroll with 
+                                    <desc type="StampExlibris">Paper sticker attached sideways on the unwritten back of the scroll with 
                                         stamped number.</desc>
                                     <q xml:lang="sv">
                                         507
@@ -242,13 +304,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             <origDate notBefore="1800" notAfter="1899">19th century.</origDate>
                         </origin>
                         <provenance>
-                            The name of the original owner, as present in supplications, has regularly been erased.
-                            In a first stage, it was substituted by the names
-                            <foreign xml:lang="gez-tr"><persName ref="PRS14555EdaKrestos">ʾƎda Krəstos</persName></foreign> and
-                            <foreign xml:lang="gez-tr"><persName ref="PRS14556MahdaraKrestos">Māḫdara Krəstos</persName></foreign>.
-                            These names, which belong to the same layer (see <locus target="#124va"/>)
-                            were subsequently also blotted out (for the first name, see e.g. <locus target="#11ra #30va #60ra #76vb #127va"/>;
-                            for the second, see e.g. <locus target="#64vb #120vb #142vb"/>).
+                            The name of the original owner, as present in supplications, has regularly been erased and substituted by the name
+                            <persName></persName>. 
                             
                             Names in a later layer include
                             <foreign xml:lang="gez-tr"><persName ref="PRS14557WaldaMikael">Walda Mikāʾel</persName></foreign>
@@ -306,6 +363,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                 </bibl>
             </sourceDesc>
 
+
+
+
+
+
+
+
+
+
+
+
         </fileDesc>
         <encodingDesc>
             <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
@@ -323,23 +391,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             </textClass>
             <langUsage><language ident="en">English</language></langUsage>
             <langUsage><language ident="gez">Gəʿəz</language></langUsage>
-            <langUsage><language ident="gez-tr">Gəʿəz transliterated</language></langUsage>
-            <langUsage><language ident="de">German</language></langUsage>
             <langUsage><language ident="sv">Swedish</language></langUsage>
-            <langUsage><language ident="am">Amharic</language></langUsage>
         </profileDesc>
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
         
         <revisionDesc>
             <change who="JK" when="2024-12-06">Created record</change>

--- a/Uppsala/UppEt45.xml
+++ b/Uppsala/UppEt45.xml
@@ -1,0 +1,363 @@
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" type="mss" xml:lang="en" xml:id="UppEt45">
+    <teiHeader xml:base="https://betamasaheft.eu/">
+        <fileDesc>
+            <titleStmt>
+                <title xml:id="t1">
+                    Magic scroll
+                </title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                            This file is licensed under the Creative Commons
+                            Attribution-ShareAlike 4.0.
+                    </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS0356Upp"/>
+                        <collection>O Etiop.</collection>
+                        <idno>O Etiop. 45</idno>
+                        <altIdentifier><idno>Löfgren 44</idno></altIdentifier>
+                        <altIdentifier><idno>Löfgren X</idno></altIdentifier>
+                    </msIdentifier>
+                    
+                    
+                    
+                    
+                    
+                    
+                    
+                    
+                    
+                    
+                    <msContents>
+                        <msItem xml:id="ms_i1">
+                            <locus from="1ra" to="151rb"/>
+                            <title type="complete" ref="LIT1146Argano"/>
+                            <note><bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">43–44</citedRange></bibl>
+                                provides a general introduction to the work, discussing the number of manuscripts available in Europe.
+                            </note>
+                            
+                            <incipit xml:lang="gez">
+                                <locus from="1ra" to="1rb"/>
+                                <hi rend="rubric">በስመ፡ እግዚአብሔር፡፡ ሥሉስ፡ ዘእን</hi>በለ፡ 
+                                ፍልጠት፡ ወአሐዱ፡ በጽምረት፡ ኅቡረ፡ 
+                                <hi rend="rubric">ህላዌ፡ ዕሩየ፡ መለኮት፡ ዘአሐተ፡ ይሰገድ፡</hi>
+                                እምኀበ፡ ሰብእ፡ ወመ<sic resp="JK">ለ</sic>እክት<hi rend="partialRubric">፨</hi>
+                                ንጽሐፍ፡ እን<hi rend="rubric">ከ፡ ዘንተ፡ መጽሐፈ፡ <del rend="effaced">ዘ</del>ይሠመይ፡ አርጋኖ</hi>
+                                <del rend="effaced" unit="lines" quantity="3"/><cb n="rb"/>
+                                <hi rend="rubric">ት፡ ዘአስተብጽዖ፡ ድንግልናሃ፡ ወነጊ</hi>ረ፡ 
+                                ዕበያ፡ ወአክብሮ፡ ስማ፡ ወሰብሖ፡
+                                ቅድ<hi rend="rubric">ስናሃ፡ ወግናይ፡ ለንግሣ፡ ለቅድስት፡ ወ</hi>ንጽሕት፡ 
+                                ወቡርክት፡ ማርያም፡ ዘበዕብራ<hi rend="rubric">ይስጢ፡ ማሪሃም፡ ድንግል፡ ወላዲተ፡</hi> 
+                                ኣምላክ፡ እንተ፡ ይእቲ፡ ሐመረ፡ ወርቅ፡ እሞገደ፡ ኣስራም፡
+                            </incipit>
+                            <explicit>
+                                <locus from="151ra" to="151rb"/>
+                                በረከተ፡ ክልኤ<cb n="rb"/>ሆን፡ ሰንበታት<hi rend="partialRubric">፨</hi> 
+                                ወበረከተ፡ ቤተ፡ ክርስቲያን<hi rend="partialRubric">፨</hi> 
+                                ቅድስት<hi rend="partialRubric">፨</hi> 
+                                ወበረከተ፡ ሥጋሁ፡ ወደሙ፡ ለወልድኪ<hi rend="partialRubric">፨</hi> 
+                                ወበረከተ፡ ዚአኪ<hi rend="partialRubric">፨</hi> 
+                                ወበረከተ፡ <hi rend="rubric">አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ።</hi> 
+                                ይኩን፡ ምስለ፡ ኃጥእ፡ 
+                                            <subst>
+                                                <del rend="erasure" unit="lines" quantity="2"/>
+                                                    <add place="overstrike">
+                                                        ለገብርኪ፡ 
+                                                        <persName ref="PRS14555EdaKrestos"><del rend="effaced"/>እ<gap reason="illegible"/>ክርስቶስ፡</persName>
+                                                        <add place="above"><persName ref="PRS14557WaldaMikael">ወልደ፡ ሚካኤል</persName></add>
+                                                        ለዓለመ፡ ዓለም፡ አሜን።
+                                                    </add>
+                                            </subst>
+                                ወኢትርሐቂ፡ ወትረ፡ እምኔሆሙ<hi rend="partialRubric">፨</hi> 
+                                በኵሉ፡ መዋዕሊሆሙ<hi rend="partialRubric">፨</hi> 
+                                ዘምስለ፡ ደቂቆሙ፡ ወአዋልዲሆሙ<hi rend="partialRubric">፨</hi> 
+                                ይእዜኒ<hi rend="partialRubric">፨</hi> 
+                                ወዘልፈኒ<hi rend="partialRubric">፨</hi> 
+                                ወለዓለመ፡ ዓለም<hi rend="partialRubric">፨</hi> 
+                                ኣሜን<hi rend="partialRubric">፨</hi> 
+                                ወኣሜን<hi rend="partialRubric">፨</hi> 
+                            </explicit>
+                            
+                            <msItem xml:id="ms_i1.1">
+                                <locus from="1ra" to="30va"/>
+                                <title type="complete" ref="LIT1146Argano#Monday"></title>
+                                <note><bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">39</citedRange></bibl>
+                                    notes that folios are in the wrong order, correcting it to: 
+                                    <locus target="#1"/>, <locus target="#3"/>, <locus target="#4"/>, 
+                                    <locus target="#7"/>, <locus target="#16"/>, <locus target="#5"/>, 
+                                    <locus target="#6"/>, <locus target="#2"/>, <locus from="8" to="15"/>,
+                                    <locus from="17" to="30"/>.
+                                </note>
+                            </msItem>
+                            
+                            <msItem xml:id="ms_i1.2">
+                                <locus from="30vb" to="55va"/>
+                                <title type="complete" ref="LIT1146Argano#Tuesday"></title>
+                            </msItem>
+                            
+                            <msItem xml:id="ms_i1.3">
+                                <locus from="55va" to="79vb"/>
+                                <title type="complete" ref="LIT1146Argano#Wednesday"></title>
+                            </msItem>
+                            
+                            <msItem xml:id="ms_i1.4">
+                                <locus from="80ra" to="86rb"/>
+                                <locus from="87ra" to="104vb"/>
+                                <title type="complete" ref="LIT1146Argano#Thursday"></title>
+                                <note>The text on <locus target="#86r"/> is written by a different hand.</note>
+                            </msItem>
+                            
+                            <msItem xml:id="ms_i1.5.">
+                                <locus from="105ra" to="127va"/>
+                                <title type="complete" ref="LIT1146Argano#Friday"></title>
+                            </msItem>
+                            
+                            <msItem xml:id="ms_i1.6">
+                                <locus from="127vb" to="139vb"/>
+                                <title type="complete" ref="LIT1146Argano#Saturday"></title>
+                            </msItem>
+                            
+                            <msItem xml:id="ms_i1.7">
+                                <locus from="139vb" to="151rb"/>
+                                <title type="complete" ref="LIT1146Argano#Sunday"></title>
+                                <note>According to <bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">39</citedRange></bibl>,
+                                    for the original redactor of the text version attested in this manuscript,
+                                    the reading for Sunday began only on <locus target="143ra"/>.
+                                    (This is clear from the presence of <foreign xml:lang="gez">ḥarag</foreign> only there.)
+                                </note>
+                            </msItem>
+                        </msItem>
+                      
+                    </msContents>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                    <physDesc>
+                        <objectDesc form="Scroll">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf">1</measure>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>940</height>
+                                        <width>240</width>
+                                    </dimensions>
+                                    <note>Composed of one strip.</note>
+                                </extent>
+                            </supportDesc>
+                            <layoutDesc>
+                                <layout columns="3" writtenLines="101">
+                                </layout>
+                            </layoutDesc>
+                        </objectDesc>
+                        
+                        <handDesc>
+                            <handNote xml:id="h1" script="Ethiopic">
+                                <desc>Able hand of the 19th century (<foreign xml:lang="de">von einer habilen Hand des 19. Jahrhunderts</foreign>, 
+                                    <bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">137</citedRange></bibl>).
+                                    </desc>
+                                <date notBefore="1800" notAfter="1899">19th century.</date>
+                            </handNote>
+                        </handDesc>
+
+                        <decoDesc>
+                            <decoNote xml:id="d1" type="miniature">
+                                <desc>Coloured <term key="Magic">magic picture</term> of 
+                                    a man with round eyes showing the onlooker the palms of his hands.
+                                    From the top of his head, two snakes emerges, one reaching towards the left
+                                    and the other to the right.
+                                    The picture is placed in a field of 42 cm height, which it almost fills.</desc>
+                            </decoNote>
+                        </decoDesc>
+
+                        <additions>
+                            <list>
+                                
+                                <item xml:id="e1">
+                                    <desc type="StampExlibris">Paper sticker attached sideways on the unwritten back of the scroll with 
+                                        a handwritten note in pen.</desc>
+                                    <q xml:lang="sv">
+                                        X II. a
+                                    </q>
+                                </item>
+                                
+                                <item xml:id="e2">
+                                    <desc type="StampExlibris">Paper sticker attached sidewayson the unwritten back of the scroll with 
+                                        stamped number.</desc>
+                                    <q xml:lang="sv">
+                                        507
+                                    </q>
+                                </item>
+                                
+                                <item xml:id="e3">
+                                    <desc type="StampExlibris">Paper sticker on the unwritten back of the scroll, partly stamped and partly
+                                    handwritten</desc>
+                                    <q xml:lang="sv">
+                                        O<lb/>
+                                        Etiop.<lb/>
+                                        45<lb/>
+                                        Löfgren 44<lb/>
+                                    </q>
+                                </item>
+                                
+                                <item xml:id="e4">
+                                    <desc type="AcquisitionNote">Note in pencil at the bottom of the unwritten back.</desc>
+                                    <q xml:lang="sv">
+                                        x 1968/33
+                                    </q>
+                                </item>
+                                
+                            </list>
+                        </additions>
+                        
+                        <bindingDesc>
+                            <binding contemporary="true" xml:id="binding">
+                                <decoNote xml:id="b1" type="Boards">Wooden boards.
+                                </decoNote>
+                                <decoNote xml:id="b2" type="SewingStations">4
+                                </decoNote>
+                                <decoNote xml:id="b3" type="bindingMaterial"><material key="wood"></material>
+                                </decoNote>
+                            </binding>
+                        </bindingDesc>
+                        
+                    </physDesc>
+                    
+                    <history>
+                        <origin>
+                            <origDate notBefore="1400" notAfter="1499">15th century</origDate>
+                        </origin>
+                        <provenance>
+                            The name of the original owner, as present in supplications, has regularly been erased.
+                            In a first stage, it was substituted by the names
+                            <foreign xml:lang="gez-tr"><persName ref="PRS14555EdaKrestos">ʾƎda Krəstos</persName></foreign> and
+                            <foreign xml:lang="gez-tr"><persName ref="PRS14556MahdaraKrestos">Māḫdara Krəstos</persName></foreign>.
+                            These names, which belong to the same layer (see <locus target="#124va"/>)
+                            were subsequently also blotted out (for the first name, see e.g. <locus target="#11ra #30va #60ra #76vb #127va"/>;
+                            for the second, see e.g. <locus target="#64vb #120vb #142vb"/>).
+                            
+                            Names in a later layer include
+                            <foreign xml:lang="gez-tr"><persName ref="PRS14557WaldaMikael">Walda Mikāʾel</persName></foreign>
+                            (e.g. on <locus target="#16vb #20vb #30va #50rb"/>),
+                            <foreign xml:lang="gez-tr"><persName ref="PRS14559IyasuWaldaAbiyaEgz">ʾIyāsu Walda ʾAbiya ʾƎgziʾ</persName></foreign>
+                            (e.g. on <locus target="#32ra #46va #50rb #55vb"/>),
+                            <foreign xml:lang="gez-tr"><persName ref="PRS14560Abamelek">ʾAbamelek</persName></foreign>
+                            (e.g. on <locus target="#39ra #72vb #142vb"/>), and
+                            <foreign xml:lang="gez-tr"><persName ref="PRS14558WalattaMikael">Walatta Mikāʾel</persName></foreign>
+                            (e.g. on <locus target="#43vb #55va #64vb"/>).
+                        </provenance>
+                        <acquisition>According to <ref target="#e3"/>, the manuscript reached its current repository
+                            in <date when="1894"/>. It was a gift from <persName ref="PRS2680Bergman">August Bergman</persName>, 
+                            who had been active as a missionary in <placeName ref="LOC1741Balaza"/>.</acquisition>
+                    </history>
+                    
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl> 
+                                            <ptr target="bm:Loefgren1974Katalog"/>
+                                            <citedRange unit="page">39–40</citedRange>
+                                            <citedRange unit="number">10</citedRange>
+                                        </bibl>
+                                        <bibl> 
+                                            <ptr target="bm:Zettersteen1899Upsala"/>
+                                            <citedRange unit="page">515–518</citedRange>
+                                            <citedRange unit="number">8</citedRange>
+                                        </bibl>
+                                        <bibl> 
+                                            <ptr target="bm:alvin"/>
+                                        </bibl>
+                                        <bibl> 
+                                            <ptr target="bm:BmWebsite"/>
+                                        </bibl>
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                    
+                </msDesc>
+                
+                <bibl> 
+                    <ptr target="bm:Loefgren1974Katalog"/>
+                    <citedRange unit="page">43–45</citedRange>
+                    <citedRange unit="number">14</citedRange>
+                </bibl>
+                <bibl> 
+                    <ptr target="bm:Zettersteen1899Upsala"/>
+                    <citedRange unit="page">519</citedRange>
+                    <citedRange unit="number">10</citedRange>
+                </bibl>
+            </sourceDesc>
+
+        </fileDesc>
+        <encodingDesc>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+                <xi:fallback>
+                    <p>Definitions of prefixes used.</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
+        <profileDesc>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Magic"/>
+                </keywords>
+            </textClass>
+            <langUsage><language ident="en">English</language></langUsage>
+            <langUsage><language ident="gez">Gəʿəz</language></langUsage>
+            <langUsage><language ident="gez-tr">Gəʿəz transliterated</language></langUsage>
+            <langUsage><language ident="de">German</language></langUsage>
+            <langUsage><language ident="sv">Swedish</language></langUsage>
+            <langUsage><language ident="am">Amharic</language></langUsage>
+        </profileDesc>
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        <revisionDesc>
+            <change who="JK" when="2024-12-06">Created record</change>
+        </revisionDesc>
+    </teiHeader>
+    <facsimile>
+        <graphic url="http://urn.kb.se/resolve?urn=urn:nbn:se:alvin:portal:record-489055"/>
+    </facsimile>
+    <text xml:base="https://betamasaheft.eu/">
+        <body>
+            <ab/>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
Added description of UUB O Etiop. 45 (http://www.alvin-portal.org/alvin/view.jsf?pid=alvin-record%3A489055&dswid=3967) based primarily on the catalogues and added work to Portland, Ethiopic Manuscript Imaging Project, Weiner Codex 157 based on a new identification (based on comparison with UUB O Etiop. 45).