### PR TITLE
Update ESdd028.xml

### DIFF
--- a/ES/ESdd028.xml
+++ b/ES/ESdd028.xml
@@ -400,12 +400,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <desc type="Unclear">Scribbles.</desc></item>
                         <item xml:id="e8">
                            <desc type="findingAid">Daily readings of <ref target="#ms_i1.4"/> are indicated by the names of the days of the week written in the upper margin, in the <ref target="#h1">main hand</ref>:
-                           <foreign xml:lang="gez">ዘሠሉሥ:</foreign> <locus target="#160va"/> 
-                              <foreign xml:lang="gez">ዘረቡዕ:</foreign> <locus target="#162va"/>
-                              <foreign xml:lang="gez">ዘሐሙስ:</foreign> <locus target="#164rb"/>
-                                 <foreign xml:lang="gez">ዘዓርብ:</foreign> <locus target="#166va"/>
-                              <foreign xml:lang="gez">ዘቀዳሚት:</foreign> <locus target="#168ra"/>
-                                 <foreign xml:lang="gez">ዘእሑድ:</foreign> <locus target="#169rb"/>.</desc>
+                           <foreign xml:lang="gez">ዘሠሉሥ፡</foreign> <locus target="#160va"/> 
+                              <foreign xml:lang="gez">ዘረቡዕ፡</foreign> <locus target="#162va"/>
+                              <foreign xml:lang="gez">ዘሐሙስ፡</foreign> <locus target="#164rb"/>
+                                 <foreign xml:lang="gez">ዘዓርብ፡</foreign> <locus target="#166va"/>
+                              <foreign xml:lang="gez">ዘቀዳሚት፡</foreign> <locus target="#168ra"/>
+                                 <foreign xml:lang="gez">ዘእሑድ፡</foreign> <locus target="#169rb"/>.</desc>
                         </item>
                         <item xml:id="e9">
                            <locus target="#3r"/>

--- a/ES/ESdd028.xml
+++ b/ES/ESdd028.xml
@@ -105,9 +105,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                  <dim unit="leaf">8</dim>
                                  <locus from="11r" to="18v"/></item>
                               <item xml:id="q4" n="3">
-
                                  <num value="3">፫</num>
-
                                  <dim unit="leaf">8</dim>
                                  <locus from="19r" to="26v"/></item>
                               <item xml:id="q5" n="4">
@@ -143,9 +141,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                  <dim unit="leaf">8</dim>
                                  <locus from="85r" to="92v"/></item>
                               <item xml:id="q13" n="12">
-
                                  <num value="12">፲፪</num>
-
                                  <dim unit="leaf">8</dim>
                                  <locus from="93r" to="110v"/></item>
                               <item xml:id="q14" n="13">

--- a/ES/ESdd028.xml
+++ b/ES/ESdd028.xml
@@ -180,8 +180,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                  <num value="20">፳</num>
                                  <dim unit="leaf">8</dim>
                                  <locus from="168r" to="175v"/> 
-                                 5 stub after 4
-                                 9 is missing
+                                 5 stub after 4,
+                                 9 is missing.
 
                                  <note>The last leaf of the codex has been removed.</note></item>
                            </list>
@@ -211,7 +211,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A/0-0/0-0/C</ab>
                            <ab type="pricking">Primary pricks are visible.</ab>
                            <ab type="pricking">Ruling pricks are not visible.</ab>
-                           <ab type="ruling">The upper line is written above the ruling (below the ruling on <locus from="79r" to="80v"/>).</ab>
+                           <ab type="ruling">The upper line is written above the ruling; below the ruling on <locus from="79r" to="80v"/>.</ab>
                            <ab type="ruling">The bottom line is written above the ruling. The bottom ruled line was not used by the scribe on <locus from="78v" to="80v"/>.</ab>
 
                         </layout>
@@ -244,20 +244,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      <handNote xml:id="h1" script="Ethiopic">
                         <seg type="script">Eighteenth-century script (?)</seg>
                         <seg type="ink">Black, red.</seg>
-                        <date notBefore="1700" notAfter="1799" cert="medium">18th century (?)</date>
                         <desc>Fine, careful. Numeral <foreign xml:lang="gez">፮</foreign> ‘six’ looks like compressed numeral <foreign xml:lang="gez">፯</foreign> ‘seven’.
                            The scribe reduced the size of his handwriting to accommodate the whole line or the end of the line: <locus target="#19r #25v #41v #42v #72v #84v #111v #120v #121r #138v"/>.
