### PR TITLE
Magda dd 034 minor changes 3

### DIFF
--- a/ES/ESdd034.xml
+++ b/ES/ESdd034.xml
@@ -91,7 +91,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                  <dim unit="leaf">7</dim>
                                  <locus from="11r" to="17v"/>
                                  1, no stub
-                              <note>The exact structure of this quire cannot be determined.</note>
                               </item>
                               <item xml:id="q3" n="3">
                                  <num value="3">፫</num>
@@ -155,7 +154,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               <item xml:id="q20" n="20">
                                  <dim unit="leaf">9</dim>
                                  <locus from="145r" to="153v"/> 
-                                 1, no stub</item>
+                                 1, no stub.</item>
+                              <note>The exact structure of <ref target="#q2"/> cannot be determined.</note>
                            </list>
                         </collation>
                         <condition key="good">The manuscript is worn. It has been resewn; some quires are crudely repaired with stitches. 
@@ -178,7 +178,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               <dim type="left">5</dim>
                               <dim type="intercolumn"/>
                            </dimensions>
-                           <note>Texts: <ref target="#ms_i1.1"/>, <ref target="#ms_i1.2"/> and <ref target="#ms_i1.3"/>: all data for <locus target="#3r"/>.</note>
+                           <note><ref target="#ms_i1.1">Text 1.1</ref>, <ref target="#ms_i1.2">Text 1.2</ref> and <ref target="#ms_i1.3">Text 1.3</ref>: all data for <locus target="#3r"/>.</note>
                            <ab type="ruling">Ruling is visible.</ab>
                            <ab type="pricking">Pricking  is visible.</ab>
                            <ab type="ruling" subtype="pattern">1A-1A/0-0/0-0/C</ab>
@@ -200,7 +200,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               <dim type="left">15</dim>
                               <dim type="intercolumn">10</dim>
                            </dimensions>
-                           <note>Texts: <ref target="#ms_i1.4"/> and <ref target="#ms_i1.5"/>: all data are for <locus target="#140r"/>.</note>
+                           <note><ref target="#ms_i1.4">Text 1.4</ref> and <ref target="#ms_i1.5">Text 1.5</ref>: all data are for <locus target="#140r"/>.</note>
                            <ab type="ruling">Ruling is visible.</ab>
                            <ab type="pricking">Pricking  is visible.</ab>
                            <ab type="ruling" subtype="pattern">1A-1A-1A1A/0-0/0-0/C</ab>
@@ -235,7 +235,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                  <abbr>ስ፡</abbr> for <expan>ስቡሕኒ፡ ውእቱ፡ ወልዑልኒ፡ ውእቱ፡ ለዓለም፡</expan></item>
                            </list>
                            </item>
-                           <item>Abbreviations in <ref target="#ms_i1.4"/>
+                           <item>Abbreviations in <ref target="#ms_i1.4">Text 1.4</ref>
                               <list>
                            <item>
                               <abbr>ሰ፤ ቅ፤</abbr> for <expan>ሰአሊ፡ ለነ፡ ቅድስት፡</expan></item>
@@ -263,7 +263,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               (<locus from="147rb" to="148ra"/>)</item>
                               </list>
                            </item>
-                           <item>Abbreviations in <ref target="#ms_i1.5"/>
+                           <item>Abbreviations in <ref target="#ms_i1.5">Text 1.5</ref>
                            <list>
                            <item>ወ፡ ድ፤ ሣ፤ ይ፤ ሰ፤ ቅ or ወልድኪ፡ ሣህሎ፡ ይክፍለነ፡ ሰዓሊ፡ ለነ፡ ቅድስት፡ <locus target="#149vb #150ra #151ra"/></item>
                            <item>
@@ -272,14 +272,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            </list>
                            </item>
                         </list>
