### PR TITLE
Update mss with divininatory texts

### DIFF
--- a/Cambridge/CamOr1885.xml
+++ b/Cambridge/CamOr1885.xml
@@ -40,276 +40,272 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
                             emphasis on astrological matters. </summary>
                   <msItem xml:id="ms_i1">
                      <locus from="2v" to="2v">2r-8r</locus>
-                     <title xml:lang="gez">ሐሳበ ፡ ሕሙም</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <title xml:lang="gez" ref="LIT7594HassabSick">ሐሳበ ፡ ሕሙም</title>
+                     <textLang mainLang="gez"/>
                      <note/>
                   </msItem>
                   <msItem xml:id="ms_i2">
                      <locus from="3r" to="3v">3r-3v</locus>
                      <title xml:lang="gez">ናሁ ፡ ወጠንኩ ፡ ፍካሬሆሙ ፡ ለ፲ወ፪ክዋክብት</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                      <note>large number of magical names and words</note>
                      <note><!--Illuminated border showing evil eye.--></note>
                   </msItem>
                   <msItem xml:id="ms_i3">
-                     <locus from="4r" to="5r">4r-5r</locus>
+                     <locus from="4r" to="5r"/>
                      <title xml:lang="gez">ሠውር</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i4">
-                     <locus from="5v" to="6r">5v-6r</locus>
+                     <locus from="5v" to="6r"/>
                      <title xml:lang="gez">ሸርጣን</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i5">
-                     <locus from="6v" to="7v">6v-7v</locus>
+                     <locus from="6v" to="7v"/>
                      <title xml:lang="gez">አሰድ</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i6">
-                     <locus from="8r" to="9r">8r-9r</locus>
+                     <locus from="8r" to="9r"/>
                      <title xml:lang="gez">አሰድ</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i7">
-                     <locus from="9v" to="10r">9v-10r</locus>
+                     <locus from="9v" to="10r"/>
                      <title xml:lang="gez">ሰንቦላ</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i8">
-                     <locus from="10v" to="11v">9v-11v</locus>
+                     <locus from="10v" to="11v"/>
                      <title xml:lang="gez">ሚዛን</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i9">
-                     <locus from="12r" to="12r">12r</locus>
+                     <locus from="12r" to="12r"/>
                      <title xml:lang="gez">አቅራብ</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i10">
-                     <locus from="12v" to="13r">12v-13r</locus>
+                     <locus from="12v" to="13r"/>
                      <title xml:lang="gez">ሰውስ</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i11">
-                     <locus from="13v" to="14r">13v-14r</locus>
+                     <locus from="13v" to="14r"/>
                      <title xml:lang="gez">XX</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i12">
-                     <locus from="14v" to="15r">14v-15r</locus>
+                     <locus from="14v" to="15r"/>
                      <title xml:lang="gez">ደላዊ</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i13">
-                     <locus from="15v" to="16r">15v-16r</locus>
+                     <locus from="15v" to="16r"/>
                      <title xml:lang="gez">ሑት</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i14">
-                     <locus from="16v" to="16v">16v</locus>
+                     <locus target="#16v"/>
                      <title xml:lang="gez">ሐሳበ ፡ ልደት</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <note>Similar or identical to <ref type="work" corresp="LIT7623HassBirth"/>.</note>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i15">
-                     <locus from="16v" to="16v">16v</locus>
+                     <locus target="#16v"/>
                      <title xml:lang="gez">ሐሳበ ፡ ብእሲ ፡ ወብእሲት</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i16">
-                     <locus from="16v" to="16v">16v</locus>
-                     <title xml:lang="gez">ሐሳበ ፡ አድባር</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <locus target="#16v"/>
+                     <title xml:lang="gez" ref="LIT7611HassAdbar">ሐሳበ ፡ አድባር</title>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i17">
-                     <locus from="16v" to="17v">16v-17v</locus>
-                     <title xml:lang="gez">ሐሳበ ፡ አድባር</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <locus from="16v" to="17v"/>
+                     <title xml:lang="gez" ref="LIT7611HassAdbar">ሐሳበ ፡ አድባር</title>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i18">
-                     <locus from="18r" to="18r">18r</locus>
-                     <title xml:lang="gez">ሐሳበ ፡ ፍኖት</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <locus from="18r" to="18r"/>
+                     <title xml:lang="gez" ref="LIT7579HassabaFen">ሐሳበ ፡ ፍኖት</title>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i19">
-                     <locus from="18r" to="18v">18r-18v</locus>
+                     <locus from="18r" to="18v"/>
                      <title xml:lang="gez">ሐሳበ ፡ ሐዊረ ፡ ቤተ ፡ ደዉይ</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i20">
-                     <locus from="19r" to="28v">19r-28v</locus>
+                     <locus from="19r" to="28v"/>
                      <title xml:lang="gez">አንቀጽ ፡ በእንተ ፡ ብእሲ ፡ ወብእሲት</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i21">
-                     <locus from="29r" to="29r">29r</locus>
+                     <locus target="#29r"/>
                      <title xml:lang="gez">ሐሳበ ፡ ብሩህ ፡ ደመና ፡ በወርኃ ፡ መስከረም</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i22">
-                     <locus from="29v" to="29v">29v</locus>
-                     <title xml:lang="gez">ሐሳበ ፡ ጠቢባን</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <locus target="#29v"/>
+                     <title xml:lang="gez" ref="LIT7614HassabWise">ሐሳበ ፡ ጠቢባን</title>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i23">
-                     <locus from="30r" to="31v">30r-31v</locus>
-                     <title xml:lang="gez">ሐሳበ ፡ አድባር</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <locus from="30r" to="31v"/>
+                     <title xml:lang="gez" ref="LIT7611HassAdbar">ሐሳበ ፡ አድባር</title>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i24">
-                     <locus from="32r" to="34v">32r-34v</locus>
-                     <title xml:lang="gez">ሐሳበ ፡ ክዋክብት</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <locus from="32r" to="34v"/>
+                     <title xml:lang="gez" ref="LIT7599HassStars">ሐሳበ ፡ ክዋክብት</title>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i25">
-                     <locus from="35r" to="36r">35r-36r</locus>
+                     <locus from="35r" to="36r"/>
                      <title xml:lang="gez">ሐሳበ ፡ አርእስተ ፡ አጣሊስ</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i26">
-                     <locus from="36v" to="41v">36v-41v</locus>
-                     <title xml:lang="gez">ሐሳበ ፡ ጥብፅ</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <locus from="36v" to="41v"/>
+                     <title xml:lang="gez" ref="LIT7622HassabWar">ሐሳበ ፡ ጥብፅ</title><!-- ሐሳበ፡ ጸብእ፡ or  ሐሳበ ፡ ጥበብ ?-->
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i27">
-                     <locus from="42r" to="42v">42r-42v</locus>
+                     <locus from="42r" to="42v"/>
                      <title xml:lang="gez">ሐሳበ ፡ መዋዒ ፡ ወተመዋዒ</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i28">
-                     <locus from="43r" to="43v">43r-43v</locus>
+                     <locus from="43r" to="43v"/>
                      <title xml:lang="gez">አውደ ፡ ነቢያት</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i29">
