### PR TITLE
Create BLorient12114B

### DIFF
--- a/LondonBritishLibrary/orient/BLorient11763.xml
+++ b/LondonBritishLibrary/orient/BLorient11763.xml
@@ -68,7 +68,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </handDesc>
                         <decoDesc>
                             <decoNote xml:id="d1" type="drawing">
-                                <desc>One coloured <term key="Magic">magic picture</term>.</desc>
+                                <desc>One coloured <term key="MagicDrawing">magic picture</term>.</desc>
                             </decoNote>
                         </decoDesc>
                         <bindingDesc>

--- a/LondonBritishLibrary/orient/BLorient11764.xml
+++ b/LondonBritishLibrary/orient/BLorient11764.xml
@@ -73,7 +73,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                         <height>1730</height>
                                         <width>70</width>
                                     </dimensions>
-                                    <note>Composed of three strips.</note>
+                                    <note>Scroll composed of <measure unit="strips">3</measure> strips.</note>
                                 </extent>
                             </supportDesc> 
                         </objectDesc>
@@ -85,19 +85,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </handDesc>
                         <decoDesc>
                             <decoNote xml:id="d1" type="drawing">
-                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
+                                <desc>Coloured <term key="MagicDrawing">magic picture</term>.</desc>
                             </decoNote>
                             <decoNote xml:id="d2" type="drawing">
-                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
+                                <desc>Coloured <term key="MagicDrawing">magic picture</term>.</desc>
                             </decoNote>
                             <decoNote xml:id="d3" type="drawing">
-                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
+                                <desc>Coloured <term key="MagicDrawing">magic picture</term>.</desc>
                             </decoNote>
                             <decoNote xml:id="d4" type="drawing">
-                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
+                                <desc>Coloured <term key="MagicDrawing">magic picture</term>.</desc>
                             </decoNote>
                             <decoNote xml:id="d5" type="drawing">
-                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
+                                <desc>Coloured <term key="MagicDrawing">magic picture</term>.</desc>
                             </decoNote>
                         </decoDesc>
                     </physDesc>

--- a/LondonBritishLibrary/orient/BLorient12114B.xml
+++ b/LondonBritishLibrary/orient/BLorient12114B.xml
@@ -22,8 +22,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                 <msDesc xml:id="ms">
                     <msIdentifier>
                         <repository ref="INS00001BL"/>
-                        <idno>BL Oriental 12114B</idno>
-                        <altIdentifier><idno>Or. 12114B</idno></altIdentifier>
+                        <idno>BL Oriental 12114 B</idno>
+                        <altIdentifier><idno>Or. 12114 B</idno></altIdentifier>
                         <altIdentifier><idno>Strelcyn 88</idno></altIdentifier>
                     </msIdentifier>
                     <msContents>
@@ -70,31 +70,32 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             <textLang mainLang="gez"/>
                         </msItem>
                         <msItem xml:id="ms_i5">
-                            <title ref="LIT0000000000000000000000000000000">Prayer for a successful delivery</title>
+                            <title ref="LIT7283PrBirth">Prayer for a successful delivery</title>
                             <note>Written on the fourth page of the recto.</note>
                             <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ ወሊድ፡ ቤሃ፡ ፯ ጊዜ። ለልሃ፡ ፯ ጊዜ፡</incipit>
                             <textLang mainLang="gez"/>
                         </msItem>
                         <msItem xml:id="ms_i6">
-                            <title ref="LIT0000000000000000000000000000000">Prayer for pregnant women</title>
-                            <note>Written on the fifth page of the recto.</note>
+                            <title ref="LIT4274AkkonuB#Stanza31"/>
+                            <note>31st stanza of <ref type="work" corresp="LIT4274AkkonuB#Stanza31"/> being a prayer for a pregnant woman.
+                               The text is written on the fifth page of the recto.</note>
                             <incipit xml:lang="gez">ለብእሲት፡ ፅንስት፡ ወልድ፡ ወሐሪስ። ማዕከለ፡ ሞገድ፡ መፍርህ፡ ዘከደንኪያ፡ በልብስ፡</incipit>
                             <textLang mainLang="gez"/>
                         </msItem>
                         <msItem xml:id="ms_i7">
-                            <title ref="LIT0000000000000000000000000000000">Prayer for a successful delivery</title>
+                            <title ref="LIT7284PPBirth"/>
                             <note>Written on the fifth to seventh page of the recto.</note>
-                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/>ጸሎት፡ በእንተ፡ ሕማመ፡ ወሊድ፡ ቁርቃር፡ 
-                                7 ጊዜ፡
-                                በል።<pb/><gap reason="ellipsis"/> ፍታሕ፡ ማኅፀና፡ ለልጁ፡ ወለእንግዴ፡ ልጅ፡ ለዓመትከ፡ እገሊት፡ በስሙ፡ ለአብ፡</incipit>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/>ጸሎት፡ በእንተ፡ ሕማመ፡ ወሊድ፡ ቁርቃር፡ ፯ ጊዜ፡ በል።<pb/><gap reason="ellipsis"/> 
+                                ፍታሕ፡ ማኅፀና፡ ለልጁ፡ ወለእንግዴ፡ ልጅ፡ ለዓመትከ፡ እገሊት፡ በስሙ፡ ለአብ፡</incipit>
                             <explicit xml:lang="gez">አርግዕ፡ ደማ፡ ለ<pb/>ዓመትከ፡ እገሊት።</explicit>
                             <textLang mainLang="gez"/>
                         </msItem>
                         <msItem xml:id="ms_i8">
