### PR TITLE
Magda dd 028 minor changes 2

### DIFF
--- a/ES/ESdd028.xml
+++ b/ES/ESdd028.xml
@@ -79,7 +79,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <material key="parchment"/>
                         </support>
                         <extent><measure unit="leaf" quantity="175">175</measure>
-                           <measure unit="leaf" type="blank"/>2 <locus target="#1v #2rv"/>
+                           <measure unit="page" type="blank"/>2 <locus target="#1v #2rv"/>
                            <measure unit="quire" quantity="21">A+20</measure>
                            <dimensions type="outer">
                               <height unit="mm">200</height>
@@ -330,10 +330,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </item>
                         <item xml:id="a2">
                            <locus target="#10r #85r"/>
-                           <desc type="Exhortation">Exhortation to the readers to call the name of the owner. The note is written in Amharic, in the same, secondary hand as <ref target="#a3"/>, partly in red ink. 
-                              A similar supplication with the name of Walda Yoḥannǝs is written by the same hand on <locus target="#85r"/></desc>
-                           <q xml:lang="am">በዚሕ፡ ዳዊት፡ የምትደግሙት፡ ኵሉ፡ ስሜን፡ ጽሩኝ። አማጽኒ፡ አችሁ፡ አለሁ፡ <persName role="owner" ref="PRS14688WaldaMaryam">ወልደ፡ ማርያም፡</persName> ብላችሁ።</q>
-                           <q xml:lang="en">Those reading this Psalter, I implore you to call my name, <persName role="owner" ref="PRS14688WaldaMaryam">Walda Māryām</persName>.</q> 
+                           <desc type="Exhortation">Exhortation to the readers to call the name of <persName role="owner" ref="PRS14688WaldaMaryam">Walda Māryām</persName>. The note is written in Amharic, in the same, secondary hand as <ref target="#a3"/>, partly in red ink. 
+                              A similar supplication with the name of Walda Yoḥannǝs is written by the same hand on <locus target="#85r"/>.</desc>
+                           <q xml:lang="am">በዚሕ፡ ዳዊት፡ የምትደግሙት፡ ኵሉ፡ ስሜን፡ ጽሩኝ። አማጽኒ፡ አችሁ፡ አለሁ፡ ወልደ፡ ማርያም፡ ብላችሁ።</q>
+                           <q xml:lang="en">Those reading this Psalter, I implore you to call my name Walda Māryām.</q> 
                         </item>
                         <item xml:id="a3">
                            <locus target="#10r #17v #50r #59v #98r #120r #131r #159r"/>

--- a/ES/ESdd028.xml
+++ b/ES/ESdd028.xml
@@ -207,8 +207,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A/0-0/0-0/C</ab>
                            <ab type="pricking">Primary pricks are visible.</ab>
                            <ab type="pricking">Ruling pricks are not visible.</ab>
-                           <ab type="ruling">The upper line is written above the ruling; below the ruling on <locus from="79r" to="80v"/>.</ab>
-                           <ab type="ruling">The bottom line is written above the ruling. The bottom ruled line was not used by the scribe on <locus from="78v" to="80v"/>.</ab>
+                           <ab type="ruling">The upper line is written above the ruling; below the ruling on <locus from="79r" to="80v"/></ab>
+                           <ab type="ruling">The bottom line is written above the ruling. The bottom ruled line was not used by the scribe on <locus from="78v" to="80v"/></ab>
 
                         </layout>
                         <layout columns="2" writtenLines="19">
@@ -246,20 +246,20 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         </desc>
                         
                         <list type="abbreviations">
-                           <item>Abbreviations in <ref target="#ms_i1.1"/> Ps. 135<locus target="#127rv"/>
+                           <item>Abbreviations in <ref target="#ms_i1.1">Text 1.1,  Ps. 135</ref><locus target="#127rv"/>:
                               <list>
                                  <item>
                                  <abbr>እ፡</abbr> for <expan>እስመ፡ ለዓለም፡ ምሕረቱ፡</expan> </item>
                                  </list>
                            </item>
-                           <item>Abbreviations in <ref target="#ms_i1.2"/> Canticle 10<locus target="#147rv"/>
+                           <item>Abbreviations in <ref target="#ms_i1.2">Text 1.2, Canticle 10</ref><locus target="#147rv"/>:
                                  <list>
                                     <item>
                               <abbr>ስ፡</abbr> for <expan>ስቡሕኒ፡ ውእቱ፡ ወልዑልኒ፡ ውእቱ፡ ለዓለም፡</expan>
                               </item>
                         </list>
                               </item>
-                           <item>Abbreviations in <ref target="#ms_i1.4"/>
+                           <item>Abbreviations in <ref target="#ms_i1.4">Text 1.4</ref>:
                               <list>
                            <item>
                               <abbr>ሰአ፡ (ቅ፡)</abbr> for <expan>ሰአሊ፡ ለነ፡ ቅድስት፡</expan></item>
@@ -287,7 +287,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                 (<locus from="169va" to="170rb"/>)</item>
                               </list>
                            </item>
