### PR TITLE
2025 03 12 jk uub o etiop. 47

### DIFF
--- a/Munich/Museum5Kont/MfVK02233.xml
+++ b/Munich/Museum5Kont/MfVK02233.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="MfVK02233" type="mss">
+   <teiHeader xml:base="https://betamasaheft.eu/">
+      <fileDesc>
+         <titleStmt>
+            <title>Magic prayers</title>
+            <editor key="JK"/>
+            <editor key="AB" role="generalEditor"/>
+            <funder></funder>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+            <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
+            <pubPlace>Hamburg</pubPlace>
+            <availability>
+               <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                  licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:id="ms">
+                  <msIdentifier>
+                     <repository ref="INS0969Munich5kont"/>
+                     <collection/>
+                     <idno>MfVK 02.233</idno>
+                  </msIdentifier>
+                  <history>
+                     <origin>
+                        <origPlace>
+                     </origPlace>
+<origDate ></origDate>
+                     </origin>
+                  </history>
+                  <additional>
+                     <adminInfo>
+                        <recordHist>
+                           <source>
+                              <listBibl type="secondary">
+                                 <bibl>
+                                 <ptr target="bm:Six1994VOHD6"/>
+                                 <citedRange unit="page">409-410</citedRange>
+                              </bibl>
+                            </listBibl>
+                           </source>
+                        </recordHist>
+                        </adminInfo>
+                  </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <projectDesc>
+            <p>Encoded according to TEI P5 Guidelines.</p>
+         </projectDesc>
+         <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+            <xi:fallback>
+               <p>Definitions of prefixes used.</p>
+            </xi:fallback>
+         </xi:include>
+      </encodingDesc>
+      <profileDesc>
+         <langUsage><language ident="en">English</language></langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change who="JK" when="2025-03-14">Created catalogue entry stub</change>
+      </revisionDesc>
+   </teiHeader>
+   <text xml:base="https://betamasaheft.eu/">
+      <body>
+         <ab/>
+      </body>
+   </text>
+</TEI>

--- a/Uppsala/UppEt47.xml
+++ b/Uppsala/UppEt47.xml
@@ -183,6 +183,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                       
                     </msContents>
 
+
+
+
+
+
+
+
+
+
+
+
                     <physDesc>
                         <objectDesc form="Scroll">
                             <supportDesc>
@@ -192,14 +203,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                 <extent>
                                     <measure unit="leaf">1</measure>
                                     <dimensions type="outer" unit="mm">
-                                        <height>830</height>
+                                        <height>420</height>
                                         <width>240</width>
                                     </dimensions>
-                                    <note>Consists of <measure unit="strips">1</measure> strip.</note>
+                                    <note>Consists of <measure unit="strips" quantity="1">1</measure> strip.</note>
                                 </extent>
                             </supportDesc>
                             <layoutDesc>
-                                <layout columns="3" writtenLines="93 96">
+                                <layout columns="3" writtenLines="42 44">
                                 </layout>
                             </layoutDesc>
                         </objectDesc>