-                            <title ref="LIT0000000000000000000000000000000">Salām to Phanuel, followed by a prayer for a safe delivery</title>
+                            <title ref="LIT7300PrPhanuel"/>
                             <note>Written on the seventh page of the recto.</note>
                             <incipit xml:lang="gez">ሰላም፡ ለልሳንከ፡ ዘኢጸርዕ፡ ስብሐታተ።</incipit>
-                            <explicit xml:lang="gez">ኦአምላከ፡ ፋኑኤል፡ ፈውሳ፡ እምሕማመ፡ ወሊድ፡ ለዓመትከ፡ እገሊት። <add place="unspecified">በማይ፡ ድግም፡ አስትያ።</add></explicit>
+                            <explicit xml:lang="gez">ኦአምላከ፡ ፋኑኤል፡ ፈውሳ፡ እምሕማመ፡ ወሊድ፡ ለዓመትከ፡ እገሊት። 
+                                <add place="unspecified">በማይ፡ ድ<choice><sic>ግ</sic><corr>ገ</corr></choice>ም፡ አስትያ።</add></explicit>
                             <textLang mainLang="gez"/>
                         </msItem>
                         <msItem xml:id="ms_i9">
@@ -138,13 +139,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </handDesc>
                         <decoDesc>
                             <decoNote xml:id="d1" type="drawing">
-                                <desc><term key="Magic">Magic drawing</term> on the first page of the recto.</desc>
+                                <desc><term key="MagicDrawing">Magic drawing</term> on the first page of the recto.</desc>
                             </decoNote>
                             <decoNote xml:id="d2" type="drawing">
-                                <desc><term key="Magic">Magic drawing</term> on the second page of the recto.</desc>
+                                <desc><term key="MagicDrawing">Magic drawing</term> on the second page of the recto.</desc>
                             </decoNote>
                             <decoNote xml:id="d3" type="drawing">
-                                <desc><term key="Magic">Magic drawing</term> on the third page of the recto.</desc>
+                                <desc><term key="MagicDrawing">Magic drawing</term> on the third page of the recto.</desc>
                             </decoNote>
                         </decoDesc>
                         <additions>

--- a/LondonBritishLibrary/orient/BLorient12114B.xml
+++ b/LondonBritishLibrary/orient/BLorient12114B.xml
@@ -64,7 +64,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <msItem xml:id="ms_i4">
                             <title ref="LIT7282ColicPleurisy"/>
                             <note>Written on the third page of the recto.</note>
-                            <incipit xml:lang="gez">ጋኔን፡ <gap reason="ellipsis"/> አውዬን፡ <gap reason="ellipsis"/> በዝንቱ፡ አስማቲከ፡ አድኅኖ፡ 
+                            <incipit xml:lang="gez">ጋኔን፡ ጋኔን፡ አውዬን፡ አውዬን፡ በዝንቱ፡ አስማቲከ፡ አድኅኖ፡ 
                                 እመኳንንተ፡ ጽል<choice><sic>ማ</sic><corr>መ</corr></choice>ት፡ ወእምእለ፡ ይነከንኩ፡ ነፍስ፡ ወሥጋ፡</incipit>
                             <explicit xml:lang="gez">፯ ጊዜ፡ ድግም፡ በማተብ፡ ወበማይ፡ ለሆድ፡ ቍርፀት፡ ወለጉሥምት፡</explicit>
                             <textLang mainLang="gez"/>

