### PR TITLE
Created BNFet391 and BNFet654

### DIFF
--- a/ParisBNF/et/BNFet390.xml
+++ b/ParisBNF/et/BNFet390.xml
@@ -28,7 +28,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <collection>Collection Griaule</collection>
                         <idno>BnF Éthiopien 390</idno>
                         <altIdentifier>
-                            <idno>Griaule 87</idno>
+                            <idno>Griaule 86</idno>
                         </altIdentifier>
                     </msIdentifier>
                     <msContents>
@@ -62,6 +62,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </supportDesc>  
                         </objectDesc>    
                     </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1900" notAfter="1954">20th century, but not after 1954</origDate>
+                        </origin>
+                    </history>
                     <additional>
                         <adminInfo>
                             <recordHist>
@@ -90,6 +95,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <textClass>
                 <keywords>
                     <term key="Magic"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="Divination"/>
                 </keywords>
             </textClass>   
             <langUsage>
@@ -100,6 +107,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <revisionDesc>
             <change who="CH" when="2025-05-26">Created stub with ID for LIT7479Saalt (no. 13 in Strelcyn's catalogue)</change>
             <change when="2025-06-17" who="CH">Added ms_i23 and ms_i50, updated ms_i1 to ms_i13</change>
+            <change when="2025-08-08" who="CH">Corrected altIdentifier, updated keywords, added origin</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/ParisBNF/et/BNFet391.xml
+++ b/ParisBNF/et/BNFet391.xml
@@ -1,0 +1,210 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="BNFet391" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Divinatory texts</title>
+                <editor role="generalEditor" key="AB"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine
+                    multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS0303BNF"/>
+                        <collection>Manuscrits orientaux</collection>
+                        <collection>Fonds éthiopien</collection>
+                        <collection>Collection Griaule</collection>
+                        <idno>BnF Éthiopien 391</idno>
+                        <altIdentifier>
+                            <idno>Griaule 87</idno>
+                        </altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                        <summary/>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Codex">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>  
+                                </support> 
+                                <extent>
+                                    <measure unit="leaf" quantity="34">32+2</measure>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>165</height>
+                                        <width>150</width>
+                                    </dimensions>
+                                </extent>
+                            </supportDesc>  
+                        </objectDesc>    
+                    </physDesc>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1954Griaule"/>
+                                            <citedRange unit="page">25-26</citedRange>
+                                        </bibl>
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                    <msPart xml:id="p1">
+                        <msIdentifier/>
+                        <msContents>
+                            <summary>Treatise on divination</summary>
+                            <msItem xml:id="p1_i1">
+                                <locus from="1v"/>
+                                <title type="complete">Ḥassāba ṭabibān</title>
+                                <incipit xml:lang="gez">ሐሳበ፡ ጠቢባን፡</incipit>
+                            </msItem>
+                            <msItem xml:id="p1_i2">
+                                <locus from="2r"/>
+                                <title type="complete">Ḥassāba kawākǝbt</title>
+                                <incipit xml:lang="gez">ሐሳበ፡ ከዋክብት፡</incipit>
+                            </msItem>
+                            <msItem xml:id="p1_i3">
+                                <locus from="14v"/>
+                                <title type="complete">Ḥassāba ʾadbār</title>
+                                <incipit xml:lang="gez">ሐሳበ፡ አድባር፡</incipit>
+                            </msItem>
+                            <msItem xml:id="p1_i4">
+                                <locus from="16r"/>
+                                <title type="complete">Ḥassāba ḥǝmum</title>
+                                <incipit xml:lang="gez">ሐሳበ፡ ሕሙም፡</incipit>
+                            </msItem>
+                            <msItem xml:id="p1_i5">
+                                <locus from="16v"/>
+                                <title type="complete">Ḥassāba dǝwwǝy</title>
+                                <incipit xml:lang="gez">ሐሳበ፡ ድውይ</incipit>
+                            </msItem>
+                            <msItem xml:id="p1_i6">
+                                <locus from="16v"/>
+                                <title type="complete">Ḥassāba bǝʾsit</title>
+                                <note>Divinatory text concerning whether or not a woman will give birth.</note>
+                                <incipit xml:lang="gez">ሐሳበ፡ ብእሲት፡ በእንተ፡ ዘትሁብ፡ ወኢትሁብ፡</incipit>
+                            </msItem>
+                            <msItem xml:id="p1_i7">
+                                <locus from="18v"/>
+                                <title type="complete">Ḥassāba bǝʾsit</title>
+                                <incipit xml:lang="gez">ሐሳበ፡ ብእሲት፡</incipit>
+                            </msItem>
+                            <msItem xml:id="p1_i8">
+                                <locus from="18v"/>
+                                <title type="complete">Ḥassāba zaman</title>
+                                <incipit xml:lang="gez">ሐሳበ፡ ዘመን፡</incipit>
+                            </msItem>
+                            <msItem xml:id="p1_i9">
+                                <locus from="19r"/>
+                                <title type="complete">Ḥassāba ʿǝns</title>
+                                <incipit xml:lang="gez">ሐሳበ፡ ዕንስ፡</incipit>
+                            </msItem>
+                            <msItem xml:id="p1_i10">
+                                <locus from="19r"/>
+                                <title type="complete">Ḥassāba bǝʾsit wa-bǝʾsi</title>
+                                <incipit xml:lang="gez"><supplied reason="omitted">ሐሳበ፡</supplied> ብእሲት፡ ወብእሲ፡</incipit>
+                            </msItem>
+                            <msItem xml:id="p1_i11">
+                                <locus from="19v"/>
+                                <title type="complete">Ḥassāba fǝnot</title>
+                                <incipit xml:lang="gez">ሐሳበ፡ ፍኖት፡</incipit>
+                            </msItem>
+                            <msItem xml:id="p1_i12">
+                                <locus from="19v"/>
+                                <title type="complete">Ḥassāba ʾƎgziʾ</title>
+                                <incipit xml:lang="gez">ሐሳበ፡ እግዚእ፡</incipit>
+                            </msItem>
+                            <msItem xml:id="p1_i13">
+                                <locus from="20r"/>
+                                <title type="complete">Ḥassāba baza-taʾammǝr moto la-sabʾ</title>
+                                <incipit xml:lang="gez">ሐሳበ፡ በዘተአምር፡ ሞቶ፡ ለሰብእ፡</incipit>
+                            </msItem>
+                            <msItem xml:id="p1_i14">
+                                <locus from="20v"/>
+                                <title type="complete">Computus of the sick</title>
+                            </msItem>
+                            <msItem xml:id="p1_i15">
+                                <locus from="20v"/>
+                                <title type="complete">Ḥassāba bǝʾse ḍabʾ</title>
+                                <incipit xml:lang="gez">ሐሳበ፡ ብእሴ፡ ፀብእ፡</incipit>
+                            </msItem>
+                            <msItem xml:id="p1_i16">
+                                <locus from="21r"/>
+                                <title type="complete">Ḥassāba ḥarā</title>
+                                <incipit xml:lang="gez">ሐሳበ፡ ሐራ፡</incipit>
+                            </msItem>
+                            <msItem xml:id="p1_i17">
+                                <locus from="21v"/>
+                                <title type="complete">Ḥassāba ṣǝl</title>
+                                <incipit xml:lang="gez">ሐሳበ፡ ጽል፡</incipit>
+                            </msItem>
+                        </msContents>
+                        <history>
+                            <origin>
+                                <origDate notBefore="1800" notAfter="1899">19th century</origDate>
+                            </origin>
+                        </history>
+                    </msPart>
+                    <msPart xml:id="p2">
+                        <msIdentifier/>
+                        <msContents>
+                            <summary>Fragment of a ḥassāb (divinatory text)</summary>
+                            <msItem xml:id="p2_i1">
+                                <locus from="23v"/>
+                                <title type="incomplete">Fragment of a computus of the stars (Ḥassāba kawākǝbt)</title>
+                            </msItem>
+                        </msContents>
+                        <history>
+                            <origin>
+                                <origDate notBefore="1800" notAfter="1899">19th century</origDate>
+                            </origin>
+                        </history>
+                    </msPart>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>  
+            <textClass>
+                <keywords>
+                    <term key="Magic"/>
+                    <term key="Divination"/>
+                    <term key="ChristianLiterature"/>
+                </keywords>
+            </textClass>   
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2025-05-26">Created draft version</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <ab/>  
+        </body>
+    </text>
+</TEI>

--- a/ParisBNF/et/BNFet391.xml
+++ b/ParisBNF/et/BNFet391.xml
@@ -131,7 +131,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </msItem>
                             <msItem xml:id="p1_i13">
                                 <locus from="20r"/>
-                                <title type="complete">Ḥassāba baza-taʾammǝr moto la-sabʾ</title>
+                                <title type="complete">Ḥassāba ba-za-taʾammǝr moto la-sabʾ</title>
                                 <incipit xml:lang="gez">ሐሳበ፡ በዘተአምር፡ ሞቶ፡ ለሰብእ፡</incipit>
                             </msItem>
                             <msItem xml:id="p1_i14">

--- a/ParisBNF/et/BNFet654.xml
+++ b/ParisBNF/et/BNFet654.xml
@@ -1,0 +1,157 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="BNFet654" xml:lang="en" type="mss">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Malkǝʾa Giyorgis, Magic Prayers, Divinatory Texts</title>
+                <editor role="generalEditor" key="AB"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine
+                    multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS0303BNF"/>
+                        <collection>Manuscrits orientaux</collection>
+                        <collection>Fonds éthiopien</collection>
+                        <collection>Collection Griaule</collection>
+                        <idno>BnF Éthiopien 654</idno>
+                        <altIdentifier>
+                            <idno>Griaule 346</idno>
+                        </altIdentifier>
+                    </msIdentifier>
+                    <msContents>
+                        <summary/>
+                        <msItem xml:id="ms_i1">
+                            <locus from="1v"/>
+                            <title>Magic prayers against the evil eye</title>
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> በል፡ አብርሃም፡ በከራን፡ ሀገሩ፡ ተከለ፡ ፫ዕፀወ፡ ፩ነግሠ፡ ወ፩የብሰ፡ ወ፩መገጸ፡ ዘብናዝር፡
+                                ሐቲሞ፡ ወለቤተ፡ ቅራሐ፡ አልቀሐኝና፡ ረሐሞጸጅ፡ ሐቲሞ፡ ወለቤተ፡ ቅራሐ፡ አድኅኖ፡ ወበልሖ፡ እምሕማመ፡ ዓይነት፡</incipit>
+                            <explicit xml:lang="gez">ለገብርከ፡ <gap reason="lost"/> ለዓለመ፡ ዓለም፡ አሜን፡</explicit>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <locus from="2r"/>
+                            <title>Malkǝʾa Giyorgis</title>
+                        </msItem>
+                        <msItem xml:id="ms_i3">
+                            <locus from="4v"/>
+                            <title>Ḥassāba Dāwit</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ዳዊት፡</incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i4">
+                            <locus from="12r"/>
+                            <title>Ḥassāba fǝqr</title>
+                            <incipit xml:lang="gez">አንቀጽ፡ በእንተ፡ ፍቅረ፡ ብእሲ፡ ወብእሲት፡</incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i5">
+                            <locus from="19r"/>
+                            <title>Ḥassāba ḥarā</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ሐራ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i6">
+                            <locus from="19v"/>
+                            <title>Ḥassāba ʾadbār</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ አድባር፡</incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i7">
+                            <locus from="20v"/>
+                            <title>Ḥassāba Yudit</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ዩዲት፡</incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i8">
+                            <locus from="21v"/>
+                            <title>Magic prayer against Bāryā and Legewon</title>
+                            <incipit xml:lang="gez">ብስመ፡ አብ፡ ጸሎተ፡ ባርያ፡ ወሌጌዎን፡ ርኩሳን፡ ዘይሰልብ፡ ልበ፡ <sic>ል</sic>ሰብእ፡</incipit>
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Codex">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/>  
+                                </support> 
+                                <extent>
+                                    <measure unit="leaf" quantity="21">21</measure>
+                                    <dimensions type="outer" unit="mm">
+                                        <height>150</height>
+                                        <width>100</width>
+                                    </dimensions>
+                                </extent>
+                            </supportDesc>  
+                        </objectDesc>    
+                        <additions>
+                            <list>
+                                <item xml:id="a1">
+                                    <locus target="#1r"/>
+                                    <desc type="CustomaryLaw">Record of a divorce in Amharic</desc>
+                                </item>
+                                <item xml:id="a2">
+                                    <desc type="RecordDistribution">Note on revenues of monks, written in pencil, in Amharic</desc>
+                                    <q xml:lang="am">መጽሐፈ፡ መነኮሳት፡ ከአለቃ፡ ዮሐንስ፡ አለ፡ ሃይማኖት፡ አበው፡ ተመሪጌታ፡ መንገሻ፡ አለ፡ ፲ብር፡</q>
+                                </item>
+                            </list>
+                        </additions>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1900" notAfter="1954">20th century, but not after 1954</origDate>
+                        </origin>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1954Griaule"/>
+                                            <citedRange unit="page">232-233</citedRange>
+                                        </bibl>
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                        </adminInfo>
+                    </additional>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>  
+            <textClass>
+                <keywords>
+                    <term key="Magic"/>
+                    <term key="Divination"/>
+                    <term key="ChristianLiterature"/>
+                </keywords>
+            </textClass>   
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2025-05-26">Created draft version</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <ab/>  
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I created two draft versions for  BNFet391 and BNFet654, i.e. I described the content of the two manuscripts as it is presented by Strelcyn in his catalogue of 1954, but did not consult any images and did not look up CAe or PRS IDs. The records are necessary to refer to it in some newly created work record and I think, there will be more than one more case in future. I made one correction and two updates to BNFet390.