-                     <locus from="44r" to="45r">44r-45r</locus>
+                     <locus from="44r" to="45r"/>
                      <title xml:lang="gez">ሐሳበ ፡ ደዊት[sic]</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i30">
-                     <locus from="45v" to="45v">45v</locus>
+                     <locus target="#45v"/>
                      <title xml:lang="gez">ሐሳበ ፡ ዕለት</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i31">
-                     <locus from="46r" to="47v">46r-47v</locus>
+                     <locus from="46r" to="47v"/>
                      <title xml:lang="gez">ሐሳበ ፡ ደንኤል[sic]</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i32">
-                     <locus from="48r" to="50v">48r-50v</locus>
+                     <locus from="48r" to="50v"/>
                      <title xml:lang="gez">ሐሳበ ፡ ንጽቢ</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i33">
-                     <locus from="51r" to="52v">51r-52v</locus>
-                     <title xml:lang="gez">ሐሳበ ፡ ሕሙም</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <locus from="51r" to="52v"/>
+                     <title xml:lang="gez" ref="LIT7593HassHemum">ሐሳበ ፡ ሕሙም</title>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i34">
-                     <locus from="53r" to="53v">53r-53v</locus>
+                     <locus from="53r" to="53v"/>
                      <title xml:lang="gez">ሐሳበ ፡ ጥፍዓተ ፡ ንዋይ</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i35">
-                     <locus from="54r" to="68r">54r-68r</locus>
+                     <locus from="54r" to="68r"/>
                      <title xml:lang="gez">ሐሳበ ፡ ኍልቈ ፡ ፋል</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i36">
-                     <locus from="68v" to="69v">68v-69v</locus>
-                     <title xml:lang="gez">ሐሳበ ፡ ድዉይ</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <locus from="68v" to="69v"/>
+                     <title xml:lang="gez" ref="LIT7594HassabSick">ሐሳበ ፡ ድዉይ</title>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i37">
-                     <locus from="70r" to="72v">70r-72v</locus>
+                     <locus from="70r" to="72v"/>
                      <title xml:lang="gez">ሐሳበ ፡ ነባር ፡ ዘኮከብ</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i38">
-                     <locus from="73r" to="76v">73r-76v</locus>
+                     <locus from="73r" to="76v"/>
                      <title xml:lang="gez">ሐሳበ ፡ ሠርቀ ፡ ሌሊት</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i39">
-                     <locus from="77r" to="77r">77r</locus>
+                     <locus target="#77r"/>
                      <title xml:lang="gez">ሐሳበ ፡ ዘትሁብ ፡ ሰማ ፡ ወእማ</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i40">
-                     <locus from="77v" to="77v">77v</locus>
+                     <locus target="#77v"/>
                      <title xml:lang="gez">ሐሳበ ፡ እንግዳ</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i41">
-                     <locus from="77v" to="77v">77v</locus>
+                     <locus target="#77v"/>
                      <title xml:lang="gez">ሐሳበ ፡ ፍቅር</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i42">
-                     <locus from="78r" to="78r">78r</locus>
-                     <title xml:lang="gez">ሐሳበ ፡ ጸብእ</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <locus target="#78r"/>
+                     <title xml:lang="gez" ref="LIT7622HassabWar">ሐሳበ ፡ ጸብእ</title>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i43">
-                     <locus from="78r" to="79r">78r-79r</locus>
-                     <title xml:lang="gez">ሐሳበ ፡ ብእሲ ፡ ወብእሲት</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <locus from="78r" to="79r"/>
+                     <title xml:lang="gez" ref="LIT7626HasHusband">ሐሳበ ፡ ብእሲ ፡ ወብእሲት</title>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i44">
-                     <locus from="79v" to="82r">79v-82r</locus>
+                     <locus from="79v" to="82r"/>
                      <title xml:lang="gez">ጸሎተ ፡ በእንተ ፡ ሕማመ ፡ ዓይን</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i45">
-                     <locus from="82v" to="86r">82v-86r</locus>
+                     <locus from="82v" to="86r"/>
                      <title xml:lang="gez">መጽሔተ ፡ ሰሎሞን</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i46">
-                     <locus from="86v" to="86v">86v</locus>
+                     <locus target="#86v"/>
                      <title xml:lang="gez">ጸሎተ ፡ ድንጋፄ ፡ ኢየሱስ</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i47">
-                     <locus from="87r" to="87v">87r-87v</locus>
+                     <locus from="87r" to="87v"/>
                      <title xml:lang="gez">ጸሎተ ፡ ድንጋፄ ፡ ኢየሱስ</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i48">
-                     <locus from="87r" to="87v">87r-87v</locus>
+                     <locus from="87r" to="87v"/>
                      <title xml:lang="gez">ጸሎት ፡ በእንተ ፡ ሕማመ ፡ ቁርፀት</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i49">
-                     <locus from="88r" to="91v">88r-91v</locus>
+                     <locus from="88r" to="91v"/>
                      <title xml:lang="gez">ጸሎት ፡ በእንተ ፡ ሕማመ ፡ ባርያ ፡ ወሌጌዎን</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i50">
-                     <locus from="92r" to="92r">92r</locus>
+                     <locus target="#92r"/>
                      <title xml:lang="gez">ጸሎት ፡ በእንተ ፡ ሕማመ ፡ ባርያ ፡ ወሌጌዎን</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i51">
-                     <locus from="92v" to="93r">92v-93r</locus>
+                     <locus from="92v" to="93r"/>
                      <title xml:lang="gez">ጸሎት ፡ በእንተ ፡ ሕማመ ፡ ዛር</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i52">
-                     <locus from="92v" to="93r">92v-93r</locus>
+                     <locus from="92v" to="93r"/>
                      <title xml:lang="gez">ጸሎት ፡ በእንተ ፡ ሕማመ ፡ ዛር</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                   <msItem xml:id="ms_i53">
-                     <locus from="93v" to="96v">93v-96v</locus>
+                     <locus from="93v" to="96v"/>
                      <title xml:lang="gez">ጸሎት ፡ ጽንስ</title>
-                     <textLang mainLang="gez">Geez</textLang>
-                  </msItem>
-                  <msItem xml:id="ms_i54">
-                     <locus from="97r" to="103v">97r-103v</locus>
-                     <title xml:lang="ltn">additiones</title>
-                     <textLang mainLang="gez">Geez</textLang>
+                     <textLang mainLang="gez"/>
                   </msItem>
                </msContents>
                <physDesc>
@@ -348,6 +344,14 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
                         
                      </decoNote>
                   </decoDesc>
+                  <additions>
+                     <list>
+                        <item xml:id="a1">
+                           <locus from="97r" to="103v"/>
+                           <desc type="Mixed">Various additions</desc>
+                        </item> 
+                     </list>  
+                  </additions>
                   <bindingDesc>
                      <binding>
                         <decoNote xml:id="b1">Loose wooden boards. Water stained towards end.</decoNote>
@@ -393,6 +397,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
       <profileDesc>
          <langUsage>
             <language ident="en">English</language>