--- a/LondonBritishLibrary/orient/BLorient12114B.xml
+++ b/LondonBritishLibrary/orient/BLorient12114B.xml
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" type="mss" xml:lang="en" xml:id="BLorient12114B">
+    <teiHeader xml:base="https://betamasaheft.eu/">
+        <fileDesc>
+            <titleStmt>
+                <title>Concertina with magic prayers and prescriptions</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS00001BL"/>
+                        <idno>BL Oriental 12114B</idno>
+                        <altIdentifier><idno>Or. 12114B</idno></altIdentifier>
+                        <altIdentifier><idno>Strelcyn 88</idno></altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                        <summary/>
+                        <msItem xml:id="ms_i1">
+                            <title>Prayers against vaginal haemmorrhage</title>
+                            <note>Written on the first page of the recto.</note>
+                            <msItem xml:id="ms_i1.1">
+                                <title ref="LIT7263PPHaem"/>
+                                <incipit xml:lang="gez">ጨራታኤል፡ በርናኤል፡ ከኩሳኤል፡</incipit>
+                                <explicit xml:lang="gez">ክትር፡ ደመ፡ ዓመትከ፡ እገሊት።</explicit>
+                                <textLang mainLang="gez"/>                                
+                            </msItem>
+                            <msItem xml:id="ms_i1.2">
+                                <title ref="LIT7264PPHaemorrhage"/>
+                                <incipit xml:lang="gez">ሰየሃሃ፡ ቅቅ፡ ሶቤሃ፡ ላሃ፡ <gap reason="ellipsis"/> ከማሁ፡ አርግዕ፡ ደመ፡ ዓመትከ፡ 
+                                    <expan>እገ<abbr></abbr><ex>ሊት</ex></expan>፡ ለዝንቱ፡ ደም፡ እስከ፡ የዓርግ፡</incipit>
+                                <textLang mainLang="gez"/>                                
+                            </msItem>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <title ref="LIT7277PrDiseases">Anathema against the diseases of Bāryā, the evil eye, chest pain,
+                                mǝtʿat, ṣǝfʿat, rheumatism, mǝč, Magāññā, contagion, fever, talāwāš, Legewon, Dask, and the eye of the shadow</title>
+                            <note>Written on the second page of the recto.</note>
+                            <note>Containing <term key="MagicSymbols">magic glyphs (charaktêres)</term> in the incipit.</note>
+                            <incipit xml:lang="gez"><gap reason="ellipsis"/> ከማሁ፡ አጽርእ፡ ሕማመ፡ ባርያ፡ ወዓይነት፡ ወውግዓት፡ ወምትዓት፡ ወጽፍዓት፡ 
+                                ወqʷǝርጥማት፡
+                                ምች፡ መጋኛ፡ ወንዳድ፡ ወተላዋሽ፡ ወሌጌዎን፡ ደስክ፡ ወዓይነ፡ ጽላ፡ አውገዝ፡ ኩክሙ፡ እምላዕለ፡ ዓመትከ፡ 
+                                <expan><abbr>እገ</abbr><ex>ሊት</ex></expan>፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i3">
+                            <title ref="LIT7278AmhPrescription"/>
+                            <note>Written on the second page of the recto.</note>
+                            <incipit xml:lang="am">ጤና፡ አዳም፡ ቅጸል፡ ጸሌንጅ፡ ቅጸል፡</incipit>
+                            <textLang mainLang="am"/>
+                        </msItem>
+                        <msItem xml:id="ms_i4">
+                            <title ref="LIT7282ColicPleurisy"/>
+                            <note>Written on the third page of the recto.</note>
+                            <incipit xml:lang="gez">ጋኔን፡ <gap reason="ellipsis"/> አውዬን፡ <gap reason="ellipsis"/> በዝንቱ፡ አስማቲከ፡ አድኅኖ፡ 
+                                እመኳንንተ፡ ጽል<choice><sic>ማ</sic><corr>መ</corr></choice>ት፡ ወእምእለ፡ ይነከንኩ፡ ነፍስ፡ ወሥጋ፡</incipit>
+                            <explicit xml:lang="gez">፯ ጊዜ፡ ድግም፡ በማተብ፡ ወበማይ፡ ለሆድ፡ ቍርፀት፡ ወለጉሥምት፡</explicit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i5">
+                            <title ref="LIT0000000000000000000000000000000">Prayer for a successful delivery</title>
+                            <note>Written on the fourth page of the recto.</note>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ ወሊድ፡ ቤሃ፡ ፯ ጊዜ። ለልሃ፡ ፯ ጊዜ፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i6">
+                            <title ref="LIT0000000000000000000000000000000">Prayer for pregnant women</title>
+                            <note>Written on the fifth page of the recto.</note>
+                            <incipit xml:lang="gez">ለብእሲት፡ ፅንስት፡ ወልድ፡ ወሐሪስ። ማዕከለ፡ ሞገድ፡ መፍርህ፡ ዘከደንኪያ፡ በልብስ፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i7">
+                            <title ref="LIT0000000000000000000000000000000">Prayer for a successful delivery</title>
+                            <note>Written on the fifth to seventh page of the recto.</note>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/>ጸሎት፡ በእንተ፡ ሕማመ፡ ወሊድ፡ ቁርቃር፡ 
+                                7 ጊዜ፡
+                                በል።<pb/><gap reason="ellipsis"/> ፍታሕ፡ ማኅፀና፡ ለልጁ፡ ወለእንግዴ፡ ልጅ፡ ለዓመትከ፡ እገሊት፡ በስሙ፡ ለአብ፡</incipit>
+                            <explicit xml:lang="gez">አርግዕ፡ ደማ፡ ለ<pb/>ዓመትከ፡ እገሊት።</explicit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i8">
+                            <title ref="LIT0000000000000000000000000000000">Salām to Phanuel, followed by a prayer for a safe delivery</title>
+                            <note>Written on the seventh page of the recto.</note>
+                            <incipit xml:lang="gez">ሰላም፡ ለልሳንከ፡ ዘኢጸርዕ፡ ስብሐታተ።</incipit>
+                            <explicit xml:lang="gez">ኦአምላከ፡ ፋኑኤል፡ ፈውሳ፡ እምሕማመ፡ ወሊድ፡ ለዓመትከ፡ እገሊት። <add place="unspecified">በማይ፡ ድግም፡ አስትያ።</add></explicit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i9">
+                            <title ref="LIT7280PresBirthAmh"/>
+                            <note>Written on the second page of the verso.</note>
+                            <incipit xml:lang="gez">ቶሎ፡ ለማይ፡ ሂድ፡ ልጅ፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                        <msItem xml:id="ms_i10">
+                            <title ref="LIT7281PresCataractAmh"/>
+                            <note>Written on the third to seventh page of the verso.</note>
+                            <incipit xml:lang="gez">ዓይኑ፡ ለጣለበት፡</incipit>
+                            <textLang mainLang="gez"/>
+                        </msItem>
+                    </msContents>
+                        <physDesc>
+                            <objectDesc form="Leaf">
+                                <supportDesc>
+                                    <support>
+                                        <material key="parchment"/>
+                                    </support>
+                            <extent>
+                                <dimensions type="outer" unit="mm">
+                                    <height>445</height>
+                                    <width>70</width>
+                                </dimensions>
+                                <note><measure unit="strips">1</measure> strip of 445x70 mm folded to a concertina with eight pages of 56x70 mm, 
+                                    with the last page blank on both sides.</note>
+                            </extent>
+                            </supportDesc>
+                        </objectDesc>
+                        <handDesc>
+                            <handNote xml:id="h1" script="Ethiopic">
+                                <desc>Written in a small regular hand.</desc> 
+                                <date notAfter="1899" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                            <handNote xml:id="h2" script="Ethiopic">
+                                <desc>Written in a small regular hand.</desc> 
+                                <date notAfter="1899" resp="PRS8999Strelcyn"/>
+                            </handNote>
+                        </handDesc>
+                        <decoDesc>
+                            <decoNote xml:id="d1" type="drawing">
+                                <desc><term key="Magic">Magic drawing</term> on the first page of the recto.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d2" type="drawing">
+                                <desc><term key="Magic">Magic drawing</term> on the second page of the recto.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d3" type="drawing">
+                                <desc><term key="Magic">Magic drawing</term> on the third page of the recto.</desc>
+                            </decoNote>
+                        </decoDesc>
+                        <additions>
+                            <list>
+                                <item xml:id="a1">
+                                    <desc type="AcquisitionNote">Note on the first page of the verso.</desc> 
+                                    <q>Found in Theodore's Church, at the storming of Magdala</q>
+                                </item>
+                            </list>
+                        </additions>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notAfter="1867">Not after 1867.</origDate>
+                        </origin>
+                        <provenance></provenance> 
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1978BritishLibrary"/>
+                                            <citedRange unit="page">134-135</citedRange>
+                                        </bibl>
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+                <xi:fallback>
+                    <p>Definitions of prefixes used.</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
+        <profileDesc>
+            <textClass>
+                <keywords>
+                    <term key="Magic"/>
+                    <term key="Prayers"/>
+                    <term key="Asmat"/>
+                    <term key="EvilEye"/>
+                    <term key="demon"/>
+                    <term key="DiseaseWomen"/>
+                    <term key="DiseasePain"/>
+                    <term key="DiseaseFever"/>
+                    <term key="AmharicLiterature"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-01-31">Created record.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text xml:base="https://betamasaheft.eu/">
+        <body>
+            <ab/>
+        </body>
+    </text>
+</TEI>

