### PR TITLE
Magda dd 002 minor changes 

### DIFF
--- a/ES/ESdd002.xml
+++ b/ES/ESdd002.xml
@@ -194,7 +194,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                     <note>All data for <locus target="#1ra"/></note>
                                     <ab type="ruling">Ruling is visible.</ab>
                                     <ab type="pricking">Pricking is not visible.</ab>
-                                    <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A-1A1A/0-0/0-0/C</ab>
+                                    <ab type="ruling" subtype="pattern">1A-1A-1A1A/0-0/0-0/C</ab>
                                     <ab type="pricking">Primary pricks are not visible.</ab>
                                     <ab type="pricking">Ruling pricks are not visible.</ab>
                                     <ab type="ruling">The upper line is written above the ruling.</ab>
@@ -294,7 +294,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               <material key="parchment"/>
                            </support>
                            <extent><measure unit="leaf" quantity="94">94</measure> 
-                              <measure unit="leaf" type="blank">1</measure><locus target="71v"/>
+                              <measure unit="leaf" type="blank">1</measure><locus target="#71v"/>
                               <measure unit="quire" quantity="12">12</measure>
                               <locus from="2ra" to="95vb"/>
                            </extent>
@@ -333,8 +333,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <seg type="ink">Black, red (vivid vermilion).</seg>
                         <desc>Fine, careful. The handwriting remains uniform throughout the manuscript and is characterized by finely shaped, slender and upright letters.</desc>
                        
-                        <seg type="rubrication">Divine names; a few lines on the incipit page of <ref target="p2_i1"/> and <ref target="p2_i2"/> alternating with black lines; 
-                           two initial lines of each daily section of <ref target="p2_i1"/>; elements of the punctuation signs;
+                        <seg type="rubrication">Divine names; a few lines on the incipit page of <ref target="#p2_i1"/> and <ref target="#p2_i2"/> alternating with black lines; 
+                           two initial lines of each daily section of <ref target="#p2_i1"/>; elements of the punctuation signs;
                            elements of Ethiopic numerals; the word <foreign>mǝʿrāf</foreign> ‘chapter’ e.g., <locus target="#84ra, #85vb #90rb"/>; days of the week: <foreign xml:lang="gez">ዘሠሉሥ፡</foreign> <locus target="#15r"/>, 
                            <foreign xml:lang="gez">ዘዓርብ፡</foreign> <locus target="#53r"/>, <foreign xml:lang="gez">ዘእሑድ፡</foreign> <locus target="#72r"/> in the margins.</seg>
                      </handNote>
@@ -375,7 +375,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <placeName ref="INS0105DD"/>
                         </origPlace>
                         <origDate notBefore="1700" notAfter="1799" evidence="lettering"/>
-                        The name of the donor has been erased from the supplication formulas, see <ref target="e5">Extras 5.</ref> Only on <locus target="#89va"/> the second part of the name, Krǝstos, has been preserved.
+                        The name of the donor has been erased from the supplication formulas, see <ref target="#e5">Extras 5.</ref> Only on <locus target="#89va"/> the second part of the name, Krǝstos, has been preserved.
                      </origin>
                   </history>
               

--- a/ES/ESdd002.xml
+++ b/ES/ESdd002.xml
@@ -28,7 +28,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <msIdentifier>
                   <repository ref="INS0105DD"/>
                   <collection>Ethio-SPaRe</collection>
-                  <idno>DD-002</idno>
+                  <idno facs="DD/002/DD-002" n="104">DD-002</idno>
                   <altIdentifier>
                      <idno>C3-IV-267</idno>
                   </altIdentifier>
@@ -201,7 +201,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                     <ab type="ruling">The bottom line is written above the ruling.</ab>
                                  </layout>
                                  <layout>
-                                    <ab type="punctuation" subtype="Dividers"/>
                                     <ab type="ChiRho">Chi-Rho sign appears on <locus target="#1v"/>.</ab>
                                  </layout>
                                  </layoutDesc>
@@ -225,7 +224,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               <placeName ref="INS0105DD"/>
                            </origPlace>
                            <origDate notBefore="1470" notAfter="1599" evidence="lettering"/>
-                           <ref target="#p1"/> originates from an older Four Gospel manuscript. The folium was inserted most probably only during the resewing in order to serve as a protective leaf and, possibly, to keep the old item. 
+                           <ref target="#p1">Unit 1</ref> originates from an older Four Gospel manuscript.
+                           The folium was inserted most probably only during the resewing in order to serve as a protective leaf and, possibly, to keep the old item. 
                         </origin>
                      </history>
                   </msPart>
@@ -293,9 +293,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <support>
                               <material key="parchment"/>
                            </support>
-                           <extent><measure unit="leaf" quantity="94"/> 
-                              <measure unit="page" type="blank"/>1 <locus target="71v"/>
-                              <measure unit="quire" quantity="12"/>
+                           <extent><measure unit="leaf" quantity="94">94</measure> 
+                              <measure unit="leaf" type="blank">1</measure><locus target="71v"/>
+                              <measure unit="quire" quantity="12">12</measure>
                               <locus from="2ra" to="95vb"/>
                            </extent>
                         </supportDesc>
@@ -317,7 +317,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            </note>
                            <ab type="ruling">Ruling is visible.</ab>
                            <ab type="pricking">Pricking is visible.</ab>
