### PR TITLE
Magda dd 034 minor changes 

### DIFF
--- a/ES/ESdd034.xml
+++ b/ES/ESdd034.xml
@@ -90,7 +90,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               <item xml:id="q2" n="2">
                                  <dim unit="leaf">7</dim>
                                  <locus from="11r" to="17v"/>
-                                 1 or 2, no stub
+                                 1, no stub
                               <note>The exact structure of this quire cannot be determined.</note>
                               </item>
                               <item xml:id="q3" n="3">
@@ -127,7 +127,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                  <locus from="82r" to="89v"/></item>
                               <item xml:id="q12" n="12">
                                  <dim unit="leaf">9</dim>
-                                 <locus from="90r" to="98v"/></item>
+                                 <locus from="90r" to="98v"/>
+                                 9, no stub</item>
                               <item xml:id="q13" n="13">
                                  <dim unit="leaf">6</dim>
                                  <locus from="99r" to="104v"/></item>
@@ -140,7 +141,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                  <locus from="114r" to="117v"/></item>
                               <item xml:id="q16" n="16">
                                  <dim unit="leaf">9</dim>
-                                 <locus from="118r" to="126v"/></item>
+                                 <locus from="118r" to="126v"/>
+                                 9, no stub</item>
                               <item xml:id="q17" n="17">
                                  <dim unit="leaf">6</dim>
                                  <locus from="127r" to="132v"/></item>
@@ -213,22 +215,21 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <handDesc>
    
                      <handNote xml:id="h1" script="Ethiopic">
-                        <seg type="script">Nineteenth-century script.</seg>
+                        <seg type="script">Nineteenth-century script (?)</seg>
                         <seg type="ink">Black, red (vivid vermilion).</seg>
-                        <date notBefore="1800" notAfter="1899" cert="medium">19th century (?)</date>
                         <desc>Fine and regular. The main hand of the manuscript.
                           The scribe reduced the size of his handwriting to accommodate the end of the line: <locus target="#12r #14r #22v #23r #27r #42r #44r #45v #66r #86v #110r"/>.
                           Part of the line is taken up: <locus target="#11v #16v #20v #24v #27v #29r #38v #87r #103r"/>.
                           Part of the line is taken down: <locus target="#102r"/>.</desc>
                      
                         <list type="abbreviations">
-                           <item> Abbreviations in <ref target="#ms_i1.1">Text 1.1, Ps. 145</ref> <locus from="107r" to="107v"/>
+                           <item> Abbreviations in <ref target="#ms_i1.1">Text 1.1, Ps. 145</ref> (<locus from="107r" to="107v"/>)
                               <list>
                                  <item>
                                     <abbr>ስ፡/እ፡</abbr> for <expan>እስመ፡ ለዓለም፡ ምሕረቱ፡</expan></item>
                               </list>
                            </item>
-                           <item>Abbreviations in <ref target="#ms_i1.2">Text 1.2, Canticle 10</ref> <locus from="126r" to="126v"/>
+                           <item>Abbreviations in <ref target="#ms_i1.2">Text 1.2, Canticle 10</ref> (<locus from="126r" to="126v"/>)
                            <list>
                               <item>
                                  <abbr>ስ፡</abbr> for <expan>ስቡሕኒ፡ ውእቱ፡ ወልዑልኒ፡ ውእቱ፡ ለዓለም፡</expan></item>
@@ -241,25 +242,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <item>Words or their abbreviations stand for the whole refrain.</item>
                            <item>
                               <abbr>ሠ፡ / ሠረ፡</abbr> for <expan>ሠረቀ፡ በሥጋ፡ እምድንግል፡ ዘእንበለ፡ ዘርአ፡ ብእሲ፡  ወአድኅነነ፡</expan>
-                              <locus target="#138ra"/></item>
+                              (<locus target="#138ra"/>)</item>
                            <item>
                               <abbr>እ፡ / እስ፡ / እስመ፡</abbr> for <expan>እስመ፡ በፈቃዱ፡ ወበሥምረቱ፡ አቡሁ፡ ወመንፈስ፡ ቅዱስ፡ መጽአ፡ ወአድኅነነ፡</expan> 
-                              <locus from="139ra" to="140ra"/></item>
+                              (<locus from="139ra" to="140ra"/>)</item>
                            <item>
                               <abbr>ኵሉ፡</abbr> for <expan>ኵሉ፡ ትውልድ፡ ያስተበፅዑኪ፡ ለኪ፡ ለበሕቲትኪ፡ ኦእግዝእትነ፡  ወላዲተ፡ አምላክ፡</expan>