+            <language ident="gez">Gǝʿǝz</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>
@@ -401,6 +406,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
                     Or_1885. Original file
                 for transformation viewable at https://www.fihrist.org.uk/catalog/manuscript_11903 downloaded from GitHub at
                     https://github.com/fihristorg/fihrist-mss/blob/master/collections/cambridge%20university/Or_1885.xml </change>
+         <change when="2025-08-20" who="CH">Add LIT IDs for Hassabs to msItems</change>
       </revisionDesc>
    </teiHeader>
    <facsimile><graphic url="https://cudl.lib.cam.ac.uk/view/MS-OR-01885"></graphic></facsimile>

--- a/ParisBNF/et/BNFet390.xml
+++ b/ParisBNF/et/BNFet390.xml
@@ -31,21 +31,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <idno>Griaule 86</idno>
                         </altIdentifier>
                     </msIdentifier>
-                    <msContents>
-                        <summary>Treatise on divination</summary>
-                        <msItem xml:id="ms_i13">
-                            <locus from="20v"/>
-                            <title ref="LIT7489Saalt"/>
-                        </msItem>
-                        <msItem xml:id="ms_i23">
-                            <locus from="58ra"/>
-                            <title ref="LIT7538CycleAleph"/>
-                        </msItem>
-                        <msItem xml:id="ms_i50">
-                            <locus from="65va"/>
-                            <title ref="LIT1987Mashet"/>
-                        </msItem>
-                    </msContents>
+                    <msContents><summary/></msContents>
                     <physDesc>
                         <objectDesc form="Codex">
                             <supportDesc>
@@ -60,7 +46,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </dimensions>
                                 </extent>
                             </supportDesc>  
-                        </objectDesc>    
+                        </objectDesc>
+                        <decoDesc>
+                            <decoNote type="drawing" xml:id="d1">
+                                <locus target="#15v"/>
+                                <desc>Lunar circle</desc><!-- Any suitable authFile? -->
+                            </decoNote>
+                        </decoDesc>
                     </physDesc>
                     <history>
                         <origin>
@@ -81,6 +73,417 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </recordHist>
                         </adminInfo>
                     </additional>