--- a/LondonBritishLibrary/orient/BLorient13228.xml
+++ b/LondonBritishLibrary/orient/BLorient13228.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
-type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" type="mss" xml:lang="en" xml:id="BLorient11602">
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" type="mss" xml:lang="en" xml:id="BLorient13228">
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
@@ -22,49 +22,45 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                 <msDesc xml:id="ms">
                     <msIdentifier>
                         <repository ref="INS00001BL"/>
-                        <idno>BL Oriental 11602</idno>
-                        <altIdentifier><idno>Or. 11602</idno></altIdentifier>
-                        <altIdentifier><idno>Strelcyn 75</idno></altIdentifier>
+                        <idno>BL Oriental 13228</idno>
+                        <altIdentifier><idno>Or. 13228</idno></altIdentifier>
+                        <altIdentifier><idno>Strelcyn 89</idno></altIdentifier>
                     </msIdentifier>
                     <msContents>
                         <summary/>
                         <msItem xml:id="ms_i1">
-                            <title ref="LIT7074AynatTsella" type="incomplete"/>
-                            <note>The first two lines written in red containing probably magic characters are mostly illegible.</note>
-                            <incipit xml:lang="gez">በስመ፡ <gap reason="illegible"/> በዝ፡ ጠልሰም፡ ወበዝ፡ ክታብ፡ 
-                                አድኅ<supplied reason="undefined" resp="PRS8999Strelcyn">ነ</supplied>ኒ፡ እምሕማመ፡ ዓይነ፡ ጽላ፡ አድኅኖ፡ ለገብረ፡ እግዚአብሔር፡ 
-                                ኪዳነ፡ ማርያም፡</incipit>
+                            <title ref="LIT0000000000000000000000">Prayer against the evil eye of Bāryā, Maggāññā, Šotolāy, Tayāž, Ṣārāri, Zār, ...,
+                                Dǝdǝq, and the demon of noon.</title>
+                            <note>Containing <ref type="work" corresp="LIT1763Legend"/>.</note>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="illegible"/> ጸሎት፡ በእንተ፡ ሕማመ፡ ዓይነት፡ ባርያ፡ ወመጋኛ፡ ወሾቶላይ፡ ተያዥ፡ ወፃራሪ፡ ዛር፡ 
+                                ወተዋ<gap reason="illegible"/>ድድቅ፡ ወጋኔነ፡ ቀትር፡ በስመ፡ እግዚአብሔር፡ ሕያው፡ ነባቢ፡ ወተናጋሪ፡ ጸሎተ፡ ቅዱስ፡ 
+                                ሱ<choice><sic>ሱ</sic><corr>ስ</corr></choice>ንዮስ፡ በእንተ፡ አሰስሎ፡ ደዌ፡ እምሕፃናት፡ እለ፡ ደጠብው፡ ጥበ፡ እሞሙ፡</incipit>
                             <textLang mainLang="gez"/>
                         </msItem>
                         <msItem xml:id="ms_i2">