-                                <locus from="140vb" to="142ra"/></item>
+                                (<locus from="140vb" to="142ra"/>)</item>
                            <item>
                               <abbr>ና፡ / ናዓ:</abbr> for <expan>ናዓብየኪ፡ ኵልነ፡ ኦእግዝእትነ፡ ወላዲተ፡ አምላክ። እስመ፡ ሣህልኪ፡ ይኵን፡ ላዕለ፡ ኵልነ፡</expan>
-                              <locus from="143ra" to="144rb"/></item>
+                              (<locus from="143ra" to="144rb"/>)</item>
                            <item>
                               <abbr>ለኪ፡</abbr> for <expan>ለኪ፡ ለበሕቲትኪ፡ ኦእግዝእትነ፡ ማርያም፡ ወላዲተ፡ አምላክ፡ እመ፡ ብርሃን፡ ናዓብየኪ፡ በስብሐት፡ ወበውዳሴ፡</expan> 
-                              <locus target="#146vb"/></item>
+                              (<locus target="#146vb"/>)</item>
                            <item>
                               <abbr>ተ፡ / ተፈ፡</abbr> for <expan>ተፈሥሒ፡ ኦምልዕልተ፡ ጸጋ፡ ተፈሥሒ፡ እስመ፡ ረከብኪ፡ ሞገስ፡ ተፈሥሒ፡ እግዚአብሔር፡ ምስሌኪ፡</expan> 
-                              <locus from="146rb" to="146vb"/></item>
+                              (<locus from="146rb" to="146vb"/>)</item>
                            <item>
                               <abbr>ወ፡ / ወበ፡ / ወበእንተዝ፡</abbr> for <expan>ወበእንተዝ፡ ናዓብየኪ፡ ኵልነ፡ ኦእግዝእትነ፡ ወላዲተ፡ አምላክ፡ ንጽሕት፡ ኵሎ፡ ጊዜ፡ ንስእል፡ ወናንቀዓዱ፡ ከመ፡ ንርከብ፡ ሣህለ፡ በኀበ፡ መፍቀሬ፡ ሰብእ፡</expan> 
-                              <locus from="147rb" to="148ra"/></item>
+                              (<locus from="147rb" to="148ra"/>)</item>
                               </list>
                            </item>
                            <item>Abbreviations in <ref target="#ms_i1.5"/>
@@ -267,7 +268,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <item>ወ፡ ድ፤ ሣ፤ ይ፤ ሰ፤ ቅ or ወልድኪ፡ ሣህሎ፡ ይክፍለነ፡ ሰዓሊ፡ ለነ፡ ቅድስት፡ <locus target="#149vb #150ra #151ra"/></item>
                            <item>
                               <abbr>ወ፡ / ወበ፡ / ወበእንተዝ፡</abbr> for <expan>ወበእንተዝ፡ ናዓብየኪ፡ ኵልነ፡ ኦእግዝእትነ፡ ወላዲተ፡ አምላክ፡ ንጽሕት፡ ኵሎ፡ ጊዜ፡ ንስእል፡ ወናንቀዓዱ፡ ከመ፡ ንርከብ፡ ሣህለ፡ በኀበ፡ መፍቀሬ፡ ሰብእ፡</expan> 
-                              <locus from="148va" to="152va"/></item>
+                              (<locus from="148va" to="152va"/>)</item>
                            </list>
                            </item>
                         </list>

--- a/ES/ESdd034.xml
+++ b/ES/ESdd034.xml
@@ -44,8 +44,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <msItem xml:id="ms_i1.1">
                      <locus from="2r" to="117v"/>
                      <title type="complete" ref="LIT2000Mazmur">Mazmura Dāwit ‘Psalms of David’</title>
-                     <note>Traditional interpretation of the Hebrew letters in Ps. 118 is missing.</note>
-                     <note>Ps. 148 is interrupted on <locus target="#115r"/>and continued on <locus target="#116r"/>.</note>
+                     <note>Traditional interpretation of the Hebrew letters in Ps. 118 is missing. Ps. 148 is interrupted on <locus target="#115r"/>and continued on <locus target="#116r"/>.</note>
                   </msItem>
                   <msItem xml:id="ms_i1.2">
                      <locus from="118r" to="129v"/>
@@ -282,12 +281,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            Ethiopic numerals or their elements. A few lines (alternating with black lines) in the incipit page of <ref target="#ms_i1.1"/>, <ref target="#ms_i1.2"/>, <ref target="#ms_i1.3"/> and <ref target="#ms_i1.4"/>.</seg>
                      </handNote>
                     
