### PR TITLE
Create BLorient4943 and BLorient4944

### DIFF
--- a/LondonBritishLibrary/orient/BLorient4943.xml
+++ b/LondonBritishLibrary/orient/BLorient4943.xml
@@ -108,7 +108,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <desc>Large, rather careful handwriting.</desc> 
-                                <date notBefore="1700" notAfter="1899" resp="PRS8999Strelcyn"/>
+                                <date notBefore="1700" notAfter="1895" resp="PRS8999Strelcyn"/>
                             </handNote>
                         </handDesc>
                         <decoDesc>
@@ -122,7 +122,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                     </physDesc>
                     <history>
                         <origin>
-                            <origDate notBefore="1700" notAfter="1899">18th/19th century, but not after 1895.</origDate>
+                            <origDate notBefore="1700" notAfter="1895">18th/19th century, but not after 1895.</origDate>
                         </origin>
                         <provenance>A strip from a scroll, probably the last but one of three or four strips. Another slightly longer strip, probably 
                             forming the part of the scroll immediately after, is preserved as <ref type="mss" corresp="BLorient4944"/> in the same library.

--- a/LondonBritishLibrary/orient/BLorient4943.xml
+++ b/LondonBritishLibrary/orient/BLorient4943.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" type="mss" xml:lang="en" xml:id="BLorient4943">
+    <teiHeader xml:base="https://betamasaheft.eu/">
+        <fileDesc>
+            <titleStmt>
+                <title>Fragment of a magic scroll</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS00001BL"/>
+                        <idno>BL Oriental 4943</idno>
+                        <altIdentifier><idno>Or. 4943</idno></altIdentifier>
+                        <altIdentifier><idno>Strelcyn 82</idno></altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                        <summary/>
+                        <msItem xml:id="ms_i1">
+                            <title ref="LIT6609ProtectPrayer" type="incomplete">Prayer against Bāryā, Legewon, Maggāññā and Šotolāy</title>
+                            <note>The beginning is missing.</note>
+                            <incipit xml:lang="gez">ወጸላዒ፡ ባርያ፡ ወሌጌ<sic resp="PRS8999Strelcyn">ዋ</sic>ን፡ መጋኛ፡ ወሾቶላይ፡ ለገብርከ፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <title ref="LIT7234PPSolomonHand" type="incomplete"/>
+                            <note>Prayer by the virtue of the names which descended from heaven to Solomon and were inscribed on his hands. 
+                                The end is missing.</note>
+                            <incipit xml:lang="gez">አስማተ፡ እዴሁ፡ ለሰሎሞን፡ ኢያስ፡ ኢያያስ፡ አይግባዖስ። በዝንቱ፡ አስማት፡ ወበዝ፡ ቃላት፡ ዘወረደ፡ እምሰማያት፡ ኅቡዕ፡ ቃሉ፡
+                                ለአብ፡ <gap reason="ellipsis"/> ሾተክላሽ፡ ሾላሆም፡ ሽዓት፡ ሸላግ፡ በሲኢለዕ፡ ስሙ፡ ለእግዚአብሔር፡ በዝንቱ፡ አስማተ፡ ሰሎሞን፡ ከመ፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i3">
+                            <title ref="LIT7235PPSolomonSmiths" type="incomplete"/>
+                            <note>The beginning is missing.</note>
+                            <incipit xml:lang="gez">ድኅነ፡ ሰሎሞን፡ እምእዴሆሙ፡ ለነሀብት፡ ከማሁ፡ አድኅኖ፡ እምእዴሆሙ፡ ለነሀብት፡ <sic>ከለገብረ፡</sic> እግዚአብሔር፡
+                                እምድኅረ፡ አኅዝዎ፡ ወአንበርዎ፡ እስከ፡ ይከውን፡ ሰኑየ፡ መዋዕለ፡ ወሠሉሰ፡ ለያልየ፡ ወወሰድዎ፡ በሌሊት፡ ኀበ፡ ን<sic>ጕ</sic>ሦኦሙ፡ 
+                                <add resp="PRS8999Strelcyn">ኀበ፡ ንጕሦኦሙ፡</add> ወይቤሎ፡ ኅቡዕ፡ ንጉሥ፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i4">
+                            <title ref="LIT7236PPSalamPhanuel"/>
+                            <note>Similar to <ref target="ms_i6"/>.</note>
+                            <incipit xml:lang="gez">ሰላም፡ ለከ፡ ፋኑኤል፡ ግበር፡ ትእምርተ፡ ሰላም፡ ምስሌየ፡ በኵናት፡ ጸሊም፡ አርግዝ፡ ገቦየ፡ ዘአንሀበ፡ በእንቲአየ፡ ሰላም፡ ለከ፡ ሰይፈከ፡ 
+                                ምላህ፡ ዲበ፡ ፀርየ፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i5">
+                            <title ref="LIT4644MagicPr">Prayer by the virtue of the secret names of Solomon</title>
+                            <note>Against various diseases and demons: Bāryā, Legewon, Maggāññā, Šotolāy, migraine, colic, contagion, malarial fever,
+                                Mǝč, pestilence, <foreign xml:lang="gez">fǝrqǝqāt</foreign>, <foreign xml:lang="gez">sǝqsǝqāt</foreign>, Dask, 
+                                Gudāle, and the breath of devils. The beginning is missing and the text starts abruptly.</note>
+                            <incipit xml:lang="gez">ይመስሎሙ፡ ውሉዶሙ፡ ወንኅነኒ፡ ነአምር፡ በምሥጢር፡ ወራብዕ፡ ንቅትል፡ ዘይንእስሂ፡ ወዘየዓቢ፡ ወዘክልኤ፡ ዓመት፡ ወሐምስ፡ 
+                                አርአዮ፡ ፼ገጸ፡ ሰብእ፡ ወባሕም፡ ፼<supplied reason="undefined" resp="PRS8999Strelcyn">ገ</supplied>ጸ፡ አንበሳ፡ ወነምር፡ 
+                                <gap reason="ellipsis"/> ወሶበ፡ ርእየ፡ ዘንተ፡ ግ<surplus resp="PRS8999Strelcyn">፡</surplus>ብረ፡ ፈርሃ፡ ወደንገጸ፡
+                                <surplus resp="PRS8999Strelcyn">ወደንገጸ፡</surplus> ሰሎሞን፡ ወአተበ፡ ገጾ፡ በትእምርተ፡ መስቀል፡ እንዘ፡ ይብል፡
+                                <gap reason="ellipsis"/>መርመሬዎን፡ <gap reason="ellipsis"/> በኃይለ፡ ዝንቱ፡ አስማቲከ፡ ዕቀቦ፡ ወአድኅኖ፡ 
+                                እምሕማመ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ባርያ፡ ወሌጌዎን፡ መጋኛ፡ ወሾቶላይ፡ ፍልፀት፡ 
+                                ወቍርፀ<supplied reason="undefined" resp="PRS8999Strelcyn">ት</supplied>፡ ፌራ፡ ወንዳድ፡ ምች፡ 
+                                ወቸነፈር<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ፍርቅቃት፡ ወሥቅስቃት፡ ደስክ፡ ወጕዳሌ፡ 
+                                ወኢምአየረ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> አጋንንት፡ ለገብረ፡ እግዚአብሔር፡ 
+                                <gap reason="illegible"/></incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i6">
+                            <title ref="LIT2765RepCh49"/>
+                            <note>Similar to <ref target="ms_i4"/>.</note>
+                            <incipit xml:lang="gez">ሰላም፡ ሰዳዴ፡ ሰይጣናት፡ ፋኑኤል፡ በእግዚአብሔር፡ እምጽርሑ፡ ከመ፡ ኢይስክዩ፡ 
+                                ሰብእ<supplied reason="undefined" resp="PRS8999Strelcyn">፡</supplied> እለ፡ ይኔስሁ፡ ዘዘዚአሁ፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i7">
+                            <title ref="LIT5690MagicPrayer">Prayer against the evil eye</title>
+                            <note>Legend of the witch seen by the apostles on the shore of the Sea of Galilee.</note>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ወእንዘ፡ የሐውር፡ እግዚእነ፡ ውስተ፡ ባሕረ፡ 
+                                <placeName ref="LOC7368Tiberias">ጥብርያደስ፡</placeName> ምስለ፡ ፲ወ፪ አርዳኢሁ፡ ርእየ፡
+                                መልክአ፡ ብእሲት፡ ዓርጊት፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Scroll">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf">1</measure>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>780</height>
+                                        <width>165</width>
+                                    </dimensions>
+                                </extent>
+                            </supportDesc>
+                        </objectDesc>
+                        <handDesc>
+                            <handNote xml:id="h1" script="Ethiopic">
+                                <desc>Large, rather careful handwriting.</desc> 
+                                <date notBefore="1700" notAfter="1899" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                        </handDesc>
+                        <decoDesc>
+                            <decoNote xml:id="d1" type="miniature">
+                                <desc>Coloured <term key="Magic">magic picture</term> in the middle of the strip.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d2" type="miniature">
+                                <desc>Coloured <term key="Magic">magic picture</term> in the middle of the strip.</desc>
+                            </decoNote>
+                        </decoDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1700" notAfter="1899">18th/19th century, but not after 1895.</origDate>
+                        </origin>
+                        <provenance>A strip from a scroll, probably the last but one of three or four strips. Another slightly longer strip, probably 
+                            forming the part of the scroll immediately after, is preserved as <ref type="mss" corresp="BLorient4944"/> in the same library.
+                            Two consecutive owners are mentioned in one of the strips: 
+                            <persName role="owner" ref="PRS14646GabraTH">Gabra Takla Hāymānot</persName> and
+                            <persName role="owner" ref="PRS14647GabraKidan">Gabra Kidān</persName>
+                        </provenance>
+                        <acquisition>Bought from <persName role="owner" ref="PRS14645WAJudah">W. A. Judah</persName>.
+                            <date when="1895-09-25"/>.</acquisition>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                            <citedRange unit="page">129-130</citedRange>
+                                        </bibl>
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+                <xi:fallback>
+                    <p>Definitions of prefixes used.</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
+        <profileDesc>
+            <textClass>
+                <keywords>
+                    <term key="Magic"/>
+                    <term key="Prayers"/>
+                    <term key="demon"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-12-19">Created record.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text xml:base="https://betamasaheft.eu/">
+        <body>
+            <ab/>
+        </body>
+    </text>
+</TEI>