-                           Part of the line is taken up: <locus target="#10v #25r #72v #146r #155v"/>
+                           Part of the line is taken up: <locus target="#10v #25r #72v #146r #155v"/>.
                         </desc>
                         
                         <list type="abbreviations">
-                           <item>Abbreviations in <ref target="#ms_i1.1"/> Text 1.1, Ps. 135<locus target="#127rv"/>
+                           <item>Abbreviations in <ref target="#ms_i1.1"/> Ps. 135<locus target="#127rv"/>
                               <list>
                                  <item>
                                  <abbr>እ፡</abbr> for <expan>እስመ፡ ለዓለም፡ ምሕረቱ፡</expan> </item>
                                  </list>
                            </item>
-                           <item>Abbreviations in <ref target="#ms_i1.2"/> Text 1.2, Canticle 10<locus target="#147rv"/>
+                           <item>Abbreviations in <ref target="#ms_i1.2"/> Canticle 10<locus target="#147rv"/>
                                  <list>
                                     <item>
                               <abbr>ስ፡</abbr> for <expan>ስቡሕኒ፡ ውእቱ፡ ወልዑልኒ፡ ውእቱ፡ ለዓለም፡</expan>
@@ -268,7 +267,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               <list>
                            <item>
                               <abbr>ሰአ፡ (ቅ፡)</abbr> for <expan>ሰአሊ፡ ለነ፡ ቅድስት፡</expan></item>
-                           <item>Words or their abbreviations stand for the whole refrain.</item>
+                           <item>Words or their abbreviations stand for the whole refrain for the following items:</item>
                            <item>
                               <abbr>ሠ፡</abbr> for <expan>ሠረቀ፡ በሥጋ፡ እምድንግል፡ ዘእንበለ፡ ዘርአ፡ ብእሲ፡ ወአድኅነነ፡</expan>
                                (<locus from="159va" to="160rb"/>)</item>
@@ -296,7 +295,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               <list>
                                  <item>
                                     <abbr>ወ፡ ሣ፡ ይ፡ ሰ፡ ቅ፡</abbr> for <expan>ወልድኪ፡ ሣህሎ፡ ይክፈለነ፡ ሰአሊ፡ ለነ፡ ቅድስት፡</expan></item>
-                           <item>The abbreviations stand for the whole refrain.</item>
+                           <item>The abbreviations stand for the whole refrain for the following item:</item>
                            <item>
                               <abbr>ወ፡ / ወበ፡</abbr> for <expan>ወበእንተዝ፡ ናዓብየኪ፡ ኵልነ፡ ኦእግዝእትነ፡ ወላዲተ፡ አምላክ፡ ንጽሕት፡ ኵሎ፡ ጊዜ፡ ንስእል፡ ወናንቀዓዱ፡ ከመ፡ ንርከብ፡ ሣህለ፡ በኀበ፡ መፍቀሬ፡ ሰብእ፡</expan>
                                (<locus from="171vb" to="175ra"/>)</item>
@@ -307,11 +306,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            titles and numbers of the Psalms and Canticles; incipits and numbers of the Song of Songs; 
                            title of <ref target="#ms_i1.2"/>, <ref target="#ms_i1.3"/> and <ref target="#ms_i1.5"/>; title and incipit of the daily
                            readings of <ref target="#ms_i1.4"/>; refrains of <ref target="#ms_i1.4"/> and <ref target="#ms_i1.5"/> (written out fully or abbreviated); 
-                           name of the Hebrew letters in <ref target="#ms_i1.1"/> Text 1.1, Ps. 118; letter <foreign xml:lang="gez">እ</foreign> in the word <foreign xml:lang="gez">እስመ፡</foreign> in <ref target="#ms_i1.1"/> Text 1.1, Ps. 135;
+                           name of the Hebrew letters in <ref target="#ms_i1.1"/> Ps. 118; letter <foreign xml:lang="gez">እ</foreign> in the word <foreign xml:lang="gez">እስመ፡</foreign> in <ref target="#ms_i1.1"/> Ps. 135;
                            names of the days of the week in the upper margin in <ref target="#ms_i1.4"/>; 
                            elements of the punctuation signs; Ethiopic numerals or their elements. 
                            A few groups of lines (alternating with black lines) on the incipit page of <ref target="#ms_i1.1"/>; two lines (alternating with a black
-                           line) on the incipit page of <ref target="#ms_i1.1"/> Text 1.1, Ps. 101 (<locus target="85r"/>) and of <ref target="#ms_i1.4"/>.</seg>
+                           line) on the incipit page of <ref target="#ms_i1.1"/> Ps. 101 (<locus target="85r"/>) and of <ref target="#ms_i1.4"/>.</seg>
                      </handNote>
                      
                   </handDesc>
