### PR TITLE
BLorient12071B and KopCodEtiopAdd20

### DIFF
--- a/Kop/KopCodEtiopAdd20.xml
+++ b/Kop/KopCodEtiopAdd20.xml
@@ -28,19 +28,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <msContents>
                   <summary/>
                 <msItem xml:id="ms_i1">
-                   <title ref="LIT5888AsmatPrayer">Asmat prayer for binding demons and their drowning</title>
+                   <title ref="LIT5888AsmatPrayer">ʾAsmāt prayer for binding demons and their drowning</title>
                    <incipit xml:lang="gez">ጸሎት፡ በእንተ፡ ማእሰሮሙ፡ ለአጋንንት፡ ጸሎተ፡ መስጥም፡ ዓቃቢሁኒ፡ ዑራኤል፡ ወሳቁኤል፡ ወኮከቡኒ፡ ሸምሸያለሁማ፡ ያተናዚ፡ እልመለኪ፡
                       ወያኑራተዋቀራ፡</incipit>
                   </msItem>
                   <msItem xml:id="ms_i2">
-                     <title ref="LIT5888AsmatPrayer">Asmat prayer for binding demons, devils and the evil eyes of Warq and ʿƎslām</title>
+                     <title ref="LIT5888AsmatPrayer">ʾAsmāt prayer for binding demons, devils and the evil eyes of Warq and ʿƎslām</title>
                      <incipit xml:lang="gez">ጸሎት፡ በእንተ፡ ማእሰሮሙ፡ ለአጋንንት፡ ወለሰይጣናት፡ ዓይነ፡ ወርቅ፡ ዓይነ፡ ዕስላም፡</incipit>
                   </msItem>
                   <msItem xml:id="ms_i3">
                      <title ref="LIT7242PPEssenceSolomon"/>
                      <incipit xml:lang="gez">ጸሎት፡ አስማተ፡ ሰሎሞን፡ አስማተ፡ ህላዌሁ፡ ንእህዝ፡ አድያኖስ፡ አያይኖስ፡</incipit>
                      <explicit xml:lang="gez">ፈርሃ፡ ወደንገፀ፡ ዲያብሎስ፡ ርእዮ፡ ብሁተ፡ ልደት፡ በሥጋ፡ አምላክ፡ በሲኦል፡ በዝቃልከ፡ ወበዝአስማቲከ፡ አድኅና፡ እምሕማመ፡ ባርያ፡
-                        ወሌጌዎን፡ ባርያ፡ ወሰራቅያን፡ ሊተ፡ አመትከ፡ ደስታ፡ ወለተ፡ ገብርኤል፡&lt;…&gt; አዲራ፡ እር፡ ስብርቅንኖተ፡ መስ&lt;…&gt;፡</explicit>
+                        ወሌጌዎን፡ ባርያ፡ ወሰራቅያን፡ ሊተ፡ አመትከ፡ ደስታ፡ ወለተ፡ ገብርኤል፡ <gap reason="illegible"/><!-- Is "&lt;…&gt;" a markup for an ellipsis or illegible? --> አዲራ፡ እር፡ ስብርቅንኖተ፡ መስ<gap reason="illegible"/></explicit>
                   </msItem>
                </msContents>
                <physDesc>

--- a/Kop/KopCodEtiopAdd20.xml
+++ b/Kop/KopCodEtiopAdd20.xml
@@ -26,21 +26,22 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <idno>Cod. Etiop Add. 20</idno>
                </msIdentifier>
                <msContents>