--- a/LondonBritishLibrary/orient/BLorient4943.xml
+++ b/LondonBritishLibrary/orient/BLorient4943.xml
@@ -30,7 +30,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <summary/>
                         <msItem xml:id="ms_i1">
                             <title ref="LIT6609ProtectPrayer" type="incomplete">Prayer against Bāryā, Legewon, Maggāññā and Šotolāy</title>
-                            <note>The beginning is missing.</note>
+                            <note>The beginning is missing and was probably written on the previous strip, which is lost.</note>
                             <incipit xml:lang="gez">ወጸላዒ፡ ባርያ፡ ወሌጌ<sic resp="PRS8999Strelcyn">ዋ</sic>ን፡ መጋኛ፡ ወሾቶላይ፡ ለገብርከ፡</incipit>
                             <textLang mainLang="gez"/>
                         </msItem>
@@ -102,6 +102,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                         <height>780</height>
                                         <width>165</width>
                                     </dimensions>
+                                    <note>One of the original <measure unit="strips">three or four</measure> strips.</note>
                                 </extent>
                             </supportDesc>
                         </objectDesc>

--- a/LondonBritishLibrary/orient/BLorient4944.xml
+++ b/LondonBritishLibrary/orient/BLorient4944.xml
@@ -65,7 +65,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
                                 <desc>Large, rather careful handwriting.</desc> 