-                            <title ref="LIT1763Legend">Magic prayer to Susǝnyos to protect suckling infants</title>
-                            <incipit xml:lang="gez">በስመ፡<gap reason="ellipsis"/> በስመ፡ እግዚአብሔር፡ ሕያው፡ ነባቢ፡ ወተናጋሪ፡ ለቅዱስ፡ ሱስንዮስ፡ በእንተ፡ አሰስሎ፡
-                                ደዌ፡ እምሕፃናት፡ እለ፡ ይጠብው፡ ጥበ፡ እሞሙ፡ </incipit>
+                            <title ref="LIT0000000000000000000000">Prayer against the evil eye of Bāryā, Magāññā, and Šotolāy, chest pain, rheumatism,
+                                pleurisy, colic, Budā, and blacksmiths</title>  
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="illegible"/> ጸሎት፡ በእንተ፡ ዓይነተ፡ ባርያ፡ መጋኛ፡ ወሾቶላይ፡ ውግዓት፡ ወቍርጥማት፡ ፍልፀት፡ 
+                                ወ<supplied reason="omitted" resp="PRS8999Strelcyn">ቍ</supplied>ርጸት፡ ቡዳ፡ ወጠቢብ። አአትብ፡ ገጽየ፡ ከመ፡ ኢይቅረብ፡ ደልፋኤል፡
+                                ሀልኤል፡</incipit>
                             <textLang mainLang="gez"/>
                         </msItem>
                         <msItem xml:id="ms_i3">
-                            <title ref="LIT7080NamesGod" type="incomplete"/>
-                            <note>The end is missing.</note>
-                            <incipit xml:lang="gez">በስመ፡<gap reason="ellipsis"/> ዝውእቱ፡ አስማቲሁ፡ ለእግዚአብሔር፡ ዘየአምር፡ አልኤና፡ እግዚአብሔር፡ ኵሎ፡ አሚረ፡ 
-                                ሕልው፡ እግዚአብሔር፡ ዘይጼሉ፡ ሀልዮሙ፡ ወመስተሣህል፡ ልዑል፡ ኀያል፡ ባዕል፡ ኄር፡ ክቡር፡ ወመንክር፡ ማዕምር፡ ወመምህር፡</incipit>
+                            <title ref="LIT0000000000000000000000">Prayer against rheumatism</title>  
+                            <incipit xml:lang="gez">ጸሎት፡ በእንተ፡ ሕማመ፡ ቍትጥማት፡ ቀር<sic>ር</sic>ጥማትስ፡</incipit>
                             <textLang mainLang="gez"/>
                         </msItem>
                         <msItem xml:id="ms_i4">
-                            <title ref="LIT7127Manso"/>
-                            <incipit xml:lang="gez">በስመ፡<gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ ሕማመ፡ ዓይነት፡ ወመንሶ፡ ወማዕሠረ፡ አጋንንት፡ ኢትቅረቡ፡ በሌሊት፡
-                                ዕቀበኒ፡ መስቀል፡ መድኃኒተ፡ ኵሉ፡ ዓለም። መስቀል፡ መግረሬ፡ ፀር፡ መስቀል፡ መዋዔ፡ ፀር፡</incipit>
+                            <title ref="LIT0000000000000000000000">Prayer against chest pain</title>
+                            <incipit xml:lang="gez">ጸሎት፡ በእንት፡ ሕማመ፡ ውግዓት፡ ሊቃኖስ፡ ብሂል፡ ዕፁብ፡</incipit>
                             <textLang mainLang="gez"/>
                         </msItem>
                         <msItem xml:id="ms_i5">