@@ -322,7 +321,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <desc>Small cross in black and red.</desc>
                      </decoNote>
                      <decoNote type="frame" xml:id="d2">
-                        <locus target="#84v"/>Explicit of <ref target="#ms_i1.1"/> Text 1.1, Ps 100; simple coloured (red, black) ornamental band, geometric motifs.</decoNote>
+                        <locus target="#84v"/>Explicit of <ref target="#ms_i1.1"/> Ps 100; simple coloured (red, black) ornamental band, geometric motifs.</decoNote>
                   </decoDesc>
                   <additions>
                      <list>
@@ -330,7 +329,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <locus target="#3r #98r #120r #131r #137v #151v #159r"/>
                            <desc type="Supplication">Supplication for protection written in the same secondary hand as <ref target="#a2 #a3"/>. 
                               The name of the original supplicant, <persName role="owner" ref="PRS14688WaldaMaryam">Walda Māryām</persName>, has been erased and replaced with that of <persName role="owner" ref="PRS14689GabraIyasus">Gabra ʾIyasus</persName>. 
-                              Some of the supplications were overwritten by another hand and supplied with the name of <persName role="owner" ref="PRS14689GabraIyasus">Gabra ʾIyasus</persName>.</desc>
+                              Some of the supplications were overwritten by the same hand and supplemented with the name of <persName role="owner" ref="PRS14689GabraIyasus">Gabra ʾIyasus</persName>.</desc>
                            <q xml:lang="gez">ኦአምላከ፡ ዳዊት፡ ዕቀበኒ፡ እመከራ፡ ሥጋ፡ ወነፍስ፡ ለገብርከ፡ <persName role="owner" ref="PRS14689GabraIyasus">ገብረ፡ ኢየሱስ</persName>።</q>
                         </item>
                         <item xml:id="a2">
@@ -349,7 +348,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <item xml:id="a4">
                            <locus target="#159r"/>
                            <desc type="OwnershipNote">Ownership note written in the same hand as <ref target="#a5"/>. <foreign >ʾAndǝnnat</foreign> (‘unity, oneness’) is the Amharic term for the coenobitic monastic community.</desc>
-                           <q xml:lang="gez">ዝመጻሃፍ፡ ዘማህበር፡ አንድነት</q>
+                           <q xml:lang="gez">ዝመጻሃፍ፡ ዘማህበር፡ አንድነት፡</q>
                            <q xml:lang="en">This book is of the coenobitic community.</q>
                         </item>
                         <item xml:id="a5">
@@ -359,20 +358,20 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </item>
                         <item xml:id="a6">
                            <locus target="#175v"/>
-                           <desc type="GuestText"><title type="incomplete" corresp="LIT6205Saalnaka">Saʿālnāka maḥari... ‘We ask You, the Merciful...’</title>, litanic prayer written in a secondary hand.</desc>
-                           <q xml:lang="gez"> ሰዓልናከ፡  አምላከ፡ መሐሪ፡ ሰዓልናከ፡ ሰዓልናከ፡
+                           <desc type="GuestText"><title type="incomplete" ref="LIT6205Saalnaka">Saʿalnāka maḥari ‘We beseech You, merciful God...’</title>, litanic prayer written in a secondary hand.</desc>
+                           <q xml:lang="gez">ሰዓልናከ፡ አምላከ፡ መሐሪ፡ ሰዓልናከ፡ ሰዓልናከ፡
                               አምላከ፡ ከህሊ፡ ሰዓልናከ። ሰዓልናከ፡ አምላከ፡ ፈጣሪ፡ ሰዓልናከ። ዘሰዐሉከ፡ ዘኢትከልዕ፡ ዘኢትፈልጥ፡
                               ወዘኢትሊሊ፡ የማንከ፡ ነቅዓ፡ ኅይወት፡ የማንከ፡ ነቅዓ፡ ፊልፊለ፡ በረከተ፡ ወሐሴት፤ ባርከኒ፡ ክርስቶስ፡
                               በበረከተ፡ ነቢያት፡ ወሐዋርያት፤ በበረከተ፡ ጻድቃን፡ ወሰማዕታት፤ በበረከተ፡ ደናግል፡ ወመነኰሳት፤ በበረከተ፡
                               ትጉሃን፡ መላእክት፤ በበረከታ፡ ለእግዝእትነ፡ ማርያም፡ ወላዲተ፡ አምላክ፡ በበረከ... </q>
                            <q xml:lang="en">We beseech You, merciful God, we
                               beseech You, We beseech You, mighty God, we beseech You, We beseech