+                    <msPart xml:id="p1">
+                        <msIdentifier/>
+                        <msContents>
+                        <summary>Treatise on divination</summary>
+                        <msItem xml:id="p1_i1">
+                            <locus from="1ra"/>
+                            <title>Computus of Contagion</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ንኪት፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i2">
+                            <locus from="1rb"/>
+                            <title ref="LIT7593HassHemum"/>
+                            <note>Different from <ref target="#p1_i17"/>, <ref target="#p1_i25"/> and <ref target="#p1_i42"/>.
+                                Edited in <bibl><ptr target="bm:Griaule1934arithmomancie"/><citedRange unit="page">28-29</citedRange></bibl>.</note>
+                            <incipit xml:lang="gez">ሐሳበ፡ ሕሙም፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i3">
+                            <locus from="1va"/>
+                            <title>Treatise on divination in 15 chapters</title>
+                            <incipit xml:lang="gez">በስመ፡ እግ<gap reason="ellipsis"/>፡ ሥሉስ፡ ልዑል፡ ዘኢይረከብዎ፡ ንጉሥ፡ ዘኢይሰምዎ፡ ወኢይሥዕርዎ፡ ዘንተ፡ 
+                                መጽሐፈ፡ አእምሮ፡ ወለብዎ፡ ጠቢባን፡ ዘአስተጋብዕዎ፡ ወማዕምራን፡ እለ፡ ተርጐምዎ፡ ከመ፡ ይኩን፡ በቍዔተ፡ ለእለ፡ የኃሥሥዎ፡ ወተስፋ፡ ለእለ፡ ይሴዓልዎ።</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i4">
+                            <locus from="3va"/>
+                            <title>Computus of Daniel</title>
+                            <note>Edited in <bibl><ptr target="bm:Griaule1934arithmomancie"/><citedRange unit="page">27</citedRange></bibl>.</note>
+                            <incipit xml:lang="gez">ሐሳበ፡ ዳንኤል፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i5">
+                            <locus from="4ra"/>
+                            <title ref="LIT7599HassStars"/>
+                            <incipit xml:lang="gez">ሐሳበ፡ ከዋክብት፡</incipit>
+                            <note>Different from <ref target="#p1_i57"/>.</note>
+                        </msItem>
+                        <msItem xml:id="p1_i6">
+                            <locus from="10vb"/>
+                            <title>Computus of the church</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ቤተ፡ ክርስቲያን፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i7">
+                            <locus from="10vb"/>
+                            <title ref="LIT7594HassabSick"/>
+                            <note>Different to <ref target="p1_i32"/>.</note>
+                            <incipit xml:lang="gez">ሐሳበ፡ ድውይ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i8">
+                            <locus from="13va"/>
+                            <title>Treatise on divination</title>
+                            <incipit xml:lang="gez">መጽሐፍ፡ ጥዩቅ፡ ወጽሩይ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i9">
+                            <locus from="17rb"/>
+                            <title>Computus of Ephrem</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ኤፍሬም፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i10">
+                            <locus from="18rb"/>
+                            <title ref="LIT7611HassAdbar"/>
+                            <note>Different from <ref target="#p1_i12"/>, <ref target="#p1_i28"/>, <ref target="#p1_i41"/> and 
+                                <ref target="#p1_i63"/>.</note>
+                            <incipit xml:lang="gez">ሐሳበ፡ አድባር፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i11">
+                            <locus from="18vb"/>
+                            <title>Ḥassāba qʷǝz (?)</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ቍዝ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i12">
+                            <locus from="20rb"/>
+                            <title ref="LIT7611HassAdbar"/>
+                            <note>Different from <ref target="#p1_i10"/>, <ref target="#p1_i28"/>, <ref target="#p1_i41"/> and 
+                                <ref target="#p1_i63"/>.</note>
+                        </msItem>
+                        <msItem xml:id="p1_i13">
+                            <locus from="20v"/>
+                            <title ref="LIT7489Saalt"/>
+                            <incipit xml:lang="gez">፩ አንቀጽ፡ በእንተ፡ ፍቅረ፡ ብእሲ፡ ወብእሲት፡ <gap reason="ellipsis"/>
+                                ፪ አንቀጽ፡ በእንተ፡ ሞቅሕ፡ <gap reason="ellipsis"/>
+                                ፫ አንቀጽ፡ በእንተ፡ ሽፋጭ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i14">
+                            <locus from="26va"/>
+                            <title>Computus of victory</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ መዊዕ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i15">
+                            <locus from="27ra"/>
+                            <title>Computus of Aristotle</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ አርስጣጣሊስ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i16">
+                            <locus from="27vb"/>
+                            <title>Computus of Alexander</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ እስክንድር፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i17">
+                            <locus from="28vb"/>
+                            <title ref="LIT7593HassHemum"/>
+                            <note>Different from <ref target="#p1_i2"/> and <ref target="#p1_i25"/>.</note>
+                            <incipit xml:lang="gez">ሕሙም፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i18">
+                            <locus from="28vb"/>
+                            <title>Computus of David</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ዳዊት፡</incipit>
+                            <note>Edited in <bibl><ptr target="bm:Griaule1934arithmomancie"/><citedRange unit="page">27</citedRange></bibl>;
+                                different from <ref target="#p1_i27"/>.</note>
+                        </msItem>
+                        <msItem xml:id="p1_i19">
+                            <locus from="30r"/>
+                            <title ref="LIT1171Awdana"/>
+                        </msItem>
+                        <msItem xml:id="p1_i20">
+                            <locus from="50ra"/>
+                            <title>Ḥassāb with 16 solutions</title>
+                        </msItem>
+                        <msItem xml:id="p1_i21">
+                            <locus from="52vb"/>
+                            <title>ʿAwda ramalba (?)</title>
+                            <note>Ḥassāb</note>
+                        </msItem>
+                        <msItem xml:id="p1_i22">
+                            <locus from="55ra"/>
+                            <title>Ḥassāb with 44 possibilities</title>
+                        </msItem>
+                        <msItem xml:id="p1_i23">
+                            <locus from="58ra"/>
+                            <title ref="LIT7538CycleAleph"/>
+                        </msItem>
+                        <msItem xml:id="p1_i24">
+                            <locus from="58ra"/>
+                            <title>Ḥassāba qʷǝz (?)</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ቍዝ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i25">
+                            <locus from="58rb"/>
+                            <title ref="LIT7593HassHemum"/>
+                            <note>Different from <ref target="#p1_i2"/> and <ref target="#p1_i17"/>.</note>
+                            <incipit xml:lang="gez">ሐሳበ፡ ሕሙም፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i26">
+                            <locus from="58rb"/>
+                            <title>Computus of Adam</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ አዳም፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i27">
+                            <locus from="61va"/>
+                            <title>Computus of David</title>
+                            <note>Different from <ref target="#p1_i18"/>.</note>
+                        </msItem>
+                        <msItem xml:id="p1_i28">
+                            <locus from="63va"/>
+                            <title ref="LIT7611HassAdbar"/>
+                            <note>Different from <ref target="#p1_i10"/>, <ref target="#p1_i12"/>, <ref target="#p1_i41"/> and 
+                                <ref target="#p1_i63"/>.</note>
+                        </msItem>
+                        <msItem xml:id="p1_i29">
+                            <locus from="63vb"/>
+                            <title ref="LIT7579HassabaFen"/>
+                        </msItem>
+                        <msItem xml:id="p1_i30">
+                            <locus from="64ra"/>
+                            <title>Computus concerning the entering in the house of the king</title>
+                            <incipit xml:lang="gez">ሐሳብ፡ በእንተ፡ በዊአ<supplied reason="undefined" resp="PRS8999Strelcyn">፡</supplied> ሐዊረ፡ ቤተ፡ 
+                                ንጉሥ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i31">
+                            <locus from="64ra"/>
+                            <title>Computus concerning the one who will give and the one who will not give</title>
+                            <note>Possibly similar to <ref type="work" corresp="LIT7598HassRiches"/>.</note>
+                            <incipit xml:lang="gez">ሐሳበ፡ በእንተ፡ ዘይሁበከ፡ ወኢይሁበካ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i32">
+                            <locus from="64ra"/>
+                            <title ref="LIT7594HassabSick"/>
+                            <note>Different to <ref target="p1_i7"/>.</note>
+                        </msItem>
+                        <msItem xml:id="p1_i33">
+                            <locus from="64ra"/>
+                            <title>Computus on love</title>
+                            <note>Cf. <ref target="#p1_i53"/> and <ref target="#p1_i55"/>.</note>
+                            <incipit xml:lang="gez">ሐሳበ፡ ፍቅር፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i34">
+                            <locus from="64rb"/>
+                            <title>Computus about the loss of goods</title>
+                            <note>Edited in <bibl><ptr target="bm:Griaule1934arithmomancie"/><citedRange unit="page">29</citedRange></bibl>.</note>
+                            <incipit xml:lang="gez">ሐሳብ፡ በእንተ፡ ጥፍዓተ፡ ንዋይ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i35">
+                            <locus from="64rb"/>
+                            <title>Computus on the kingdom</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ መንግሥት፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i36">
+                            <locus from="64rb"/>
+                            <title ref="LIT7622HassabWar">Computus of war</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ፀብዕ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i37">
+                            <locus from="64rb"/>
+                            <title>Computus for the man for whom you know the moment of his death</title>
+                            <incipit xml:lang="gez">ሐሳብ፡ በእንተ፡ ብእሲ፡ በዘቦተአምር፡ ጊዜሁ፡ ለሞት፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i38">
+                            <locus from="64rb"/>
+                            <title>Computus about sickness</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ደዌ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i39">
+                            <locus from="64rb"/>             
+                            <title>Computus on the rain</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ዝናም፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i40">
+                            <locus from="64va"/>
+                            <title>Computus about who will reign and who not</title>
+                            <incipit xml:lang="gez">ሐሳብ፡ በእንተ፡ ዘይነግሥ፡ ወኢይነግሥ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i41">
+                            <locus from="64va"/>
+                            <title ref="LIT7611HassAdbar"/>
+                            <note>Different from <ref target="#p1_i10"/>, <ref target="#p1_i12"/>, <ref target="#p1_i28"/> and 
+                                <ref target="#p1_i63"/>.</note>
+                        </msItem>
+                        <msItem xml:id="p1_i42">
+                            <locus from="64va"/>
+                            <title ref="LIT7593HassHemum"/>
+                            <note>Different from <ref target="#p1_i2"/>, <ref target="#p1_i17"/> and <ref target="#p1_i25"/>.
+                                Edited in <bibl><ptr target="bm:Griaule1934arithmomancie"/><citedRange unit="page">28-29</citedRange></bibl>.</note>
+                            <incipit xml:lang="gez">ሐሳበ፡ ሕሙም፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i43">
+                            <locus from="64vb"/>
+                            <title ref="LIT7579HassabaFen"/>
+                        </msItem>
+                        <msItem xml:id="p1_i44">
+                            <locus from="64vb"/>
+                            <title>Computus concerning the one who will give and the one who will not give</title>
+                            <note>Possibly similar to <ref type="work" corresp="LIT7598HassRiches"/>.</note>
+                        </msItem>
+                        <msItem xml:id="p1_i45">
+                            <locus from="64vb"/>
+                            <title>Ḥassāba surǝst (?)</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ሱርስት፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i46">
+                            <locus from="65ra"/>
+                            <title>Computus about beer (ṭallā)</title>
+                            <note>Cf. <ref target="#p1_i62"/>.</note>
+                            <incipit xml:lang="gez">ሐሳበ፡ ፀላ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i47">
+                            <locus from="65ra"/>
+                            <title>Ḥassāba nǝṣalen (?)</title>
+                        </msItem>
+                        <msItem xml:id="p1_i48">
+                            <locus from="65rb"/>
+                            <title>Computus of the hours</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ሰዓታት፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i49">
+                            <locus from="65rb"/>
+                            <title>Computus of the weights</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ መዳልው፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i50">
+                            <locus from="65va"/>
+                            <title ref="LIT1987Mashet"/>
+                            <note>Cf. <ref target="#p1_i51"/> and <ref target="#p1_i60"/>.</note>
+                        </msItem>
+                        <msItem xml:id="p1_i51">
+                            <locus from="66vb"/>
+                            <title>Computus of Solomon</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ሰሎሞን፡</incipit>
+                            <note>Cf. <ref target="#p1_i50"/> and <ref target="#p1_i60"/>.</note>
+                        </msItem>
+                        <msItem xml:id="p1_i52">
+                            <locus from="67ra"/>
+                            <title>Computus of the enemy</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ፀር፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i53">
+                            <locus from="67ra"/>
+                            <title>Computus about love</title>
+                            <note>Cf. <ref target="#p1_i33"/> and <ref target="#p1_i55"/>.</note>
+                        </msItem>
+                        <msItem xml:id="p1_i54">
+                            <locus from="67ra"/>
+                            <title>Computus on the sterile woman</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ መካን፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i55">
+                            <locus from="67ra"/>
+                            <title>Computus on love</title>
+                            <note>Cf. <ref target="#p1_i33"/> and <ref target="#p1_i53"/>.</note>
+                        </msItem>
+                        <msItem xml:id="p1_i56">
+                            <locus from="67ra"/>
+                            <title>Computus on the falling night</title>
+                            <incipit xml:lang="gez"><supplied reason="undefined" resp="PRS8999Strelcyn">ሐሳበ፡</supplied> ሠርቀ፡ ሌሊት፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i57">
+                            <locus from="68va"/>
+                            <title ref="LIT7599HassStars"/>
+                            <note>Different from <ref target="#p1_i5"/>.</note>
+                        </msItem>
+                        <msItem xml:id="p1_i58">
+                            <locus from="69ra"/>
+                            <title ref="LIT7626HasHusband">Computus for the man and the woman</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ብእሲ፡ ወብእሲት፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i59">
+                            <locus from="69ra"/>
+                            <title>Computus on the lonely (woman)</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ባሕቲታ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i60">
+                            <locus from="69ra"/>
+                            <title>Computus of the mirror of Solomon</title>
+                            <note>Cf. <ref target="#p1_i50"/> and <ref target="#p1_i51"/>.</note>
+                        </msItem>
+                        <msItem xml:id="p1_i61">
+                            <locus from="69rb"/>
+                            <title>Computus to know the character of a man</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ባሕርያት፡ ከመ፡ ታአምር፡ ባሕርዮ፡ ለሰብእ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i62">
+                            <locus from="69vb"/>
+                            <title>Computus on the beer (ṭallā)</title>
+                            <note>Cf. <ref target="#p1_i46"/>.</note>
+                            <incipit xml:lang="gez">ሕሳበ፡ ጸላ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i63">
+                            <locus from="69vb"/>
+                            <title>Ḥassāba ʾadbār</title>
+                            <note>Different from <ref target="#p1_i10"/>, <ref target="#p1_i12"/>, <ref target="#p1_i28"/> and
+                                <ref target="#p1_i41"/>.</note>
+                        </msItem>
+                        <msItem xml:id="p1_i64">
+                            <locus from="70ra"/>
+                            <title>Computus of Enoch</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ሄኖክ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i65">
+                            <locus from="70ra"/>
+                            <title>Computus of the day</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ዕለት፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i66">
+                            <locus from="70rb"/>
+                            <title>Computus on war</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ፃር፡ ይመጽእ፡ ወኢይመጽእ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="p1_i67">
+                            <locus from="70rb"/>
+                            <title>Computus of the prophets</title>
+                            <incipit xml:lang="gez">ሐሳበ፡ ነቢያት፡</incipit>
+                        </msItem>
+                    </msContents>
+                        <physDesc>
+                            <objectDesc form="Codex">
+                                <supportDesc>
+                                    <support>
+                                        <material key="parchment"/>
+                                    </support>
+                                    <extent>
+                                        <measure unit="leaf" quantity="70">70</measure><locus from="1" to="70"/>
+                                    </extent>
+                                </supportDesc>
+                                <layoutDesc>
+                                    <layout columns="2" writtenLines="37">
+                                        <locus from="1r" to="20r"/>
+                                        <locus from="27r" to="29v"/>
+                                        <locus from="32r" to="40r"/>
+                                        <locus from="41r" to="70v"/>
+                                    </layout>
+                                    <layout columns="1" writtenLines="37">
+                                        <locus from="20v" to="26v"/>
+                                        <locus from="30r" to="31v"/>
+                                        <locus target="#40v"/>
+                                    </layout>
+                                </layoutDesc>
+                            </objectDesc>
+                        </physDesc>
+                    </msPart>
+                    <msPart xml:id="p2">
+                        <msIdentifier/>
+                        <msContents>
+                            <summary>Fragments of John XI, XII</summary>
+                            <msItem xml:id="p2_i1">
+                                <locus from="72r" to="72v"/><locus from="78r" to="78v"/>
+                                <title>Fragments of John XI and XII</title>
+                                <note>Written on <locus from="72r" to="72v"/> and <locus from="78r" to="78v"/>, which are foliated 'b' and 'h'.</note>
+                            </msItem>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Codex">
+                                <supportDesc>
+                                    <support>
+                                        <material key="parchment"/>
+                                    </support>
+                                    <extent>
+                                        <measure unit="leaf" quantity="8">8</measure><locus from="71" to="78"/>
+                                        <measure unit="leaf" quantity="6" type="blank">6</measure><locus target="71"/><locus from="73" to="77"/>
+                                    </extent>
+                                    <foliation>Foliated a-h.</foliation>
+                                </supportDesc>
+                            </objectDesc>
+                        </physDesc>
+                    </msPart>
                 </msDesc>
             </sourceDesc>
         </fileDesc>