-                            <title ref="LIT7085Papur">Magic prayer for binding demons</title>
-                            <incipit xml:lang="gez">በስመ፡<gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ ማዕሠረ፡ አጋንንት፡ ጰጱር፡ ጵውያካኤል፡</incipit>
+                            <title ref="LIT00000000000000000000000000">Prayer against the evil eye of Bāryā</title>
+                            <note>Containing a salām to the archangel <persName ref="PRS7840Phanuel">Phanuel</persName>.</note>
+                            <incipit xml:lang="gez">ጸሎት፡ በእንተ፡ ሕማመ፡ ዓይነተ፡ ባርያ።</incipit>
                             <textLang mainLang="gez"/>
-                        </msItem>
-                        <msItem xml:id="ms_i6">
-                            <title ref="LIT7093BlackBarya"/>
-                            <incipit xml:lang="gez">በስመ፡<gap reason="ellipsis"/> ተሰደድ፡ አንተ፡ ባርያ፡ ጸሊም፡ አጽመ፡ ዘትሰብር፡</incipit>
-                            <textLang mainLang="gez"/>
-                        </msItem>
+                        </msItem> 
                     </msContents>
                     <physDesc>
                         <objectDesc form="Scroll">
@@ -75,17 +71,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                 <extent>
                                     <measure unit="leaf">1</measure>
                                     <dimensions type="outer" unit="mm">
-                                        <height>1620</height>
-                                        <width>115</width>
+                                        <height>1770</height>
+                                        <width>85</width>
                                     </dimensions>
                                     <note>Scroll composed of <measure unit="strips">3</measure> strips.</note>
                                 </extent>
+                                <condition>First strip is damaged at the top and on the right side.</condition>
                             </supportDesc> 
                         </objectDesc>
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <desc>Rather careful handwriting.</desc>
-                                <date notBefore="1700" notAfter="1799" resp="PRS8999Strelcyn"/>
+                                <desc>Rather careless handwriting.</desc>
+                                <date notBefore="1800" notAfter="1899" resp="PRS8999Strelcyn"/>
                             </handNote>
                         </handDesc>
                         <decoDesc>
@@ -95,26 +92,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             <decoNote xml:id="d2" type="miniature">
                                 <desc>Coloured <term key="MagicDrawing">magic picture</term>.</desc>
                             </decoNote>
-                            <decoNote xml:id="d3" type="miniature">
-                                <desc>Coloured <term key="MagicDrawing">magic picture</term>.</desc>
+                            <decoNote xml:id="d3" type="drawing">
+                                <desc><term key="MagicDrawing">Magic square</term> and 
+                                    <term key="MagicSymbols">magic glyphs (charaktêres)</term>.</desc>
                             </decoNote>
-                        </decoDesc>
-                        <additions>
-                            <list>
-                                <item xml:id="e1">
-                                    <desc type="Unclear"><term key="MagicSymbols">Magic glyphs (charaktêres)</term>.</desc>
-                                </item>
-                            </list>
-                        </additions>
+                        </decoDesc> 
                     </physDesc>
                     <history>
                         <origin>
-                            <origDate notBefore="1700" notAfter="1799">18th century</origDate>
+                            <origDate notBefore="1800" notAfter="1899">19th century</origDate>
                         </origin>
-                        <provenance>The owner was <persName role="owner" ref="PRS14537KidanaMaryam">Kidāna Māryām</persName>.</provenance>
-                        <acquisition>On a slip stuck on the verso: 
-                            'Bought of Mr. <persName role="owner" ref="PRS14536JLowe">J. St. Lowe</persName>.
-                            <date when="1936-08-15">15 Aug. 1936</date>.</acquisition>
+                        <provenance>The name of the owner is <persName role="owner" ref="PRS14711WalattaMad">Walatta Madḫen</persName></provenance>
+                        <acquisition></acquisition>
                     </history>
                     <additional>
                         <adminInfo>
@@ -123,7 +112,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                     <listBibl type="catalogue">
                                         <bibl>
                                             <ptr target="bm:Strelcyn1978BritishLibrary"/>
-                                            <citedRange unit="page">119</citedRange>
+                                            <citedRange unit="page">136</citedRange>
                                         </bibl>
                                     </listBibl>
                                 </source>
@@ -144,7 +133,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <langUsage><language ident="en">English</language><language ident="gez">Gǝʿǝz</language></langUsage>
         </profileDesc>
         <revisionDesc>
-            <change who="CH" when="2024-07-30">Created record.</change>
+            <change who="CH" when="2025-02-19">Created record.</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">

--- a/LondonBritishLibrary/orient/BLorient3663.xml
+++ b/LondonBritishLibrary/orient/BLorient3663.xml
@@ -74,7 +74,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                         <height>1735</height>
                                         <width>90</width>
                                     </dimensions>