-                           <item>Abbreviations in <ref target="#ms_i1.5"/>
+                           <item>Abbreviations in <ref target="#ms_i1.5">Text 1.5</ref>:
                               <list>
                                  <item>
                                     <abbr>ወ፡ ሣ፡ ይ፡ ሰ፡ ቅ፡</abbr> for <expan>ወልድኪ፡ ሣህሎ፡ ይክፈለነ፡ ሰአሊ፡ ለነ፡ ቅድስት፡</expan></item>
@@ -298,15 +298,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               </list>
                            </item>
                         </list>
-                        <seg type="rubrication">Divine names (name of St Mary in <ref target="#ms_i1.4"/> and <ref target="#ms_i1.5"/>);
+                        <seg type="rubrication">Divine names (name of St Mary in <ref target="#ms_i1.4">Text 1.4</ref> and <ref target="#ms_i1.5">Text 1.5</ref>);
                            titles and numbers of the Psalms and Canticles; incipits and numbers of the Song of Songs; 
-                           title of <ref target="#ms_i1.2"/>, <ref target="#ms_i1.3"/> and <ref target="#ms_i1.5"/>; title and incipit of the daily
-                           readings of <ref target="#ms_i1.4"/>; refrains of <ref target="#ms_i1.4"/> and <ref target="#ms_i1.5"/> (written out fully or abbreviated); 
-                           name of the Hebrew letters in <ref target="#ms_i1.1"/> Ps. 118; letter <foreign xml:lang="gez">እ</foreign> in the word <foreign xml:lang="gez">እስመ፡</foreign> in <ref target="#ms_i1.1"/> Ps. 135;
+                           title of <ref target="#ms_i1.2">Text 1.2</ref>, <ref target="#ms_i1.3">Text 1.3</ref> and <ref target="#ms_i1.5">Text 1.5</ref>; title and incipit of the daily
+                           readings of <ref target="#ms_i1.4">Text 1.4</ref>; refrains of <ref target="#ms_i1.4">Text 1.4</ref> and <ref target="#ms_i1.5">Text 1.5</ref> (written out fully or abbreviated); 
+                           name of the Hebrew letters in <ref target="#ms_i1.1">Text 1.1, Ps. 118</ref>; letter <foreign xml:lang="gez">እ</foreign> in the word <foreign xml:lang="gez">እስመ፡</foreign> in <ref target="#ms_i1.1">Text 1.1, Ps. 135</ref>;
                            names of the days of the week in the upper margin in <ref target="#ms_i1.4"/>; 
                            elements of the punctuation signs; Ethiopic numerals or their elements. 
-                           A few groups of lines (alternating with black lines) on the incipit page of <ref target="#ms_i1.1"/>; two lines (alternating with a black
-                           line) on the incipit page of <ref target="#ms_i1.1"/> Ps. 101 (<locus target="85r"/>) and of <ref target="#ms_i1.4"/>.</seg>
+                           A few groups of lines (alternating with black lines) on the incipit page of <ref target="#ms_i1.1">Text 1.1</ref>; two lines (alternating with a black
+                           line) on the incipit page of <ref target="#ms_i1.1">Text 1.1, Ps. 101</ref> (<locus target="85r"/>) and of <ref target="#ms_i1.4">Text 1.4</ref>.</seg>
                      </handNote>
                      
                   </handDesc>
@@ -317,7 +317,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <desc>Small cross in black and red.</desc>
                      </decoNote>
                      <decoNote type="frame" xml:id="d2">
-                        <locus target="#84v"/>Explicit of <ref target="#ms_i1.1"/> Ps 100; simple coloured (red, black) ornamental band, geometric motifs.</decoNote>
+                        <locus target="#84v"/>Explicit of <ref target="#ms_i1.1">Text 1.1, Ps. 100</ref>; simple coloured (red, black) ornamental band, geometric motifs.</decoNote>
                   </decoDesc>
                   <additions>
                      <list>
@@ -326,7 +326,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <desc type="Supplication">Supplication for protection written in the same secondary hand as <ref target="#a2 #a3"/>. 
                               The name of the original supplicant, <persName role="owner" ref="PRS14688WaldaMaryam">Walda Māryām</persName>, has been erased and replaced with that of <persName role="owner" ref="PRS14689GabraIyasus">Gabra ʾIyasus</persName>. 
                               Some of the supplications were overwritten by the same hand and supplemented with the name of <persName role="owner" ref="PRS14689GabraIyasus">Gabra ʾIyasus</persName>.</desc>
-                           <q xml:lang="gez">ኦአምላከ፡ ዳዊት፡ ዕቀበኒ፡ እመከራ፡ ሥጋ፡ ወነፍስ፡ ለገብርከ፡ <persName role="owner" ref="PRS14689GabraIyasus">ገብረ፡ ኢየሱስ</persName>።</q>
+                           <q xml:lang="gez">ኦአምላከ፡ ዳዊት፡ ዕቀበኒ፡ እመከራ፡ ሥጋ፡ ወነፍስ፡ ለገብርከ፡ ገብረ፡ ኢየሱስ።</q>
                         </item>
                         <item xml:id="a2">
                            <locus target="#10r #85r"/>