-                                <date notBefore="1700" notAfter="1899" resp="PRS8999Strelcyn"/>
+                                <date notBefore="1700" notAfter="1895" resp="PRS8999Strelcyn"/>
                             </handNote>
                         </handDesc>
                         <decoDesc>
@@ -79,7 +79,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                     </physDesc>
                     <history>
                         <origin>
-                            <origDate notBefore="1700" notAfter="1899">18th/19th century</origDate>
+                            <origDate notBefore="1700" notAfter="1895">18th/19th century, but not after 1895.</origDate>
                         </origin>
                         <provenance>A strip from a scroll, probably the last of three or four strips. Another smaller strip, probably forming the part of
                             the scroll immediately before, is preserved as <ref type="mss" corresp="BLorient4944"/> in the same library.

--- a/LondonBritishLibrary/orient/BLorient4944.xml
+++ b/LondonBritishLibrary/orient/BLorient4944.xml
@@ -59,6 +59,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                         <height>780</height>
                                         <width>180</width>
                                     </dimensions>
+                                    <note>One of the original <measure unit="strips">three or four</measure> strips.</note>
                                 </extent>
                             </supportDesc>
                         </objectDesc>

--- a/LondonBritishLibrary/orient/BLorient4944.xml
+++ b/LondonBritishLibrary/orient/BLorient4944.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" type="mss" xml:lang="en" xml:id="BLorient4944">
+    <teiHeader xml:base="https://betamasaheft.eu/">
+        <fileDesc>
+            <titleStmt>
+                <title>Fragment of a magic scroll</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS00001BL"/>
+                        <idno>BL Oriental 4944</idno>
+                        <altIdentifier><idno>Or. 4944</idno></altIdentifier>
+                        <altIdentifier><idno>Strelcyn 82</idno></altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                        <summary/>
+                        <msItem xml:id="ms_i1">
+                            <title>Last words of a prayer against the evil eye and the eye of Bāryā and Legewon</title>
+                            <note>Short fragment of a magic prayer, which is probably the end of the text written on 
+                                <ref type="mss" corresp="BLorient4943#ms_i4"/> or <ref type="mss" corresp="BLorient4943#ms_i7"/>, which was 
+                                separated, forming the last words of <ref type="work" corresp="LIT7236PPSalamPhanuel"/> or 
+                                <ref type="work" corresp="LIT5690MagicPrayer"/> respectively.</note>
+                            <incipit xml:lang="gez">በኃይለ፡ ዝንቱ፡ አስማቲከ፡ ዕቀቦ፡ ወአድኅኖ፡ እምሕማመ፡ ዓይነት፡ ዓይነ፡ ባርያ፡ ወሌጌዎን። ። ።</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <title ref="LIT6609ProtectPrayer">End of a prayer against Bāryā, Legewon, Maggāññā, Šotolāy, Budā, blacksmiths, 
+                                migraine, colic, contagion, malarial fever, etc.</title>
+                            <note>The beginning is missing.</note>
+                            <explicit xml:lang="gez">በዝ፡ ቃለ፡ መለኮትከ፡ ዕቀቦ፡ ወአድኅኖ፡ እምሕማመ፡ ባርያ፡ ወሌጌዎን፡ መጋኛ፡ ወሾቶላይ፡ 
+                                ቡዳ<supplied reason="undefined">፡</supplied> ወነሀብት፡ ፍልጸት፡ ወቍፀት፡ ፌራ፡ ወንዳድ፡ <gap reason="illegible"/> ወዓይነት፡ ዛር፡ 
+                                ወትግሪዳ፡ ፙቅዮ፡ ወውግዓት፡ መንሾ፡ ወተዘዋሪ፡ ቀውዣ፡ ወውርዝልያ፡ ወእምአየረ፡ አጋንንት፡ ለ<gap reason="illegible"/></explicit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Scroll">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf">1</measure>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>780</height>
+                                        <width>180</width>
+                                    </dimensions>
+                                </extent>
+                            </supportDesc>
+                        </objectDesc>
+                        <handDesc>
+                            <handNote xml:id="h1" script="Ethiopic">
+                                <desc>Large, rather careful handwriting.</desc> 
+                                <date notBefore="1700" notAfter="1899" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                        </handDesc>
+                        <decoDesc>
+                            <decoNote xml:id="d1" type="miniature">
+                                <desc>Coloured <term key="Magic">magic picture</term> in the middle of the strip.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d2" type="miniature">
+                                <desc>Coloured <term key="Magic">magic picture</term> in the middle of the strip.</desc>
+                            </decoNote>
+                        </decoDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1700" notAfter="1899">18th/19th century</origDate>
+                        </origin>
+                        <provenance>A strip from a scroll, probably the last of three or four strips. Another smaller strip, probably forming the part of
+                            the scroll immediately before, is preserved as <ref type="mss" corresp="BLorient4944"/> in the same library.
+                            Two consecutive owners are mentioned in one of the strips: 
+                            <persName role="owner" ref="PRS14646GabraTH">Gabra Takla Hāymānot</persName> and
+                            <persName role="owner" ref="PRS14647GabraKidan">Gabra Kidān</persName>
+                        </provenance>
+                        <acquisition>Bought from <persName role="owner" ref="PRS14645WAJudah">W. A. Judah</persName>.
+                            <date when="1895-09-25"/>.</acquisition>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                            <citedRange unit="page">129-130</citedRange>
+                                        </bibl>
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+                <xi:fallback>
+                    <p>Definitions of prefixes used.</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
+        <profileDesc>
+            <textClass>
+                <keywords>
+                    <term key="Magic"/>
+                    <term key="Prayers"/>
+                    <term key="Disease"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-12-19">Created record.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text xml:base="https://betamasaheft.eu/">
+        <body>
+            <ab/>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I created records for BLorient4943 and BLorient4944, which are fragments of originally one scroll. They have independant shelfmarks in the library and for this reason, I created two records. I tried to describe the situation in provenance.

![grafik](https://github.com/user-attachments/assets/a04b7c36-a5b8-4d05-975b-8ace66ebc5ea)