-                                    <note>Composed of three strips.</note>
+                                    <note>Scroll composed of <measure unit="strips">3</measure> strips.</note>
                                 </extent>
                             </supportDesc> 
                         </objectDesc>
@@ -86,13 +86,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </handDesc>
                         <decoDesc>
                             <decoNote xml:id="d1" type="miniature">
-                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
+                                <desc>Coloured <term key="MagicDrawing">magic picture</term>.</desc>
                             </decoNote>
                             <decoNote xml:id="d2" type="miniature">
-                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
+                                <desc>Coloured <term key="MagicDrawing">magic picture</term>.</desc>
                             </decoNote>
                             <decoNote xml:id="d3" type="miniature">
-                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
+                                <desc>Coloured <term key="MagicDrawing">magic picture</term>.</desc>
                             </decoNote>
                         </decoDesc>
                         <additions>

--- a/LondonBritishLibrary/orient/BLorient3716b.xml
+++ b/LondonBritishLibrary/orient/BLorient3716b.xml
@@ -89,7 +89,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                         <height>1270</height>
                                         <width>75</width>
                                     </dimensions>
-                                    <note>Composed of two strips.</note>
+                                    <note>Scroll composed of <measure unit="strips">2</measure> strips.</note>
                                 </extent>
                             </supportDesc> 
                         </objectDesc>
@@ -101,13 +101,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </handDesc>
                         <decoDesc>
                             <decoNote xml:id="d1" type="drawing">
-                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
+                                <desc>Coloured <term key="MagicDrawing">magic picture</term>.</desc>
                             </decoNote>
                             <decoNote xml:id="d2" type="drawing">
-                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
+                                <desc>Coloured <term key="MagicDrawing">magic picture</term>.</desc>
                             </decoNote>
                             <decoNote xml:id="d3" type="drawing">
-                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
+                                <desc>Coloured <term key="MagicDrawing">magic picture</term>.</desc>
                             </decoNote>
                         </decoDesc>
                         <bindingDesc>

--- a/LondonBritishLibrary/orient/BLorient4865.xml
+++ b/LondonBritishLibrary/orient/BLorient4865.xml
@@ -74,7 +74,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                         <height>1670</height>
                                         <width>100</width>
                                     </dimensions>
-                                    <note>Composed of three strips.</note>
+                                    <note>Scroll composed of <measure unit="strips">3</measure> strips.</note>
                                 </extent>
                             </supportDesc> 
                         </objectDesc>
@@ -86,16 +86,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </handDesc>
                         <decoDesc>
                             <decoNote xml:id="d1" type="miniature">
-                                <desc><term key="Magic">Magic picture</term> in black and red.</desc>
+                                <desc><term key="MagicDrawing">Magic picture</term> in black and red.</desc>
                             </decoNote>
                             <decoNote xml:id="d2" type="miniature">
-                                <desc><term key="Magic">Magic picture</term> in black and red.</desc>
+                                <desc><term key="MagicDrawing">Magic picture</term> in black and red.</desc>
                             </decoNote>
                             <decoNote xml:id="d3" type="miniature">
-                                <desc><term key="Magic">Magic picture</term> in black and red.</desc>
+                                <desc><term key="MagicDrawing">Magic picture</term> in black and red.</desc>
                             </decoNote>
                             <decoNote xml:id="d4" type="miniature">
-                                <desc><term key="Magic">Magic picture</term> in black and red.</desc>
+                                <desc><term key="MagicDrawing">Magic picture</term> in black and red.</desc>
                             </decoNote>
                         </decoDesc>
                     </physDesc>

--- a/LondonBritishLibrary/orient/BLorient5423.xml
+++ b/LondonBritishLibrary/orient/BLorient5423.xml
@@ -75,7 +75,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </handDesc>
                         <decoDesc>
                             <decoNote xml:id="d1" type="miniature">
-                                <desc>A coloured magic picture at the top of the scroll.</desc>
+                                <desc>A coloured <term key="MagicDrawing">magic picture</term> at the top of the scroll.</desc>
                             </decoNote>
                         </decoDesc>
                         <bindingDesc>

--- a/LondonBritishLibrary/orient/BLorient5425.xml
+++ b/LondonBritishLibrary/orient/BLorient5425.xml
@@ -48,7 +48,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </msItem>
                         <msItem xml:id="ms_i3">
                             <title ref="LIT5889UndoingOfCharms"/>