-                           <ab type="ruling" subtype="pattern">Ruling pattern: 1A-1A-1A1A/0-0/0-0/C</ab>
+                           <ab type="ruling" subtype="pattern">1A-1A-1A1A/0-0/0-0/C</ab>
                            <ab type="pricking">Primary pricks are visible.</ab>
                            <ab type="pricking">Ruling pricks are visible.</ab>
                            <ab type="ruling">The upper line is written above the ruling.</ab>

--- a/ES/ESdd002.xml
+++ b/ES/ESdd002.xml
@@ -224,8 +224,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            <origPlace>
                               <placeName ref="INS0105DD"/>
                            </origPlace>
-                           <ref target="#p1"/> originates from an older Four Gospel manuscript. The folium was inserted most probably only during the resewing in order to serve as a protective leaf and, possibly, to keep the old item. 
                            <origDate notBefore="1470" notAfter="1599" evidence="lettering"/>
+                           <ref target="#p1"/> originates from an older Four Gospel manuscript. The folium was inserted most probably only during the resewing in order to serve as a protective leaf and, possibly, to keep the old item. 
                         </origin>
                      </history>
                   </msPart>
@@ -334,7 +334,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <desc>Fine, careful. The handwriting remains uniform throughout the manuscript and is characterized by finely shaped, slender and upright letters.</desc>
                        
                         <seg type="rubrication">Divine names; a few lines on the incipit page of <ref target="p2_i1"/> and <ref target="p2_i2"/> alternating with black lines; 
-                           two initial lines of each section of <ref target="#ms_i1"/>, <ref target="#ms_i2"/> and <ref target="#ms_i3"/>; elements of the punctuation signs;
+                           two initial lines of each daily section of <ref target="p2_i1"/>; elements of the punctuation signs;
                            elements of Ethiopic numerals; the word <foreign>mǝʿrāf</foreign> ‘chapter’ e.g., <locus target="#84ra, #85vb #90rb"/>; days of the week: <foreign xml:lang="gez">ዘሠሉሥ፡</foreign> <locus target="#15r"/>, 
                            <foreign xml:lang="gez">ዘዓርብ፡</foreign> <locus target="#53r"/>, <foreign xml:lang="gez">ዘእሑድ፡</foreign> <locus target="#72r"/> in the margins.</seg>
                      </handNote>
@@ -374,9 +374,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <origPlace>
                            <placeName ref="INS0105DD"/>
                         </origPlace>
-                        <ref target="#p2"/>
                         <origDate notBefore="1700" notAfter="1799" evidence="lettering"/>
-                        The name of the donor has been erased from the supplication formulas, see <ref target="e5">Varia 5.</ref> Only on <locus target="#89va"/> the second part of the name, Krǝstos, has been preserved.
+                        The name of the donor has been erased from the supplication formulas, see <ref target="e5">Extras 5.</ref> Only on <locus target="#89va"/> the second part of the name, Krǝstos, has been preserved.
                      </origin>
                   </history>
               

--- a/ES/ESdd002.xml
+++ b/ES/ESdd002.xml
@@ -294,7 +294,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               <material key="parchment"/>
                            </support>
                            <extent><measure unit="leaf" quantity="94"/> 
-                              <measure unit="leaf" type="blank"/>1 <locus target="71v"/>
+                              <measure unit="page" type="blank"/>1 <locus target="71v"/>
                               <measure unit="quire" quantity="12"/>
                               <locus from="2ra" to="95vb"/>
                            </extent>
@@ -333,7 +333,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <seg type="ink">Black, red (vivid vermilion).</seg>
                         <desc>Fine, careful. The handwriting remains uniform throughout the manuscript and is characterized by finely shaped, slender and upright letters.</desc>
                        
-                        <seg type="rubrication">Divine names; a few lines on the incipit page of <ref target="#ms_i2"/> and <ref target="#ms_i3"/> alternating with black lines; 
+                        <seg type="rubrication">Divine names; a few lines on the incipit page of <ref target="p2_i1"/> and <ref target="p2_i2"/> alternating with black lines; 
                            two initial lines of each section of <ref target="#ms_i1"/>, <ref target="#ms_i2"/> and <ref target="#ms_i3"/>; elements of the punctuation signs;
                            elements of Ethiopic numerals; the word <foreign>mǝʿrāf</foreign> ‘chapter’ e.g., <locus target="#84ra, #85vb #90rb"/>; days of the week: <foreign xml:lang="gez">ዘሠሉሥ፡</foreign> <locus target="#15r"/>, 
                            <foreign xml:lang="gez">ዘዓርብ፡</foreign> <locus target="#53r"/>, <foreign xml:lang="gez">ዘእሑድ፡</foreign> <locus target="#72r"/> in the margins.</seg>


### PR DESCRIPTION
The reference to the text is wrong so I have corrected it.
Do you know why the info about the Chi-Rho sign has been duplicated? What shall I do to avoid it? 
And what to do with the hanging dots?! I have noticed that they are taken to the next line after the "locus". 

Here is the encoding: ` <layout>
                                    <ab type="punctuation" subtype="Dividers"/>
                                    <ab type="ChiRho">Chi-Rho sign appears on <locus target="#1v"/>.</ab>
                                 </layout>` 

Visualization: 
![chirho](https://github.com/user-attachments/assets/7c6cadb4-eb96-489d-85f9-8bbf78a7b7e6)