-                  <summary>
-                     <p>I) ጸሎት᎓በእንተ᎓ማእሰሮሙ᎓ለአጋንንት᎓ጸሎተ᎓መስጥም᎓ ዓቃቢሁኒ᎓ ዑራኤል᎓ ወሳቁኤል᎓...,ˀAsmat prayer for binding demons</p>
-                     <p>II) ጸሎት᎓በእንተ᎓ማእሰሮሙ᎓ለአጋንንት᎓ ወለሰይጣናት᎓ ዓይነ᎓ ወርቅ᎓ ዓይነ᎓ ዕስላም᎓...,ˀAsmat prayer for binding demons</p>
-                     <p>III) ጸሎት᎓አስማተ᎓ሰሎሞን᎓አስማተ᎓ህላዌሁ᎓ ንእህዝ᎓ አድያኖስ᎓ አያይኖስ᎓...,ˀAsmat prayer</p>
-                     <!--Transcribed titles: I) Ṣälot bä-ˀǝntä maˀǝsäromu lä-ˀaganǝnt ṣälotä mäsṭǝm ˁaqqabihuni ˁUraˀel wä-Saquˀel… II) Ṣälot bä-ˀǝntä maˀǝsäromu lä-ˀaganǝnt wä-lä-säyṭanat ˁaynä wärq ˁaynä ˁǝslam… III) Ṣälotä ˀasmatä Sälomon ˀasmatä hǝllawehu nǝˀǝhǝz ˀadyanos ˀayaynos…-->
-                     <!--Alternative titles: None-->
-                     <!--Author: Unknown-->
-                  </summary>
-                <!--   <msItem xml:id="ms_i1">
-                     <listBibl type="editions">
-                        <bibl>
-                           <ptr target="I-III) For comparable texts, see, e.g., Worrel 1909, 1910, 1914-15, Dobberahn 1976, Burtea 2001"/>
-                        </bibl>
-                     </listBibl>
-                  </msItem>  -->
+                  <summary/>
+                <msItem xml:id="ms_i1">
+                   <title ref="LIT5888AsmatPrayer">Asmat prayer for binding demons and their drowning</title>
+                   <incipit xml:lang="gez">ጸሎት፡ በእንተ፡ ማእሰሮሙ፡ ለአጋንንት፡ ጸሎተ፡ መስጥም፡ ዓቃቢሁኒ፡ ዑራኤል፡ ወሳቁኤል፡ ወኮከቡኒ፡ ሸምሸያለሁማ፡ ያተናዚ፡ እልመለኪ፡
+                      ወያኑራተዋቀራ፡</incipit>
+                  </msItem>
+                  <msItem xml:id="ms_i2">
+                     <title ref="LIT5888AsmatPrayer">Asmat prayer for binding demons, devils and the evil eyes of Warq and ʿƎslām</title>
+                     <incipit xml:lang="gez">ጸሎት፡ በእንተ፡ ማእሰሮሙ፡ ለአጋንንት፡ ወለሰይጣናት፡ ዓይነ፡ ወርቅ፡ ዓይነ፡ ዕስላም፡</incipit>
+                  </msItem>
+                  <msItem xml:id="ms_i3">
+                     <title ref="LIT7242PPEssenceSolomon"/>
+                     <incipit xml:lang="gez">ጸሎት፡ አስማተ፡ ሰሎሞን፡ አስማተ፡ ህላዌሁ፡ ንእህዝ፡ አድያኖስ፡ አያይኖስ፡</incipit>
+                     <explicit xml:lang="gez">ፈርሃ፡ ወደንገፀ፡ ዲያብሎስ፡ ርእዮ፡ ብሁተ፡ ልደት፡ በሥጋ፡ አምላክ፡ በሲኦል፡ በዝቃልከ፡ ወበዝአስማቲከ፡ አድኅና፡ እምሕማመ፡ ባርያ፡
+                        ወሌጌዎን፡ ባርያ፡ ወሰራቅያን፡ ሊተ፡ አመትከ፡ ደስታ፡ ወለተ፡ ገብርኤል፡&lt;…&gt; አዲራ፡ እር፡ ስብርቅንኖተ፡ መስ&lt;…&gt;፡</explicit>
+                  </msItem>
                </msContents>
                <physDesc>
                   <objectDesc form="Scroll">
@@ -53,36 +54,32 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </extent>
                         <condition key="other">
                            <p>Good. In Text II, in a passage of <locus target="#19"/>written lines, each letter is placed in a net drawn with blue ink.</p>
-                           <!--Good. In Text II, in a passage of 19 written lines, each letter is placed in a net drawn with blue ink.-->
                         </condition>
                      </supportDesc>
                      <layoutDesc>
                         <layout>
                            <ab type="ruling">Unruled</ab>
                         </layout>
-                        <layout><!--Layout One column-->
+                        <layout>
                            <p>One column</p>
-                           <!--lines to folio -->
                         </layout>
                      </layoutDesc>
                   </objectDesc>
                   <handDesc>
-                     <handNote xml:id="h1" script="Ethiopic">Late 19th – 20th-century script; fine, careful hand.<!----><note>
+                     <handNote xml:id="h1" script="Ethiopic">Late 19th – 20th-century script; fine, careful hand.<note>
                            <p>Unknown</p>
-                           <!--Unknown-->
                         </note>
-                        <note><!--Scribal Practices The text and images are embraced with black frame along the edges of the scroll. Angels’ names and four lines of demons’ names around the second image are rubricated. -->
+                        <note>
                            <p>The text and images are embraced with black frame along the edges of the scroll. Angels’ names and four lines of demons’ names around the second image are rubricated. </p>
                         </note>
                         <seg type="rubrication">
                            Executed in the main hand