@@ -338,8 +338,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <item xml:id="a3">
                            <locus target="#10r #17v #50r #59v #98r #120r #131r #159r"/>
                            <desc type="Supplication">Short supplication for the soul of <persName role="owner" ref="PRS14688WaldaMaryam">Walda Māryām</persName>. The notes are written in the same hand as <ref target="#a2"/>, in red ink.</desc>
-                           <q xml:lang="gez">አእርፍ፡ ነፍሰ፡ ገብርከ፡ <persName role="owner" ref="PRS14688WaldaMaryam">ወልደ፡ ማርያም</persName>።</q>
-                           <q xml:lang="en">May the soul of <persName role="owner" ref="PRS14688WaldaMaryam">Walda Māryām</persName> rest in peace.</q>
+                           <q xml:lang="gez">አእርፍ፡ ነፍሰ፡ ገብርከ፡ ወልደ፡ ማርያም።</q>
+                           <q xml:lang="en">May the soul of Walda Māryām rest in peace.</q>
                         </item>
                         <item xml:id="a4">
                            <locus target="#159r"/>
@@ -377,29 +377,33 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            </desc>
                         </item>
                         <item xml:id="e2">
+                           <locus target="#3r"/>
+                           <desc type="StampExlibris">Shelfmark C3-IV-276</desc>
+                        </item>
+                        <item xml:id="e3">
                            <locus target="#65v"/>
                            <desc type="Unclear">The midpoint of the ‘Psalms of David’ (in Ps. 77) is marked with a cross (see also <ref target="#d1"/>).</desc>
                         </item>
-                        <item xml:id="e3">
+                        <item xml:id="e4">
                            <desc type="Unclear">The Psalms are divided into groups of ten separated by a crudely drawn zig zag, in blue pen.</desc> 
                         </item>
-                        <item xml:id="e4">
+                        <item xml:id="e5">
                            <desc type="Correction">Omitted letters, words, lines or passages written interlineally, in a secondary hand the same as that of <ref target="#a2 #a3"/>, e.g., 
                               <locus target="#10v #18r #27r #41v #54v #59r #66v #71r #80r #86v #92v #113v #118v #136r #144r #158r"/>.</desc>
                         </item>
-                        <item xml:id="e5">
+                        <item xml:id="e6">
                            <locus target="#41v #71v #163ra"/>
                            <desc type="Correction">Corrections written over erasures.</desc>
                         </item>
-                        <item xml:id="e6">
+                        <item xml:id="e7">
                            <locus target="#60r #131r"/>
                            <desc type="Correction">Erasures.</desc>
                         </item>
-                        <item xml:id="e7">
+                        <item xml:id="e8">
                            <locus target="#2v #36r #41r #42r #74r #133r #152v"/>
                            <desc>Scribbles.</desc></item>
-                        <item xml:id="e8">
-                           <desc type="findingAid">Daily readings of <ref target="#ms_i1.4"/> are indicated by the names of the days of the week written in the upper margin, in the <ref target="#h1">main hand</ref>:
+                        <item xml:id="e9">
+                           <desc type="findingAid">Daily readings of <ref target="#ms_i1.4">Text 1.4</ref> are indicated by the names of the days of the week written in the upper margin, in the <ref target="#h1">main Hand 1</ref>:
                            <foreign xml:lang="gez">ዘሠሉሥ፡</foreign> <locus target="#160va"/> 
                               <foreign xml:lang="gez">ዘረቡዕ፡</foreign> <locus target="#162va"/>
                               <foreign xml:lang="gez">ዘሐሙስ፡</foreign> <locus target="#164rb"/>
@@ -407,10 +411,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               <foreign xml:lang="gez">ዘቀዳሚት፡</foreign> <locus target="#168ra"/>
                                  <foreign xml:lang="gez">ዘእሑድ፡</foreign> <locus target="#169rb"/>.</desc>
                         </item>
-                        <item xml:id="e9">
-                           <locus target="#3r"/>
-                           <desc type="StampExlibris">Shelfmark C3-IV-276</desc>
-                        </item>
+                       
                      </list>
                   </additions>
                   <bindingDesc>
@@ -471,7 +472,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         
+         <particDesc>
+            <listPerson>
+               <person>
+                  <persName role="owner" ref="PRS14688WaldaMaryam"/>
+               </person>
+               <person>
+                  <persName role="owner" ref="PRS14689GabraIyasus"/>
+               </person>
+            </listPerson>
+         </particDesc>
          <textClass>
             <keywords scheme="#ethioauthlist">
                <term key="OldTestament"/>


### PR DESCRIPTION
I go for the option `<ref target="#ms_i1.1">Text 1.1, Ps. 100</ref>`, which will be visualized as Text 1.1, Ps. 100 and not 
![content](https://github.com/user-attachments/assets/ecff89a3-0f70-4677-b742-ff93107cb0ec).

I have corrected some minor mistakes. 
There is a list of the persons at the end because currently they have not been visualized against the red background in the app. 