-                        <seg type="rubrication">Divine names (name of St Mary in Texts <ref target="#ms_i1.4"/> and <ref target="#ms_i1.5"/>);
-                           title of <ref target="#ms_i1.2"/> and <ref target="#ms_i1.3"/>; titles and numbers of the Psalms, Canticles and Song of Songs; 
-                           title and incipit of the daily readings of <ref target="#ms_i1.4"/>; 
-                           part of the title of <ref target="#ms_i1.5"/>; name and occassionally number of the Hebrew letters in <ref target="#ms_i1.1">Text 1.1, Ps. 118</ref>;
+                        <seg type="rubrication">Divine names (name of St Mary in Texts <ref target="#ms_i1.4">Text 1.4</ref> and <ref target="#ms_i1.5">Text 1.5</ref>);
+                           title of <ref target="#ms_i1.2">Text 1.2</ref> and <ref target="#ms_i1.3">Text 1.3</ref>; titles and numbers of the Psalms, Canticles and Song of Songs; 
+                           title and incipit of the daily readings of <ref target="#ms_i1.4">Text 1.4</ref>; 
+                           part of the title of <ref target="#ms_i1.5">Text 1.5</ref>; name and occassionally number of the Hebrew letters in <ref target="#ms_i1.1">Text 1.1, Ps. 118</ref>;
                            letters <foreign>ስ</foreign> and <foreign>ሕ</foreign> in the word <foreign>ስብሕዎ፡</foreign> in <ref target="#ms_i1.1">Text 1.1, Ps. 150</ref>; 
                            letters <foreign>ባ</foreign> and <foreign>ክ</foreign> of the word <foreign>ይባርክዎ፡</foreign> in <ref target="#ms_i1.2">Text 1.2, Canticle 10</ref>; 
-                           one line of the refrains of <ref target="#ms_i1.4"/> and  <ref target="#ms_i1.5"/> (written out fully or abbreviated); elements of the punctuation  signs; 
-                           Ethiopic numerals or their elements. A few lines (alternating with black lines) in the incipit page of <ref target="#ms_i1.1"/>, <ref target="#ms_i1.2"/>, <ref target="#ms_i1.3"/> and <ref target="#ms_i1.4"/>.</seg>
+                           one line of the refrains of <ref target="#ms_i1.4">Text 1.4</ref> and  <ref target="#ms_i1.5">Text 1.5</ref> (written out fully or abbreviated); elements of the punctuation  signs; 
+                           Ethiopic numerals or their elements. A few lines (alternating with black lines) in the incipit page of <ref target="#ms_i1.1">Text 1.1</ref>, <ref target="#ms_i1.2">Text 1.2</ref>, <ref target="#ms_i1.3">Text 1.3</ref> and <ref target="#ms_i1.4">Text 1.4</ref>.</seg>
                      </handNote>
                     
                      <handNote xml:id="h2" script="Ethiopic" corresp="#a1 #a2 #a4 #a6 #a7"> 
@@ -299,32 +299,32 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <item xml:id="a2">
                            <locus target="#1v"/>
                            <desc type="ScribalSignature">Scribal note mentioning <persName role="scribe" ref="PRS14662TsaggaLaEgziabeher">Ḍaggā la-ʾƎgziʾab<supplied reason="omitted" resp="MK">ḥe</supplied>r.</persName> 
-                              The note is very crudely written in the <ref type="hand" target="#h2">secondary hand.</ref></desc>
-                           <q xml:lang="gez"><persName role="scribe" ref="PRS14662TsaggaLaEgziabeher">ፀጋ፡ ለእግዚአብ<supplied reason="omitted" resp="MK">ሔ</supplied>ር፡</persName>.</q>
+                              The note is very crudely written in <ref type="hand" target="#h2">Hand 2.</ref></desc>
+                           <q xml:lang="gez">ፀጋ፡ ለእግዚአብ<supplied reason="omitted" resp="MK">ሔ</supplied>ር፡</q>
                         </item>
                         <item xml:id="a3">
                            <locus target="#115v"/>
-                           <desc type="GuestText"><title ref="LIT7243PrayerMaryKwellon" type="incomplete">Hymn to St Mary</title> written in the upper part of the folium. It is written in the <ref type="hand" target="#h1">main hand.</ref></desc>
+                           <desc type="GuestText"><title ref="LIT7243PrayerMaryKwellon" type="incomplete">Hymn to St Mary</title> written in the upper part of the folium. It is written in the <ref type="hand" target="#h1">main Hand 1.</ref></desc>
                            <q xml:lang="gez">ኵሎን፡ አዋልዲሃ፡<add place="above"> ለሔዋ፡ </add>በምግባረ፡ ሰናይ፡ እለ፡ ተሰርገዋ፡ ዕበያተ፡ ኪ፡ ዜነዋ፡ ተፈስሒ፡ ማርያም፡ አዳስዮ፡ ጣዕዋ፤</q>
                         </item>
                         <item xml:id="a4">
                            <locus target="#115v"/>
                            <desc type="GuestText"><title ref="LIT6946InvocationMary" type="incomplete">Invocation to St. Mary</title> written in the lower part of the folium. 