@@ -105,9 +508,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </langUsage>
         </profileDesc>
         <revisionDesc>
-            <change who="CH" when="2025-05-26">Created stub with ID for LIT7479Saalt (no. 13 in Strelcyn's catalogue)</change>
-            <change when="2025-06-17" who="CH">Added ms_i23 and ms_i50, updated ms_i1 to ms_i13</change>
+            <change who="CH" when="2025-05-26">Created record with ID for LIT7479Saalt (p1_i13)</change>
+            <change when="2025-06-17" who="CH">Added p1_i23 and p1_i50, updated p1_i1 to p1_i13</change>
             <change when="2025-08-08" who="CH">Corrected altIdentifier, updated keywords, added origin</change>
+            <change when="2025-08-20" who="CH">Added p1_i2 and p1_i48 to msContents</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/ParisBNF/et/BNFet391.xml
+++ b/ParisBNF/et/BNFet391.xml
@@ -70,27 +70,27 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <summary>Treatise on divination</summary>
                             <msItem xml:id="p1_i1">
                                 <locus from="1v"/>
-                                <title type="complete">Ḥassāba ṭabibān</title>
+                                <title type="complete" ref="LIT7614HassabWise"/>
                                 <incipit xml:lang="gez">ሐሳበ፡ ጠቢባን፡</incipit>
                             </msItem>
                             <msItem xml:id="p1_i2">
                                 <locus from="2r"/>
-                                <title type="complete">Ḥassāba kawākǝbt</title>
+                                <title type="complete" ref="LIT7599HassStars"/>
                                 <incipit xml:lang="gez">ሐሳበ፡ ከዋክብት፡</incipit>
                             </msItem>
                             <msItem xml:id="p1_i3">
                                 <locus from="14v"/>
-                                <title type="complete">Ḥassāba ʾadbār</title>
+                                <title type="complete" ref="LIT7611HassAdbar"/>
                                 <incipit xml:lang="gez">ሐሳበ፡ አድባር፡</incipit>
                             </msItem>
                             <msItem xml:id="p1_i4">
                                 <locus from="16r"/>
-                                <title type="complete">Ḥassāba ḥǝmum</title>
+                                <title type="complete" ref="LIT7593HassHemum"/>
                                 <incipit xml:lang="gez">ሐሳበ፡ ሕሙም፡</incipit>
                             </msItem>
                             <msItem xml:id="p1_i5">
                                 <locus from="16v"/>
-                                <title type="complete">Ḥassāba dǝwwǝy</title>
+                                <title type="complete" ref="LIT7594HassabSick"/>
                                 <incipit xml:lang="gez">ሐሳበ፡ ድውይ</incipit>
                             </msItem>
                             <msItem xml:id="p1_i6">
@@ -121,7 +121,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </msItem>
                             <msItem xml:id="p1_i11">
                                 <locus from="19v"/>
-                                <title type="complete">Ḥassāba fǝnot</title>
+                                <title type="complete" ref="LIT7579HassabaFen"/>
                                 <incipit xml:lang="gez">ሐሳበ፡ ፍኖት፡</incipit>
                             </msItem>
                             <msItem xml:id="p1_i12">
@@ -140,12 +140,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </msItem>
                             <msItem xml:id="p1_i15">
                                 <locus from="20v"/>
-                                <title type="complete">Ḥassāba bǝʾse ḍabʾ</title>
+                                <title type="complete" ref="LIT7622HassabWar"/>
                                 <incipit xml:lang="gez">ሐሳበ፡ ብእሴ፡ ፀብእ፡</incipit>
                             </msItem>
                             <msItem xml:id="p1_i16">
                                 <locus from="21r"/>
-                                <title type="complete">Ḥassāba ḥarā</title>
+                                <title type="complete" ref="LIT7570HassabHara"/>
                                 <incipit xml:lang="gez">ሐሳበ፡ ሐራ፡</incipit>
                             </msItem>
                             <msItem xml:id="p1_i17">
@@ -200,6 +200,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2025-05-26">Created draft version</change>
+            <change when="2025-08-20" who="CH">Add LIT IDs for Hassabs to msItems</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/ParisBNF/et/BNFet405.xml
+++ b/ParisBNF/et/BNFet405.xml
@@ -35,8 +35,145 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <summary>Treatise on divination; Magic prayers</summary>
                         <msItem xml:id="ms_i1">
                             <locus from="26r"/>
-                            <title ref="LIT7489Saalt"/>
-                        </msItem>
+                            <title ref=""/>
+                            <msItem xml:id="ms_i1.1">
+                                <locus from="1r"/>
+                                <title>Computus of the stars</title>
+                                <incipit xml:lang="gez">ንጽሕፍ፡ ኀሳበ፡ ከዋክብት፡</incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.2">
+                                <locus from="22v"/>
+                                <title>Computus of death</title>
+                                <incipit xml:lang="gez">ሐሳብ፡ መዊት፡</incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.3">
+                                <locus from="22v"/>
+                                <title>Computus for knowing if someone will grow tall or not</title>
+                                <incipit xml:lang="gez">ሐሳብ፡ በእንተ፡ ዘይልሕቁ፡ ወኢይልሕቁ፡</incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.4">
+                                <locus from="22v"/>
+                                <title>Computus to know the moment of death</title>
+                                <incipit xml:lang="gez">ሐሳብ፡ በእንተ፡ ብእሲ፡ ወብእሲት፡ ዘይትፋትሁ፡ ወዘኢይትፋትሁ፡</incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.5">
+                                <locus from="23r"/>
+                                <title>Computus to determine whether or not a husband and wife will divorce</title>
+                                <incipit xml:lang="gez">ሐሳብ፡ በእንተ፡ ብእሲ፡ ወብእሲት፡ ዘይትፋትሁ፡ ወዘኢይትፋትሁ፡</incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.6">
+                                <locus from="23r"/>
+                                <title>Computus to know whether a husband will reconcile with his wife</title>
+                                <incipit xml:lang="gez">ሐሳብ፡ ዕርቅ፡</incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.7">
+                                <locus from="23r"/>
+                                <title>Computus to know if a leader will be removed or not removed</title>
+                                <incipit xml:lang="gez">ሐሳብ፡ በእንተ፡ መኰንን፡ ዘይሠዓር፡ ወዘኢይሠዓር፡</incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.8">
+                                <locus from="23r"/>
+                                <title>Computus of lot</title>
+                                <incipit xml:lang="gez">ሐሳበ፡ ክፍል፡</incipit>
+                            </msItem>
+                            
+                            <msItem xml:id="ms_i1.9">
+                                <locus from="1r"/>
+                                <title>Computus of </title>
+                                <incipit xml:lang="gez"></incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.10">
+                                <locus from="1r"/>
+                                <title>Computus of </title>
+                                <incipit xml:lang="gez"></incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.11">
+                                <locus from="1r"/>
+                                <title>Computus of </title>
+                                <incipit xml:lang="gez"></incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.12">
+                                <locus from="1r"/>
+                                <title>Computus of </title>
+                                <incipit xml:lang="gez"></incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.13">
+                                <locus from="1r"/>
+                                <title>Computus of </title>
+                                <incipit xml:lang="gez"></incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.14">
+                                <locus from="26r"/>
+                                <title ref="LIT7489Saalt"/>
+                                <incipit xml:lang="gez">መጽሐፈ፡ ሣአልት፡</incipit>
+                                <note>Treatise on divination in 30 chapters with 15 possibilities for each of them.</note>
+                            </msItem>
+                            <msItem xml:id="ms_i1.15">
+                                <locus from="1r"/>
+                                <title>Computus of </title>
+                                <incipit xml:lang="gez"></incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.16">
+                                <locus from="1r"/>
+                                <title>Computus of </title>
+                                <incipit xml:lang="gez"></incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.17">
+                                <locus from="1r"/>
+                                <title>Computus of </title>
+                                <incipit xml:lang="gez"></incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.18">
+                                <locus from="1r"/>
+                                <title>Computus of </title>
+                                <incipit xml:lang="gez"></incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.19">
+                                <locus from="1r"/>
+                                <title>Computus of </title>
+                                <incipit xml:lang="gez"></incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.20">
+                                <locus from="1r"/>
+                                <title>Computus of </title>
+                                <incipit xml:lang="gez"></incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.21">
+                                <locus from="1r"/>
+                                <title>Computus of </title>
+                                <incipit xml:lang="gez"></incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.22">
+                                <locus from="1r"/>
+                                <title>Computus of </title>
+                                <incipit xml:lang="gez"></incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.23">
+                                <locus from="1r"/>
+                                <title>Computus of </title>
+                                <incipit xml:lang="gez"></incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.24">
+                                <locus from="1r"/>
+                                <title>Computus of </title>
+                                <incipit xml:lang="gez"></incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.25">
+                                <locus from="1r"/>
+                                <title>Computus of </title>
+                                <incipit xml:lang="gez"></incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.26">
+                                <locus from="1r"/>
+                                <title>Computus of </title>
+                                <incipit xml:lang="gez"></incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i1.27">
+                                <locus from="1r"/>
+                                <title>Computus of </title>
+                                <incipit xml:lang="gez"></incipit>
+                            </msItem>
+                        </msItem><!-- LIT7627HassChild in Cf. Strelcyn (B.N.- Griaule) 405, 1 (24) -->
                     </msContents>
                     <physDesc>
                         <objectDesc form="Codex">
@@ -82,6 +219,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <textClass>
                 <keywords>
                     <term key="Magic"/>
+                    <term key="Divination"/>
                 </keywords>
             </textClass>   
             <langUsage>
@@ -91,6 +229,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2025-05-26">Created stub with ID for LIT7479Saalt (no. 14 in Strelcyn's catalogue)</change>
+            <change when="2025-05-26" who="CH">Update msContents</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/StPetersburg/IVorlov15.xml
+++ b/StPetersburg/IVorlov15.xml
@@ -119,7 +119,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
 
                         <item xml:id="a4">
                           <locus target="#103v"/>
-                          <desc type="MagicText">Eight formulas for divination over the property</desc>
+                           <desc type="MagicText">Eight formulas for <ref type="work" corresp="LIT7596HassabRich">divination over the property</ref>.</desc>
                           <q xml:lang="gez">ሐሳበ፡ ንዋይ፡</q>
 
                         </item>
@@ -208,6 +208,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
       <revisionDesc>
          <change who="DN" when="2018-12-12">Created catalogue entry</change>
          <change who="DN" when="2018-12-21">Additions</change>
+         <change when="2025-08-20" who="CH">Add LIT ID for Hassab to a4</change>
       </revisionDesc>
   </teiHeader>
   <text xml:base="https://betamasaheft.eu/">

--- a/VaticanBAV/et/BAVet244.xml
+++ b/VaticanBAV/et/BAVet244.xml
@@ -28,14 +28,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <collection>Aethiopici</collection>
                         <idno>Aeth. 244</idno>
                     </msIdentifier>
-
-                    <msContents>
-                    <summary />
-                    
-
-                    
-                    </msContents>
-                    
+                    <msContents><summary/></msContents>
                     <physDesc>
                       <objectDesc form="Codex">
                         <supportDesc>
@@ -50,15 +43,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </dimensions>
                           </extent>
                         </supportDesc>
-                      </objectDesc>
-                      
-
-
-                      
-
-                      
+                      </objectDesc>                      
                     </physDesc>
-
                   <additional>
                     <adminInfo>
                       <recordHist>
@@ -73,7 +59,199 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                       </recordHist>
                     </adminInfo>
                   </additional>
-
+                    <msPart xml:id="p1"><msIdentifier/>
+                        <msContents>
+                            <summary>Divination</summary>
+                            <msItem xml:id="p1_i1">
+                                <locus from="1" to="5"/>
+                                <title>Treatise of divination through the signs of the zodiac</title>
+                                <incipit xml:lang="am">ጸሩ፡ አቅራብ፡ ክፍሉ፡ ሚዛን፡ ሐመል፡ ሆዱን፡ እራሱን፡ ያመዋል፡ አፈ፡ ከነው፡ የ፬ ማዕዘን፡ 
+                                    ይሰግ<add place="above">ድ</add>ለታል፡ በድብ፡ ይትሜሰል፡</incipit>
+                                <explicit xml:lang="am">ሴት፡ ዓይነ፡ ደረቅ፡ ነች፡ ነገሯ፡ መራር፡ <gap reason="ellipsis"/> ለሰውም፡ አዛኝ፡ ነች።</explicit>
+                            </msItem>
+                            <msItem xml:id="p1_i2">
+                                <locus from="5" to="8v"/>
+                                <title>Chapter of divination</title>
+                                <msItem xml:id="p1_i2.1">
+                                    <locus target="#5"/>
+                                    <title ref="LIT7611HassAdbar"/>
+                                    <note>Divinatory text described as 'divination of mountains' (<foreign xml:lang="la">subputatio montium</foreign>)
+                                        by <bibl><ptr target="bm:GrebTiss1935Codices"/><citedRange unit="page">753-755</citedRange></bibl>, but
+                                        more likely a divination concerning 'monasteries'.</note>
+                                    <incipit xml:lang="gez">ሐሳበ፡ አድባር፡ ስም፡ ስመ፡ ሀገር፡ በ፯፡ 
+                                        ግ<choice><sic>ደ</sic><corr>ድ</corr></choice><supplied reason="undefined">ፍ</supplied>፡ ፩ ብእሲትከ፡ 
+                                        ትዜሙ፡ ሠራቂ፡ እሳት፡ ህማም፡ ጥፍአት፡ አራዊተ፡ ገዳም፡ ይትሄየለከ፡ ሰብእ፡ ይፃረረከ፡ <del>ሰብእ፡ ይፃ</del> ህሙም፡ 
+                                        ይ<choice><sic>ሙ</sic><corr>መ</corr></choice>ውት፡</incipit>
+                                </msItem>
+                                <msItem xml:id="p2_i2.2">
+                                    <locus target="#6"/>
+                                    <title>Ḥassāba makānǝn</title>
+                                    <note>Divinatory text concerning judges.</note>
+                                    <incipit xml:lang="gez">ሐሳበ፡ መካንን፡</incipit>
+                                </msItem>
+                                <msItem xml:id="p2_i2.3">
+                                    <locus target="#6"/>
+                                    <title>Ḥassāba warh</title>
+                                    <note>Divination concerning the moon</note>
+                                </msItem>
+                                <msItem xml:id="p1_i2.4">
+                                    <locus target="#7v"/>
+                                    <title ref="LIT7611HassAdbar"/>
+                                    <note>Divinatory text described as 'divination of mountains' (<foreign xml:lang="la">subputatio montium</foreign>)
+                                        by <bibl><ptr target="bm:GrebTiss1935Codices"/><citedRange unit="page">753-755</citedRange></bibl>, but
+                                        more likely a divination concerning 'monasteries'.</note>
+                                    <incipit xml:lang="gez">ሐሳበ፡ አድባር፡</incipit>
+                                </msItem>
+                                <msItem xml:id="p1_i2.5">
+                                    <locus target="#7v"/>
+                                    <title>Ḥassāba dawe</title>
+                                    <note>Divination concerning illness.</note>
+                                </msItem>
+                                <msItem xml:id="p1_i2.6">
+                                    <locus target="#8"/>
+                                    <title>Ḥassāba nǝwāy</title>
+                                    <explicit xml:lang="gez">፪ <choice><sic>ም</sic><corr>መ</corr></choice>ንገለ፡ ምዕራብ፡ የሐውር፡ በሳኒታ፡ ይትረከብ፡ 
+                                        ፫፡ መንገለ፡ ሰሜን፡ የሐውር፡ በዝንቱ፡ ድ<del>ተ</del>ካም፡ ይትረ<unclear>ከ</unclear>ብ፡ ፬ በደቡብ፡ ይትረካብ፡</explicit>
+                                </msItem>
+                            </msItem>
+                            <msItem xml:id="p1_i3">
+                                <locus target="#8v"/>
+                                <title ref="LIT6609ProtectPrayer" type="incomplete">Magic prayer</title>
+                                <note>Ending abruptly.</note>
+                                <incipit xml:lang="gez">በስመ፡ አብ፡ በል፡ ጸሎት፡ በእን<unclear>ተ</unclear>፡ ምስሓቦሙ፡ 
+                                    <supplied reason="undefined">ለ</supplied>ንዋይ፡ ለወ<gap reason="illegible" unit="chars" quantity="3"/>፡ ንዋይ፡ 
+                                    አስማተ፡ ንዋይ፡ በአን<gap reason="illegible" unit="chars" quantity="2"/>ን፡ ኤልሳ፡ ዮሳር፡ <gap reason="ellipsis"/> 
+                                    በኃ<unclear>ይለ፡</unclear> ዝንቱ፡ አስማቲካ፡</incipit>
+                                <explicit xml:lang="gez">ከመ፡ ያ<choice><sic>መ</sic><corr>ም</corr></choice>ጽኡ፡ 
+                                    <supplied reason="undefined">ን</supplied>ዋይየ፡ የሐቡኒ፡ በልቦሙ፡ ያመጽኡ፡ ንዋ<gap reason="lost"/></explicit>
+                            </msItem>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Codex">
+                                <supportDesc>
+                                    <support>
+                                        <material key="parchment"/>
+                                    </support>
+                                    <extent>
+                                        <measure unit="leaf" n="8">8</measure>
+                                        <dimensions type="inner" unit="mm">
+                                            <width>114</width>
+                                            <height>77</height>
+                                        </dimensions>
+                                    </extent>
+                                </supportDesc>
+                            </objectDesc>                      
+                        </physDesc>
+                        <history>
+                            <origin>
+                                <origDate notBefore="1800" notAfter="1899">19th century</origDate>
+                            </origin>
+                        </history>
+                    </msPart>
+                    <msPart xml:id="p2"><msIdentifier/>
+                        <msContents>
+                            <summary>Dǝggʷā</summary>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Codex">
+                                <supportDesc>
+                                    <support>
+                                        <material key="parchment"/>
+                                    </support>
+                                    <extent>
+                                        <measure unit="leaf" n="4">4</measure>
+                                        <dimensions type="inner" unit="mm">
+                                            <width>126</width>
+                                            <height>90</height>
+                                        </dimensions>
+                                    </extent>
+                                </supportDesc>
+                            </objectDesc>                      
+                        </physDesc>
+                        <history>
+                            <origin>
+                                <origDate notBefore="1800" notAfter="1899">19th century</origDate>
+                            </origin>
+                        </history>
+                    </msPart>
+                    <msPart xml:id="p3"><msIdentifier/>
+                        <msContents>
+                            <summary>Magic prayers</summary>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Codex">
+                                <supportDesc>
+                                    <support>
+                                        <material key="parchment"/>
+                                    </support>
+                                    <extent>
+                                        <measure unit="leaf" n="7">7</measure>
+                                        <dimensions type="inner" unit="mm">
+                                            <width>137</width>
+                                            <height>75</height>
+                                        </dimensions>
+                                    </extent>
+                                </supportDesc>
+                            </objectDesc>                      
+                        </physDesc>
+                        <history>
+                            <origin>
+                                <origDate notBefore="1800" notAfter="1899">19th century</origDate>
+                            </origin>
+                        </history>
+                    </msPart>
+                    <msPart xml:id="p4"><msIdentifier/>
+                        <msContents>
+                            <summary>Amulet against enemies</summary>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Scroll">
+                                <supportDesc>
+                                    <support>
+                                        <material key="parchment"/>
+                                    </support>
+                                    <extent>
+                                        <measure unit="leaf" n="1">1</measure>
+                                        <dimensions type="outer" unit="mm">
+                                            <width>97</width>
+                                            <height>58</height>
+                                        </dimensions>
+                                    </extent>
+                                </supportDesc>
+                            </objectDesc>                      
+                        </physDesc>
+                        <history>
+                            <origin>
+                                <origDate notBefore="1800" notAfter="1899">19th century</origDate>
+                            </origin>
+                        </history>
+                    </msPart>
+                    <msPart xml:id="p5"><msIdentifier/>
+                        <msContents>
+                            <summary>Amulet to gain love</summary>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Codex">
+                                <supportDesc>
+                                    <support>
+                                        <material key="parchment"/>
+                                    </support>
+                                    <extent>
+                                        <measure unit="leaf" n="1"></measure>
+                                        <dimensions type="inner" unit="mm">
+                                            <width>71</width>
+                                            <height>43</height>
+                                        </dimensions>
+                                    </extent>
+                                </supportDesc>
+                            </objectDesc>                      
+                        </physDesc>
+                        <history>
+                            <origin>
+                                <origDate notBefore="1800" notAfter="1899">19th century</origDate>
+                            </origin>
+                        </history>
+                    </msPart>
                 </msDesc>
             </sourceDesc>
         </fileDesc>
@@ -88,23 +266,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <textClass>
                 <keywords>
                     <term key="ChristianLiterature"/>
+                    <term key="Magic"/>
+                    <term key="Divination"/>
+                    <term key="Asmat"/>
                 </keywords>
             </textClass>
             <langUsage>
                 <language ident="en">English</language>
                 <language ident="gez">Gǝʿǝz</language>
+                <language ident="am">Amharic</language>
             </langUsage>
         </profileDesc>
         <revisionDesc>
             <change who="JK" when="2024-09-02">Created entity</change>
-
+            <change when="2025-08-27" who="CH">Created msParts and added msContents to p1</change>
         </revisionDesc>
     </teiHeader>
     <text>
         <body>
-
-            <div type="bibliography"/>
-
+            <div type="bibliography"/>  
         </body>
     </text>
 </TEI>


### PR DESCRIPTION
I updated a number of manuscript records with divinatory texts (ḥassābs), which are referenced in Strelcyns description on BLorient12034. I created a number of records for ḥassābs, which I wanted to include also in the records of CamOr1885, BNFet390, BNFet391, BNFet405, IVorlov15 and BAVet244, all of which I have updated without having a look into the images and some of which the physDesc and msContents are not complete, yet.

For the latest pull request see https://github.com/BetaMasaheft/Manuscripts/pull/3017 (without LIT IDs for ḥassābs). A new pull request with a large number of LIT IDs for ḥassābs and other LIT IDs with follow soon.