-                           <!--Executed in the main hand-->
                         </seg>
                      </handNote>
                   </handDesc>
                   <decoDesc>
 
-                     <decoNote type="other" xml:id="d2"><!----></decoNote>
+                     <decoNote type="other" xml:id="d2"></decoNote>
                      <decoNote type="mixed" xml:id="d3">
                         <p>Three polychrome (black, violet, red) pictures: </p>
                         <p>
@@ -91,22 +88,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <locus target="#2"/>) An angel with a sword and scabbard, in the midst of Text II </p>
                         <p>
                            <locus target="#3"/>) A face framed with eight “horns” (“The Net of Solomon”), finely executed.</p>
-                        <!--Three polychrome (black, violet, red) pictures:  1) A face framed with “horns” (“The Net of Solomon”), at the top of the scroll, finely executed  2) An angel with a sword and scabbard, in the midst of Text II  3) A face framed with eight “horns” (“The Net of Solomon”), finely executed.-->
                      </decoNote>
                   </decoDesc>
-                  <additions>
-                     <list>
-                        <item xml:id="a1">
-                           <p>በስመ᎓አብ᎓"... ጸሎት᎓በእንተ᎓ማእሰሮሙ᎓ለአጋንንት᎓ጸሎተ᎓መስጥም᎓ ዓቃቢሁኒ᎓ ዑራኤል᎓ ወሳቁኤል᎓ወኮከቡኒ᎓ ሸምሸያለሁማ᎓ ያተናዚ᎓ እልመለኪ᎓ወያኑራተዋቀራ᎓...</p>
-                           <!--በስመ᎓አብ᎓"... ጸሎት᎓በእንተ᎓ማእሰሮሙ᎓ለአጋንንት᎓ጸሎተ᎓መስጥም᎓ ዓቃቢሁኒ᎓ ዑራኤል᎓ ወሳቁኤል᎓ወኮከቡኒ᎓ ሸምሸያለሁማ᎓ ያተናዚ᎓ እልመለኪ᎓ወያኑራተዋቀራ᎓...-->
-                        </item>
-                     </list>
-                  </additions>
                   <bindingDesc>
                      <binding contemporary="true">
                         <decoNote xml:id="b1">
                            <p>Scroll made of four pieces of parchment (ca. <locus target="#75"/>.<locus target="#5 #65"/>.<locus target="#5 #55 #63"/>.<locus target="#5"/>cm long) sewn together with narrow leather strips. </p>
-                           <!--Scroll made of four pieces of parchment (ca. 75.5, 65.5, 55, 63.5 cm long) sewn together with narrow leather strips. -->
                         </decoNote>
                      </binding>
                   </bindingDesc>
@@ -114,7 +101,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <history>
                   <origin>
                      <origPlace/>
-                     <origDate>Copying date: Late 19th or 20th century</origDate>
+                     <origDate notBefore="1870" notAfter="1999">Copying date: Late 19th or 20th century</origDate>
                   </origin>
                </history>
             </msDesc>
@@ -143,20 +130,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
       </profileDesc>
       <revisionDesc>
          <change who="DN" when="2016-12-15">Final record in Word File</change>
-         <change who="PL" when="2017-02-22">transformed from Word to TEI
-                            P5</change>
+         <change who="PL" when="2017-02-22">transformed from Word to TEI P5</change>
+         <change when="2025-01-14" who="CH">Updated ms-contents</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
       <body>
-         <div type="edition">
-            <div type="textpart" subtype="incipit">
-               <ab>በስመ᎓ አብ᎓" ...  ጸሎት᎓ በእንተ᎓ ማእሰሮሙ᎓ ለአጋንንት᎓ ጸሎተ᎓ መስጥም᎓ ዓቃቢሁኒ᎓ ዑራኤል᎓ ወሳቁኤል᎓ ወኮከቡኒ᎓ ሸምሸያለሁማ᎓ ያተናዚ᎓ እልመለኪ᎓ ወያኑራተዋቀራ᎓ ...</ab>
-            </div>
-            <div type="textpart" subtype="explicit">
-               <ab>...  ፈር ሃ᎓  ወደንገፀ᎓ ዲያብሎስ᎓ ርእዮ᎓ ብሁተ᎓ ልደት᎓ በሥጋ᎓ አምላክ᎓ በሲኦል᎓ በዝቃልከ᎓ ወበዝአስማቲከ᎓ አድኅና᎓ እምሕማመ᎓ ባርያ᎓ ወሌጌዎን᎓ ባርያ᎓ ወሰራቅያን᎓ ሊተ᎓ አመትከ᎓ ደስታ᎓ ወለተ᎓ ገብርኤል᎓ &lt;…&gt; አዲራ᎓ እር ስብርቅንኖተ᎓ መስ &lt;…&gt;</ab>
-            </div>
-         </div>
+         <div type="edition"/>
       </body>
    </text>
 </TEI>