@@ -208,7 +219,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             <handNote xml:id="h1" script="Ethiopic">
                                 <desc>Skilled hand of the 19th century (<foreign xml:lang="de">von einer habilen Hand des 19. Jahrhunderts</foreign>, 
                                     <bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">137</citedRange></bibl>).
-                                    The same hand wrote <ref type="mss" target="UppEt45"/> and <ref type="mss" target="UppEt47"/>.
+                                    The same hand wrote <ref type="mss" target="UppEt45"/> and <ref type="mss" target="UppEt46"/>.
                                     </desc>
                                 <date notBefore="1800" notAfter="1899">19th century.</date>
                             </handNote>
@@ -216,32 +227,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
 
                         <decoDesc>
                             <decoNote xml:id="d1" type="miniature">
-                                <desc>Coloured <term key="Magic">magic picture</term> of 
-                                    a rider on a white horse and a dragon being speared.
+                                <desc>Coloured <term key="MagicDrawing">magic picture</term> of 
+                                    a two figures wielding swords.
                                     <persName ref="PRS6337Lofgren"/>
-                                    identifies the scene as either <persName ref="PRS4585Georgeo"/> defeating the dragon 
-                                    or <persName ref="PRS8886Sisinios"/> killing <persName ref="PRS10134Werzely"/>
+                                    identifies them as an <term key="angel">angel</term> and a man
                                     (<bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">138</citedRange></bibl>).
                                 </desc>
                                 <dimensions unit="mm">
-                                    <height>240</height>
+                                    <height>200</height>
                                     <width>240</width>
                                 </dimensions>
                             </decoNote>
-                            
-                            <decoNote xml:id="d2" type="miniature">
-                                <desc>Coloured <term key="Magic">magic picture</term> of 
-                                    a blue <term key="demon">demon</term> holding two figures (in the interpretation of
-                                    <bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">138</citedRange></bibl>: 
-                                    a man and a child),
-                                    while, on his right, an angel waives a sword in his face and, on his left, a saint either
-                                    dressed in white or covered in his own white hair holds a cross.
-                                </desc>
-                                <dimensions unit="mm">
-                                    <height>90</height>
-                                    <width>240</width>
-                                </dimensions>
-                            </decoNote>
+
                         </decoDesc>
 
                         <additions>
@@ -250,7 +247,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                 <item xml:id="e1">
                                     <desc type="AcquisitionNote">Note in pencil at the bottom of the unwritten back.</desc>
                                     <q xml:lang="sv">
-                                        x 1968/33
+                                        O Etiop. 47
+                                        x 1973/25
                                     </q>
                                 </item>
                                 
@@ -264,13 +262,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             <origDate notBefore="1800" notAfter="1899">19th century.</origDate>
                         </origin>
                         <provenance>
-                            The latter part of the name of the original owner <persName ref="PRS14626WalattaAbiyaEgzi" role="owner"/>, 
-                            as present in supplications, has regularly been erased 
+                            The latter part of the name of the original owner (<persName ref="PRS14626WalattaAbiyaEgzi" role="owner"/>?, see below), 
+                            as present in the final supplication, has been erased 
                             and substituted, producing the name of a secondary owner
                             <persName ref="PRS14625WalattaMaryam" role="owner"/>. According to 
                             <bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">138</citedRange></bibl>,
                             this manuscript shares the same history as <ref type="mss" corresp="#UppEt45"/> and
-                            <ref type="mss" corresp="#UppEt47"/>: they were all owned by the same original owner and later
+                            <ref type="mss" corresp="#UppEt46"/>: they were all owned by the same original owner and later
                             all passed into the ownership of <persName ref="PRS14625WalattaMaryam" role="owner"/>.
                             At some point between <date when="1866">1866</date>
                             (when the first missionaries connected to Evangeliska fosterlandsstiftelsen arrived in Ethiopia) and
@@ -281,19 +279,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             Johannelund (Ulvsunda, <placeName ref="LOC7456Stockholm"/>).
                         </provenance>
                         <acquisition>
-                            According to <ref target="#e1"/>, the manuscript reached its current repository in <date when="1968"/>.
+                            According to <ref target="#e1"/>, the manuscript reached its current repository in <date when="1973"/>.
                         </acquisition>
                     </history>
-
-
-
-
-
-
-
-
-
-
 
                     <additional>
                         <adminInfo>

--- a/Uppsala/UppEt47.xml
+++ b/Uppsala/UppEt47.xml
@@ -1,0 +1,374 @@
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" type="mss" xml:lang="en" xml:id="UppEt47">
+    <teiHeader xml:base="https://betamasaheft.eu/">
+        <fileDesc>
+            <titleStmt>
+                <title xml:id="t1">
+                    Protective prayers
+                </title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
+                            This file is licensed under the Creative Commons
+                            Attribution-ShareAlike 4.0.
+                    </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS0356Upp"/>
+                        <collection>O Etiop.</collection>
+                        <idno>O Etiop. 47</idno>
+                        <altIdentifier><idno>Löfgren 46</idno></altIdentifier>
+                        <altIdentifier><idno>Löfgren XII</idno></altIdentifier>
+                        <altIdentifier><idno>509.</idno></altIdentifier>
+                    </msIdentifier>
+                    
+                    
+                    
+                    
+                    
+                    
+                    
+                    
+                    
+                    
+                    
+                    
+                    
+                    
+                    <msContents>
+                        
+                        <msItem xml:id="ms_i1">
+                            <locus target="#1ra"/>
+                            <title type="complete" ref="LIT7241PPSalakwa"/>
+                            <incipit xml:lang="gez">
+                                <hi rend="rubric">ሰላኰ፡ ማያች፡ እልመኪ፡ ወሹራ፡ ቀግተራ፡ ወይኑራ፡ ቀ</hi>ቲ፡ 
+                                ማርዲ፡ በሐቅ፡ መግኑን<supplied reason="omitted">፡</supplied> ኖቢዮ፡ በሕትሙኪን፡ 
+                                ናዝዚ<supplied reason="omitted">፡</supplied> ሐልጣቆን፡ ከጠውር፡
+                                ሸጢሽ<supplied reason="omitted">፡</supplied> ሾንሸፈ፡
+                            </incipit>
+                            <explicit xml:lang="gez">
+                                ምንቅብሎ፡ መናርሚ<supplied reason="omitted">፡</supplied>
+                                መጅሀም፡ አምኪራ፡ ባርያ። ወሌጌዎን፡ ወተግባረ፡ ሰብእ<supplied reason="omitted">፡</supplied>
+                                አድኅነኒ፡ እምሕማመ፡ ሰይጣን፡ 
+                                ለአመትከ፡ <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
+                                <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst></persName>
+                            </explicit>
+                        </msItem>
+                        
+                        <msItem xml:id="ms_i2">
+                            <locus target="#1ra"/>
+                            <title type="complete" ref="LIT7244PPBaha"/>
+                            <note>Contains <term key="MagicSymbols"><foreign xml:lang="de">Brillenbuchstaben (charaktêres)</foreign></term>.</note>
+                            <incipit xml:lang="gez">
+                                <hi rend="rubric">ጸሎት፡ በእንተ፡ ማዕሠሮሙ፡ ለ</hi>አጋንንት፡ 
+                                በሐ፡ በሐ፡ ሸቢ፡ በሐሸቢም፡ አሽ፡ አሽረዋሽ፡ አራውትል፡
+                            </incipit>
+                            <explicit xml:lang="gez">
+                                በዝ፡ ቃለ፡ ዓረቢ፡ በዝ<supplied reason="omitted">፡</supplied> አብነት፡ 
+                                ዘያፈርሃኒ፡ እምኵሉ፡ ሥራይ፡ እምአጕርዕ፡ ወእምትግርትያ፡ እምአጋንንት።
+                                ወሰይጣናት፡ ወእምኵሉ፡ ፀር<supplied reason="omitted">፡</supplied>
+                                ወፀላኢ፡ አድኅነኒ፡ ለዓመትከ፡ 
+                               <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
+                                <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst></persName>
+                            </explicit>
+                        </msItem>
+                        
+                        <msItem xml:id="ms_i3">
+                            <locus target="#1ra"/>
+                            <title type="complete" ref="LIT7245PPYokin"/>
+                            <note>The entire text is reproduced below.</note>
+                            <incipit xml:lang="gez">
+                                <hi rend="rubric">በስመ<supplied reason="omitted">፡</supplied> ሥሉስ፡ ቅዱስ፡
+                                በእንተ፡ ሥራየ፡ ዮኪን፡ ዮፍታሔ፡ ዮፍታሔ፡ ፍታሕ፡</hi> ድድንግኤል፡ ፍታሕ፡ 
+                                ክፍትናኤል፡ ፍታሕ፡ እራፎን፡ ፍታሕ፡ እራዛን፡ ፍታሕ፡ አድኅነኒ፡ እምሥራይ፡ 
+                                ወእምጸላወጊ፡ ለአመትከ፡ 
+                                <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
+                                 <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst></persName>
+                            </incipit>
+                        </msItem>
+                      
+                        <msItem xml:id="ms_i4">
+                            <locus target="#1ra"/>
+                            <title type="complete" ref="LIT7246PPSelawagi"/>
+                            <note>The entire text is reproduced below.</note>
+                            <incipit xml:lang="gez">
+                                <hi rend="rubric">ጸሎት፡</hi> ዘጽላወጊ፡ በላህ፡ ከርፋስ፡ አርም፡ አዶቶል፡ አኰቶ፡ እያስ፡ 
+                                ነፍሱ፡ እያስ፡ እያስ፡ ነፍሳ<supplied reason="omitted">፡</supplied> ወሥጋሃ፡ ለአመትከ፡ 
+                                <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
+                                    <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም፡</add></subst></persName><hi rend="rubric">፡</hi>
+                                እስመ፡ አልቦ፡ ነገር፡ ዘይሰአኖ፡ ለእግዚአብሔር፡ ቃል፡ ሥጋ፡ ኮነ።
+                            </incipit>
+                        </msItem>
+                        
+                        <msItem xml:id="ms_i5">
+                            <locus target="#1rb"/>
+                            <title type="complete" ref="LIT7249PPSoba"/>
+                            <incipit xml:lang="gez">
+                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡ ሶበ፡</hi>
+                                ይመጽኡ፡ ገባርያነ፡ እከይ፡ ወኃይል፡ ኀቤየ፡ እመሂ፡ በፍኖትየ። ወእመሂ፡ በንዋይየ፡ 
+                                ወኵሎ<supplied reason="omitted">፡</supplied> እንዘ፡ እበልዕ፡ <sic resp="JK">ወእሴቲ፡</sic> 
+                                በሰይፈ፡ መለኮትከ፡ ይትገዘሙ፡ <sic resp="JK">ወይትመትሩ፡</sic> በሐፀ፡ መለኮትከ፡ 
+                                ይትነደፉ፡ በኵናተ፡ መለኮትከ፡ ይትረገዙ፡ በወልታ፡ መለኮትከ፡ ይከልዖሙ፡ እሳተ፡ መለኮትከ፡
+                            </incipit>
+                            <explicit xml:lang="gez">
+                                ባርያ፡ ወሌጌዎን፡ ኅሱም፡ ወቄዳር<supplied reason="omitted">፡</supplied> 
+                                ነሀቢ፡ ወሥራይ፡ ዶቢ፡ ወዶቢት፡ ማሪ፡ ወማሪት፡ ውግዓት<supplied reason="omitted">፡</supplied>
+                                ወምትዓት፡ ኵልኵሙ፡ ሕማመ፡ ደዌ፡ እለ፡ ያስተአልው<supplied reason="omitted">፡</supplied>
+                                ነፍስ፡ በነፍስ፡ ሥጋ፡ በሥጋ፡ ኢትቅረቡ፡ ኀበ፡ ነፍሳ፡ ወሥጋሀ፡ ለአመትከ፡ 
+                                <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
+                                    <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst></persName>
+                            </explicit>
+                        </msItem>
+                      
+                        <msItem xml:id="ms_i6">
+                            <locus target="#1rb"/>
+                            <title type="complete" ref="LIT7250PPFanuel"/>
+                            <note>The entire text, which ends abruptly in the manuscript, is reproduced below.</note>
+                            <incipit xml:lang="gez">
+                                <hi rend="rubric">ነዓ፡ ኀቤየ፡ ፋኑኤል፡ እሳት፡ ነዳዲ፡</hi>
+                                ማኅበረ፡ ሰይጣናት፡ በሰማይ፡ እስመ፡ አንተ፡ ሰዳዲ፡ 
+                                አልብሰኒ፡ ጽድቀ፡ ለዓለመ፡ <sic resp="JK">ዓለመ፡</sic> ወዓዲ፡
+                                ወበትንባሌከ፡ እደ። ኃጣውእየ፡ ፍዲ፡ 
+                                መናሥግተ፡ ቤትየ፡ አጽንዕ፡ ኢይባእ፡ ረዋዲ፡ 
+                                ኦአምላከ፡ ፋኑኤል፡ ዕቀባ፡ እምዓይነተ፡ ባርያ፡ ወ
+                            </incipit>
+                        </msItem>
+                        
+                        <msItem xml:id="ms_i7">
+                            <locus target="#1rc"/>
+                            <title type="complete" ref="LIT7253PPMarySaid"/>
+                            <incipit xml:lang="gez">
+                                <hi rend="rubric">ወትቤ፡ እግዝእትነ፡ ማርያም፡ በነገረ፡ ዕብራይስጢ<supplied reason="omitted">፡</supplied></hi> ዕ፡ 
+                                ሰፎሶፎያሮስቦ፡ ያክርርሜል፡ ፒፒያኤል፡ ጵርስቦስ፡ አዴሌዕ፡ መትዋፎን፡ ወርእየቶሙ፡ እግዝእትነ፡ 
+                                <hi rend="rubric">ማርያም፡</hi> እምርሑቅ፡ ወትቤ<supplied reason="omitted">፡</supplied>
+                                ትብያቶያላን፡ ጥብያቶላን፡ ጥብያቶጳራን፡ ጰአውያን፡
+                            </incipit>
+                            <explicit xml:lang="gez">
+                                ኮርኮርያስም፡ ፓፓል፡ ልጤርያስ፡ አንሰባኪዱክባ፡ ኵጉኩያስ፡ ምንያኤል<supplied reason="omitted">፡</supplied>
+                                ደትኤል፡ ስምዓኒ፡ ለአመትከ፡ 
+                               <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
+                                    <subst><del rend="effaced" unit="chars" quantity="8"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst></persName>
+                            </explicit>
+                        </msItem>
+                      
+                        <msItem xml:id="ms_i8">
+                            <locus target="#1rc"/>
+                            <title type="complete" ref="LIT7254PPMagic"/>
+                            <incipit xml:lang="gez">
+                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡</hi>
+                                ጸሎት፡ በእንተ፡ ሕማመ<supplied reason="omitted">፡</supplied> ዓይነ፡ ወጋርር፡ 
+                                ወትግሪዳ፡ አድኅና፡ ለአመትከ፡ 
+                                <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
+                                    <subst><del rend="effaced" unit="chars" quantity="8"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst></persName>
+                                ይትነሣእ፡ እግዚአብሔር፡ ወይዘረው<supplied reason="omitted">፡</supplied>
+                                ጾሩ፡ ወይጕየዩ፡ ጸላእቱ።
+                            </incipit>
+                            <explicit xml:lang="gez">
+                                ከመ፡ ኢይምጽኡ<supplied reason="omitted">፡</supplied> ኀቤየ፡ ወከመ፡ ኢይቅረቡኒ፡ 
+                                ኀቤየ፡ ወመንገሌየ፡ ወኢይበውኡ፡ ውስተ፡ ጽላሎተ፡ ቤትየ፡ ወከመ፡ ኢይቅረቡ፡ ኀበ፡ ነፍስየ፡ 
+                                ወሥጋየ፡ ወአነኒ፡ ለአመትከ፡ 
+                                <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi><surplus><hi rend="rubric">ወለተ፡</hi></surplus>
+                                    <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst></persName>
+                            </explicit>
+                        </msItem>
+                      
+                    </msContents>
+
+                    <physDesc>
+                        <objectDesc form="Scroll">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>
+                                </support>
+                                <extent>
+                                    <measure unit="leaf">1</measure>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>830</height>
+                                        <width>240</width>
+                                    </dimensions>
+                                    <note>Consists of <measure unit="strips">1</measure> strip.</note>
+                                </extent>
+                            </supportDesc>
+                            <layoutDesc>
+                                <layout columns="3" writtenLines="93 96">
+                                </layout>
+                            </layoutDesc>
+                        </objectDesc>
+                        
+                        <handDesc>
+                            <handNote xml:id="h1" script="Ethiopic">
+                                <desc>Skilled hand of the 19th century (<foreign xml:lang="de">von einer habilen Hand des 19. Jahrhunderts</foreign>, 
+                                    <bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">137</citedRange></bibl>).
+                                    The same hand wrote <ref type="mss" target="UppEt45"/> and <ref type="mss" target="UppEt47"/>.
+                                    </desc>
+                                <date notBefore="1800" notAfter="1899">19th century.</date>
+                            </handNote>
+                        </handDesc>
+
+                        <decoDesc>
+                            <decoNote xml:id="d1" type="miniature">
+                                <desc>Coloured <term key="Magic">magic picture</term> of 
+                                    a rider on a white horse and a dragon being speared.
+                                    <persName ref="PRS6337Lofgren"/>
+                                    identifies the scene as either <persName ref="PRS4585Georgeo"/> defeating the dragon 
+                                    or <persName ref="PRS8886Sisinios"/> killing <persName ref="PRS10134Werzely"/>
+                                    (<bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">138</citedRange></bibl>).
+                                </desc>
+                                <dimensions unit="mm">
+                                    <height>240</height>
+                                    <width>240</width>
+                                </dimensions>
+                            </decoNote>
+                            
+                            <decoNote xml:id="d2" type="miniature">
+                                <desc>Coloured <term key="Magic">magic picture</term> of 
+                                    a blue <term key="demon">demon</term> holding two figures (in the interpretation of
+                                    <bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">138</citedRange></bibl>: 
+                                    a man and a child),
+                                    while, on his right, an angel waives a sword in his face and, on his left, a saint either
+                                    dressed in white or covered in his own white hair holds a cross.
+                                </desc>
+                                <dimensions unit="mm">
+                                    <height>90</height>
+                                    <width>240</width>
+                                </dimensions>
+                            </decoNote>
+                        </decoDesc>
+
+                        <additions>
+                            <list>
+                                
+                                <item xml:id="e1">
+                                    <desc type="AcquisitionNote">Note in pencil at the bottom of the unwritten back.</desc>
+                                    <q xml:lang="sv">
+                                        x 1968/33
+                                    </q>
+                                </item>
+                                
+                            </list>
+                        </additions>
+                        
+                    </physDesc>
+                    
+                    <history>
+                        <origin>
+                            <origDate notBefore="1800" notAfter="1899">19th century.</origDate>
+                        </origin>
+                        <provenance>
+                            The latter part of the name of the original owner <persName ref="PRS14626WalattaAbiyaEgzi" role="owner"/>, 
+                            as present in supplications, has regularly been erased 
+                            and substituted, producing the name of a secondary owner
+                            <persName ref="PRS14625WalattaMaryam" role="owner"/>. According to 
+                            <bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">138</citedRange></bibl>,
+                            this manuscript shares the same history as <ref type="mss" corresp="#UppEt45"/> and
+                            <ref type="mss" corresp="#UppEt47"/>: they were all owned by the same original owner and later
+                            all passed into the ownership of <persName ref="PRS14625WalattaMaryam" role="owner"/>.
+                            At some point between <date when="1866">1866</date>
+                            (when the first missionaries connected to Evangeliska fosterlandsstiftelsen arrived in Ethiopia) and
+                            <date when="1928">1928</date> (when the manuscript was catalogued for the first time in Sweden),
+                            the manuscript was acquired by an unknown missionary of
+                            Evangeliska fosterlandsstiftelsen and brought to Sweden. For a while, 
+                            it was kept at <placeName ref="INS1020EFSmissionsmuseum"/> in 
+                            Johannelund (Ulvsunda, <placeName ref="LOC7456Stockholm"/>).
+                        </provenance>
+                        <acquisition>
+                            According to <ref target="#e1"/>, the manuscript reached its current repository in <date when="1968"/>.
+                        </acquisition>
+                    </history>
+
+
+
+
+
+
+
+
+
+
+
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Loefgren1929Evangeliska"/>
+                                            <citedRange unit="page">17–18</citedRange>
+                                            <citedRange unit="number">XII</citedRange>
+                                        </bibl>
+                                        <bibl>
+                                            <ptr target="bm:Loefgren1974Katalog"/>
+                                            <citedRange unit="page">138</citedRange>
+                                            <citedRange unit="number">46</citedRange>
+                                        </bibl>
+                                        <bibl>
+                                            <ptr target="bm:alvin"/>
+                                        </bibl>
+                                        <bibl>
+                                            <ptr target="bm:BmWebsite"/>
+                                        </bibl>
+                                    </listBibl>
+                                    <listBibl type="secondary">
+                                        <bibl>
+                                            <ptr target="bm:Loefgren1962Wandamulette"/>
+                                        </bibl>
+                                        <bibl>
+                                            <ptr target="bm:Lundin2023Osamlingen"/>
+                                            <citedRange unit="page">60–61</citedRange>
+                                        </bibl>
+                                        <bibl>
+                                            <ptr target="bm:Lundin2023Ocollection"/>
+                                            <citedRange unit="page">60–61</citedRange>
+                                        </bibl>
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                    
+                </msDesc>
+                
+            </sourceDesc>
+
+        </fileDesc>
+        <encodingDesc>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+                <xi:fallback>
+                    <p>Definitions of prefixes used.</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
+        <profileDesc>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Magic"/>
+                </keywords>
+            </textClass>
+            <langUsage><language ident="en">English</language></langUsage>
+            <langUsage><language ident="gez">Gəʿəz</language></langUsage>
+            <langUsage><language ident="sv">Swedish</language></langUsage>
+        </profileDesc>
+
+        <revisionDesc>
+            <change who="JK" when="2025-03-12">Created record</change>
+        </revisionDesc>
+    </teiHeader>
+    <facsimile>
+        <graphic url="http://urn.kb.se/resolve?urn=urn:nbn:se:alvin:portal:record-489058"/>
+    </facsimile>
+    <text xml:base="https://betamasaheft.eu/">
+        <body>
+            <ab/>
+        </body>
+    </text>
+</TEI>

--- a/Uppsala/UppEt47.xml
+++ b/Uppsala/UppEt47.xml
@@ -36,7 +36,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         
                         <msItem xml:id="ms_i1">
                             <locus target="#1ra"/>
-                            <title type="complete" ref=""/>
+                            <title type="complete" ref="LIT14518PPSolomon"/>
                             <incipit xml:lang="gez">
                                 <hi rend="rubric">አስማተ፡ <surplus resp="PRS6337Lofgren">ህላሁ፡</surplus> ህላዌሁ<supplied reason="subaudible" resp="JK">፡</supplied> 
                                     ለሰሎሞን፡ ንዑድ፡ ኢያስ<supplied reason="subaudible" resp="JK">፡</supplied> ኢያበስ፡ ኢየበአስ፡ አድዳኤ</hi>ል፡

--- a/Uppsala/UppEt47.xml
+++ b/Uppsala/UppEt47.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
         <fileDesc>
             <titleStmt>
                 <title xml:id="t1">
-                    Protective prayers
+                    Magic prayer
                 </title>
             </titleStmt>
             <publicationStmt>

--- a/Uppsala/UppEt47.xml
+++ b/Uppsala/UppEt47.xml
@@ -149,7 +149,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <decoDesc>
                             <decoNote xml:id="d1" type="miniature">
                                 <desc>Coloured <term key="MagicDrawing">magic picture</term> of 
-                                    a two figures wielding swords.
+                                    two figures wielding swords.
                                     <persName ref="PRS6337Lofgren"/>
                                     identifies them as an <term key="angel">angel</term> and a man
                                     (<bibl><ptr target="bm:Loefgren1974Katalog"/><citedRange unit="page">138</citedRange></bibl>).
@@ -195,7 +195,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                             (when the first missionaries connected to Evangeliska fosterlandsstiftelsen arrived in Ethiopia) and
                             <date when="1928">1928</date> (when the manuscript was catalogued for the first time in Sweden),
                             the manuscript was acquired by an unknown missionary of
-                            Evangeliska fosterlandsstiftelsen and brought to Sweden. For a while, 
+                            <foreign xml:lang="sv">Evangeliska fosterlandsstiftelsen</foreign> and brought to Sweden. For a while, 
                             it was kept at <placeName ref="INS1020EFSmissionsmuseum"/> in 
                             Johannelund (Ulvsunda, <placeName ref="LOC7456Stockholm"/>).
                         </provenance>

--- a/Uppsala/UppEt47.xml
+++ b/Uppsala/UppEt47.xml
@@ -266,6 +266,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <langUsage><language ident="en">English</language></langUsage>
             <langUsage><language ident="gez">Gəʿəz</language></langUsage>
             <langUsage><language ident="sv">Swedish</language></langUsage>
+            <langUsage><language ident="de">German</language></langUsage>
         </profileDesc>
 
         <revisionDesc>

--- a/Uppsala/UppEt47.xml
+++ b/Uppsala/UppEt47.xml
@@ -30,169 +30,90 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <altIdentifier><idno>Löfgren XII</idno></altIdentifier>
                         <altIdentifier><idno>509.</idno></altIdentifier>
                     </msIdentifier>
-                    
-                    
-                    
-                    
-                    
-                    
-                    
-                    
-                    
-                    
-                    
-                    
-                    
+
                     
                     <msContents>
                         
                         <msItem xml:id="ms_i1">
                             <locus target="#1ra"/>
-                            <title type="complete" ref="LIT7241PPSalakwa"/>
+                            <title type="complete" ref=""/>
                             <incipit xml:lang="gez">
-                                <hi rend="rubric">ሰላኰ፡ ማያች፡ እልመኪ፡ ወሹራ፡ ቀግተራ፡ ወይኑራ፡ ቀ</hi>ቲ፡ 
-                                ማርዲ፡ በሐቅ፡ መግኑን<supplied reason="omitted">፡</supplied> ኖቢዮ፡ በሕትሙኪን፡ 
-                                ናዝዚ<supplied reason="omitted">፡</supplied> ሐልጣቆን፡ ከጠውር፡
-                                ሸጢሽ<supplied reason="omitted">፡</supplied> ሾንሸፈ፡
+                                <hi rend="rubric">አስማተ፡ <surplus resp="PRS6337Lofgren">ህላሁ፡</surplus> ህላዌሁ<supplied reason="subaudible" resp="JK">፡</supplied> 
+                                    ለሰሎሞን፡ ንዑድ፡ ኢያስ<supplied reason="subaudible" resp="JK">፡</supplied> ኢያበስ፡ ኢየበአስ፡ አድዳኤ</hi>ል፡
+                                ዝቃል፡ ዘወረደ፡ እምሰማይ፡ ዘእንበለ፡ ይ<supplied reason="omitted" resp="PRS6337Lofgren">ት</supplied>ወለድ፡
+                                ክርስቶስ፡ እማ<hi rend="rubric">ርያም፡
+                                    ኀበ፡ ሀሎ፡ ሰሎሞን፡</hi> 
+                                <app>
+                                    <lem resp="JK">ሻተክላ<supplied reason="subaudible">፡</supplied></lem>
+                                    <rdg resp="PRS6337Lofgren">ሸተከላ፡</rdg>
+                                </app>
+                                <app>
+                                    <lem resp="JK">ሸተክላ፡</lem>
+                                    <rdg resp="PRS6337Lofgren">ሸተከላ፡</rdg>
+                                </app>
+                                <app>
+                                    <lem resp="JK">ሸተክላ፡</lem>
+                                    <rdg resp="PRS6337Lofgren">ሸተከላ፡</rdg>
+                                </app>
+                                ሹኤልሹ፡ 
+                                <app>
+                                    <lem resp="JK">ተሽታሽር፡</lem>
+                                    <rdg resp="PRS6337Lofgren">ተሸታሸር፡</rdg>
+                                </app>
+                                ሸላሆም።
+                                <app>
+                                    <lem resp="JK">ሾአቱ፡</lem>
+                                    <rdg resp="PRS6337Lofgren">ሸአቱ፡</rdg>
+                                </app>
+                                <app>
+                                    <lem resp="JK">ሾአቱ፡</lem>
+                                    <rdg resp="PRS6337Lofgren">ሸአቱ፡</rdg>
+                                </app>
+                                ዝብልዓቱ<supplied reason="subaudible">፡</supplied>
+                                አማኑኤል፡ 
+                                <app>
+                                    <lem resp="JK">ሶመ፡</lem>
+                                    <rdg resp="PRS6337Lofgren"><unclear>ስመ፡</unclear></rdg>
+                                </app>
+                                ገቦሁ፡ በዝንቱ፡ አስማቲከ፡ ተማኅፀንኩ፡ 
+                                ከመ፡ 
+                                <app>
+                                    <lem resp="JK">እድኃን፡</lem>
+                                    <rdg resp="PRS6337Lofgren"><unclear>እድኅን፡</unclear></rdg>
+                                </app>
+                                <hi rend="rubric">ሰሎሞን፡</hi> እምእዴሆሙ፡ 
+                                ለነሀብት፡ እምድኅረ፡ አኃዝዎ፡ ወአንበርዎ፡ ፫ ዕለተ፡ ወ፫ ሌሊተ<supplied reason="subaudible">፡</supplied>
+                                በአምሳለ፡ ንዋም፡ 
+                                <app>
+                                    <lem resp="JK">ወአቀምዎ፡</lem>
+                                    <rdg resp="PRS6337Lofgren"><surplus>ወ</surplus>አቀምዎ፡</rdg>
+                                </app>
+                                ቅድመ፡ ንጉሦሙ፡ ለነሀብት፡ ወይቤሎ፡ 
+                                አፍራህከኒ፡ ወፈድፋደ፡ ገረምከኒ፡ ምንተ<supplied reason="subaudible" resp="JK">፡</supplied>
+                                ረገም<sic resp="PRS6337Lofgren">ገ</sic>ኒ፡ 
+                                <app>
+                                    <lem>ምንተ፡</lem>
+                                    <rdg resp="PRS6337Lofgren">ምንት፡</rdg>
+                                </app>
+                                ሀሎ፡ ውስተ፡ ከርሥከ፡ 
+                                ወይቤሎ፡ <hi rend="rubric">ሰሎሞን፡</hi>
                             </incipit>
+                            
                             <explicit xml:lang="gez">
-                                ምንቅብሎ፡ መናርሚ<supplied reason="omitted">፡</supplied>
-                                መጅሀም፡ አምኪራ፡ ባርያ። ወሌጌዎን፡ ወተግባረ፡ ሰብእ<supplied reason="omitted">፡</supplied>
-                                አድኅነኒ፡ እምሕማመ፡ ሰይጣን፡ 
-                                ለአመትከ፡ <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
-                                <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst></persName>
-                            </explicit>
-                        </msItem>
-                        
-                        <msItem xml:id="ms_i2">
-                            <locus target="#1ra"/>
-                            <title type="complete" ref="LIT7244PPBaha"/>
-                            <note>Contains <term key="MagicSymbols"><foreign xml:lang="de">Brillenbuchstaben (charaktêres)</foreign></term>.</note>
-                            <incipit xml:lang="gez">
-                                <hi rend="rubric">ጸሎት፡ በእንተ፡ ማዕሠሮሙ፡ ለ</hi>አጋንንት፡ 
-                                በሐ፡ በሐ፡ ሸቢ፡ በሐሸቢም፡ አሽ፡ አሽረዋሽ፡ አራውትል፡
-                            </incipit>
-                            <explicit xml:lang="gez">
-                                በዝ፡ ቃለ፡ ዓረቢ፡ በዝ<supplied reason="omitted">፡</supplied> አብነት፡ 
-                                ዘያፈርሃኒ፡ እምኵሉ፡ ሥራይ፡ እምአጕርዕ፡ ወእምትግርትያ፡ እምአጋንንት።
-                                ወሰይጣናት፡ ወእምኵሉ፡ ፀር<supplied reason="omitted">፡</supplied>
-                                ወፀላኢ፡ አድኅነኒ፡ ለዓመትከ፡ 
-                               <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
-                                <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst></persName>
-                            </explicit>
-                        </msItem>
-                        
-                        <msItem xml:id="ms_i3">
-                            <locus target="#1ra"/>
-                            <title type="complete" ref="LIT7245PPYokin"/>
-                            <note>The entire text is reproduced below.</note>
-                            <incipit xml:lang="gez">
-                                <hi rend="rubric">በስመ<supplied reason="omitted">፡</supplied> ሥሉስ፡ ቅዱስ፡
-                                በእንተ፡ ሥራየ፡ ዮኪን፡ ዮፍታሔ፡ ዮፍታሔ፡ ፍታሕ፡</hi> ድድንግኤል፡ ፍታሕ፡ 
-                                ክፍትናኤል፡ ፍታሕ፡ እራፎን፡ ፍታሕ፡ እራዛን፡ ፍታሕ፡ አድኅነኒ፡ እምሥራይ፡ 
-                                ወእምጸላወጊ፡ ለአመትከ፡ 
-                                <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
-                                 <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst></persName>
-                            </incipit>
-                        </msItem>
-                      
-                        <msItem xml:id="ms_i4">
-                            <locus target="#1ra"/>
-                            <title type="complete" ref="LIT7246PPSelawagi"/>
-                            <note>The entire text is reproduced below.</note>
-                            <incipit xml:lang="gez">
-                                <hi rend="rubric">ጸሎት፡</hi> ዘጽላወጊ፡ በላህ፡ ከርፋስ፡ አርም፡ አዶቶል፡ አኰቶ፡ እያስ፡ 
-                                ነፍሱ፡ እያስ፡ እያስ፡ ነፍሳ<supplied reason="omitted">፡</supplied> ወሥጋሃ፡ ለአመትከ፡ 
-                                <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
-                                    <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም፡</add></subst></persName><hi rend="rubric">፡</hi>
-                                እስመ፡ አልቦ፡ ነገር፡ ዘይሰአኖ፡ ለእግዚአብሔር፡ ቃል፡ ሥጋ፡ ኮነ።
-                            </incipit>
-                        </msItem>
-                        
-                        <msItem xml:id="ms_i5">
-                            <locus target="#1rb"/>
-                            <title type="complete" ref="LIT7249PPSoba"/>
-                            <incipit xml:lang="gez">
-                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡ ሶበ፡</hi>
-                                ይመጽኡ፡ ገባርያነ፡ እከይ፡ ወኃይል፡ ኀቤየ፡ እመሂ፡ በፍኖትየ። ወእመሂ፡ በንዋይየ፡ 
-                                ወኵሎ<supplied reason="omitted">፡</supplied> እንዘ፡ እበልዕ፡ <sic resp="JK">ወእሴቲ፡</sic> 
-                                በሰይፈ፡ መለኮትከ፡ ይትገዘሙ፡ <sic resp="JK">ወይትመትሩ፡</sic> በሐፀ፡ መለኮትከ፡ 
-                                ይትነደፉ፡ በኵናተ፡ መለኮትከ፡ ይትረገዙ፡ በወልታ፡ መለኮትከ፡ ይከልዖሙ፡ እሳተ፡ መለኮትከ፡
-                            </incipit>
-                            <explicit xml:lang="gez">
-                                ባርያ፡ ወሌጌዎን፡ ኅሱም፡ ወቄዳር<supplied reason="omitted">፡</supplied> 
-                                ነሀቢ፡ ወሥራይ፡ ዶቢ፡ ወዶቢት፡ ማሪ፡ ወማሪት፡ ውግዓት<supplied reason="omitted">፡</supplied>
-                                ወምትዓት፡ ኵልኵሙ፡ ሕማመ፡ ደዌ፡ እለ፡ ያስተአልው<supplied reason="omitted">፡</supplied>
-                                ነፍስ፡ በነፍስ፡ ሥጋ፡ በሥጋ፡ ኢትቅረቡ፡ ኀበ፡ ነፍሳ፡ ወሥጋሀ፡ ለአመትከ፡ 
+                                ከመ፡ ይፍታሕ፡ ኵሉ፡ ሥራየ፡ ወኵሉ፡ ዓይነ፡ እኩይ፡ እመሂ። ማሪ፡ ወማሪት፡ ወእመሂ፡ 
+                                ራእይት፡ ወእመሂ፡ ዲኖ፡ ወመቃውዚ፡ ወእመሂ፡ ደስክ።
+                                ወጉዳሌ፡ ወእመሂ፡ ጠፈንት፡ ወእመሂ፡ ባርያ፡ ወእመሂ፡ ብድብድ፡ 
+                                ወእመሂ፡ ፌራ፡ ወፈንጻፃ፡ ወእመሂ<supplied reason="subaudible">፡</supplied> 
+                                ዘይረግም፡ ሰማየ፡ ነጺሮሙ፡ ከመ፡ ታድኅኖ፡ ሜሎስ፡ ሰይፈ፡ እሳት፡ 
+                                ሐፀ፡ መለኮት፡ ዘያነድዶሙ፡ ለሰማይ፡ በኢየሩ<sic resp="JK">፡</sic>
+                                ሳሌም፡ ሀገርከ፡ በደብረ፡ <hi rend="rubric">ጽዮን፡</hi>
+                                በአተ፡ መንግሥትከ፡ ከመ፡ ታድኅነኒ፡ ለአመትከ፡
                                 <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
                                     <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst></persName>
                             </explicit>
                         </msItem>
-                      
-                        <msItem xml:id="ms_i6">
-                            <locus target="#1rb"/>
-                            <title type="complete" ref="LIT7250PPFanuel"/>
-                            <note>The entire text, which ends abruptly in the manuscript, is reproduced below.</note>
-                            <incipit xml:lang="gez">
-                                <hi rend="rubric">ነዓ፡ ኀቤየ፡ ፋኑኤል፡ እሳት፡ ነዳዲ፡</hi>
-                                ማኅበረ፡ ሰይጣናት፡ በሰማይ፡ እስመ፡ አንተ፡ ሰዳዲ፡ 
-                                አልብሰኒ፡ ጽድቀ፡ ለዓለመ፡ <sic resp="JK">ዓለመ፡</sic> ወዓዲ፡
-                                ወበትንባሌከ፡ እደ። ኃጣውእየ፡ ፍዲ፡ 
-                                መናሥግተ፡ ቤትየ፡ አጽንዕ፡ ኢይባእ፡ ረዋዲ፡ 
-                                ኦአምላከ፡ ፋኑኤል፡ ዕቀባ፡ እምዓይነተ፡ ባርያ፡ ወ
-                            </incipit>
-                        </msItem>
                         
-                        <msItem xml:id="ms_i7">
-                            <locus target="#1rc"/>
-                            <title type="complete" ref="LIT7253PPMarySaid"/>
-                            <incipit xml:lang="gez">
-                                <hi rend="rubric">ወትቤ፡ እግዝእትነ፡ ማርያም፡ በነገረ፡ ዕብራይስጢ<supplied reason="omitted">፡</supplied></hi> ዕ፡ 
-                                ሰፎሶፎያሮስቦ፡ ያክርርሜል፡ ፒፒያኤል፡ ጵርስቦስ፡ አዴሌዕ፡ መትዋፎን፡ ወርእየቶሙ፡ እግዝእትነ፡ 
-                                <hi rend="rubric">ማርያም፡</hi> እምርሑቅ፡ ወትቤ<supplied reason="omitted">፡</supplied>
-                                ትብያቶያላን፡ ጥብያቶላን፡ ጥብያቶጳራን፡ ጰአውያን፡
-                            </incipit>
-                            <explicit xml:lang="gez">
-                                ኮርኮርያስም፡ ፓፓል፡ ልጤርያስ፡ አንሰባኪዱክባ፡ ኵጉኩያስ፡ ምንያኤል<supplied reason="omitted">፡</supplied>
-                                ደትኤል፡ ስምዓኒ፡ ለአመትከ፡ 
-                               <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
-                                    <subst><del rend="effaced" unit="chars" quantity="8"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst></persName>
-                            </explicit>
-                        </msItem>
-                      
-                        <msItem xml:id="ms_i8">
-                            <locus target="#1rc"/>
-                            <title type="complete" ref="LIT7254PPMagic"/>
-                            <incipit xml:lang="gez">
-                                <hi rend="rubric">በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡</hi>
-                                ጸሎት፡ በእንተ፡ ሕማመ<supplied reason="omitted">፡</supplied> ዓይነ፡ ወጋርር፡ 
-                                ወትግሪዳ፡ አድኅና፡ ለአመትከ፡ 
-                                <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi>
-                                    <subst><del rend="effaced" unit="chars" quantity="8"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst></persName>
-                                ይትነሣእ፡ እግዚአብሔር፡ ወይዘረው<supplied reason="omitted">፡</supplied>
-                                ጾሩ፡ ወይጕየዩ፡ ጸላእቱ።
-                            </incipit>
-                            <explicit xml:lang="gez">
-                                ከመ፡ ኢይምጽኡ<supplied reason="omitted">፡</supplied> ኀቤየ፡ ወከመ፡ ኢይቅረቡኒ፡ 
-                                ኀቤየ፡ ወመንገሌየ፡ ወኢይበውኡ፡ ውስተ፡ ጽላሎተ፡ ቤትየ፡ ወከመ፡ ኢይቅረቡ፡ ኀበ፡ ነፍስየ፡ 
-                                ወሥጋየ፡ ወአነኒ፡ ለአመትከ፡ 
-                                <persName ref="PRS14625WalattaMaryam" role="owner"><hi rend="rubric">ወለተ፡</hi><surplus><hi rend="rubric">ወለተ፡</hi></surplus>
-                                    <subst><del rend="effaced" unit="chars" quantity="7"/><add>ማርያም<supplied reason="omitted">፡</supplied></add></subst></persName>
-                            </explicit>
-                        </msItem>
-                      
                     </msContents>
-
-
-
-
-
-
-
-
-
-
-
 
                     <physDesc>
                         <objectDesc form="Scroll">


### PR DESCRIPTION
Description of UUB O Etiop. 47, with images here: http://urn.kb.se/resolve?urn=urn:nbn:se:alvin:portal:record-489058

Also, stub of a Munich scroll needed to refer to the work in UUB O Etiop. 47