-                              A common prayer after the reading of Psalms of David. It is similar to that in <ref type="mss" corresp="EMIP00175">Additio 6</ref>. It is crudely written in the <ref type="hand" target="#h2">secondary hand</ref>.</desc>
+                              A common prayer after the reading of Psalms of David. It is similar to that in <ref type="mss" corresp="EMIP00175">Additio 6</ref>. It is crudely written in <ref type="hand" target="#h2">Hand 2</ref>.</desc>
                         </item>
                         <item xml:id="a5">
                            <locus target="#117v"/>
-                           <desc type="OwnershipNote">It is written in the <ref type="hand" target="#h1">main hand.</ref> Names of the donor and her/his family members have been erased.</desc>
+                           <desc type="OwnershipNote">It is written in the <ref type="hand" target="#h1">main Hand 1.</ref> Names of the donor and her/his family members have been erased.</desc>
                            <q xml:lang="gez">ዝ፡ መጽሐፍ፡ ... ወለወልዱ፡ ... ዘሠ<supplied reason="omitted" resp="MK">ረ</supplied>ቆ፡ ወዘፈሐቆ፡ ወዘተአገሎ፡ በስልጣነ፡ ጴጥ<add place="above">ሮ</add>፡ ወጳው<supplied reason="omitted" resp="MK">ሎ</supplied>ስ፡ ውጉዘ፡ ለይኩን፡ ከመ፡ አሬዎስ።</q>
                         </item>
                         <item xml:id="a6">
                            <locus from="136r" to="137v"/>
-                           <desc type="GuestText"><title  ref="LIT7251PrayerMaryKullomuSarawitaMalaekt" type="incomplete">Hymn to St Mary</title> crudely written in the <ref type="hand" target="#h2">secondary hand</ref>.</desc>
+                           <desc type="GuestText"><title  ref="LIT7251PrayerMaryKullomuSarawitaMalaekt" type="incomplete">Hymn to St Mary</title> crudely written in the <ref type="hand" target="#h2">Hand 2.</ref></desc>
                            <q xml:lang="gez">ኵሎሙ፡ ሰራዊተ፡ መላእክት፡ ይሴብሁኪ፤ ዘእምቅድመ፡ ዓለም፡ ሃሎተኪ፤ ለማሕደረ፡ ወልዱ፡ እግዚአብሔር፡ ሐረየኪ፤</q>
                         </item>
                         <item xml:id="a7">
                            <locus target="#137v #153r"/>
-                           <desc type="OwnershipNote">It is very crudely written in the <ref type="hand" target="#h2">secondary hand</ref>.</desc>
+                           <desc type="OwnershipNote">It is very crudely written in the <ref type="hand" target="#h2">Hand 2.</ref></desc>
                            <q xml:lang="gez">ዛቲ፡ መጽሐፍ፡ <persName role="owner" ref="PRS14663Yehdago">ዘ<roleName type="title">አቤቶ፡</roleName> ይሕደጎ፡</persName></q>
                            <q xml:lang="en">This book is of <persName role="owner" ref="PRS14663Yehdago"><roleName type="title">ʾabeto </roleName> Yǝḥdago</persName>.</q>
                         </item>
@@ -345,11 +345,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            </item>
                         <item xml:id="e5">
                            <locus target="#5r #5v #6v #7r #11v #14r #18v #23v #24r #30v #34r #42v #52r #59v #71v #75v #82r #90v #105v #111v #146va #149ra #151ra"/> 
