### PR TITLE
Add change notes to mss records_no.7

### DIFF
--- a/FlorenceBML/BMLacq784/BMLacq784.xml
+++ b/FlorenceBML/BMLacq784/BMLacq784.xml
@@ -5,7 +5,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <title>Prayers; Ṭabiba ṭabibān</title>
+                <title>Prayers, Ṭabiba ṭabibān</title>
                 <editor key="AB" role="generalEditor"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
@@ -244,6 +244,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
         <revisionDesc>
             <change who="PL" when="2019-02-21">Created catalogue entry</change>
             <change when="2021-09-20" who="PL">added text from transkribus and facsimile with xi:include</change>
+            <change when="2023-12-05" who="CH">Added msContents, physDesc and history</change>
         </revisionDesc>
     </teiHeader>
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" 

--- a/LondonBritishLibrary/orient/BLorient11601.xml
+++ b/LondonBritishLibrary/orient/BLorient11601.xml
@@ -340,6 +340,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2024-01-31">Created entity</change>
+            <change who="CH" when="2024-06-01">Corrections after review by Eugenia Sokolinski and Denis Nosnitsin</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/LondonBritishLibrary/orient/BLorient8822.xml
+++ b/LondonBritishLibrary/orient/BLorient8822.xml
@@ -171,6 +171,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2024-02-02">Created entity</change>
+            <change who="CH" when="2024-02-07">Corrections after review by Eugenia Sokolinski and Dorothea Reule</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/ParisBNF/et/BNFet211.xml
+++ b/ParisBNF/et/BNFet211.xml
@@ -643,7 +643,8 @@
             </langUsage>
         </profileDesc>
         <revisionDesc>            
-            <change who="CH" when="2024-12-03">Created stub</change>
+            <change who="CH" when="2024-12-03">Created entity</change>
+            <change when="2025-01-15" who="CH">Updated msContents and physDesc</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">

--- a/RomeALincei/ANLcr71.xml
+++ b/RomeALincei/ANLcr71.xml
@@ -75,7 +75,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <langUsage><language ident="en">English</language><language ident="gez">Gǝʿǝz</language></langUsage>
         </profileDesc>
         <revisionDesc>
-            <change who="CH" when="2023-03-16">Created stub</change>
+            <change who="CH" when="2023-03-16">Created draft</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">

--- a/Vienna/ONBAeth18.xml
+++ b/Vienna/ONBAeth18.xml
@@ -67,7 +67,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
             <langUsage><language ident="en">English</language></langUsage>
         </profileDesc>
         <revisionDesc>
-            <change who="CH" when="2023-03-16">Created catalogue entry</change>
+            <change who="CH" when="2023-03-16">Created stub</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">


### PR DESCRIPTION
The seventh and last pull request on manuscript records, for which I have added a change element, so that they no longer count as drafts or stubs. For the remaining handful of records, the label "stub" or "draft" is legitimate because they contain very little information. 
Cf. https://github.com/BetaMasaheft/Documentation/issues/2976.