-                              You, Creator, we beseech You, Do not reject, do not detach, do not
+                              You, Creator, we beseech You. Do not reject, do not detach, do not
                               withdraw from those who beg You Your right hand – the fountain of life
-                              Your right hand – the fountain of blessing and joy Bless us, o Christ,
-                              with the gifts of the prophets and the apostles With the gifts of the
-                              righteous and martyrs With the gifts of the pure and monks With the
-                              gifts of vigilant angels With the gifts of Our Lady Mary, the Mother
+                              Your right hand – the fountain of blessing and joy; bless us, o Christ,
+                              with the gifts of the prophets and the apostles; with the gifts of the
+                              righteous and martyrs; with the gifts of the pure and monks; with the
+                              gifts of vigilant angels; with the gifts of Our Lady Mary, the Mother
                               of God....</q>
                            <note>For the same prayer see <ref type="mss" corresp="ESsdm023"/>, <ref type="mss" corresp="EMML328"/> and <ref type="mss" corresp="EMML931"/> </note>
                         </item>
@@ -416,10 +415,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <locus target="#3r"/>
                            <desc type="StampExlibris">Shelfmark C3-IV-276</desc>
                         </item>
-                        <item xml:id="e10">
-                           <locus target="#1r"/>
-                           <desc type="StampExlibris">Shelfmark 324</desc>
-                        </item>
                      </list>
                   </additions>
                   <bindingDesc>
@@ -444,7 +439,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <placeName ref="INS0105DD"/>
                      </origPlace>
                      <origDate notBefore="1700" notAfter="1799" cert="medium" source="lettering">18th century (?)</origDate>
-                     Most probably the manuscript first belonged to <persName role="owner" ref="PRS14688WaldaMaryam">Walda Māryām</persName> (see <ref target="#a1 #a2 #a3"/>) and then to <persName role="owner" ref="PRS14689GabraIyasus">Gabra ʾIyasus</persName> (see <ref target="#a1"/>).
+                     Most probably the manuscript first belonged to <persName role="owner" ref="PRS14688WaldaMaryam">Walda Māryām</persName>, see <ref target="#a1 #a2 #a3"/>, and then to <persName role="owner" ref="PRS14689GabraIyasus">Gabra ʾIyasus</persName>, see <ref target="#a1"/>.
                   </origin>
                   <provenance>According to <ref target="#a4"/>, the manuscript belongs to the coenobitic community.</provenance>
                </history>

--- a/ES/ESdd028.xml
+++ b/ES/ESdd028.xml
@@ -397,7 +397,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </item>
                         <item xml:id="e7">
                            <locus target="#2v #36r #41r #42r #74r #133r #152v"/>
-                           <desc type="Unclear">Scribbles.</desc></item>
+                           <desc>Scribbles.</desc></item>
                         <item xml:id="e8">
                            <desc type="findingAid">Daily readings of <ref target="#ms_i1.4"/> are indicated by the names of the days of the week written in the upper margin, in the <ref target="#h1">main hand</ref>:
                            <foreign xml:lang="gez">ዘሠሉሥ፡</foreign> <locus target="#160va"/> 
@@ -434,7 +434,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      <origPlace>
                         <placeName ref="INS0105DD"/>
                      </origPlace>
-                     <origDate notBefore="1700" notAfter="1799" cert="medium" source="lettering">18th century (?)</origDate>
+                     <origDate notBefore="1700" notAfter="1799" cert="medium" evidence="lettering">18th century (?)</origDate>
                      Most probably the manuscript first belonged to <persName role="owner" ref="PRS14688WaldaMaryam">Walda Māryām</persName>, see <ref target="#a1 #a2 #a3"/>, and then to <persName role="owner" ref="PRS14689GabraIyasus">Gabra ʾIyasus</persName>, see <ref target="#a1"/>.
                   </origin>
                   <provenance>According to <ref target="#a4"/>, the manuscript belongs to the coenobitic community.</provenance>


### PR DESCRIPTION
I have made some small changes to optimize the visualization. 
As in DD-034 there are no commas between folia in quire marks. No idea why. Maybe you can figure out? 
`   <signatures>Undecorated quire marks are written in the left upper margin of
                              <locus target="#11r #19r #27r #35r #43r #51r #59r #67r #75r #85r #93r #111r #119r #128r #136r #144r #152r #160r #168r"/>.
                           </signatures>`

Here is the visualisation. 

![image](https://github.com/user-attachments/assets/0749b2f2-f270-45b1-b105-54d221cbcf38)