-                     <handNote xml:id="h2" script="Ethiopic"> 
+                     <handNote xml:id="h2" script="Ethiopic" corresp="#a1 #a2 #a4 #a6 #a7"> 
                         <seg type="script" cert="medium">Twentieth-century script.</seg>
                         <seg type="ink">Black, red.</seg>
-                        <date notBefore="1900" notAfter="1999" cert="medium">20th century (?)</date>
-                        <persName role="scribe" ref="PRS14662TsaggaLaEgziabeher">mentioned as scribe on<locus target="#1v"/></persName>
-                        <desc>Crude and careless. Hand of <ref target="#a1 #a2 #a4 #a6 #a7"/></desc>
+                        <desc>Crude and careless. <persName role="scribe" ref="PRS14662TsaggaLaEgziabeher"/> mentioned as scribe in <ref target="#a2"/>.</desc>
                      </handNote>  
                   </handDesc>
                   
@@ -295,40 +292,40 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      <list>
                         <item xml:id="a1">
                            <locus target="#1v"/>
-                           <desc type="OwnershipNote">Ownership note; it mentions the ‘coenobitic community’ as the owner.</desc>
+                           <desc type="OwnershipNote">It mentions the ‘coenobitic community’ as the owner.</desc>
                            <q xml:lang="gez">ዝመፂሃፍ፡ ዘማህበር፡ አንድነት፡</q>
                         </item>
                         <item xml:id="a2">
                            <locus target="#1v"/>
                            <desc type="ScribalSignature">Scribal note mentioning <persName role="scribe" ref="PRS14662TsaggaLaEgziabeher">Ḍaggā la-ʾƎgziʾab<supplied reason="omitted" resp="MK">ḥe</supplied>r.</persName> 
-                              The note is very crudely written in <ref type="hand" target="#h1"/>.</desc>
+                              The note is very crudely written in the <ref type="hand" target="#h2">secondary hand.</ref></desc>
                            <q xml:lang="gez"><persName role="scribe" ref="PRS14662TsaggaLaEgziabeher">ፀጋ፡ ለእግዚአብ<supplied reason="omitted" resp="MK">ሔ</supplied>ር፡</persName>.</q>
                         </item>
                         <item xml:id="a3">
                            <locus target="#115v"/>
                            <desc type="GuestText"><title ref="LIT7243PrayerMaryKwellon" type="incomplete">Hymn to St Mary</title> written in the upper part of the folium. It is written in the <ref type="hand" target="#h1">main hand.</ref></desc>
-                           <q xml:lang="gez">ኵሎን፡ አዋልዲሃ፡<add place="above"> ለሔዋ፡ </add>በምግባረ፡ ሰናይ፡ እለ፡ ተሰርገዋ፡ ዕበያተ፡ ኪ፡ ዜነዋ፡ ተፈስሒ፡ ማርያም፡ አዳስዮ፡ ጣዕዋ፤...</q>
+                           <q xml:lang="gez">ኵሎን፡ አዋልዲሃ፡<add place="above"> ለሔዋ፡ </add>በምግባረ፡ ሰናይ፡ እለ፡ ተሰርገዋ፡ ዕበያተ፡ ኪ፡ ዜነዋ፡ ተፈስሒ፡ ማርያም፡ አዳስዮ፡ ጣዕዋ፤</q>
                         </item>
                         <item xml:id="a4">
                            <locus target="#115v"/>
                            <desc type="GuestText"><title ref="LIT6946InvocationMary" type="incomplete">Invocation to St. Mary</title> written in the lower part of the folium. 
-                              A common prayer after the reading of Psalms of David. It is similar to that in <ref type="mss" corresp="EMIP00175#a6"/>. It is crudely written in <ref type="hand" target="#h2"/>.</desc>
+                              A common prayer after the reading of Psalms of David. It is similar to that in <ref type="mss" corresp="EMIP00175">Additio 6</ref>. It is crudely written in the <ref type="hand" target="#h2">secondary hand</ref>.</desc>
                         </item>
                         <item xml:id="a5">
                            <locus target="#117v"/>
-                           <desc type="OwnershipNote">Ownership note written in the <ref type="hand" target="#h1">main hand.</ref> Names of the donor and her/his family members have been erased.</desc>
+                           <desc type="OwnershipNote">It  written in the <ref type="hand" target="#h1">main hand.</ref> Names of the donor and her/his family members have been erased.</desc>
                            <q xml:lang="gez">ዝ፡ መጽሐፍ፡ ... ወለወልዱ፡ ... ዘሠ<supplied reason="omitted" resp="MK">ረ</supplied>ቆ፡ ወዘፈሐቆ፡ ወዘተአገሎ፡ በስልጣነ፡ ጴጥ<add place="above">ሮ</add>፡ ወጳው<supplied reason="omitted" resp="MK">ሎ</supplied>ስ፡ ውጉዘ፡ ለይኩን፡ ከመ፡ አሬዎስ።</q>
                         </item>
                         <item xml:id="a6">
                            <locus from="136r" to="137v"/>