-                           <desc type="Correction">Omitted letters, words, lines or passages written interlineally, in the <ref type="hand" target="h1">main hand</ref> and in a secondary hand.</desc>
+                           <desc type="Correction">Omitted letters, words, lines or passages written interlineally, in the <ref type="hand" target="h1">main Hand 1</ref> and in a secondary hand.</desc>
                         </item>
                         <item xml:id="e6">
                            <locus target="#21r #28v #30r #40r #47r #52r #57v #87r #106r #117v #147ra #151rb"/>
-                           <desc type="Correction">Corrections over erasures, in the <ref type="hand" target="h1">main hand</ref> and in a secondary hand.</desc>
+                           <desc type="Correction">Corrections over erasures, in the <ref type="hand" target="h1">main Hand 1</ref> and in a secondary hand.</desc>
                         </item>
                         <item xml:id="e7">
                            <locus target="#7r #33v #46v #80r #84r"/>

--- a/ES/ESdd034.xml
+++ b/ES/ESdd034.xml
@@ -278,7 +278,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            part of the title of <ref target="#ms_i1.5">Text 1.5</ref>; name and occassionally number of the Hebrew letters in <ref target="#ms_i1.1">Text 1.1, Ps. 118</ref>;
                            letters <foreign>ስ</foreign> and <foreign>ሕ</foreign> in the word <foreign>ስብሕዎ፡</foreign> in <ref target="#ms_i1.1">Text 1.1, Ps. 150</ref>; 
                            letters <foreign>ባ</foreign> and <foreign>ክ</foreign> of the word <foreign>ይባርክዎ፡</foreign> in <ref target="#ms_i1.2">Text 1.2, Canticle 10</ref>; 
-                           one line of the refrains of <ref target="#ms_i1.4">Text 1.4</ref> and  <ref target="#ms_i1.5">Text 1.5</ref> (written out fully or abbreviated); elements of the punctuation  signs; 
+                           one line of the refrains of <ref target="#ms_i1.4">Text 1.4</ref> and <ref target="#ms_i1.5">Text 1.5</ref> (written out fully or abbreviated); elements of the punctuation  signs; 
                            Ethiopic numerals or their elements. A few lines (alternating with black lines) in the incipit page of <ref target="#ms_i1.1">Text 1.1</ref>, <ref target="#ms_i1.2">Text 1.2</ref>, <ref target="#ms_i1.3">Text 1.3</ref> and <ref target="#ms_i1.4">Text 1.4</ref>.</seg>
                      </handNote>
                     

--- a/ES/ESdd034.xml
+++ b/ES/ESdd034.xml
@@ -161,7 +161,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <condition key="good">The manuscript is worn. It has been resewn; some quires are crudely repaired with stitches. 
                            Many folia are stained with wax and water. The text on some folia, esp. <locus from="144v" to="152v"/>, is illegible due to smeared ink.
                          <locus target="#1 #153"/>are mutilated. Tear amended on <locus target="#14"/>. Holes carefully amended on <locus target="#109 #110"/>.
-                           Almost all of the quires are mounted on parchment guards. 
+                           <ref type="quire" target="#q1 #q2 #q3 #q5 #q6 #q8 #q9 #q10 #q11 #q13 #q14 #q15 #q16 #q17 #q18 #q19"/>
+                           are reinforced by parchment guards. 
                         </condition>
                      </supportDesc>
                      <layoutDesc>
@@ -372,9 +373,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <decoNote xml:id="b5" type="Endbands"/>
                         <decoNote xml:id="b6" type="Other">Small holes are visible in the centre
                            fold of the quires, one close to the head and to the tail of the codex.</decoNote>
-                        <decoNote xml:id="b7">
-                          <ref type="quire" target="#q1 #q2 #q3 #q5 #q6 #q8 #q9 #q10 #q11 #q13 #q14 #q15 #q16 #q17 #q18 #q19"/>
-                           are reinforced by parchment guards.</decoNote>
+                      
                      </binding>
                   </bindingDesc>
                </physDesc>


### PR DESCRIPTION
In the current visualization the collation diagrams and the formula do not appear. 
![collation](https://github.com/user-attachments/assets/9fd04862-f900-49eb-9e7a-fcb2950dadf4)

Do you think it is because of the note after quire 2?
![Quire table](https://github.com/user-attachments/assets/eff01ee6-adf4-4a2d-94a7-3b77971ee9ed)



In the current file I have move the note to the end. Will it help?
