### PR TITLE
Create BNUet5.xml

### DIFF
--- a/Strasbourg/BNUet5.xml
+++ b/Strasbourg/BNUet5.xml
@@ -127,7 +127,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <placeName ref="LOC1465Ankoba">Ankobar, Ethiopia</placeName>.</desc>
                                     <q xml:lang="en">Siena Aihud in Aethiopic
                                         To be delivered to Schmidt D.D. at Tubingen, <sic>Wurtemberg</sic>, Germany.
-                                        <placeName ref="LOC1465Ankoba">Ankobar</placeName>, Capital of Efat and Shoa 
+                                        <placeName ref="LOC1464Ankoba">Ankobar</placeName>, Capital of Efat and Shoa 
                                         <date when="1841-02-01">1st Febr. 1841</date>.</q>
                                 </item>
                                 <item xml:id="e2">


### PR DESCRIPTION
I created a record for BNUet5. Contrary to my announcements in https://github.com/BetaMasaheft/Documentation/issues/3054, I did not suffice myself with creating a stub, but added  information available to me from the listed catalogues, my own PhD thesis and from images online. I found out, that the Tarika Walda Amid-text is not part of the α-recension, but probably an interpolated version of α and β with the basis of the β-recension (cf. https://github.com/BetaMasaheft/Works/pull/1716).

The PRS record for the scribe Habta Mikael is still missing. I create a pull request in person as soon as this will be possible again hopefully in the next week.