--- a/LondonBritishLibrary/orient/BLorient12071B.xml
+++ b/LondonBritishLibrary/orient/BLorient12071B.xml
@@ -109,7 +109,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             <origDate notBefore="1700" notAfter="1899">18th/19th century.</origDate>
                         </origin>
                         <provenance>The name of the first owner seems to be erased. The name of the second owner is
-                            <persName role="owner" ref="PRS14655EmnaSeyon">ʾƎmna Ṣǝyon</persName>.</provenance>
+                            <persName role="owner" ref="PRS14655EmnaSeyon">ʾƎmmǝna Ṣǝyon</persName>.</provenance>
                         <acquisition>Presented by Miss 
                             <persName role="bequeather" ref="PRS14654Mathison">G. E. Mathieson</persName>. 
                             <date when="1949-08-31">31 August 1949</date>.</acquisition>

--- a/LondonBritishLibrary/orient/BLorient12071B.xml
+++ b/LondonBritishLibrary/orient/BLorient12071B.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" type="mss" xml:lang="en" xml:id="BLorient12071B">
+    <teiHeader xml:base="https://betamasaheft.eu/">
+        <fileDesc>
+            <titleStmt>
+                <title>Magic scroll</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS00001BL"/>
+                        <idno>BL Oriental 12071 B</idno>
+                        <altIdentifier><idno>Or. 12071 B</idno></altIdentifier>
+                        <altIdentifier><idno>Strelcyn 83</idno></altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                        <summary/>
+                        <msItem xml:id="ms_i1">
+                            <title ref="LIT7106Shinbone">Prayer against devils and the action of magicians by virtue of the names revealed by 
+                                God to Solomon</title>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ አጋንንት፡ ወተግባረ፡ አጋንንት፡ ወመስተገብራን፡ ለእለ፡ ይበውኡ፡ በእንተ፡
+                                አቍይጻት፡ ወዓቃብያነ፡ ሥራይ፡ እለ፡ ይቀትሉ፡ ነፍሰ፡ ዘእንበለ፡ ጊዜሁ፡ <gap reason="ellipsis"/> ወዘንተ፡ ብሂሎ፡ ሰሎሞን፡ ለእግዚአብሔር፡ ዘኵሎ፡ ወሀብከኒ፡
+                                ጥበበ፡ <gap reason="ellipsis"/> ይቤሎ፡ እግዚአብሔር፡ ለሰሎሞን፡ አነ፡ እሁበከ፡ ዕፀ፡ አንህዮ፡ ወዕፀ፡ መፍርሂ፡ በዘኢይክሉከ፡ ነሀብት፡ ወበዝንቱ፡ ትመውኦሙ፡ 
+                                ኵሎ፡ መናግንቲሆሙ፡ ወሥራዮሙ፡ <gap reason="ellipsis"/></incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <title ref="LIT7239Miscarriage"/>
+                            <note>Including the incipit of the <ref type="work" corresp="LIT2257salota">Song of Hannah (1 Sam. II, 1-10)</ref>.</note>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ዓምደ፡ ብርሃን፡ መ<choice><sic resp="PRS8999Strelcyn">ስ</sic><corr resp="DR">ሰ</corr></choice>ረተ፡ ጽድቅ፡ ዓምደ፡ ብርሃን፡ ብሂል፡ እግዚአብሔር፡ ማዕምር፡ ፈጣሬ፡ 
+                                ሰማያት<supplied reason="undefined" resp="PRS8999Strelcyn">።</supplied> ጸሎተ፡ ሐና፡ እመ፡ ሳሙኤል፡ ነቢይ፡ </incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i3">
+                            <title ref="LIT1827Magnif"/>
+                            <incipit xml:lang="gez">ጸሎተ፡ እግዝእ<supplied reason="undefined" resp="PRS8999Strelcyn">ት</supplied>ነ፡ ማርያም፡ ተአብዮ፡ 
+                                ነፍስየ፡ ለእግዚአብሔር፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i4">
+                            <title ref="LIT7240PPAddam" type="incomplete"/>
+                            <note>The beginning is missing.</note>
+                            <incipit xml:lang="gez">ወምድር፡ ዘአቀም፡ ለሰማይ፡ ወሣረራ፡ ለምድር፡ ዲበ፡ ማይ፡ ዘለሐ<choice><sic>ከ</sic><corr resp="DR">ኰ</corr></choice>፡ ለአዳም፡ ነሢኦ፡ መሬተ፡ እምድረ፡ ዱዴሌም፡ በአርአያሁ፡ ወበዓቢይ፡ ግብሩ፡
+                                ወነፍሐ፡ ላዕሌሁ፡ መንፈሰ፡ ሕይወት፡ እንዘ፡ ይብል፡ በስመ፡ <gap reason="ellipsis"/> ወይቤሎ፡ እግዚአብሔር፡ ለአዳም፡ ሀበኒ፡ ንሥሐ፡ ከመ፡ እትወከፍ፡ እምኔከ፡ ወይቤሎ፡
+                                አዳም፡ ለእግዚኡ፡ አንተኬ፡ እግዚእየ፡ ሀበኒ፡ ንስሐ፡ ወይቤሎ፡ ክርስቶስ፡ ለአዳም፡ በል፡ አንተ፡ ሀበኒ፡ ንስሐ፡ <gap reason="ellipsis"/> በዝ፡ ቃል፡ 
+                                በሕቡዕ<supplied reason="undefined">፡</supplied> ስምከ፡ በኢያኤል፡ ስምከ፡ በኢያኤል፡ ስምከ፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i5">
+                            <title ref="LIT7242PPEssenceSolomon"/>
+                            <incipit xml:lang="gez">ወካዕበ፡ ዓዲ፡ ጸሎት፡ ዘሰሎሞን፡ አስማተ፡ ህላዌሁ፡ ለሰሎሞን፡ <gap reason="ellipsis"/> ዝቃል፡ ዘወረደ፡ እምላዕሉ፡ ኅቡእ፡ ቃሉ፡ ለአብ፡
+                                እምቅድመ፡ ትለዶ፡ ማርያም<supplied reason="undefined">፡</supplied> ወረደ፡ ዝቃል፡ ኀበ፡ ሰሎሞን፡ <gap reason="ellipsis"/> በዝንቱ፡ አስማቲከ፡
+                                አድኅና፡ ለዓመትከ፡ <gap reason="illegible"/></incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Scroll">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf">1</measure>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>1730</height>
+                                        <width>85</width>
+                                    </dimensions>
+                                    <note>Consists of <measure unit="strips">2</measure> strips.</note>
+                                </extent>
+                            </supportDesc>
+                        </objectDesc>
+                        <handDesc>
+                            <handNote xml:id="h1" script="Ethiopic">
+                                <desc>Large square script in a poor hand.</desc> 
+                                <date notBefore="1700" notAfter="1899" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                        </handDesc>
+                        <decoDesc>
+                            <decoNote xml:id="d1" type="miniature">
+                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d2" type="miniature">
+                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d3" type="miniature">
+                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d4" type="miniature">
+                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
+                            </decoNote>
+                        </decoDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1700" notAfter="1899">18th/19th century.</origDate>
+                        </origin>
+                        <provenance>The name of the first owner seems to be erased. The name of the second owner is
+                            <persName role="owner" ref="PRS14655EmnaSeyon">ʾƎmna Ṣǝyon</persName>.</provenance>
+                        <acquisition>Presented by Miss 
+                            <persName role="bequeather" ref="PRS14654Mathison">G. E. Mathieson</persName>. 
+                            <date when="1949-08-31">31 August 1949</date>.</acquisition>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                            <citedRange unit="page">130-131</citedRange>
+                                        </bibl>
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+                <xi:fallback>
+                    <p>Definitions of prefixes used.</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
+        <profileDesc>
+            <textClass>
+                <keywords>
+                    <term key="Magic"/>
+                    <term key="Prayers"/>
+                    <term key="demon"/>
+                    <term key="Asmat"></term>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-01-12">Created record.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text xml:base="https://betamasaheft.eu/">
+        <body>
+            <ab/>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I created a record for BLorient12071B, finding three new works in it, for which I created LIT ID according to our discussion in  https://github.com/BetaMasaheft/Documentation/issues/2768, 
https://github.com/BetaMasaheft/Documentation/issues/2769 and 
https://github.com/BetaMasaheft/Documentation/issues/2770. 

For ms_i1, I decided for LIT7106Shinbone as discussed in https://github.com/BetaMasaheft/Documentation/issues/2767.

I found the text of LIT7242PPEssenceSolomon also in KopCodEtiopAdd20 and updated this record.