-                            <note>Containing <term key="Magic">magic characters</term> after <foreign xml:lang="gez">ገብርከ፡ መድኅን፡</foreign>.</note>
+                            <note>Containing <term key="MagicSymbols">magic glyphs (charaktêres)</term> after <foreign xml:lang="gez">ገብርከ፡ መድኅን፡</foreign>.</note>
                             <incipit xml:lang="gez">ቆቤር፡ ጅጅብ፡ ላኂቢላሆሙ፡ ለዜቤለ፡ <gap reason="ellipsis"/> ፍታሕ፡ ሥራየ፡ ዘተገብረ፡ በላዕለ፡ ገብርከ፡ መድኅን፡ 
                                 <term key="Magic"><gap reason="illegible"/></term> ብእሲትየ፡ ወውሉድየ፡ ወአዝማድየ፡ ወዘአኀዝኩ፡ ኵሎ፡ በእዴየ፡ ተማኅፀንኩ፡ ከመ፡ ኢይቅረቡኒ፡ ሶበድአት፡ ወቃግስት፡ 
                                 በ፸፻፼አእላፋት፡ ወትእልፊተ፡ አእላፋት፡ ስሙ፡ ለአብ፡ በ፸፻፼አእላፋት፡ ወትእልፊተ፡ አእላፋት፡ ስሙ፡ ለወልድ፡ በ፸፻፼አእላፋት፡ ወትእልፊተ፡ አእላፋት፡ ስሙ፡ 
@@ -95,7 +95,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                         <height>1410</height>
                                         <width>125</width>
                                     </dimensions>
-                                    <note>Composed of two strips.</note>
+                                    <note>Scroll composed of <measure unit="strips">2</measure> strips.</note>
                                 </extent>
                             </supportDesc> 
                         </objectDesc>
@@ -107,13 +107,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </handDesc>
                         <decoDesc>
                             <decoNote xml:id="d1" type="miniature">
-                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
+                                <desc>Coloured <term key="MagicDrawing">magic picture</term>.</desc>
                             </decoNote>
                             <decoNote xml:id="d2" type="miniature">
-                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
+                                <desc>Coloured <term key="MagicDrawing">magic picture</term>.</desc>
                             </decoNote>
                             <decoNote xml:id="d3" type="miniature">
-                                <desc>Coloured <term key="Magic">magic picture</term>.</desc>
+                                <desc>Coloured <term key="MagicDrawing">magic picture</term>.</desc>
                             </decoNote>
                         </decoDesc>
                     </physDesc>

--- a/LondonBritishLibrary/orient/BLorient5426.xml
+++ b/LondonBritishLibrary/orient/BLorient5426.xml
@@ -143,7 +143,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </handDesc>
                         <decoDesc>
                             <decoNote xml:id="d1" type="miniature">
-                                <desc>A magic picture.</desc>
+                                <desc><term key="MagicDrawing">Magic picture</term>.</desc>
                             </decoNote>
                         </decoDesc>
                     </physDesc>

--- a/PrivateCollections/Ethiopia/MarigetaDamdaEndalaw/MD001.xml
+++ b/PrivateCollections/Ethiopia/MarigetaDamdaEndalaw/MD001.xml
@@ -143,14 +143,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                        
                         <handDesc>
                             <handNote xml:id="h1" script="Ethiopic">
-                                <desc>Regular hand. The manuscript was copied by two scribes.
+                                <desc>Regular hand. The first 105 folios copied by<persName ref="PRS14581MarigetaCakola" 
+                                    role="scribe">
+                                </persName>
                                 </desc>
                                 <seg type="ink">Black, red.</seg>
-                                <date from="1950" to="1958" evidence="internal-date"> </date>
-                                <note>Marigetā Čakola (<persName ref="PRS14417MarigetaDamseEndalew"/> maternal grandfather)
-                                    copied the first 105 folios, while Marigetā Damḍa copied the last 21, with a twelve-year gap between the two 
-                                    productions. </note>
+                                <date from="1950" to="1958" evidence="internal-date"> </date>                              
+                                <note><persName ref="PRS14581MarigetaCakola"/> is maternal grandfather of
+                                    <persName ref="PRS14417MarigetaDamseEndalew"/>. The last 21 folios of the manuscript were copied after 
+                                    a twelve-year gap following the first 150 folios.</note>
                             </handNote>
+                            <handNote xml:id="h2" script="Ethiopic">
+                                <desc>Regular hand. The last 21 folies copied by <persName ref="PRS14417MarigetaDamseEndalew" 
+                                    role="scribe"/>
+                                </desc>
+                                <seg type="ink">Black, red.</seg>
+                                <date  when="1958" evidence="internal-date"> </date>
+                                </handNote>
                         </handDesc>                       
                         <bindingDesc>
                             <binding contemporary="true" xml:id="binding">                                


### PR DESCRIPTION
I created a record for BLorient12114B according to the description in St. Strelcyns catalogue, including new LIT IDs for magic prayers as discussed in: 
https://github.com/BetaMasaheft/Documentation/issues/2836,
https://github.com/BetaMasaheft/Documentation/issues/2835,
https://github.com/BetaMasaheft/Documentation/issues/2832,
https://github.com/BetaMasaheft/Documentation/issues/2831,
https://github.com/BetaMasaheft/Documentation/issues/2825,
https://github.com/BetaMasaheft/Documentation/issues/2824 and
https://github.com/BetaMasaheft/Documentation/issues/2811.

I made some minor corrections in other records to mark up the composition of two or three strips of magic scrolls and other minor corrections.