-                           <desc type="GuestText"><title  ref="LIT7251PrayerMaryKullomuSarawitaMalaekt" type="incomplete">Hymn to St Mary</title> crudely written in <ref type="hand" target="#h2"/>.</desc>
-                           <q xml:lang="gez">ኵሎሙ፡ ሰራዊተ፡ መላእክት፡ ይሴብሁኪ፤ ዘእምቅድመ፡ ዓለም፡ ሃሎተኪ፤ ለማሕደረ፡ ወልዱ፡ እግዚአብሔር፡ ሐረየኪ፤ ...</q>
+                           <desc type="GuestText"><title  ref="LIT7251PrayerMaryKullomuSarawitaMalaekt" type="incomplete">Hymn to St Mary</title> crudely written in the <ref type="hand" target="#h2">secondary hand</ref>.</desc>
+                           <q xml:lang="gez">ኵሎሙ፡ ሰራዊተ፡ መላእክት፡ ይሴብሁኪ፤ ዘእምቅድመ፡ ዓለም፡ ሃሎተኪ፤ ለማሕደረ፡ ወልዱ፡ እግዚአብሔር፡ ሐረየኪ፤</q>
                         </item>
                         <item xml:id="a7">
                            <locus target="#137v #153r"/>
-                           <desc type="OwnershipNote">Ownership note very crudely written in <ref type="hand" target="#h2"/>.</desc>
+                           <desc type="OwnershipNote">It is very crudely written in the <ref type="hand" target="#h2">secondary hand</ref>.</desc>
                            <q xml:lang="gez">ዛቲ፡ መጽሐፍ፡ <persName role="owner" ref="PRS14663Yehdago">ዘ<roleName type="title">አቤቶ፡</roleName> ይሕደጎ፡</persName></q>
-                           <q xml:lang="en">This book is of <persName role="owner" ref="PRS14663Yehdago"><roleName type="title">ʾabeto </roleName> Yǝḥdago.</persName></q>
+                           <q xml:lang="en">This book is of <persName role="owner" ref="PRS14663Yehdago"><roleName type="title">ʾabeto </roleName> Yǝḥdago</persName>.</q>
                         </item>
                         <item xml:id="e1">
                            <locus target="#2r"/>
@@ -358,7 +355,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <desc type="Correction">Erasures.</desc>
                         </item>
                         <item xml:id="e8">  
-                           <locus target="#1rv #3r #11r #16v #18r #41v #51r #102v">, inner side of the back board.</locus>
+                           <locus target="#1rv #3r #11r #16v #18r #41v #51r #102v"/> and inner side of the back board.
                            <desc>Minor notes, scribbles, doodles.</desc>
                         </item>
                      </list>

--- a/ES/ESdd034.xml
+++ b/ES/ESdd034.xml
@@ -314,7 +314,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </item>
                         <item xml:id="a5">
                            <locus target="#117v"/>
-                           <desc type="OwnershipNote">It  written in the <ref type="hand" target="#h1">main hand.</ref> Names of the donor and her/his family members have been erased.</desc>
+                           <desc type="OwnershipNote">It is written in the <ref type="hand" target="#h1">main hand.</ref> Names of the donor and her/his family members have been erased.</desc>
                            <q xml:lang="gez">ዝ፡ መጽሐፍ፡ ... ወለወልዱ፡ ... ዘሠ<supplied reason="omitted" resp="MK">ረ</supplied>ቆ፡ ወዘፈሐቆ፡ ወዘተአገሎ፡ በስልጣነ፡ ጴጥ<add place="above">ሮ</add>፡ ወጳው<supplied reason="omitted" resp="MK">ሎ</supplied>ስ፡ ውጉዘ፡ ለይኩን፡ ከመ፡ አሬዎስ።</q>
                         </item>
                         <item xml:id="a6">


### PR DESCRIPTION
I had to correct the quire structure and some other minor mistakes. 

Could you at line 84: ` <signatures>Undecorated quire marks are written in the left upper corner of <locus target="#18r #26r #42r #50r #58r"/>.` Why are the folia visualized without commas? 

![quire_marks](https://github.com/user-attachments/assets/b35ec927-e626-4211-88dc-fc3abcedf7ae)
