### PR TITLE
Removed resp="zotero tag" in BAV manuscripts

### DIFF
--- a/VaticanBAV/et/BAVet101.xml
+++ b/VaticanBAV/et/BAVet101.xml
@@ -106,7 +106,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                      <explicit xml:lang="gez">
                         አርጋዔ፡ ነፋሳት፡ ወበረድ፡ ወኃይለ፡ ሰማያት፡ 
                            <sic>ዎምድር፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ወምድር፡</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ወምድር፡</corr>
                          
                         ወኃይለ፡ ኵሎሙ፡ ዘአርጋዕከ፡ ከማሆሙ፡ አርግዕ፡ 
                            <sic>ወአቍም፡</sic>
@@ -134,7 +134,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                      <explicit xml:lang="gez">
                         በከመ፡ አድኃንኮ፡ ለወልደ፡ ኪራስቂ፡ እምሕማመ፡ ውግዓት፡ ከማሁ፡ አድኅና፡ <choice>
                            <sic>ለዓምከ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ለዓመትከ፡</corr></choice>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ለዓመትከ፡</corr></choice>
                          
                         ወለተ፡ ዓቢየ፡ እግዚእ፡ <add place="overstrike">ኪዳነ፡ ማርያም፡</add>
                      </explicit>

--- a/VaticanBAV/et/BAVet102.xml
+++ b/VaticanBAV/et/BAVet102.xml
@@ -39,7 +39,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         አሰስሎ፡ ደዌ፡ እምእሞሙ፡ ለኅፃናት፡ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/> ወሀሎ፡ ፩ብእሲ፡ ዘስሙ፡ ሱስንዮስ፡ 
                         <choice>
                            <sic>ወብእሲተ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ወብእሲቱ፡</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ወብእሲቱ፡</corr>
                         </choice> ወለደ<supplied reason="omitted">ት</supplied>፡ 
                         ወልደ፡ ተባእተ፡ ወአንስተ፡ ወበቀዳማይ፡ ወልዱ፡ መ<supplied reason="lost">ጽ</supplied>አት፡ ውርዝልያ፡
                      </incipit>

--- a/VaticanBAV/et/BAVet103.xml
+++ b/VaticanBAV/et/BAVet103.xml
@@ -73,7 +73,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         ይ<supplied reason="explanation">ብል</supplied>፡ ካ<supplied reason="explanation">ህን፡</supplied>፡ 
                         <choice>
                            <sic>አእኵትዎ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ናእኵቶ፡</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ናእኵቶ፡</corr>
                         </choice> ለአምላክነ። 
                         ይ<supplied reason="explanation">ብል</supplied>፡ ሕ<supplied reason="explanation">ዝብ</supplied>፡ ርቱዕ፡ ይደሉ። 
                         ይ<supplied reason="explanation">ብል</supplied>፡ ካ<supplied reason="explanation">ህን፡</supplied>፡ ለከ፡ ለአብ፡ ዘኢይማሥን፡ 

--- a/VaticanBAV/et/BAVet106.xml
+++ b/VaticanBAV/et/BAVet106.xml
@@ -326,7 +326,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <incipit xml:lang="gez">
                            አንቀጽ፡ ፴፯፡ ያጤይቅ፡ ውስቴቱ፡ አእምሮተ፡ መጠነ፡ ኑኃ፡ ዓመተ፡ ፀሐይ፡ ወዘየሐፅፅ፡ እምነ፡ ፫፻፷ወ፭ዕለት፡ <choice>
                               <sic>ሩብዕ።</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ወራብዕ።</corr></choice>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ወራብዕ።</corr></choice>
                            
                         </incipit>
                      </msItem>

--- a/VaticanBAV/et/BAVet107.xml
+++ b/VaticanBAV/et/BAVet107.xml
@@ -83,11 +83,11 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <q xml:lang="gez">
                                  መልዓ፡ ብስራተ፡ <choice>
                                     <sic>ሉቃሉ፡</sic>
-                                    <corr resp="bm:GrebTiss1935Codices">ሉቃስ፡</corr>
+                                    <corr resp="PRS4805Grebaut PRS9530Tisseran">ሉቃስ፡</corr>
                                  </choice> ሐዋርያ፡ ጠቢብ፡ እንተ፡ 
                                  <choice>
                                     <sic>ተሐፋ፡</sic>
-                                    <corr resp="bm:GrebTiss1935Codices">ጸሐፋ፡</corr>
+                                    <corr resp="PRS4805Grebaut PRS9530Tisseran">ጸሐፋ፡</corr>
                                  </choice> በልሳነ፡ ጽርዕ፡ ለሰብአ፡ ሀገረ፡ መቄዶንያ፡ እምድኅረ፡ 
                                  ዕርገቱ፡ ለእግዚእነ፡ ውስተ፡ ሰማይ፡ በ፳ወ፪ዓመት፨ ወበ፲ወ፬ዓመተ፡ መንግሥቱ፡ ለቀላውዴዎስ፡ ቄሳር፨ ወስብሐት፡ ለእግዚአብሔር፡ ለዓለመ፡ ዓለም፡ አሜን፨
                               </q>.

--- a/VaticanBAV/et/BAVet108.xml
+++ b/VaticanBAV/et/BAVet108.xml
@@ -56,7 +56,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            ናስተበቍዕ፡ ዘኵሎ፡ ይእኅዝ፡ እግዚአብ<supplied reason="omitted">ሔር</supplied>፡ አብ፡ ለእግዚእ<supplied reason="omitted">ነ</supplied>፡ ወመድኀኒነ፡ 
                            ኢየሱስ፡ <choice>
                               <sic>ክርስትስ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ክርስቶስ፡</corr></choice>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ክርስቶስ፡</corr></choice>
                             እንዘ፡ 
                            
                               <sic>ነአኵት፡</sic>
@@ -131,7 +131,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <q xml:lang="gez">
                            ተአምር፡ ቅዱስ፡ ዘሰበከ፡ ዮሐንስ፡ ክብራ፡ ለእመ፡ ንጉሥ፡ ስብሐት፡ ለኪ፡ ኦማርያም፡ እግዝእትነ፡ ወመድኀኒትነ፡ ኵሎ፡ ጊዜ፡ ወንጌል፡ <choice>
                                     <sic>ወያቀውማ፡</sic>
-                                    <corr resp="bm:GrebTiss1935Codices">ወይቀውማ፡</corr>
+                                    <corr resp="PRS4805Grebaut PRS9530Tisseran">ወይቀውማ፡</corr>
                                   </choice>
                            በል።
                         </q>
@@ -254,7 +254,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <note>
                            The text terminates with the following directive: <q xml:lang="gez">በዘመነ። <choice>
                                     <sic>በፎ፡</sic>
-                                    <corr resp="bm:GrebTiss1935Codices">በፍሬ፡</corr>
+                                    <corr resp="PRS4805Grebaut PRS9530Tisseran">በፍሬ፡</corr>
                                   </choice>
                            በጴጥሮስ፡ ወጳውሎስ፡ በሰማዕታት፡ ቀድስ፨</q>.
                         </note>

--- a/VaticanBAV/et/BAVet109.xml
+++ b/VaticanBAV/et/BAVet109.xml
@@ -43,7 +43,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            በስመ፡ አብ፡ <gap reason="omitted" resp="bm:GrebTiss1935Codices"/> ንዌጥን፡ ጽሒፈ፡ ሰዋስው፡ ሰዋስው፡ 
                            ብሂል፡ መሰላል፡ <choice>
                               <sic>መሸጋገርያ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">መሸጋገሪያ፡</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">መሸጋገሪያ፡</corr>
                            </choice> 
                         </incipit>
                         <explicit xml:lang="am">
@@ -61,7 +61,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <incipit xml:lang="am">
                            በሴት፡ ቅፅል፡ የሚጠብቁ፡ አናቅጽ፡ <choice>
                               <sic>፫ናቼው፤</sic>
-                              <corr resp="bm:GrebTiss1935Codices">፫ናቸው፤</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">፫ናቸው፤</corr>
                            </choice> 
                            ጠ፤ ደ፤ ተ፡ ይባላሉ፨
                         </incipit>
@@ -82,7 +82,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <explicit xml:lang="am">
                            ሁሉ፡ እየወደቁ፡ ውእቱን፡ <choice>
                               <sic>ፈለገው።</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ፈልገው።</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ፈልገው።</corr>
                            </choice> ያጠፋሉ፡ 
                            በዝየ፡ ተፈጸመ፡ ዓቢይ፡ አገባብ።
                         </explicit>
@@ -101,11 +101,11 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            ናዕስ፡ ንዕስ፡ ታናሽነት፡ ይሆናል፡ <gap reason="omitted" resp="bm:GrebTiss1935Codices"/> 
                            <choice>
                               <sic>ኢያሱ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ኢየሱስ፡</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ኢየሱስ፡</corr>
                            </choice> ላዕለ፡ እግረ፡ ፀሐይ፡ ይትዋነይ፡ በጊዜ፡ 
                            ናዕሱ፡ ወማያተ፡ ይቀድሕ፡ በልብሱ፡ <choice>
                               <sic>ይለል።</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ይላል።</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ይላል።</corr>
                            </choice> 
                            በንዕሱ፡ ወጠነ፡ መሠረተ፡ ስብሐት፡ ንድቅ፡ ለደብረ፡ ሊባኖስ፡ ስርጋዌ፡ ርእሰ፡ ተክለ፡ ሃይማኖት፡ አክሊለ፡ ወርቅ፡ ይላል። ነሥአ፡ አርዑተ፡ 
                            እምንዕሱ፡ ወተፀምዶ፡ ለእግዚአብሔር፡ ይላ<supplied reason="omitted">ል</supplied>፡ ወላዲተ፡ ሕያው፡ ክርስቶስ፡ 
@@ -122,18 +122,18 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <incipit xml:lang="am">
                            ንዑስ፡ አገባብ። አይ፡ ሚ፡ ምንት። ምን፡ ምንድር፡ አያት፡ ምንታት፡ ምኖች። ምንድሮች፡ <choice>
                               <sic>ይሆኖሉ።</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ይሆናሉ።</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ይሆናሉ።</corr>
                            </choice>
                         </incipit>
                         <explicit xml:lang="am">
                            ለዓለም፡ ለግሙራ፡ ግሙራ፡ ለዝሉፉ፡ ለዝላፉ፡ <gap reason="omitted" resp="bm:GrebTiss1935Codices"/> በደጊመ፡ ቃል፡ ከቶ፡ 
                            ተከቶ፡ <choice>
                               <sic>አስከትቶ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">አስከቶ፡</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">አስከቶ፡</corr>
                            </choice> ተካቶ፡ 
                            <choice>
                               <sic>አከቶ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">አካቶ፡</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">አካቶ፡</corr>
                            </choice> ይሆናሉ።
                         </explicit>
                      </msItem>
@@ -155,7 +155,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <incipit xml:lang="am">
                            ከሀ፡ ጀምሮ፡ እስከ፡ ፐ፡ <choice>
                               <sic>የአለ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ያለ፡</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ያለ፡</corr>
                            </choice> ግሥ፡ ሁሉ፡ በ፬ፀዋትው፡ 
                            በ፳፭ሠራዊት፡ የነገራል፡
                         </incipit>

--- a/VaticanBAV/et/BAVet11.xml
+++ b/VaticanBAV/et/BAVet11.xml
@@ -473,7 +473,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                        <choice>
                                     <sic>ወበዘንዜክር፡</sic>
                                 
-                                 <corr resp="bm:GrebTiss1935Codices">ወበዘንዜከር፡</corr>  </choice>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ወበዘንዜከር፡</corr>  </choice>
                                 
                                     <sic>ሐሰበ፡</sic>
                                  

--- a/VaticanBAV/et/BAVet110.xml
+++ b/VaticanBAV/et/BAVet110.xml
@@ -116,7 +116,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            ተአምሪሁ፡ ለአቡነ፡ ተክለ፡ ሃይማኖት። ጸሎቱ፡ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/> ወካዕበ፡ ተግሕሠ፡ 
                            መፍቀሬ፡ እግዚአብሔር፡ ይስሐቅ፡ <choice>
                               <sic>ሰሚዓ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ሰሚዖ፡</corr></choice>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ሰሚዖ፡</corr></choice>
                             ዜናሁ፡ 
                            ለዝንቱ፨ ቅዱስ፡ ወጻድቅ፨ ወአዘዘ፡ ይሕንጹ፡ ቤተ፡ ክርስቲያን፡ ዐቢየ፡
                         </incipit>
@@ -252,7 +252,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            ወበይዕቲ፡ ሰዓት፡ አስተፋጠኑ፡ ሰብአ፡ ሀገር፡ ወአምጽኡ፡ ወባኦሙ፡ በእንተ፡ ተዝካሩ፡ ለአቡነ፡ ወኮነ፡ ዓቢይ፡ በዓል፡ በይእቲ፡ ሰዓት፡ እንዘ፨ 
                            ይሴብሕዎ፡ ለእግዚአብሔር፡ <choice>
                               <sic>ዘአክበርዎ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ዘአልበሮ፡</corr></choice>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ዘአልበሮ፡</corr></choice>
                             ለዝንቱ፡ 
                            ቅዱስ፡ ተክለ፡ ሃይማኖት፡ ትንብልናሁ፡ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/> 
                         </explicit>
@@ -292,7 +292,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <explicit xml:lang="gez">
                            ወትቤ፡ አኮ፡ ማኅፀንየ፡ ዘወለደቶ፡ አላ፡ ትንብልናሁ፡ ለዝንቱ፡ አብ፡ ክቡር፨ ወእምዝ፡ <choice>
                               <sic>መጺኦ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">መጺኣ፡</corr></choice>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">መጺኣ፡</corr></choice>
                             
                            ነገረቶ፡ ለቀሲስ፡ ዘወሀባ፡ እመሬቱ፨ ወአእኰትዎ፡ ለእግዚአብሔር፡ ኅቡረ፡ ወለዝንቱ፡ ቅዱስ፡ ጸሎቱ፡ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/> 
                         </explicit>
@@ -327,7 +327,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <explicit xml:lang="gez">
                            ወእሙንቱ፡ መነኮሳት፡ <choice>
                               <sic>ሰምዕ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ሰምዑ፡</corr></choice>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ሰምዑ፡</corr></choice>
                             በዝ፡ 
                            ነገር፡ ወእስከ፡ ይእዜ፡ ይገብሩ፡ ተዝካሮ፡ በከመ፡ በፅዑ፡ ወይሴሰዩ፡ ሲሳዮሙ፡ በትፍሥሕት፡ እንዘ፡ 
                               <sic>የአኩቱ፡</sic>

--- a/VaticanBAV/et/BAVet111.xml
+++ b/VaticanBAV/et/BAVet111.xml
@@ -3113,10 +3113,10 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <q xml:lang="gez">
                               ዘአቅረብኩ፡ ማኅሌተ፡ አዘኪርየ፡ አእላፈ፡ እምእለ፡ ተጸምዱከ፡ ዘልፈ፨ ለእለ፡ <choice>
                                  <sic>አነብብ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">እነብብ፡</corr>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">እነብብ፡</corr>
                               </choice> ተወከፍ፡ ዘንዴትየ፡ መጽሐፈ፨  <choice>
                                  <sic>እንተ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">አንተ፡</corr>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">አንተ፡</corr>
                               </choice> ረሰይከ፡ እግዚኦ፡ ጸሪቀ፡ መበለት፡ ውኩፈ፨ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/> ለዘጸሐፎ፡ በክርታስ፡ ወለዘአጽሐፎ፡ እንዘ፡ ይደርስ፡ ለዘእንበቦ፡ ወለዘተርጐሞ፡ በልሳን፡
                               ሐዲስ፡ ወለዘሰምዓ፡ ቃሎ፡ በዕዝነ፡ መንፈስ፡ በጸሎተ፡ እሙ፡ ማርያም፡ አራቂተ፡ ኵሉ፡ እምባዕስ፡ ኅቡረ፡ ይምሐረነ፡ ኢየሱስ፡
                               ክርስቶስ፡ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/>

--- a/VaticanBAV/et/BAVet113.xml
+++ b/VaticanBAV/et/BAVet113.xml
@@ -417,11 +417,11 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                             
                            <choice>
                               <sic>ከልጀዋ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ከልጅዋ፡</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ከልጅዋ፡</corr>
                            </choice> 
                            <choice>
                               <sic>ጋር፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ጋራ፡</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ጋራ፡</corr>
                            </choice> ትኖራለች፡ ተፈጸመ፡ የማርያም፡ ኪዳነ፡ ምሕረት፡ ዘ፲፮ለነሐሴ፡ ስሙ፡ በዓለ፡ ፍል<add place="above">ሰ</add>ታ፡
                         </explicit>
                      </msItem>
@@ -439,7 +439,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                             
                            <choice>
                               <sic>የለቅሶ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">የልቅሶ፡</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">የልቅሶ፡</corr>
                            </choice> ጥምቀት፡ ያድናል፡ ተስፋችን፡ ብዙ፡ ነውና፨ ተፈጸመ፡ ትምሕርተ፡ ጥምቀት፡ ለዓለመ፡ ዓለም፡ አሜን፨
                         </explicit>
                      </msItem>
@@ -453,7 +453,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <explicit>
                            የአሕዛብና፡ የአይሁድ፡ ሥቃይ፡ በክርስቲያን፡ ላይ፡ የ<supplied reason="omitted">ነ</supplied>ሡበታል፡ <choice>
                               <sic>ተናግረው፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ተናገረው፡</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ተናገረው፡</corr>
                            </choice> ስምዖን፡ አረጋዊ፨ ተፈጸመ፡ ገድለ፡ ስምዖን።
                         </explicit>
                      </msItem>
@@ -463,7 +463,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <incipit>
                            ምሥጢረ፡ ሆሣዕና፡ <choice>
                               <sic>ምሥጢረ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ምሥጢር፡</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ምሥጢር፡</corr>
                            </choice> ዘውስተ፡ ቍርባን፡ ስሙ፡ የተባረካችሁ፡ ክርስቲያኖች፡ ነገሥትና፡ መሳፍንት፡ ልማድ፡ አለው፡ አዳራሽ፡ ሲገናኙ፡ ዘመድና፡ ወዳዶች፡ 
                            ሲጠሩ፡
                         </incipit>

--- a/VaticanBAV/et/BAVet115.xml
+++ b/VaticanBAV/et/BAVet115.xml
@@ -46,7 +46,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <explicit xml:lang="gez">
                               ወይቤላ፡ አነ፡ ውእቱ፡ ክርስቶስ፡ ወልደ፡ እግዚአብሔር፡  <choice>
                                  <sic>ወየአምንዎሙ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ወየአምኑ፡</corr>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ወየአምኑ፡</corr>
                               </choice> ኃጥኣን፡ ሕዝብ፡ በክርስቶስ፡ ወልደ፡ እግዚአ<supplied reason="omitted">ብ</supplied>ሔር፨ 
                            </explicit>
                         </msItem>
@@ -179,12 +179,12 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                  <sic>ወዕንጐጓዕት፡</sic>
                                እለ፡ ውስተ፡ ማያት፡ ወቈርነነዓት፡ <choice>
                                     <sic>የ፨</sic>
-                                    <corr resp="bm:GrebTiss1935Codices">ያአኵቱከ፨</corr> 
+                                    <corr resp="PRS4805Grebaut PRS9530Tisseran">ያአኵቱከ፨</corr> 
                                  </choice> ወ<supplied reason="explanation">ይሴብሑከ</supplied>፨ እ<supplied reason="explanation">ሳት</supplied>፨ 
                                  ወ<supplied reason="explanation">ስቡሕ፨</supplied> ስ<supplied reason="explanation">መ፡ እግዚአብሔር</supplied>፨ ሕያዋን፡ ወሙታን፨ 
                                  ወኵሉ፡ ፍጥረት፡ ዘቦ፡ ነፍስ፡ ወዘአልቦ፡ መንፈስ፨ <choice>
                                     <sic>የ፨</sic>
-                                    <corr resp="bm:GrebTiss1935Codices">ያአኵቱከ፨</corr> 
+                                    <corr resp="PRS4805Grebaut PRS9530Tisseran">ያአኵቱከ፨</corr> 
                                  </choice> ወ<supplied reason="explanation">ይሴብሑከ</supplied>፨ እ<supplied reason="explanation">ሳት</supplied>፨ 
                                  ወ<supplied reason="explanation">ስቡሕ፨</supplied> ስ<supplied reason="explanation">መ፡ እግዚአብሔር</supplied>፨ እግዚኦ፡ ተማኅፀንኩ፡ 
                                  አነ፡ ገብርከ፡ ዓለመ፡ ዓለም፡ አሜን፨
@@ -259,7 +259,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <explicit xml:lang="gez">
                                  አንብቡ፡ ወተርጕመ፡ ለዝንቱ፡ መጽሐፍ፡ ይኩንክሙ፡ ዓስበ፡ <choice>
                                     <sic>ይመሐርክሙ፡</sic>
-                                    <corr resp="bm:GrebTiss1935Codices">ይምሐርክሙ፡</corr>
+                                    <corr resp="PRS4805Grebaut PRS9530Tisseran">ይምሐርክሙ፡</corr>
                                  </choice> እግዚአብሔር፡ በመንግሥተ፡ ሰማያት፡ ለዓለመ፡ ዓለም፡ አሜን፨
                               </explicit>
                            </msItem>
@@ -271,7 +271,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                  ክርስቲያን፡ እስመ፡ አንጽሖን፡ ሞት። ወለእመ፡ አልቦን፡ ንጹሕ፡ ልብስ፡ ኢያበውእዎን፡ ቤተ፡ ክርስቲያን፡ አላ፡ ይጐደጕድዎን፡ አፍአ፡ 
                                  እምአንቀጽ፡ ወይብል፡ ጸሎተ፡ አኰቴት፡ <choice>
                                     <sic>ወያዕርግ፡</sic>
-                                    <corr resp="bm:GrebTiss1935Codices">ወያዐርግ፡</corr>
+                                    <corr resp="PRS4805Grebaut PRS9530Tisseran">ወያዐርግ፡</corr>
                                  </choice> ዕጣነ፡
                               </incipit>
                            </msItem>
@@ -323,7 +323,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <incipit xml:lang="gez">
                               ሣልስ፡ ጸሎተ፡ ንስሐ፡ እግዚኦ፡ እግዚአብሔር፡ አምላክነ፡ ዋህድ፡ ቃለ፡ እግዚአብሔር፡ አብ፡ <choice>
                                  <sic>ዘወጽአ፤</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ዘመጽአ፤</corr>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ዘመጽአ፤</corr>
                               </choice> ውስተ፡ ዓለም፨ ከመ፨ ይጸውዕ፡ ኃጥአነ፡ ለንስሓ፡
                            </incipit>
                            <explicit xml:lang="gez">
@@ -331,7 +331,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                  <sic>ይላህው፡</sic>
                                ናህየ፡ ወዕረፍተ፡ ጸጉ፡ ለጽዑራን፡ መድኅን፡ ወለነኒ፡ <choice>
                                  <sic>ያድኅነነ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">አድኅነነ፡</corr>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">አድኅነነ፡</corr>
                               </choice> በዝ፡ ዓለም፡ ወበዘ፡ ይመጽእ፡ በ፩ወልድከ፡ በል፡ ወእምዝ፡ እግ<supplied reason="explanation">ዚኦ፡</supplied> 
                               መሐ<supplied reason="explanation">ረነ</supplied>፡ ክር<supplied reason="explanation">ስቶስ</supplied>፡ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/>
                            </explicit>
@@ -372,7 +372,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <explicit xml:lang="gez">
                               <choice>
                                  <sic>ወኁልቆ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ወኈልቆ፡</corr>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ወኈልቆ፡</corr>
                               </choice> ምስለ፡ መስተጋድላን፨ ወምእመናን፡ ወምስለ፡ እለ፡ ድኅኑ፡ በሥምረተ፡ አቡከ፡ ኄር፡ ማኅ<supplied reason="omitted">የ</supplied>ዊ፡ 
                               ዘዕሩይ፡ ምስሌከ፡ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/>
                            </explicit>
@@ -645,7 +645,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            በስመ፡ አብ፡ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/> ጸሎተ፡ ንስሐ፡ ዘወሀቦ፡ እግዚአብሔር፡ ለጴጥሮስ፡ ወይቤሎ፡ ንሣእ፡ መራኁተ፡ መንግሥተ፡ 
                            ሰማይ፡ ከመ፡ <choice>
                               <sic>ትስ እር፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ትእስር፡</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ትእስር፡</corr>
                            </choice> ወትፍታሕ፡ ወይቤሎ፡ እግዚአብሔር፡ ኢየሱስ፡ ክርስቶስ፡ ጸጋሁ፡ ለመንፈስ፡ ቅዱስ፡ ኤልሳዕ፡ ኤልኮስ። ጰንተኮር፡ ጢሮስ፡ 
                            ወግሚሙስ፡ ወጥንትር፡ ዓዶን፡ ወአቅማቱስ፡ ወኢያል፡ 
                         </incipit>
@@ -673,7 +673,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            በሙሴ፡ ሊቀ፡ ነቢያት፡ በአላኒቆስ፡ 
                               <sic>በኢየሱስ፡</sic>
                               <sic>ዜናዊ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ዘነዌ፡</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ዘነዌ፡</corr>
                             በሳሙኤል፡ በዳዊት፡ በጋድ፡ ወናታን፡ በኤልያስ፡ ወበኤልሳዕ፡
                         </incipit>
                         <explicit xml:lang="gez">
@@ -696,14 +696,14 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <incipit xml:lang="gez">
                            በስመ፡ አብ፡ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/> ጸሎት፡ በእንተ፡ <supplied reason="omitted">እለ፡</supplied> አዕረፉ፡ <choice>
                                  <sic>ወወሀብ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ወወሀቡ፡</corr>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ወወሀቡ፡</corr>
                               </choice> ምጽዋተ፡ እምንዋዮሙ፡ ቤዛሃ፡ ለነፍሶሙ፡ ይትጋብኡ፡ ውስተ፡ ቤተ፡ ክርስቲያን፡ ይግበሩ፡ ቍርባነ፡ ሥጋሁ፡ ቅዱስ፡ <choice>
                                  <sic>ደሞ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ወደሙ፡</corr>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ወደሙ፡</corr>
                               </choice> 
                            <choice>
                                  <sic>ክቡረ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ክቡር፡</corr>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ክቡር፡</corr>
                               </choice> ወይግበሩ፡ ጸሎተ፡ ብዙኃ፡ በዕለተ፡ አዕረፉ፡ ወካዕበ፡ አመ፡ ሣልስት፡ ዕለት፡ ፯ወ፲ወ፪ወ፴ወ፵ወ<supplied reason="omitted">በ</supplied>መንፈቅ፡ 
                            ወበዓመት፡ <supplied reason="omitted">ወ</supplied>ሀቡ፡ ምጽዋተ፡ እምንዋዮሙ፡ ቤዛሃ፡ ለነፍሶሙ፡ ወይዝክርዎሙ፡ በጊዜ፡ ጸሎት፡ ወቅዳሴ፡ 
                            ከመ፡ ያብጽሕዎሙ፡ ኀበ፡ ክርስቶስ፡ 
@@ -776,14 +776,14 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <incipit xml:lang="gez">
                            <choice>
                               <sic>አብጥሊስ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">አብስልዋጢስ፡</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">አብስልዋጢስ፡</corr>
                            </choice> ዘይትነበብ፡ በጊዜ፡ ግንዘት፡ ኦመፍቀሬ፡ ሰብእ፡ ኄር፡ እግዚአብሔር፡ እግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ እስእለከ፡ ከመ፡ ኢትግድፈኒ፡ 
                            በፀጋም፡
                         </incipit>
                         <explicit xml:lang="gez">
                            ካህናት፡ እንዘ፡ <choice>
                               <sic>ኢየአጥኑ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">የአጥኑ፡</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">የአጥኑ፡</corr>
                            </choice> ሎሙ፡ ዕጣነ፡ ውስተ፡ መቃብር፡ ወእምዝ፡ ትጸርሕ፡ ሥልሰ፡ ለዓለመ፡ ዓለም፡ አሜን፡ ወአሜን፨
                         </explicit>
                      </msItem>
@@ -878,11 +878,11 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               ታስዕ፡ ቡራኬ፡ ይትባረክ፡ ስሙ፡ ለእግዚአብሔር፡ <supplied reason="omitted">ቡሩክ፡</supplied> አሜን፡ ይትአኰት፡ ስሙ፡ ለእግዚአብሔር፡ 
                               እኩት፡ <choice>
                                  <sic>ይሴባሕ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ይሰባሕ፡</corr>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ይሰባሕ፡</corr>
                               </choice> ስሙ፡ ለእግዚአብሔር፡ ስቡሕ፡ ይትቀደስ፡ ስሙ፡ ለእግዚ<supplied reason="explanation">አብሔር፡</supplied> 
                               <choice>
                                  <sic>ውዱስ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ቅዱስ፡</corr>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ቅዱስ፡</corr>
                               </choice>
                            </incipit>
                         </msItem>
@@ -893,10 +893,10 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <incipit xml:lang="gez">
                               ዓሥር፡ ቡራኬ፡ በበረከቶሙ፡ <choice>
                                  <sic>ለነቢያት፡ ሁ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ለነቢያቲሁ፡</corr>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ለነቢያቲሁ፡</corr>
                               </choice> ቡሩካን፡ <choice>
                                  <sic>ያብርከነ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ይባርከነ፡</corr>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ይባርከነ፡</corr>
                               </choice> ወይባርክሙ፡ እግዚአብሔር፡ አሜን፡ በትምህርቶሙ፡ ለሐዋርያቲሁ፡ ንጹሓን፡ ያጽንዓኒ፡ ወያጽንዕክሙ፡ እግዚአብሔር፡ በክዕወት፡ 
                               ደሞሙ፡ ለሰማዕታት፡ መዋዕያን፡ ይምሐረኒ፡ ወይምሐርክሙ፡ እግዚአብሔር፡ አሜን፨
                            </incipit>

--- a/VaticanBAV/et/BAVet118.xml
+++ b/VaticanBAV/et/BAVet118.xml
@@ -66,7 +66,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               ባቲ፡ ለለ፩፩፡ እምኔሆሙ፡ በአምጣነ፡ ክሂሎቶሙ፡ ወናሁ፡ አስተጋብኡ፡ ውስቴታ፡ ነገረ፡ ምዕዳን፡ 
                               ብዙኃ<supplied reason="omitted">ት</supplied>፡ <choice>
                                   <sic>ወተገሣጸ፡</sic>
-                                  <corr resp="bm:GrebTiss1935Codices">ወተግሣጽ፡</corr>
+                                  <corr resp="PRS4805Grebaut PRS9530Tisseran">ወተግሣጽ፡</corr>
                               </choice> ሠናያት፡ ወዜና፡ ቅሥምተ፡ ከመ፡ ፄው፡ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/> 
                         <locus target="#32r"/> ይቤ፡ እንከ፡ እስመ፡ 
                               ዘያነብብ፡ <supplied reason="omitted">ለ</supplied>ዛቲ፡ መጽሐፍ፡ አምላካዊት፡ ዘልፈ፡ 
@@ -80,7 +80,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               ይቤ፡ ጠቢብ፡ ፩እምጠቢባን፡ ሐመ፡ ደዌ፡ ጽኑዓ፡ በሕማመ፡ ከርሥ፡ ወሶበ፡ ቀርበ፡ ዕለተ፡ ሞቱ፡ 
                               ይቤልዎ፡ <choice>
                                   <sic>አርዳዊሁ፡</sic>
-                                  <corr resp="bm:GrebTiss1935Codices">አርዳኢሁ፡</corr>
+                                  <corr resp="PRS4805Grebaut PRS9530Tisseran">አርዳኢሁ፡</corr>
                               </choice> እስመ፡ ጠቢብ፡ አንተ፡ ዘትሁብ፡ ፈውሰ፡ ለኵሉ፡ እፎ፡ ዘይትፌወስ፡ ርእሰከ፡ ወእምዝ፡ 
                               አውጽአ፡ ማየ፡ ዘድልወቱ፡ ፻፡ 
                            <sic>ልጥረ፡</sic>
@@ -115,7 +115,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                          በሠናይ፡ አኅፅፁ፡ አጥርዮ፡ 
                               ከመ፡ ይኅፅፅ፡ ትካዝክሙ፡ <del rend="expunctuated">ሰ</del>ዘሰ፡ <choice>
                                   <sic>ትውኀበ፡</sic>
-                                  <corr resp="bm:GrebTiss1935Codices">ተውኅበ፡</corr>
+                                  <corr resp="PRS4805Grebaut PRS9530Tisseran">ተውኅበ፡</corr>
                               </choice> 
                            <sic>ጥብብ፡</sic>
                          ኢይኅዝን፡ በእንተ፡ ኃጢአ፡ ወርቅ፡ ወብሩር፡ 

--- a/VaticanBAV/et/BAVet119.xml
+++ b/VaticanBAV/et/BAVet119.xml
@@ -65,7 +65,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                           <explicit xml:lang="gez">
                               ፲፮ ሐቲ<supplied reason="omitted">ት፡</supplied> በተዋስቦ፡ እመሰ፡ ትፈቅድ፡ ተዋስቦ፡ ተዓገሥ፡ እስመ፡ <sic>በተዓገሦ፡</sic> ይትረከብ፡
                               በ<del rend="expunctuated">ብ</del>ትፍሥሕት፡ <sic>ወኃሢት፤</sic> ወብዕል፡ ወኵሉ፡ <sic>ተምኒትከ፡</sic> ወአንተ፡ <sic>ኵን፡</sic> ኅዱዓ፡
-                              በኵሉ፡ <choice><sic>ነገር፡</sic><corr resp="bm:GrebTiss1935Codices">ነገረ፡</corr></choice> ተዋስቦ፡ ወዝኒ፡ ተዋስቦ፡ ዘትሄሊ፡ ይከውኖሙ፡
+                              በኵሉ፡ <choice><sic>ነገር፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ነገረ፡</corr></choice> ተዋስቦ፡ ወዝኒ፡ ተዋስቦ፡ ዘትሄሊ፡ ይከውኖሙ፡
                               ለእሉ፡ ትፍሥሕት፡ <sic>ወኃሢት፡</sic> ወብዕል፨
                               </explicit>
                       </msItem>
@@ -81,7 +81,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <note>The diagram is divided into sixteen columns and seven orders.</note>
                               <incipit xml:lang="gez">
                                   ፩<supplied reason="omitted">፡</supplied> አላህያን፡ በዕል፡ ዕለት። በመጋቢት፡ በ ፳፱<supplied reason="omitted">፡</supplied>
-                                  <choice><sic>ይሠርቀ</sic><corr resp="bm:GrebTiss1935Codices">ይሠርቅ፡</corr></choice> ፳፫<supplied reason="omitted">፡</supplied> ያበርህ፡ ዕለት፡ 
+                                  <choice><sic>ይሠርቀ</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ይሠርቅ፡</corr></choice> ፳፫<supplied reason="omitted">፡</supplied> ያበርህ፡ ዕለት፡ 
                                   <surplus>ዕለት፡</surplus> ቤተ፡ ፀሩ፡ አልኬድ፡ ፪፭፮፯፲ ወ ፩፲ ወ፪<supplied reason="omitted">፡</supplied> ቤተ፡ ክፍሉ<supplied reason="omitted">፡</supplied>
                                   ፩፫፬፰፱፲ወ፬፲ወ፭ወ፲ወ፮<supplied reason="omitted">፡</supplied> ኮከቡ<supplied reason="omitted">፡</supplied> እልመሸተሪ፡ ዕለ<supplied reason="omitted">ቱ፡
                                   ሐ</supplied> <supplied reason="omitted">ሙስ፡</supplied>
@@ -104,8 +104,8 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <incipit xml:lang="gez">
                                   ፩ ቀዳማዊ፡ ዐዐዐዐዐዐዐ አላዘያን፡ ዘወጽአ፡ ለሠናይ፡ ዝንቱ፡ ቤት፡ ቤተ፡ ነፍስ፡ ወሕይወት፡ ወዝንቱ፡ ትእምርት፤ ኅሩይ፡ <sic>እሳቲዊ፡</sic> ወከዋክብት፡ አልመሻታሪ፡ 
                                   <sic>ወእመዋዕል፡</sic> ሐሙስ፡ ወእግዚአብሔር፡ <sic>የአምር፡</sic> በአሰንዮ፡ ንብረት፡ ወኵሉ፡ ፍጥረት፡ ርቱዕ፡ ወብዙኅ፡ <sic>ፍሥሐ፡</sic> ወሐሤት፡ ወፍጻሜ፡ 
-                                  መፍቅድ፡ <sic>ወጸሕቅ፡</sic> <choice><sic>ወአግርር፡</sic><corr resp="bm:GrebTiss1935Codices">ወአግርሮ፡</corr></choice>
-                                  ፀላእት፤ <choice><sic>ወነጸሮ፡</sic><corr resp="bm:GrebTiss1935Codices">ወነጽሮ፡</corr></choice> ሕልም፡ ወአስተጋብዖ፡ ሠናያት፡ እምለፌ፡ ወእምለፌ፡
+                                  መፍቅድ፡ <sic>ወጸሕቅ፡</sic> <choice><sic>ወአግርር፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ወአግርሮ፡</corr></choice>
+                                  ፀላእት፤ <choice><sic>ወነጸሮ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ወነጽሮ፡</corr></choice> ሕልም፡ ወአስተጋብዖ፡ ሠናያት፡ እምለፌ፡ ወእምለፌ፡
                                   ነጊደ፡ ኢየሩሳሌም፡ ወፍጻሜ፡ ኵሉ፡ <sic>ተምኔታተ<supplied reason="omitted">፡</supplied></sic>
                               </incipit>                     
                               </msItem>
@@ -114,9 +114,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <title type="complete" ref="LIT7107Divination#kawakebt">Calculation of the planets and lunar houses</title>
                               <incipit xml:lang="gez">
                                   ሐሳበ፡ ከዋክብት፡ ወመናዝል፡ ለኮከብ፡ ስም፡ ወእም፡ ለአድባር፡ ስመ፡ ሀገር፡ ለሐራ<supplied reason="omitted">፡</supplied> ዘመን፡ ከመ፡ ታዕምር፡ ላዕለ፡ እኪት፡ 
-                                  ወሠናይ፡ ስሞ፡ ወእሞ፡ ዓመተ፡ ምሕረት፡ ወንጌላዊ፡ ፲ ወስክ፡ <choice><sic>በ ፳፷፡</sic><corr resp="bm:GrebTiss1935Codices">በ ፳፰፡</corr></choice>
+                                  ወሠናይ፡ ስሞ፡ ወእሞ፡ ዓመተ፡ ምሕረት፡ ወንጌላዊ፡ ፲ ወስክ፡ <choice><sic>በ ፳፷፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">በ ፳፰፡</corr></choice>
                                   ግድፍ፡ ፩ አልሐመል፡ ኮከብ፡ ዘሚያዝያ፡ መስከረም፡ ራብዕ፡ ኆኅት፡ ስሙ፡ አድናኤል፡ ፀፀፀፀ፡ እሉ፡ ፬ ከዋክብት፡ ሰበ፡ ይሰርቁ፡ በራብዕ፡ ኆኅት፡ ለሰርቀት፡ ዘታጸንን፡ 
-                                  መስዓ፡ <choice><sic>ወይመጽእ፡</sic><corr resp="bm:GrebTiss1935Codices">ወይወጽእ፡</corr></choice>
+                                  መስዓ፡ <choice><sic>ወይመጽእ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ወይወጽእ፡</corr></choice>
                                   <sic>እምኒ<del rend="expunctuated">ሖ</del>ሃ፡</sic> ጠል፡ ወዝናም፡
                               </incipit>         
                           </msItem>
@@ -124,7 +124,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <locus from="49r" to="50r"/>
                               <title type="complete" ref="LIT7107Divination#mogad">Calculation of events</title>
                               <incipit xml:lang="gez">
-                                  ስመ፡ ባሕቲቱ፡ በበ፭<supplied reason="omitted">፡</supplied> ግድፍ፡ <choice><sic>፬</sic><corr resp="bm:GrebTiss1935Codices">፩</corr></choice>
+                                  ስመ፡ ባሕቲቱ፡ በበ፭<supplied reason="omitted">፡</supplied> ግድፍ፡ <choice><sic>፬</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">፩</corr></choice>
                                   ንጉሥ፡ ሠናይ፡ ብዕል፡ ቀቲል፡ ፍቅ<del rend="expunctuated">ደ</del>ረ፡ ሰ<surplus>፡</surplus>ብእ፡ መደንግፅ፡ ሐሜት፡ ሀሎ፡ መልዕልተ፡ ርዕሱ፡ ጽሑፍ፡
                                   ዓቢየ፡ <sic>ወብዓለ፡</sic> ጸጋ፡ ይከውን፡ ወሥራየ፡ ይገብሩ፡ ቦቱ፡
                               </incipit>                         
@@ -133,7 +133,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <locus from="50v" to="51r"/>
                               <title type="complete" ref="LIT7107Divination#nagar2">Calculation of things. Two</title>
                               <incipit xml:lang="gez">
-                                  <choice><sic>መፍቅሬ፡</sic><corr resp="bm:GrebTiss1935Codices">መፍቀሬ፡</corr></choice> ሕግ፡ ብዕል፤ ቀቲል፡ ሙቁሕ፡ ሀሎ፡
+                                  <choice><sic>መፍቅሬ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">መፍቀሬ፡</corr></choice> ሕግ፡ ብዕል፤ ቀቲል፡ ሙቁሕ፡ ሀሎ፡
                                   ጽሑፍ፡ በማዕከለ፡ ርእሱ፡ ዓቢየ፡ ወበዕለ፡ ጸጋ፡ ይከውን፡ ወሥራየ፡ ይገብሩ፡ ቦቱ፡
                               </incipit>                         
                               </msItem>
@@ -141,7 +141,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <locus from="51r" to="52v"/>
                               <title type="complete" ref="LIT7107Divination#negus">Calculation the king</title>
                               <incipit xml:lang="gez">
-                                  ማኅተመ፡ ፍቅር፡ ብዕል፡ ቀቲል፡ <choice><sic>ፍናዊ፡</sic><corr resp="bm:GrebTiss1935Codices">ፍናዌ፡</corr></choice>
+                                  ማኅተመ፡ ፍቅር፡ ብዕል፡ ቀቲል፡ <choice><sic>ፍናዊ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ፍናዌ፡</corr></choice>
                                   ጽድቅ፡ ሀሎ፡ ጽሑፍ፡ መልዕልተ፡ ገጹ፡ ዓቢየ፡ ባዕለ፡ ክብር፤ ይከውን፡ ወሥራየ፡ ይገብሩ፡ ቦቱ፡
                               </incipit>                         
                           </msItem>
@@ -166,7 +166,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                           <title type="complete">Diagram of the years</title>
                           <note>The diagram is divided into four circles and seven sections. It is identical to the diagram in <ref type="item" corresp="BAVet128#p1_i2"/>.</note>
                           <incipit xml:lang="gez">
-                              <choice><sic>ማቴምስ፡</sic><corr resp="bm:GrebTiss1935Codices">ማቴዎስ፡</corr></choice> ፭ እኁድ፡ ፮ መዝኃብ<supplied reason="omitted">፡</supplied> ፮
+                              <choice><sic>ማቴምስ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ማቴዎስ፡</corr></choice> ፭ እኁድ፡ ፮ መዝኃብ<supplied reason="omitted">፡</supplied> ፮
                           </incipit>      
                       </msItem>
                       
@@ -180,7 +180,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                              The headings of boxes 2-8 are incorrect, as the copyist has inscribed <foreign xml:lang="gez">እኁድ፡</foreign> ‘Sunday’ in the first box instead of the second.
                          </note>
                           <incipit xml:lang="gez">
-                              እግዚአብሔር፡ ፈጠረ፡ <choice><sic>፮</sic><corr resp="bm:GrebTiss1935Codices">፯</corr></choice> ሰማያት፡
+                              እግዚአብሔር፡ ፈጠረ፡ <choice><sic>፮</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">፯</corr></choice> ሰማያት፡
                               ወ፯ ብርሃናት<supplied reason="omitted">፡</supplied> <surplus>ሃናት፡</surplus> ወረሰዮሙ፡ ይሑሩ፡ በፈለከ፡
                               ሰማይ<supplied reason="omitted">፡</supplied> ወፈጠረ፡ ፯ አምዳረ፡ ወ፯ ዕለታተ።
                           </incipit>
@@ -212,7 +212,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                           <locus from="57r" to="64r"/>
                           <title type="complete" ref="LIT7108Astronomy">Treatise on astronomy</title>
                           <incipit xml:lang="gez">
-                              ናሁ፡ ተወጥነ፡ <choice><sic>ፍቅድ፡</sic><corr resp="bm:GrebTiss1935Codices">ፍቅደ፡</corr></choice> ፯ ከዋክብት፡
+                              ናሁ፡ ተወጥነ፡ <choice><sic>ፍቅድ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ፍቅደ፡</corr></choice> ፯ ከዋክብት፡
                               ወዘ፲። ወ ፪ ከዋክብት፡ ማኅደረ፡ ወርኅ፨ <sic>ወመሰለ፡</sic> ፀሐይ፡ ሰአተ፡ መዓልት፡ ወሌሊት፡ ፯ ከዋክብት፡ ዘይትበሃሉ፡ ቀዳማይ፡ 
                               ዙኃል፡ ካልዑ፡ ሙሽተሪ፡
                           </incipit>
@@ -241,7 +241,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                           <title type="complete" ref="LIT7110Kekros"/>
                           <incipit xml:lang="gez">
                               ለእመ፡ ፈቀድከ፡ ከመ፡ ታእምር፡ ኍልቈ፡ ኬክሮስ፡ ዘበትርጓሜሁ፡ ዓቢይ፡ ክፍል፡ ለሰዓታት፡ ዘመዓልት፡ ወዘሌሊት።
-                              <choice><sic>ወኍላቈሁኒ፡</sic><corr resp="bm:GrebTiss1935Codices">ወኍላቌሁኒ፡</corr></choice> እምሥራቅ፡ ወእምዕራብ፡
+                              <choice><sic>ወኍላቈሁኒ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ወኍላቌሁኒ፡</corr></choice> እምሥራቅ፡ ወእምዕራብ፡
                               ፷ ወየሐውሩ፡ ቦቱ፡ ፀሐይ፡ ወወርኅ፡ ወ<surplus>ወ</surplus>ከዋክብት፡
                           </incipit>
                           <explicit xml:lang="gez">
@@ -282,9 +282,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                           <title type="complete" ref="LIT6042HassabaDemetros"/>
                           <incipit xml:lang="gez">
                               በስመ፡ አብ፡ <gap reason="ellipsis"/>
-                             ንጽሕፍ፡ በረድኤተ፡ እግዚአብሔር፡ ሎቱ፡ <choice><sic>ስብሔት፡</sic><corr resp="bm:GrebTiss1935Codices">ስብሐት፡</corr></choice> አሜን፨
+                             ንጽሕፍ፡ በረድኤተ፡ እግዚአብሔር፡ ሎቱ፡ <choice><sic>ስብሔት፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ስብሐት፡</corr></choice> አሜን፨
                               <sic>ሕውሳ፡</sic> ርቱዕ፡ ዘጸሐፈ፡ ድሜጥሮስ፡ ሊቀ፡ <sic>ጰጰሳት፡</sic> ዘእስክንድርያ፡ ፩ እም፲ወ፪ ሊቃነ<supplied reason="omitted">፡</supplied> ጳጳሳት፡                              
-                              <choice><sic>በ፯</sic><corr resp="bm:GrebTiss1935Codices">በ፪፻ወ፯</corr></choice> ዓመት፡ እምዕርገተ፡ ክርስቶስ። 
+                              <choice><sic>በ፯</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">በ፪፻ወ፯</corr></choice> ዓመት፡ እምዕርገተ፡ ክርስቶስ። 
                               በዘ<supplied reason="omitted">፡</supplied> <sic>ተአምር፡</sic> አበቅቴ፡ ትእኅዝ፡ ዓመታተ፡ ዓለም፡ እስከ፡ ኀበ፡ ሀሎከ፡ ሎቱ፡ ወትገድፍ፡ በ፩፲ወ፱ ዓመት፡
                           ዝውእቱ፡ ዓውደ፡ አበቅቴ፡
                           </incipit>
@@ -314,8 +314,8 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               ወትቀትል<supplied reason="omitted">፡</supplied> ፫ አው<supplied reason="omitted">፡</supplied> 
                               ፯ <sic>ብእሲ፡</sic> ዓይነ፡ ወርቅ፡ ሀለወ፡ ባቲ። መድኃኒታ፡ ፀሊም፡ በግዕ፡ ወጠሊ፡ በፈርሱ፡ ወበደሙ፡ ትትሐፀብ፡ ወጸሐፍ፡ መርበብተ፡ 
                               ሰሎሞን፡ ቀዳሚሁ፡ ቃል። በወርኃ፡ ጥቅምት፡ ወግንቦት፡ ወመጋቢት፡ በዕለተ፡ ረቡዕ፡ ወ<surplus>ወ</surplus>ዓርብ፡ ወእኁድ፨ ለሁት፡ ኅርመቱ፡
-                              ፀዓዳ፡ ዶርሆ፡ በርእሱ፡ ሕርድ፡ ቀርነ፡ <choice><sic>ብራዕይ፡</sic><corr resp="bm:GrebTiss1935Codices">ብዕራይ፡</corr></choice> <gap reason="ellipsis"/>
-                              <choice><sic>አሰደ፡</sic><corr resp="bm:GrebTiss1935Codices">አሰድ፡</corr></choice> ለደለዊ፡ ይተርፈዋል።
+                              ፀዓዳ፡ ዶርሆ፡ በርእሱ፡ ሕርድ፡ ቀርነ፡ <choice><sic>ብራዕይ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ብዕራይ፡</corr></choice> <gap reason="ellipsis"/>
+                              <choice><sic>አሰደ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">አሰድ፡</corr></choice> ለደለዊ፡ ይተርፈዋል።
                               ሸርጣን፡ ለዢዲ፡ ይተርፈዋል፨
                           </explicit>
                       </msItem>
@@ -338,10 +338,10 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                           <title type="complete" ref="LIT7113Horoscopes">Sixteen horoscopes</title>
                           <incipit xml:lang="gez">
                               ለእመ፡ አውፃዕከ፡ በተፋስሶ፡ ስም፡ ወእም፡ ዓመተ፡ ምሕረት፡ ወንጌላዊ፡ በ፲ወ፮ ግድፍ፡ ፩ መፍቅድ፡ ፪ ነጊደ፡ ንዋይ፡ ስሞ፡ ወእሞ፡
-                              <choice><sic>ዓምተ፡</sic><corr resp="bm:GrebTiss1935Codices">ዓመተ፡</corr></choice> ምሕረት፡ ወንጌላዊ፡ ወርኅ።
+                              <choice><sic>ዓምተ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ዓመተ፡</corr></choice> ምሕረት፡ ወንጌላዊ፡ ወርኅ።
                           </incipit>
                           <explicit xml:lang="gez">
-                              ፲ወ፮<supplied reason="omitted">፡</supplied> በተዋስቦ፡ ስሞ፡ ወእሞ፡ ስማ፡ ወእማ፡ ዓመተ፡ <choice><sic>ምሕረተ፡</sic><corr resp="bm:GrebTiss1935Codices">ምሕረት፡</corr></choice>
+                              ፲ወ፮<supplied reason="omitted">፡</supplied> በተዋስቦ፡ ስሞ፡ ወእሞ፡ ስማ፡ ወእማ፡ ዓመተ፡ <choice><sic>ምሕረተ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ምሕረት፡</corr></choice>
                               ወንጌላዊ፡ ወርኅ፡ ዕለት።
                           </explicit>
                       </msItem>

--- a/VaticanBAV/et/BAVet122.xml
+++ b/VaticanBAV/et/BAVet122.xml
@@ -41,7 +41,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <locus from="5r" to="9r"/>
                         <title type="complete" ref="LIT1716Kidanz">ኪዳን፡ ዘነግህ፡</title>
                         <incipit xml:lang="gez">
-                           ንወጥን፡ በረድኤተ፡ <choice><sic>እግዚአብሒር፡</sic><corr resp="bm:GrebTiss1935Codices">እግዚአብሔር፡</corr></choice> ጽሒፈ፡ 
+                           ንወጥን፡ በረድኤተ፡ <choice><sic>እግዚአብሒር፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">እግዚአብሔር፡</corr></choice> ጽሒፈ፡ 
                            <sic>ቅደሴ፡</sic> በ፮ ይእቲ፡ ማርያም፡ እምነ፡ በ፨ ይትፌሣሕ፡ ልብኪ፡ በል፨ እግዚኦ፡ መሐ<supplied reason="explanation">ረነ</supplied>፡ ክርስቶስ፡ በል፡ 
                            ፱ ጊዜ፡
                         </incipit>
@@ -109,7 +109,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         </msItem>
                         <msItem xml:id="ms_i1.4.7">
                            <locus from="18v" to="20v"/>
-                           <title ref="LIT1960Mashaf#BaendaEllaNomu4">ሊጦን፡ <choice><sic>ዘመታ፡</sic><corr resp="bm:GrebTiss1935Codices">ዘሙታን፡</corr></choice></title>
+                           <title ref="LIT1960Mashaf#BaendaEllaNomu4">ሊጦን፡ <choice><sic>ዘመታ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ዘሙታን፡</corr></choice></title>
                            <incipit xml:lang="gez">
                               ወካዕበ፡ ናስተበቍዕ፡ በል፨ እግዚ<supplied reason="explanation">አ፡</supplied> ሕያዋን፡ ወሕይወተ፡ ሙታን፡ ተስፋ፡ ቅቡፃን፡ ረዳኤ፡ ምንዱባን፡ ወመንጽሔ፡ 
                               ኃጥአን፡ ዘሞተ፡ አጽራዕከ፡ ወማዕሠረ፡ ሰይጣን፡ በቲከከ፡ ሕይወት፡ <sic>ለትዝምድ፡</sic> ሰብእ፡
@@ -159,7 +159,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                           <note>
                              The name of the owner of the manuscript, <persName role="owner" ref="PRS14614GabraMa">Gabra Māryām</persName>, is mentioned in the supplication 
                              formula on <locus target="#74r"/>: <q xml:lang="gez">ኦቀሳውስት፡ እለ፡ ቀደስክሙ፡ ወጸለይክሙ፡ ተዘከሩኒ፡ በጸሎትክሙ፡ ለንኡስ፡ 
-                                <choice><sic>ምግር፡</sic><corr resp="bm:GrebTiss1935Codices">ገብር፡</corr></choice> <persName role="owner" ref="PRS14614GabraMa">ገብረ፡ ማርያም።</persName></q>.
+                                <choice><sic>ምግር፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ገብር፡</corr></choice> <persName role="owner" ref="PRS14614GabraMa">ገብረ፡ ማርያም።</persName></q>.
                           </note>
                         </msItem>
                         <msItem xml:id="ms_i1.7.3">
@@ -222,7 +222,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               ተድላሆሙ፡ ይረሲ፡ ለእለ፤ <sic>ይትሜጠው፡</sic> ንሥአተ፡ ቅዱስ፤ ምስጢር፡ ዘሥጋሁ፡ ወደሙ፡ ለክርስቶስ፡ ዘኵሎ፤ ይእኅዝ፤ እግዚአብሔር፤ አምላክነ፤ 
                               ይ<supplied reason="explanation">ብል</supplied>፡ ዲ<supplied reason="explanation">ያቆን</supplied>፡ ጸልዩ። ይ<supplied reason="explanation">ብል</supplied>፡ 
                               ካ<supplied reason="explanation">ህ</supplied>፡ ዘኵሎ፡ ትእኅዝ፡ ንሥአተ፡ ቅዱስ፡ ምሥጢር፤ ጽንዓተ፡ ለነ፡ ተሀበነ፡ ወኢመነሂ፡ 
-                              እምው<surplus>እ</surplus>ስቴትነ፤ <choice><sic>ኢትርስሕ፡</sic><corr resp="bm:GrebTiss1935Codices">ኢታርስሕ፡</corr></choice> አላ፡ 
+                              እምው<surplus>እ</surplus>ስቴትነ፤ <choice><sic>ኢትርስሕ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ኢታርስሕ፡</corr></choice> አላ፡ 
                               ኵሎ፡ ባርክ፡ በክርስቶስ፡ በ፩ ወልድከ፡ በል፨
                            </incipit>               
                            <explicit xml:lang="gez">

--- a/VaticanBAV/et/BAVet123.xml
+++ b/VaticanBAV/et/BAVet123.xml
@@ -34,8 +34,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <textLang mainLang="am" otherLangs="gez"/>
                             <explicit xml:lang="gez">
                                 ወኤልዩድኒ፡ ወለደ፡ አልአዛርሃ፡ ወአልአዛርኒ፡ ወለደ<supplied reason="omitted">፡</supplied> ቅስራሃ፡ ወማትያንሃ፡ ማትያንም፡ ያዕቆ<supplied reason="omitted">ብ</supplied>ሃ፡
-                                ወለደ፡ ያፅቆብኒ፡ ወለደ፡ ዮሴፍሃ፡ <choice><sic>ፈሃራሃ፡</sic><corr resp="bm:GrebTiss1935Codices">ፈሃሪሃ፡</corr></choice> ለማርያም፡ ወዮሴፍ፡ 
-                                ወለዶ፡ ለያዕቆብ፡ ኤጲስ፡  ቆጶስ፡ ዘኢየሩሳሌም፡ ወያ<surplus>ያ</surplus>ዕቆብ፡ <choice><sic>ወለደ፡</sic><corr resp="bm:GrebTiss1935Codices">ወለዶ፡</corr></choice> 
+                                ወለደ፡ ያፅቆብኒ፡ ወለደ፡ ዮሴፍሃ፡ <choice><sic>ፈሃራሃ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ፈሃሪሃ፡</corr></choice> ለማርያም፡ ወዮሴፍ፡ 
+                                ወለዶ፡ ለያዕቆብ፡ ኤጲስ፡  ቆጶስ፡ ዘኢየሩሳሌም፡ ወያ<surplus>ያ</surplus>ዕቆብ፡ <choice><sic>ወለደ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ወለዶ፡</corr></choice> 
                                 ለኢያቄም፡ ወኢያቄም፡ ወለዳ፡ ለማርያም፡ ማርያምኒ፡ ወለደቶ፡ ለእግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ ዝውእቱ<supplied reason="omitted">፡</supplied> ኍልቈ፡ 
                                 ልደተ፡ ሥጋሁ፡ ለክርስቶስ፡ ፷ወ፬ ትውልድ<supplied reason="omitted">፡</supplied> ፶፻ወ፭፻ ዓመት፡ ይህ<supplied reason="omitted">፡</supplied> ነው፡ 
                                 ስብሐት፡ ለእግዚአብሔር፡ ዘአፈጸመኒ፡ በሰላም፡ <gap reason="omitted" resp="bm:GrebTiss1935Codices"/> ይምሀረነ<supplied reason="omitted">፡</supplied> 
@@ -53,7 +53,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </incipit>
                             <explicit xml:lang="gez">
                                 ባርኮ፡ በአፈ፡ ኵሉ፡ ፍጥረት፡ ለአለመ፡ ዓለም። ኪርያላ<supplied reason="omitted">ይ</supplied>ሶን፡ በ፡ ፫ ጊዜ፡
-                                <choice><sic>ቦርክ፡</sic><corr resp="bm:GrebTiss1935Codices">ባርክ፡</corr></choice> ፫ ጊዜ፡ ወጠዓም፡ በፈሪሃ፡ እግዚአብሔር፡ ወዓይንከ።
+                                <choice><sic>ቦርክ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ባርክ፡</corr></choice> ፫ ጊዜ፡ ወጠዓም፡ በፈሪሃ፡ እግዚአብሔር፡ ወዓይንከ።
                                 <gap reason="omitted" resp="bm:GrebTiss1935Codices"/>
                             </explicit>
                         </msItem>
@@ -69,7 +69,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 ሆ፡ ብሂል፡ ትንሣዔ፡ ሙታን፡
                              </incipit>
                             <explicit xml:lang="gez">
-                                <choice><sic>ተሰብኦ፡</sic><corr resp="bm:GrebTiss1935Codices">ተሰብአ፡</corr></choice> ወተሠገወ፡ እመንፈስ፡ ቅዱስ፡ በለበሰው፡ ሥጋ፡
+                                <choice><sic>ተሰብኦ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ተሰብአ፡</corr></choice> ወተሠገወ፡ እመንፈስ፡ ቅዱስ፡ በለበሰው፡ ሥጋ፡
                                 መንፈስ፡ ቅዱስን፡ ተቀበለ፡ በአምላክነቱ፡ ከአብ፡ ከመንፈስ፡ ቅዱስ፡ አክብሮ፡ መንፈስ፡ ቅዱስን፡ በለበሰው፡ ሥጋ፡ ሰጠው፡ በሰውነቱ፡ <gap reason="omitted" resp="bm:GrebTiss1935Codices"/>
                             </explicit>
                         </msItem>

--- a/VaticanBAV/et/BAVet124.xml
+++ b/VaticanBAV/et/BAVet124.xml
@@ -313,7 +313,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </note>
                             <incipit xml:lang="gez">
                                 በስመ፡ አብ፡ <gap reason="ellipsis" extent="unknown" resp="bm:GrebTiss1935Codices"/> አመ፡ ፫ሱ፡ ለጳጕሜ<supplied reason="omitted">ን</supplied>፡ 
-                                <sic>ተዝካራ፡</sic> በአሉ፡ <choice><corr resp="bm:GrebTiss1935Codices">ለሊቀ፡</corr><sic>ለሊቅስ፡</sic></choice>  
+                                <sic>ተዝካራ፡</sic> በአሉ፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ለሊቀ፡</corr><sic>ለሊቅስ፡</sic></choice>  
                                 <supplied reason="omitted">መላእክት፡</supplied> ሚካኤል፡ <supplied reason="omitted">በረከቱ፡</supplied> የሐሉ፡ 
                                 <gap reason="ellipsis" extent="unknown" resp="bm:GrebTiss1935Codices"/> እምሊቃነ፡ <sic>መለእክት፡</sic> ትጉሃን፡ ቅዱሳን፡ ሰማይውያን፨ 
                                 ወቅዳሴ፡ ቤተ፡ ክርስቲያን፡ እንተ፡ ተሐንፀ፡ ሎቱ፡ ዲበ፡ ደሴት፨ በአፍአ፡ ሀገረ፡ እስክንድርያ፡ በመዋዕሊሁ፡ <sic>ለአበ፡</sic> ቴዎፍሎስ፡ ሊቀ፡ 
@@ -322,7 +322,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <explicit xml:lang="gez">
                                 ወነበረት፡ ይእቲ፡ ቤተ፡ ክርስቲያን፡ ከመዝ፡ እስከ፡ ነግሡ፡ <sic>ተንባለት፡</sic> ወእምድኅረ፡ ነግሡ፡ ተንባላት፡ ተንህለት፡ ይእቲ፡ ቤተ፡ ክርስቲያን፡ በተሐውኮ፡ 
                                 ዓን<add place="above">በ</add>ሪ። ወካዕበ፡ ተሐውኮ፡ <del rend="expunctuated">አንበሪ፡</del> ባሕር፡ ወአስጠሞሙ፡ ለብዙኃን፡ ሰብእ፡ እለ፡ ይነብሩ፡ 
-                                <choice><corr resp="bm:GrebTiss1935Codices">መልዕልተ፡</corr><sic>መልዕኵ፡</sic></choice> ውእቱ፡ መካን፡ በረከቱ፡ 
+                                <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">መልዕልተ፡</corr><sic>መልዕኵ፡</sic></choice> ውእቱ፡ መካን፡ በረከቱ፡ 
                                 <gap reason="ellipsis" extent="unknown" resp="bm:GrebTiss1935Codices"/>
                             </explicit>
                         </msItem>
@@ -342,16 +342,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <ref type="pers" corresp="BPRS8083Raphael">Archangel Raphael</ref>.</note>
                             <incipit xml:lang="gez">
                                 <gap reason="lost" extent="unknown"/> ዘሀገረ፡ ቍስጥንጥንያ፡ ለአኖሬዎስ፡ ጻድቅ፡ ወይቤሎ፡ አእምር፡
-                                 <choice><corr resp="bm:GrebTiss1935Codices">ኦንጉሥ፡</corr><sic>እንጉሥ፡</sic></choice> 
+                                 <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ኦንጉሥ፡</corr><sic>እንጉሥ፡</sic></choice> 
                                 እስመ፡ ንህነ፡ ተፅ<add place="above">ዕ</add>ነ፡ ዲበ፡ ሐመር፡ ከመ፡ ንምጻእ፡ ኀቤከ፡ ወእንዘ፡ ሀሎነ፡ ነሐውር፡ ርኢነ፨ አሐተ፡ <supplied reason="omitted">ቤተ፡</supplied> 
-                                ክርስቲያን፡ ውስተ፡ ደሴት፡ በዕለተ፡ <sic>ቀደሚት፡</sic> ሰንበት፨ ወበጻሕነ፡ ውስተ፡ መርሶ፡ ከመ፡ <choice><corr resp="bm:GrebTiss1935Codices">ንትመጦ፡</corr><sic>ንትመጠ፡</sic></choice> 
+                                ክርስቲያን፡ ውስተ፡ ደሴት፡ በዕለተ፡ <sic>ቀደሚት፡</sic> ሰንበት፨ ወበጻሕነ፡ ውስተ፡ መርሶ፡ ከመ፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ንትመጦ፡</corr><sic>ንትመጠ፡</sic></choice> 
                                 ምሥጢረ፡ ቅድሳት፡ ሥጋሁ፡ <sic>ወደመ፨</sic> ለክርስቶስ፡ በዕለተ፡ እሁድ፡ ወረከብነ፡ ደብረ፡ ንዑሰ፡ በገቦሃ፡ ለይእቲ፡ ቤተ፡ ክርስቲያን።
                             </incipit>
                             <explicit xml:lang="gez">
-                                አነ፡ <choice><corr resp="bm:GrebTiss1935Codices">እተነብል፡</corr><sic>እትነበብል፡</sic></choice> ኀበ፡ እግዚአብሔር። በእንቲአሆሙ፡ 
+                                አነ፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">እተነብል፡</corr><sic>እትነበብል፡</sic></choice> ኀበ፡ እግዚአብሔር። በእንቲአሆሙ፡ 
                                 ወአድኅኖሙ፡ እምንዳቤሆሙ፡ ወኢይሬእዩ፡ ግሙራ፡ ኵነኔ፡ ወዘንተ፡ ብሂሎ፡ ቅዱስ፡ ሚካኤል፡ ሊቀ፡ <sic>መለእክት፡</sic> ሰገደ፡ ቅድመ፡ እግዚአብሔር፡
                                 ወብዙኃት፡ ተአምራቲሁ፡ ለዝንቱ፡ <sic>መልአከ፡</sic> ሚካኤል፡ ሊቀ፡ መላእክት፡ ወይደልወነ፡ ከመ፡ ንግበር፡ ተዝካሮ፡ ኵሎ፡ ጊዜ፡ እስመ፡ ውእቱ፡ 
-                                <choice><corr resp="bm:GrebTiss1935Codices">ይትነብል፡</corr><sic>ይትነበብ፡</sic></choice> ኀበ፡ <surplus>እስመ፡</surplus> እግዚአብሔር፡ 
+                                <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ይትነብል፡</corr><sic>ይትነበብ፡</sic></choice> ኀበ፡ <surplus>እስመ፡</surplus> እግዚአብሔር፡ 
                                 በእንቲአነ፡ ትንብልና፡ ጸሎቱ፡ <gap reason="ellipsis" extent="unknown" resp="bm:GrebTiss1935Codices"/>
                             </explicit>
                         </msItem>

--- a/VaticanBAV/et/BAVet128.xml
+++ b/VaticanBAV/et/BAVet128.xml
@@ -182,9 +182,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <desc type="MagicFormula">Protective formula against the speech of enemies</desc>
                           <q xml:lang="gez"><seg part="I">ፌ፡ በፍልፍላኤል፡ ሰምኬት፡ በፌልኤል፡ ዮድ፡ በየማንኤል፡ 
                             <del rend="erasure" unit="chars" quantity="1"/> 
-                            <choice><corr resp="bm:GrebTiss1935Codices">ትትአሰር፡</corr><sic>ትኣሰር፡</sic></choice> አፉሁ፡ ለፀርየ፡
-                            ወለ<surplus>፡ </surplus>ፀላ<choice><corr resp="bm:GrebTiss1935Codices">እ</corr><orig>ዕ</orig></choice>ትየ፡ ለገብርከ፡ 
-                            <choice><corr resp="bm:GrebTiss1935Codices">እገሌ፡</corr><sic>እግሌ፡</sic></choice>
+                            <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ትትአሰር፡</corr><sic>ትኣሰር፡</sic></choice> አፉሁ፡ ለፀርየ፡
+                            ወለ<surplus>፡ </surplus>ፀላ<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">እ</corr><orig>ዕ</orig></choice>ትየ፡ ለገብርከ፡ 
+                            <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">እገሌ፡</corr><sic>እግሌ፡</sic></choice>
                           </seg></q>
                         </item>
                         
@@ -226,7 +226,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <locus target="#12r"/>
                           <desc type="MagicText">Protective prayer</desc>
                           <q xml:lang="gez"><seg part="I"><sic>በስመ፡</sic> ዳቦ፡ ዳብሮን፡ ሉክልያኤል፡ አሰብአኤል፡ አክሳብአኤል፡ ሰሐብ፡ ልቦሙ፡ 
-                            <choice><corr resp="bm:GrebTiss1935Codices">አኑም፡</corr><sic>አኑማ፡</sic></choice> <sic>አኑም፡</sic> በኃይለ፡ ዝንቱ፡ አስማቲከ፡ ፀርየ፡ ወጸላእትየ፡
+                            <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">አኑም፡</corr><sic>አኑማ፡</sic></choice> <sic>አኑም፡</sic> በኃይለ፡ ዝንቱ፡ አስማቲከ፡ ፀርየ፡ ወጸላእትየ፡
                           ለገብርከ፡ ቲት፡ አትዮን፡ ዮናት፡ ወለእመ፡ አምጽኡ፡ ነገረ፡ መዓት፡ ወቍጥዓ፡ ወፍርሃት፡</seg></q>
                         </item>
                         
@@ -295,26 +295,26 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <q xml:lang="gez"><seg part="I"><sic>አስማተ፡</sic> ሀቤ፡ ተካሂ<supplied reason="omitted">፡</supplied> 
                             ወዘተአሪ፡ አልቡት፡ ከልቡት፡</seg>
                             <seg part="F">በቀይ፡ ቀለም፡ አስማቱን፡ ጣፍ፡ ባፏ<supplied reason="omitted">፡</supplied>
-                              አ<choice><corr resp="bm:GrebTiss1935Codices">ጕ</corr><sic>ጉ</sic></choice>ርስ፡ አሰር<supplied reason="omitted">።</supplied></seg></q>
+                              አ<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ጕ</corr><sic>ጉ</sic></choice>ርስ፡ አሰር<supplied reason="omitted">።</supplied></seg></q>
                         </item>
                         
                         <item xml:id="a23">
                           <locus from="122r" to="122v"/>
                           <desc type="ProtectivePrayer">Protective prayer.</desc>
                           <q xml:lang="gez"><seg part="I">ቱል፡ በቱል፡ ሹል፡ በሹል፡</seg>
-                            <seg part="F">ይትሐረድ፡ ዘየዓቅብ፡ ወር<choice><corr resp="bm:GrebTiss1935Codices">ቀ</corr><sic>ቅ</sic></choice>፡ 
-                              <choice><corr resp="bm:GrebTiss1935Codices">በመንጸረ፡</corr> <sic>በምንጽረ፡</sic></choice> 
-                              እ<choice><corr resp="bm:GrebTiss1935Codices">ገ</corr><sic>ግ</sic></choice>ሌ፡</seg></q>
+                            <seg part="F">ይትሐረድ፡ ዘየዓቅብ፡ ወር<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ቀ</corr><sic>ቅ</sic></choice>፡ 
+                              <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">በመንጸረ፡</corr> <sic>በምንጽረ፡</sic></choice> 
+                              እ<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ገ</corr><sic>ግ</sic></choice>ሌ፡</seg></q>
                         </item>
                         
                         <item xml:id="a24">
                           <locus from="154v" to="155v"/>
                           <desc type="GuestText">Chapter on the calculation of the journey, written by another hand 
                             after the chapter of the same title (<ref target="#p2_i3.13"/>).</desc>
-                          <q xml:lang="gez"><seg part="I">ሐሳበ፡ ፍኖት፡ ስም፡ ወእም፡ አመተ፡ ምሕረት፡ ወንጌላዊ፡ እለት። <choice><corr resp="bm:GrebTiss1935Codices">በ</corr><sic>ባ</sic></choice>፲፪፡
-                            ግድፍ፡ ፩፡ ለእመ፡ <choice><corr resp="bm:GrebTiss1935Codices">ወጻእከ፡</corr><sic>ወጻብከ፡</sic></choice> በሌሊት፡ ሠናይ፡</seg>
+                          <q xml:lang="gez"><seg part="I">ሐሳበ፡ ፍኖት፡ ስም፡ ወእም፡ አመተ፡ ምሕረት፡ ወንጌላዊ፡ እለት። <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">በ</corr><sic>ባ</sic></choice>፲፪፡
+                            ግድፍ፡ ፩፡ ለእመ፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ወጻእከ፡</corr><sic>ወጻብከ፡</sic></choice> በሌሊት፡ ሠናይ፡</seg>
                             <seg part="F"><foreign xml:lang="am">ዝናም፡ ይመጣሃል፡ ነገርህን፡ በ<surplus>፡</surplus> ፪፡ ቀን፡ 
-                              <choice><corr resp="bm:GrebTiss1935Codices">ያቀናል፡</corr> <sic>ይቅናል፡</sic></choice> ፩፡ ሰው፡ ታገኛለህ።</foreign></seg></q>
+                              <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ያቀናል፡</corr> <sic>ይቅናል፡</sic></choice> ፩፡ ሰው፡ ታገኛለህ።</foreign></seg></q>
                         </item>
                         
                         <item xml:id="a25">
@@ -347,15 +347,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <q xml:lang="am">
                             <seg part="I">የዳዊት፡ <sic>አብ<supplied reason="omitted">ነ</supplied>ተ፡</sic> ፴፡ እገር፡ አንድ፡ <sic>ሆኖ፡</sic>
                               ተሰብ<add place="above">ስ</add>ቦ፡ <gap reason="ellipsis"/> ፫፡ <sic>ግዜ፡</sic> ደግ፡ ኪያከ፡ <sic>እግዝኦ፡</sic>
-                              ወኢይትኀፈር፡ እ<supplied reason="omitted">ስ</supplied><choice><corr resp="bm:GrebTiss1935Codices">ኪ</corr><sic>ክ</sic></choice>ፈጸም፡</seg>
-                            <seg part="F">፯፡ ምስር፡ ፯፡ ስንዴ፡ ውስተ፡ ሸም<choice><corr resp="bm:GrebTiss1935Codices">በ</corr><sic>ብ</sic></choice>ቆ።</seg></q>
+                              ወኢይትኀፈር፡ እ<supplied reason="omitted">ስ</supplied><choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ኪ</corr><sic>ክ</sic></choice>ፈጸም፡</seg>
+                            <seg part="F">፯፡ ምስር፡ ፯፡ ስንዴ፡ ውስተ፡ ሸም<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">በ</corr><sic>ብ</sic></choice>ቆ።</seg></q>
                         </item>
                         
                         <item xml:id="a29">
                           <locus target="#184v"/>
                           <desc type="MagicFormula"/>
                           <q xml:lang="am">
-                            <seg part="I">በግራ፡ እጅህ፡ ፯፡ ጠጠር፡ ከባሕር፡ አ<choice><corr resp="bm:GrebTiss1935Codices">ው</corr><sic>ወ</sic></choice>ፃ፡ በ<surplus>፡</surplus> ፬፡ ማዕዘን፡ ፯ <surplus>፯</surplus>፡ ጊዜ፡ ድግም።</seg>
+                            <seg part="I">በግራ፡ እጅህ፡ ፯፡ ጠጠር፡ ከባሕር፡ አ<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ው</corr><sic>ወ</sic></choice>ፃ፡ በ<surplus>፡</surplus> ፬፡ ማዕዘን፡ ፯ <surplus>፯</surplus>፡ ጊዜ፡ ድግም።</seg>
                          </q>
                         </item>
                         
@@ -363,11 +363,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <locus target="#185r"/>
                           <desc type="ProtectivePrayer">Charm against thieves.</desc>
                           <q xml:lang="am">
-                            <seg part="I">የሌባ፡ አብነት፡ ፀሐፍ፡ በቀይ፡ ቀለም፡ <choice><corr resp="bm:GrebTiss1935Codices">በሚዳቋ፡</corr> <sic>በመዳቋ፡</sic></choice> ብራና፡
+                            <seg part="I">የሌባ፡ አብነት፡ ፀሐፍ፡ በቀይ፡ ቀለም፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">በሚዳቋ፡</corr> <sic>በመዳቋ፡</sic></choice> ብራና፡
                               <gap reason="ellipsis"/>
                             የጐርጐርዴን፡ ሰንሰግርዴን፡ ሰንግርዴን፡ ንሰግርዴን፡</seg>
-                            <seg part="F"><foreign xml:lang="gez">ይኩኑ፡ ከመ፡ በድን፡ ፍዙዝ፡ ወከመ፡ ዕብን፡ ድን<choice><corr resp="bm:GrebTiss1935Codices">ዙ</corr><sic>ዘ</sic></choice>ዝ፡ እሥር፡ እደዊሆሙ፡ 
-                              ወእ<choice><corr resp="bm:GrebTiss1935Codices">ገ</corr><sic>ግ</sic></choice>ሪሆሙ፡ <add place="above">ወ</add>አጽልም፡ አዕይንቲሆሙ፡ በልቦሙ፡ ከመ፡ ኢይበሉ፡ በቅድሜየ፡ ወበ<choice><corr>ድ</corr><sic>ደ</sic></choice>ኅሬየ፡ <supplied reason="omitted">እ</supplied>ገሌ<supplied reason="omitted">፡</supplied></foreign></seg>
+                            <seg part="F"><foreign xml:lang="gez">ይኩኑ፡ ከመ፡ በድን፡ ፍዙዝ፡ ወከመ፡ ዕብን፡ ድን<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ዙ</corr><sic>ዘ</sic></choice>ዝ፡ እሥር፡ እደዊሆሙ፡ 
+                              ወእ<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ገ</corr><sic>ግ</sic></choice>ሪሆሙ፡ <add place="above">ወ</add>አጽልም፡ አዕይንቲሆሙ፡ በልቦሙ፡ ከመ፡ ኢይበሉ፡ በቅድሜየ፡ ወበ<choice><corr>ድ</corr><sic>ደ</sic></choice>ኅሬየ፡ <supplied reason="omitted">እ</supplied>ገሌ<supplied reason="omitted">፡</supplied></foreign></seg>
                           </q>
                         </item>
                         
@@ -385,7 +385,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <desc type="MagicFormula">Instructions for making an amulet in Modern Greek.</desc>
                           <q xml:lang="grc">
                             <seg part="I">Γραφης ης 4: αγγονης την ηποθεσην πού τη συ τας</seg>
-                            <seg part="F"><choice><corr resp="bm:GrebTiss1935Codices">17</corr><orig>18</orig></choice>
+                            <seg part="F"><choice><corr resp="PRS4805Grebaut PRS9530Tisseran">17</corr><orig>18</orig></choice>
                               Γ 4: ξελο θρεψε του ταδε σπητη Γηνετες κρηβης την φηγουραν στο σπητη του.
                               18 Γ 4.</seg>
                           </q>
@@ -396,14 +396,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <desc type="GuestText"><title ref="LIT7138PrLover"/></desc>
                           <q xml:lang="gez">
                             <seg part="I">በስመ፡ አብ፡ <gap reason="ellipsis"/> ጸሎተ፡ መስተፋቅር፡ አስማተ፡ 
-                              <choice><corr resp="bm:GrebTiss1935Codices">ን</corr><sic>ነ</sic></choice>ዋይ፡ <sic>ምሕሰበ፡</sic> 
-                              <choice><corr resp="bm:GrebTiss1935Codices">ን</corr><sic>ነ</sic></choice>ዋይ፡ አስተፋቅር፡ <gap reason="ellipsis"/>
+                              <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ን</corr><sic>ነ</sic></choice>ዋይ፡ <sic>ምሕሰበ፡</sic> 
+                              <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ን</corr><sic>ነ</sic></choice>ዋይ፡ አስተፋቅር፡ <gap reason="ellipsis"/>
                               ሽኻር፡ ወሴኻር፡ ሴቃ<surplus>፡</surplus>ሰ፡ ወሴቃስ፡ ኽራዮን፡
                             </seg>
                             <seg part="F">ን፡ ፫፡ ጥ፡ ፫፡ ኀ፡ ፫፡ አ፡ ፫፡ ሸ፡ ፫፡ ዧ፡ ፫። በዝ፡ ቃል፡ ወበዝ<supplied reason="omitted">፡</supplied> አስማት፡ ተሳሐቡ፡ ሕዝብ፡ ወአሕዛብ፡ ወከመ፡ ይ<choice><corr>ስ</corr><sic>ሰ</sic></choice>ግዱ፡
                             <gap reason="ellipsis"/>
                             ኵሎሙ፡ ሰብአ<supplied reason="omitted">፡</supplied> ሀገር፡ ውሉደ፡ አዳም፡ ወሔዋን፡ ለገብርከ፡ 
-                              እ<choice><corr resp="bm:GrebTiss1935Codices">ገ</corr><sic>ግ</sic></choice>ሌ።
+                              እ<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ገ</corr><sic>ግ</sic></choice>ሌ።
                               <foreign xml:lang="grc">Το ανοθεν το γραφης ης πετζη γενας <gap reason="ellipsis"/></foreign></seg>
                           </q>
                         </item>
@@ -428,10 +428,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <desc type="ProtectivePrayer">Protective prayer against fever.</desc>
                           <q xml:lang="gez">
                             <seg part="I">በስመ፡ አብ፡ <gap reason="ellipsis"/>
-                              ጸሎት፡ በእንተ፡ ሕማ<choice><corr resp="bm:GrebTiss1935Codices">መ</corr><orig>ም</orig></choice>፡ ንዳን። <sic>ወነቀጥቃት፡</sic> <gap reason="ellipsis"/>
+                              ጸሎት፡ በእንተ፡ ሕማ<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">መ</corr><orig>ም</orig></choice>፡ ንዳን። <sic>ወነቀጥቃት፡</sic> <gap reason="ellipsis"/>
                             ጦር፡ አላጦር፡ ያፌጠር፡ ያፌጦር፡ ክርስቶስ፡ ወልደ፡ <sic>እግዝአብሔር፡</sic> ሕያው፡ 
-                              አ<choice><corr resp="bm:GrebTiss1935Codices">ድ</corr><sic>ደ</sic></choice>ኅነኒ፡ 
-                              ወሰ<choice><corr>ው</corr><sic>ወ</sic></choice>ረኒ፡ እ<choice><corr resp="bm:GrebTiss1935Codices">ም</corr><sic>መ</sic></choice><surplus>፡</surplus> ፌራ፡ ወንዳድ፡</seg>
+                              አ<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ድ</corr><sic>ደ</sic></choice>ኅነኒ፡ 
+                              ወሰ<choice><corr>ው</corr><sic>ወ</sic></choice>ረኒ፡ እ<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ም</corr><sic>መ</sic></choice><surplus>፡</surplus> ፌራ፡ ወንዳድ፡</seg>
                             <seg part="F">ዝርዎ፡ ለአጽራርየ፡ <surplus>ይበ፡</surplus> <supplied reason="omitted">ኢ</supplied>ይበሉኒ፡ <sic>ንቅጥሎ፡</sic> ፈኒወከ፡ ላዕሌሆሙ፡ ቆባረ፡ ወአ<choice><corr>ው</corr><sic>ዉ</sic></choice>ሎ።</seg>
                           </q>
                         </item>
@@ -456,10 +456,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <seg part="I">ስምከ፡ ዓመተ፡ ም<supplied reason="explanation">ሕረት፡</supplied>
                               ወር<supplied reason="explanation">ኅ</supplied>፡ ወንጌላዊ፡ ዕለት። በ<surplus>፡</surplus> ፮፡ 
                               ግ<supplied reason="explanation">ድፍ፡</supplied> ፩፡ ሠናይ፡ ትረክብ፡ ፩፡ 
-                              ብእ<choice><corr resp="bm:GrebTiss1935Codices">ሴ</corr><sic>ሲ</sic></choice>፡ በፍኖት፡ ይሁበከ፡ መብልዓ፡
+                              ብእ<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ሴ</corr><sic>ሲ</sic></choice>፡ በፍኖት፡ ይሁበከ፡ መብልዓ፡
                             ወመስቴ፡</seg>
-                            <seg part="F">፮፡ ዓርብ፡ ወረቡዕ፡ <choice><corr resp="bm:GrebTiss1935Codices">ኢ</corr><sic>ይ</sic></choice>ትጻእ፡ 
-                              እ<choice><corr resp="bm:GrebTiss1935Codices">ም</corr><sic>መ፡</sic></choice> ቤትከ፡ ዘእንበ<choice><corr resp="bm:GrebTiss1935Codices">ለ</corr><sic>ሌ</sic></choice>፡ 
+                            <seg part="F">፮፡ ዓርብ፡ ወረቡዕ፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ኢ</corr><sic>ይ</sic></choice>ትጻእ፡ 
+                              እ<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ም</corr><sic>መ፡</sic></choice> ቤትከ፡ ዘእንበ<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ለ</corr><sic>ሌ</sic></choice>፡ 
                               ይስሰርቅ፡ ፀሓይ፡ ወምስለ፡ ብበእሲት፡ ጸሊም፡ ኢት<supplied reason="omitted">ት</supplied>ናገር። ሠናይ፡ ሑር፡ <sic>በኩሉ፡</sic>
                             ግብር፡</seg>
                           </q>
@@ -635,12 +635,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <note>The beginning is missing.</note>
                         <incipit xml:lang="am">
                           ለሐፂን፡ ዘያጸርዮ፡ የጅብ፡ 
-                          <choice><corr resp="bm:GrebTiss1935Codices">ሽንኵርት፡</corr><sic>ሽንኩርት፡</sic></choice>
-                          ሰምና፡ <choice><corr resp="bm:GrebTiss1935Codices">እህል፡</corr><sic>እኽል፡</sic></choice>
+                          <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ሽንኵርት፡</corr><sic>ሽንኩርት፡</sic></choice>
+                          ሰምና፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">እህል፡</corr><sic>እኽል፡</sic></choice>
                         </incipit>
                         <explicit xml:lang="gez">
                           ወአፍልሆሙ፤ ኅቡረ፡ ወይከውን፡ ለከ፡ ንዋየ፡ ኅሩየ፡ ወድኅረ፡ 
-                          አምጽእ፡ <choice><corr resp="bm:GrebTiss1935Codices">ሙሻዘር፡</corr><sic>ሙሻ፤ ዘርእ፡</sic></choice> ደምሮ፤ ምስለ፡ እሎንቱ፡ 
+                          አምጽእ፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ሙሻዘር፡</corr><sic>ሙሻ፤ ዘርእ፡</sic></choice> ደምሮ፤ ምስለ፡ እሎንቱ፡ 
                           አፍልሆ፡ በከውር።
                         </explicit>
                       </msItem>
@@ -719,14 +719,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <title type="complete" ref="LIT7107Divination#henok"/>
                           <incipit xml:lang="gez">
                             በስመ፡ እግዚአብሔር፡ አስማተ፡ ጭናቱ፡ ጮስ፡ <gap reason="ellipsis" resp="bm:GrebTiss1935Codices"/>
-                            ዘጸሐፍኩ፡ ለ<del rend="effaced" unit="chars" quantity="1"/>ሄኖክ፡ <choice><corr resp="bm:GrebTiss1935Codices">ኆኅያተ፡</corr><sic>ኆኅተ፡</sic></choice> 
+                            ዘጸሐፍኩ፡ ለ<del rend="effaced" unit="chars" quantity="1"/>ሄኖክ፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ኆኅያተ፡</corr><sic>ኆኅተ፡</sic></choice> 
                             ፊደል፡ ከማሁ፡ ጸሐፍ፡ ፀርየ፡ ወአርክየ፡ ሕይወትየ፡ ወእኩይየ፡ ሲሳይየ፡
-                            <choice><corr resp="bm:GrebTiss1935Codices">ወሐጕልየ፡</corr><sic>ወሐጉሉየ፡</sic></choice> <choice><corr resp="bm:GrebTiss1935Codices">ክስት፡</corr><sic>ክሳት፡</sic></choice> ሊተ፡ 
+                            <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ወሐጕልየ፡</corr><sic>ወሐጉሉየ፡</sic></choice> <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ክስት፡</corr><sic>ክሳት፡</sic></choice> ሊተ፡ 
                             <expan><abbr>ለገ</abbr><ex>ብርከ፡</ex></expan> <expan><abbr>ዕ</abbr><ex>ገሌ፡</ex></expan>
                           </incipit>
                           <explicit xml:lang="am">
-                            ለበረከት፡ ለሀብት፡ መርህ፡ ነው፡ ምቀኛ፡ <choice><corr resp="bm:GrebTiss1935Codices">ምርር</corr> <sic>በርር</sic></choice><supplied reason="omitted">፡</supplied> 
-                            ይ<del rend="expunctuated">ላ</del>ል፡ ፈልፈል<supplied reason="omitted">ቱ</supplied>፡ <choice><corr resp="bm:GrebTiss1935Codices">ይ</corr><sic>ት</sic></choice>ነገር።
+                            ለበረከት፡ ለሀብት፡ መርህ፡ ነው፡ ምቀኛ፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ምርር</corr> <sic>በርር</sic></choice><supplied reason="omitted">፡</supplied> 
+                            ይ<del rend="expunctuated">ላ</del>ል፡ ፈልፈል<supplied reason="omitted">ቱ</supplied>፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ይ</corr><sic>ት</sic></choice>ነገር።
                           <gap reason="ellipsis"/>
                           </explicit>
                         </msItem>
@@ -740,7 +740,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <locus from="142r" to="145r"/>
                           <title type="complete" ref="LIT7107Divination#helm">Chapter on the effect of dreams on individual days of the lunar month</title>
                           <incipit xml:lang="am">
-                            <choice><corr resp="bm:GrebTiss1935Codices">ሐሳብ፡</corr><sic>ሐሰብ፡</sic></choice> በጨረቃው፡ 
+                            <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ሐሳብ፡</corr><sic>ሐሰብ፡</sic></choice> በጨረቃው፡ 
                             ወራት፡ ሕልም፡ ያሳየው፡ የሚሆን፡ ነው፡ ያውቃል፡ በ፩ ጨረቃ፡ አምላክ፡ አዳምን፡ ካ፬ት፡ ፈጠረው፡ <sic>ኩሉ፡</sic>
                             ነገር፡ በጎ፡ ነው፡
                           </incipit>
@@ -790,7 +790,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <locus from="154r" to="154v"/>
                           <title type="complete" ref="LIT7107Divination#fenot">ሐሳበ፡ ፍኖት፡</title>
                           <incipit xml:lang="gez">
-                            ስምከ፡ ወእምከ፡ ወርኅ፡ ወዕለት፡ <choice><corr resp="bm:GrebTiss1935Codices">ወንጌላዊ፡</corr><sic>ወንጌለዊ፡</sic></choice> 
+                            ስምከ፡ ወእምከ፡ ወርኅ፡ ወዕለት፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ወንጌላዊ፡</corr><sic>ወንጌለዊ፡</sic></choice> 
                             በበ<supplied reason="omitted">፡</supplied> ፲ ግድፍ፡ ፩ ሠናይ፡ ሖር፡ በነግህ፡ ወትረክብ፡
                           ብዙኃ፡ ዘሀለየ፡ ልብከ፡
                           </incipit>
@@ -866,7 +866,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <locus target="#158r"/>
                         <title type="complete" ref="LIT6977PPQusl"/>
                         <incipit xml:lang="gez">በስመ፡ አብ፡  <gap reason="ellipsis" resp="bm:GrebTiss1935Codices"/>ጸሎተ፡ <sic>ቁስል፡</sic> አመ፡ ረገዝዎ፡ ለእግዚእነ፡ የማናይ፡ ገቦሁ፡ እንተ፡
-                          <choice><corr resp="bm:GrebTiss1935Codices">ኢ</corr><sic>እ</sic></choice>ጽዔአት፡ ወኢመግለት፡</incipit>
+                          <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ኢ</corr><sic>እ</sic></choice>ጽዔአት፡ ወኢመግለት፡</incipit>
                         <explicit xml:lang="gez">ሹቸኙዌ፡ ኡራኤል፡ ፄያሄል፡ ድማሄል፡ በዝንቱ፡ አስማቲከ፡ ፈውስ፡ ቍስለ፡ ገብርከ፡</explicit>
                       </msItem>
                       
@@ -876,7 +876,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <incipit xml:lang="gez">በስመ፡ አብ፡ <gap reason="ellipsis" resp="bm:GrebTiss1935Codices"/> ጸሎት፡ በእንተ፡ ፈያት፡ ኢየሱስ፡ ክርስቶስ፡ ወልደ፡ እግዚአብሔር፡
                         ጥንትያኤል፡ አማኑኤል፡ ኬዳኤል፡ አውሰጥኤል፡</incipit>
                         <explicit xml:lang="gez">ወትብል፡ እግዚኦ፡ መሐረነ፡ ክርስቶስ፡ ወትብል<supplied reason="omitted">፡</supplied> ኆኳ፡ ኆኳ፡
-                          ወአልቦ፡ <choice><corr resp="bm:GrebTiss1935Codices">ዘይሬእየከ።</corr><sic>ዘይእሬየከ።</sic></choice></explicit>
+                          ወአልቦ፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ዘይሬእየከ።</corr><sic>ዘይእሬየከ።</sic></choice></explicit>
                       </msItem>
                       
                       <msItem xml:id="p3_i6">
@@ -907,9 +907,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <locus from="159v" to="160v"/>
                         <title type="complete" ref="LIT6973PPBlacksmiths"/>
                         <incipit xml:lang="gez">በስመ፡ አብ፡ <gap reason="ellipsis" resp="bm:GrebTiss1935Codices"/>ጰራቅዮን፡ ጰራቅዮን፡ ጰራቅዮን፡ በዝንቱ፡ ስምከ፡ ዘሰለርከ፡ መናግሥቲ<surplus>፡ </surplus>ሆሙ፡ 
-                          <choice><corr resp="bm:GrebTiss1935Codices">ለነሀብት፡</corr><sic>ለነሀብተ፡</sic></choice> ወትሰብር፡ <sic>ሐፂን፡</sic> ወከማሁ፡ <choice><corr resp="bm:GrebTiss1935Codices">ስብር፡</corr><sic>ሰበር፡</sic></choice>
+                          <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ለነሀብት፡</corr><sic>ለነሀብተ፡</sic></choice> ወትሰብር፡ <sic>ሐፂን፡</sic> ወከማሁ፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ስብር፡</corr><sic>ሰበር፡</sic></choice>
                         መናግሥቲሆሙ፡ ለነሀብት፡</incipit>
-                        <explicit xml:lang="gez">ወከማሁ፡ አጥፍእ፡ እሳቶሙ፡ ለነሀብት፡ ቄዳር፡ ከመ፡ <choice><sic>ኢያውዕዩ፡</sic><corr resp="bm:GrebTiss1935Codices">ኢያስዩ፡</corr></choice> ብርተ፡
+                        <explicit xml:lang="gez">ወከማሁ፡ አጥፍእ፡ እሳቶሙ፡ ለነሀብት፡ ቄዳር፡ ከመ፡ <choice><sic>ኢያውዕዩ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ኢያስዩ፡</corr></choice> ብርተ፡
                           በውስተ፡ እሳት፡ ዘገበርከ፡ እምድር፡ እስከ፡ <sic>ፋሌክ፡</sic> ሰማይ፨</explicit>
                       </msItem>
                       
@@ -918,8 +918,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <title type="complete" ref="LIT6974PPBlacksmiths"/>
                         <incipit xml:lang="gez">በስመ፡ አብ፡ <gap reason="ellipsis" resp="bm:GrebTiss1935Codices"/>በከመ፡ ተአስረት፡ ኃምስ፡ ሰማይ፡ ወከማሁ፡ እስር፡ <sic>ነሀብት፡</sic> ቄዳር፡ በስመ<supplied reason="omitted">፡</supplied> ዚአከ፡ 
                           ብርሃናኤል፡</incipit>
-                        <explicit xml:lang="gez">ዘወሀብኮ፡ ኃይለ፡ ወመዊዓ፡ ለሶምሶን፡ ዘነገርኮ፡ <sic>ስምከ፡</sic> ለእስጢፋኖስ፡ ዲያቆን፡ ፩ስምከ፡ ሜሎስ፡ ከመ፡ <choice><corr resp="bm:GrebTiss1935Codices">ይማኦ፡</corr><sic>ይመኦ፡</sic></choice>
-                          ለሰይጣን፡ ከመ፡ <sic>ሀቦ፡</sic> <choice><corr resp="bm:GrebTiss1935Codices">ይማኦሙ፡</corr><sic>ይምኦሙ፡</sic></choice> ለነሀብት፡ ቄዳር፡ ከማሁ፡ ሀቦ፡ ኃይለ፡
+                        <explicit xml:lang="gez">ዘወሀብኮ፡ ኃይለ፡ ወመዊዓ፡ ለሶምሶን፡ ዘነገርኮ፡ <sic>ስምከ፡</sic> ለእስጢፋኖስ፡ ዲያቆን፡ ፩ስምከ፡ ሜሎስ፡ ከመ፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ይማኦ፡</corr><sic>ይመኦ፡</sic></choice>
+                          ለሰይጣን፡ ከመ፡ <sic>ሀቦ፡</sic> <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ይማኦሙ፡</corr><sic>ይምኦሙ፡</sic></choice> ለነሀብት፡ ቄዳር፡ ከማሁ፡ ሀቦ፡ ኃይለ፡
                         ለገብርከ።</explicit>
                       </msItem>
                       
@@ -936,7 +936,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <locus from="161r" to="161v"/>
                         <title type="complete" ref="LIT6982PPDiseases"/>
                         <incipit xml:lang="gez">በስመ፡ አብ፡ <gap reason="ellipsis" resp="bm:GrebTiss1935Codices"/> ጸሎት፡ ወስእለት፡ በእንተ፡ ድኅነት፡ እምሕማመ፡ ወበእንተ፡ ኵናት፡ ወንድፈተ፡ ሐፅ፡
-                          <choice><corr resp="bm:GrebTiss1935Codices">ወትደግም፡</corr><sic>ወትድግም፡</sic></choice> ዘንተ፡ አስማተ፡ ወትብል፡ ግራእድ፡
+                          <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ወትደግም፡</corr><sic>ወትድግም፡</sic></choice> ዘንተ፡ አስማተ፡ ወትብል፡ ግራእድ፡
                         ግራኤል፡ እግዚእ፡ ኢያኤል፡ ኡራኤል፡</incipit>
                         <explicit xml:lang="gez">አአሃኵኤል፡ አኩኤልግሲ፡ ጸባዖት፡ መርዮቶን፡ ወበዝንቱ፡ አስማቲከ፡ አድኅነኒ፡ <sic>ወ</sic>እምኵሉ፡ ዘእፈርህ፡ አነ፡ ገብር፤</explicit>
                       </msItem>
@@ -946,7 +946,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <title type="complete" ref="LIT6983PPAsmat"/>
                         <incipit xml:lang="gez">በስመ፡ ሥሉስ፡ እዌጥን፡ ዘንተ፡ አስማተ፡ ሳጦር፡ እፌጦር፡ እፌጦስ፡ አይአር፡ አሮአይአድ፡</incipit>
                         <explicit xml:lang="gez">በዝንቱ፡ አስማቲከ፡ አድኅነኒ፡ እም<supplied reason="omitted">ዕ</supplied>ንባዜ፡ ልብየ፡ እምተግባረ፡ ሰብእ፡ ተማኅፀንኩ፡ በእግዚአብሔር፡ አብ፡ ወበክርስቶስ፡ 
-                          <choice><corr resp="bm:GrebTiss1935Codices">ወልድ፡</corr><sic>ወልደ፡</sic></choice> ወበሣልሳይ፡ መንፈስ፡ ቅዱስ፡ ጰራቅሊጦስ፡ ተማኅፀንኩ፡
+                          <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ወልድ፡</corr><sic>ወልደ፡</sic></choice> ወበሣልሳይ፡ መንፈስ፡ ቅዱስ፡ ጰራቅሊጦስ፡ ተማኅፀንኩ፡
                           አነ፡ ገብርከ፡ <space reason="owner"/> ለዓለመ፡ ዓለም፡ አሜን።</explicit>
                       </msItem>
                       
@@ -980,7 +980,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <title type="complete" ref="LIT6987PPNames"/>
                         <incipit xml:lang="gez">ቀዳሚሁ፡ ቃል፡ ውእቱ፡ <gap reason="ellipsis" resp="bm:GrebTiss1935Codices"/> ወበሳኒታ፡ ርእዮ፡ ለኢየሱስ። ዮሐንስ፡ እንዘ፡ ይመጽእ፡ ኀቤሁ፡ ወይቤ፡ ነዋ፡ በግዑ፡ ለእግዚአብሔር፡ <gap reason="ellipsis" resp="bm:GrebTiss1935Codices"/>
                         ኪዱናኤል፡ ኅቡዕ፡ ስሙ<supplied reason="omitted">፡</supplied> ለእግዚአብሔር፡</incipit>
-                        <explicit xml:lang="gez">ወይትሜክሁ፡ ብከ፡ ኵሎሙ፡ እለ፡ ያፈቅሩ፡ <sic>ስምከ፡</sic> ወይሴብሑ፡ ለስምከ፡ <choice><corr resp="bm:GrebTiss1935Codices">ኃሠሥኩ፡ </corr><sic>ኃሥሥ፡</sic></choice>
+                        <explicit xml:lang="gez">ወይትሜክሁ፡ ብከ፡ ኵሎሙ፡ እለ፡ ያፈቅሩ፡ <sic>ስምከ፡</sic> ወይሴብሑ፡ ለስምከ፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ኃሠሥኩ፡ </corr><sic>ኃሥሥ፡</sic></choice>
                           ገጸከ፡ እምኔየ፡ በዝንቱ፡ አስማቲከ፡ ተማኅፀንኩ፡ አነ፡ ገብርከ፡ <space reason="owner"/>
                           ለዓለመ፡ ዓለም<supplied reason="omitted">፡</supplied> አሜን፡ ወአሜን፡ ለይኩ<supplied reason="omitted">ን</supplied>።</explicit>
                       </msItem>
@@ -1050,9 +1050,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <locus from="180r" to="182v"/>
                         <title type="complete" ref="LIT7007PPrayer"/>
                         <incipit xml:lang="gez">በስመ፡ አብ፡ <gap reason="ellipsis" resp="bm:GrebTiss1935Codices"/><sic>ጸሎተ፡</sic> <sic>ከዋአነ፡</sic> ኖላዊሆሙ፡ ኄር፡ ለዛቲ፡ መጽሐፍ፡ እመ፡ እበውዕ፡
-                          ለብሔረ፡ ጽልመት፡ በፈለገ፡ ኆፃ፡ ወካልሰ፡ <sic>እልቦ፡</sic> ዘይክል፡ <choice><corr resp="bm:GrebTiss1935Codices">አዕድዎቶ፡</corr><sic>አዕዳዋቶ፡</sic></choice></incipit>
+                          ለብሔረ፡ ጽልመት፡ በፈለገ፡ ኆፃ፡ ወካልሰ፡ <sic>እልቦ፡</sic> ዘይክል፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">አዕድዎቶ፡</corr><sic>አዕዳዋቶ፡</sic></choice></incipit>
                         <explicit xml:lang="gez">አውገዝኩክሙ፤ ከመ፤ ኢትልክፉኒ፤ ነፍስየ፤ ወሥጋየ፡ በኢየሱስ፤ ክርስቶስ፡ አምላኪየ፡ ዕቀበኒ፡ 
-                          <choice><corr resp="bm:GrebTiss1935Codices">እምኵሉ፡</corr><sic>እምኵለ፡</sic></choice> ሰገል፡ <gap reason="ellipsis" resp="bm:GrebTiss1935Codices"/>
+                          <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">እምኵሉ፡</corr><sic>እምኵለ፡</sic></choice> ሰገል፡ <gap reason="ellipsis" resp="bm:GrebTiss1935Codices"/>
                           ወእምዓይነ፡ ሰብእ፡ ወእምዓይነ፡ ኵሉ፡ ፀላዒ፡ ሰይጣን፡ በባሕር፡ ወበአውግር፡ አድኅኖ፡ ለገብርከ፡ <space reason="owner"/> ለዓለመ፡ ዓለም፡ አሜን።
                         </explicit>
                       </msItem>
@@ -1071,10 +1071,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <locus from="183v" to="185r"/>
                         <title type="complete" ref="LIT1398Fethat">ፍትሐት፡ ዘወልድ፡</title>
                         <incipit xml:lang="gez">እግዚአ፡ እግዚአ፡ ኢየሱስ፡ ክርስቶስ፡ ወልድ፡ ዋህድ፡ ቃለ፡ እግዚአብሔር፡ አብ፡ ሕያው፡ ዘበተከ፡ እምኔነ፡ ኵሎ፡ ማዕሠረ፡
-                          ኃጣዊነ፡ በሕማምከ፡ መድኃኒት፡ ወ<choice><corr resp="bm:GrebTiss1935Codices">ማ</corr><sic>መ</sic></choice>ኅየዊት፡ ዘነፋሕከ፡ ላዕለ፡ ገጸ፡ አርዳኢከ፡ ቅዱሳን፡</incipit>
+                          ኃጣዊነ፡ በሕማምከ፡ መድኃኒት፡ ወ<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ማ</corr><sic>መ</sic></choice>ኅየዊት፡ ዘነፋሕከ፡ ላዕለ፡ ገጸ፡ አርዳኢከ፡ ቅዱሳን፡</incipit>
                         <explicit xml:lang="gez">ወይኩኑ፡ ፍቱሐነ፡ ወግዑዛነ፡ እስመ፡ ቡሩክ፡ <add place="margin">ወሥሙር፡</add> ወምሉዕ፡ ስብሐተ፡ ስምከ፡ ቅዱስ፡ አብ፡ ወወልድ፡ <surplus>ወወልድ፡</surplus>
                         ወመንፈስ፡ ቅዱስ፡ ሥሉስ፡ ዕሩይ፡ <del rend="erasure" unit="chars" quantity="2"/> <sic>ዚ</sic>ኵሎ፡ 
-                          ጊዜ፡ ይእዜኒ፡ ወዘልፈኒ፡ ለዓለመ፡ ዓለም፡ አሜን፡ በዝ፡ ቃለ፡ ኪዳን<choice><corr resp="bm:GrebTiss1935Codices">ከ</corr><sic>ኪ</sic></choice>፡ ዕቀበነ፡ ለአግብርቲከ።</explicit>
+                          ጊዜ፡ ይእዜኒ፡ ወዘልፈኒ፡ ለዓለመ፡ ዓለም፡ አሜን፡ በዝ፡ ቃለ፡ ኪዳን<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ከ</corr><sic>ኪ</sic></choice>፡ ዕቀበነ፡ ለአግብርቲከ።</explicit>
                       </msItem>                      
                     </msContents>
                   

--- a/VaticanBAV/et/BAVet13.xml
+++ b/VaticanBAV/et/BAVet13.xml
@@ -357,7 +357,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            ቅዳሴ፡ ማርያም፡ 
                               <sic>ዘቀደሰ፡</sic>
                            
-                           <corr resp="bm:GrebTiss1935Codices">ዘደረሰ፡</corr> አባ፡ ህርያቆስ፡ ጳጳስ፡ ዘሀገረ፡ ብህንሳ፡ ጸሎታ፡ የሀሉ፡ ምስሌነ፡ አሜን።
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ዘደረሰ፡</corr> አባ፡ ህርያቆስ፡ ጳጳስ፡ ዘሀገረ፡ ብህንሳ፡ ጸሎታ፡ የሀሉ፡ ምስሌነ፡ አሜን።
                         </incipit>
                      </msItem>
                   </msContents>

--- a/VaticanBAV/et/BAVet130.xml
+++ b/VaticanBAV/et/BAVet130.xml
@@ -75,7 +75,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title xml:lang="en" type="complete" ref="LIT1297Dersan#MiracleSeaMonster">On a keeper of a church, who was carried away by a sea monster</title>
                                     <textLang mainLang="gez"/>
                                     <incipit xml:lang="gez">
-                                        <choice><sic>አጠይቀክሙ፡</sic><corr resp="bm:GrebTiss1935Codices">አጤይቀክሙ፡</corr></choice> ኦአኃውየ፡ ዕፁበ፡ ወመንክረ፡ 
+                                        <choice><sic>አጠይቀክሙ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">አጤይቀክሙ፡</corr></choice> ኦአኃውየ፡ ዕፁበ፡ ወመንክረ፡ 
                                         ካልዓ፡ ዘገብረ፡ ተአምረ፡ ሊቀ፡ መላእክት፡ ጸሎቱ፡ <gap reason="ellipsis" resp="bm:GrebTiss1935Codices"/> ስምዑ፡ እንግርክሙ፡ ኦጉባኤ፡ ማኅበራ፡ ለቤተ፡ ክርስቲያን፡
                                         ቅድስት፨ ሀሎ፡ ፩ዓቃቤ፡ ቤተ፡ ክርስቲያን፡ ወበአሐቲ፡ ዕለት፡ ቦአ፡ ከመ፡ ያብርህ፡ ማኅቶተ፡ ቅድመ፡ <sic>ሥዕል፡</sic> ክቡር፡ ሩፋኤል<supplied reason="omitted">፡</supplied>
                                     </incipit>
@@ -105,7 +105,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <textLang mainLang="gez"/>
                                     <incipit xml:lang="gez">
                                         ሣልስኒ፡ ተአምሪሁ፡ ለዝንቱ<supplied reason="omitted">፡</supplied> መልአክ፡ ነበረ፡ ፩ብእሲ፡ በዘመነ፡ አበዊነ፡ ቀደምት። 
-                                        <choice><sic>ዘልሙ</sic><corr resp="bm:GrebTiss1935Codices">ዘስሙ፡</corr></choice> ጦቢት፡ ወስመ፡ ወልዱ፡ ጦብያ። ወሠናይ፡ ውእቱ፡ 
+                                        <choice><sic>ዘልሙ</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ዘስሙ፡</corr></choice> ጦቢት፡ ወስመ፡ ወልዱ፡ ጦብያ። ወሠናይ፡ ውእቱ፡ 
                                         ብእሲሁ፡ ወያፈቅሮ፡ ለእግዚአብሔር፨ <gap reason="ellipsis" resp="bm:GrebTiss1935Codices"/> ወበእንተ፡ ዝንቱ፡ ተጽሕፈ፡ ምስለ፡ ዜና፡ 
                                         መልአክ፡ ሩፋኤል፡ መጽሐፈ፡ ነገሩ፡ ለጦቢት፡ ወልደ፡ ጦብያ፤ ወልደ፡ ገባል፡ ዘእምነ፡ አሳሔል፤ ዘእምነገደ፡ ንፍታሌም፤ 
                                     </incipit>
@@ -133,7 +133,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </incipit>
                                     <explicit xml:lang="gez">
                                         ዝውእቱ፡ ሩፋኤል<supplied reason="omitted">፡</supplied> ዘዲበ፡ ሕማም፡ ወቍስል፡ ዘ<del rend="expunctuated">ይ</del><surplus>ት</surplus>ፈትኖ፡ 
-                                        ከመ፡ ይፈውሶሙ፤ ለነፍሳተ፡  <choice><sic>እሉ፡</sic><corr resp="bm:GrebTiss1935Codices">እለ፡</corr></choice> ቈስሉ፤ በኃጢአት፡ 
+                                        ከመ፡ ይፈውሶሙ፤ ለነፍሳተ፡  <choice><sic>እሉ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">እለ፡</corr></choice> ቈስሉ፤ በኃጢአት፡ 
                                         ወቍሰለ፡ ሥጋኒ፡ እለ፡ ቈስሉ፤ በደዌ፡ ትንብልናሁ፡ <gap reason="ellipsis" resp="bm:GrebTiss1935Codices"/>
                                     </explicit>
                                 </msItem>
@@ -143,14 +143,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <title xml:lang="en" type="complete" ref="LIT7162MRTheophilus">How the patriarch Tewoflos remained buried for three days</title>
                                     <incipit xml:lang="gez">
                                         ፪ ተአምሪሁ፡ <gap reason="ellipsis" resp="bm:GrebTiss1935Codices"/> ወሀሎ፡ ፩ብእሲ፡ ኄር፡ ሊቀ፡ <sic>ጳጳስ፡</sic> ዘስሙ፡ ቴዎፍሎስ፨ 
-                                        ዘተወድየ፡ ውስተ፡ ሣፁን፡ <choice><sic>ወደፈነኒ፡</sic><corr resp="bm:GrebTiss1935Codices">ወደፈኑኒ፡</corr></choice> ከመ፡ መቃብር፨ 
-                                        <choice><sic>ውነበርኩ፡</sic><corr resp="bm:GrebTiss1935Codices">ወነበርኩ፡</corr></choice> ውስተ፡ ልበ፡ ምድር፡ ሠሉሰ፡ መዋዕለ፨ 
+                                        ዘተወድየ፡ ውስተ፡ ሣፁን፡ <choice><sic>ወደፈነኒ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ወደፈኑኒ፡</corr></choice> ከመ፡ መቃብር፨ 
+                                        <choice><sic>ውነበርኩ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ወነበርኩ፡</corr></choice> ውስተ፡ ልበ፡ ምድር፡ ሠሉሰ፡ መዋዕለ፨ 
                                         ወሠሉሰ፡ ለያልየ፨ ወአመ፡ ራብዕት፡ ዕለት፡ ነዋ፡ አስተርአየኒ፡ ጽሚተ፨ ሊቀ፡ መላእክት፡ ሩፋኤል<supplied reason="omitted">፡</supplied> ወመጽአ፡ 
                                         ኀቤየ፡ እንዘ፡ ሀሎኩ፡ ውስተ፡ ሣፁን፡ ኀበ፡ ወደዩኒ፡ ወደፈኑኒ፡ ከመ፡ መቃብር፨
                                     </incipit>
                                     <explicit xml:lang="gez">
                                         አነ፤ ውእቱ፡ ዘአብጻሕኩከ፡ እስከ፡ ዝየ፡ <sic>በደኅና፡</sic> ወበሰላም፨ ወባላሕኩከ፡ እምአኅጕሎተ፡ ዓርዌ፨ ዘይመስጥ፡ ተመን፡ ዕኩይ፡ ዘሀሎ፡ ውስተ፡ ባሕር፨ 
-                                        <choice><sic>ጼሕከ፡</sic><corr resp="bm:GrebTiss1935Codices">ጼሕኩ፡</corr></choice> ፍኖተከ፡ በከመ፡ አበዊከ፡ ቀደምት፨ ወዘንተ፡ ብሂሎ፡
+                                        <choice><sic>ጼሕከ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ጼሕኩ፡</corr></choice> ፍኖተከ፡ በከመ፡ አበዊከ፡ ቀደምት፨ ወዘንተ፡ ብሂሎ፡
                                         ሊቀ፡ መላእክት፡ ተኃብአ፡ እምኔሁ፡ ትን<surplus>ት</surplus>ብልናሁ፡ <gap reason="ellipsis" resp="bm:GrebTiss1935Codices"/>
                                     </explicit>
                                 </msItem>
@@ -161,7 +161,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <incipit xml:lang="gez">
                                         ተአምሪሁ፡ <gap reason="ellipsis" resp="bm:GrebTiss1935Codices"/> ወሀሎ<supplied reason="omitted">፡</supplied> ፩ሕፃን፡ ውስተ፡ ቤተ፡ 
                                         ክርስቲያኑ፡ ለሊቀ፡ መላእክት፡ ሩፋኤል<supplied reason="omitted">፡</supplied> ወበአሐቲ፡ ዕለት፡ 
-                                        <choice><sic>ወጽአ፡</sic><corr resp="bm:GrebTiss1935Codices">መጽአ፡</corr></choice> አርዌ፡ በአር<supplied reason="omitted">አ</supplied>ያ፡
+                                        <choice><sic>ወጽአ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">መጽአ፡</corr></choice> አርዌ፡ በአር<supplied reason="omitted">አ</supplied>ያ፡
                                         ነጌ፨ ውእቱ፡ <sic>ኅርማዝ፡</sic> ወነዊህ፨ ክሳዱ፡ ከመ፡ ክሣደ፡ ገመል፨ ወመሰጦ፡ ለሕፃን፡ በማእከለ፡ እድ፨ ወሕዝብ፡ እለ፡ <sic>ሀለው፡</sic> 
                                         ጉቡዓን፡ ውስተ፡ <sic>ገብዋቲሃ፡</sic> ለቤተ፡ ክርስቲያን፨
                                     </incipit>
@@ -221,7 +221,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <gap reason="omitted" resp="bm:GrebTiss1935Codices"/> ቤተ፡
                                     </incipit>
                                     <explicit xml:lang="gez">
-                                        ውእቱ፡ ዕፅ፡ ዘተመትረ፡ ለዓምድ፡ ወእምአበየ፡ <choice><sic>ተአምረሁ፡</sic><corr resp="bm:GrebTiss1935Codices">ተአምሪሁ፡</corr></choice>
+                                        ውእቱ፡ ዕፅ፡ ዘተመትረ፡ ለዓምድ፡ ወእምአበየ፡ <choice><sic>ተአምረሁ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ተአምሪሁ፡</corr></choice>
                                         ለመልአክ፡ ክቡር፡ ሩፋኤል፡ ሊቀ፡ መላእክት፡ ብዙኅ፡ ውእቱ፡ ተአምሪሁ፡ ዘገብሮ፡ በእዴሁ፡ ለነኒ፡ ይክድነነ፡ ታሕተ፡ ክነፊሁ፨ 
                                         ጸሎቱ፡ <gap reason="ellipsis" resp="bm:GrebTiss1935Codices"/>
                                     </explicit>

--- a/VaticanBAV/et/BAVet131.xml
+++ b/VaticanBAV/et/BAVet131.xml
@@ -514,7 +514,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         ለጽሙኣን፨ ፈኑ፡ ሣህለከ፡ ላዕሌነ። ወሣህሉሰ፡ ለእግዚአብሔር፡ እምዓለም፡ ወስከ፡ ለዓለም፡ ዲበ፡ እለ፡ ይፈርህዎ፡ ለይኩን፡ አሜን።
                                     </incipit>
                                     <explicit xml:lang="gez">
-                                        ዘጸምዓ፡ ወማየ፡ የሐምግ፡ ወሣእረ፡ <choice><corr resp="bm:GrebTiss1935Codices">ይቀፍጽ፡</corr><sic>ይቅፍጽ፡</sic></choice> ወአይነ፡ 
+                                        ዘጸምዓ፡ ወማየ፡ የሐምግ፡ ወሣእረ፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ይቀፍጽ፡</corr><sic>ይቅፍጽ፡</sic></choice> ወአይነ፡ 
                                         ጸላኢ፡ ኢይቀርቦ፡ ዘኢይርኅቅ፡ እምእግዚአብሔር፡ ወኢይወጽእ፡ እምሰብእ፡ የሀብክሙ፡ እግዚአብሔር፡ ጸልዩ፡ ወሰአሉ፨
                                     </explicit>
                                 </msItem>
@@ -767,7 +767,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <supplied reason="omitted">እግ</supplied>ዚአብሔር፡ እግዚኦ፡ ኢየሱስ፡ ክርስቶስ፡ አምላክነ፡ ዘትቤሎ፡ ለፍቁርከ፡ ዮሐንስ፡ እንዘ፡ ሀሎከ፡ ዲበ፡ ዕፀ፡ መስቀል፡ 
                                     ቅዱስ፡ ወትቤላ፡ ለማርያም፡ ነዋ፡ ወልድኪ፡ ወለረድእከኒ፡ ነያ፡ እምከ፡ <gap reason="ellipsis" extent="unknown" resp="bm:GrebTiss1935Codices"/> 
                                     ንስዕለከ፡ ወናስተበቍዓከ፡ በእንተ፡ ማርያም፡ ወላዲትከ፡ ወበእንተ፡ ዮሐንስ፡ ዘረፈቀ፡ ውስተ፡ ሕፅንከ፡ ወበእንተ፡ ኵሎሙ፡ ሐዋርያት፡ አኃዊከ፡ ከመ፡
-                                    <choice><corr resp="bm:GrebTiss1935Codices">ትረስየነ፡</corr><sic>ትረስየኒ፡</sic></choice> ድልዋነ፡ ለሰሚዓ፡ ተአርሚሃ፡ ለማርያም፡
+                                    <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ትረስየነ፡</corr><sic>ትረስየኒ፡</sic></choice> ድልዋነ፡ ለሰሚዓ፡ ተአርሚሃ፡ ለማርያም፡
                                 </incipit>
                                 <note>
                                     The text is followed on <locus target="#110r"/> by a short passage referring to the collections of different school chants in <ref target="#ms_i1.6 #ms_i1.7 #ms_i1.8"/>, 

--- a/VaticanBAV/et/BAVet135.xml
+++ b/VaticanBAV/et/BAVet135.xml
@@ -116,7 +116,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 ሠረቀ፡ ሰኔ፡ ፴ልደተ፡ ዮሐንስ፡ ሠረቀ፡ ሐምሌ፡ ፪ታዴዎስ፡      
                                 <choice>
                                     <sic>እመ፡</sic>
-                                    <corr resp="bm:GrebTiss1935Codices">አመ፡</corr>
+                                    <corr resp="PRS4805Grebaut PRS9530Tisseran">አመ፡</corr>
                                 </choice>
                                 ፭ጴጥሮስ፡ ወጳውሎስ፡ ፲ናትናኤል፡ <supplied reason="omitted">፲</supplied>ወ፰ያዕቆብ።
                             </explicit>

--- a/VaticanBAV/et/BAVet14.xml
+++ b/VaticanBAV/et/BAVet14.xml
@@ -235,7 +235,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            ፈኑ፡ ላዕሌነ፡ ውእተ፡ መንፈሰከ፡ 
                               <sic>አማዳ</sic>
                            
-                           <corr resp="bm:GrebTiss1935Codices">አማዴ፡</corr> ሰማይ፡ ወምድር፡ ባርክ፡ 
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">አማዴ፡</corr> ሰማይ፡ ወምድር፡ ባርክ፡ 
                            <supplied reason="omitted">ማ</supplied>ኅበረነ፡ በኵሉ፡ <supplied reason="omitted">ዕለት፡</supplied> ወበ<supplied reason="omitted">ኵ</supplied>ሉ፡ 
                            ሰዓት። በዋሕድ፡ <supplied reason="omitted">ወ</supplied>ልድከ፡ ኢየሱስ፡ ክ<supplied reason="omitted">ርስ</supplied>ቶስ፡ 
                            እግዚእ<supplied reason="omitted">ነ፡ ዘቦቱ፡</supplied> ለከ፡ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/>

--- a/VaticanBAV/et/BAVet15.xml
+++ b/VaticanBAV/et/BAVet15.xml
@@ -1086,7 +1086,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                  እግዚእ፡ 
                                     <sic>ፈጠረ፡</sic>
                                  
-                                 <corr resp="bm:GrebTiss1935Codices">ዘፈጠርከ፡</corr> ብርሃነ፡ እስከ፡ ለዓለም።</q>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ዘፈጠርከ፡</corr> ብርሃነ፡ እስከ፡ ለዓለም።</q>
                            </note>
                         </msItem>
                         <msItem xml:id="p1_i15.2">
@@ -1245,7 +1245,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            መሐሮሙ፡ እግዚኦ፡ ለእለ፡ ወሀቡነ፡ ዘንተ፡ ጸሎተ፡ በእንተ፡ እሉ፡ 
                               <sic>መሐረኒ፡</sic>
                            
-                           <corr resp="bm:GrebTiss1935Codices">መሐረነ፡</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">መሐረነ፡</corr>
                            <supplied reason="omitted">ለ</supplied>አግብርቲከ፡ መሐረኒ፡ ለገብርከ፡ <del rend="erasure">...</del> ወተሣሀለኒ፡ ምስለ፡ ጻድቃን፡ ደምረኒ፨ በጸሎታ፡ ወበስእለታ፡
                            ለቅድስት፡ ማርያም፡ ወላዲተ፡ አምላክ፡ ወወላዲተ፡ መድኅን፡ ወበስእለቶሙ፡ ለነቢያት፡ ወሐዋርያት፡ ወሰማዕት፡ 
                               <sic>ወጸድቃን፡</sic>

--- a/VaticanBAV/et/BAVet17.xml
+++ b/VaticanBAV/et/BAVet17.xml
@@ -57,7 +57,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                          ጊዜ፡ እግዜአብሔር፡ የሀልው፡ ምስሌክሙ፡ በዲበ፡ ምድር፡ 
                         ወበሰማያት፡ ... <choice>
                            <sic>ወወሀለ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ወወሀበ፡</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ወወሀበ፡</corr>
                          </choice>
                         
                            <sic>ሒወት፡</sic>
@@ -112,7 +112,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <sic>ታበርሂ፡</sic>
                          ልብየ፡ ወታርትዒ፡ ፍኖትየ፡ ከመ፡ እሖር፡ <choice>
                            <sic>በንጽሕ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">በንጹሕ፡</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">በንጹሕ፡</corr>
                          </choice>
                         ልብ፡ በፍኖተ፡ ክርስቶስ፡ ወትእዛዛቲሁ፡
                      </incipit>

--- a/VaticanBAV/et/BAVet18.xml
+++ b/VaticanBAV/et/BAVet18.xml
@@ -485,7 +485,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <sic>ለኀጥአነ፡</sic>
                          ምድር፡ ኵሎሙ፡ አመ፡ ይትገበር፡ ሥቃይ። ሶበ፡ ይመጽእ፡ ወልድኪ፡ <choice>
                            <sic>በሀለተ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">በዕለተ፡</corr></choice>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">በዕለተ፡</corr></choice>
                          ኵነኔ፡ ዐባይ። ትርሲተ፡ 
                            <sic>ቅዱሰን፡</sic>
                          አንቲ፡

--- a/VaticanBAV/et/BAVet201.xml
+++ b/VaticanBAV/et/BAVet201.xml
@@ -51,7 +51,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             እግዚ<supplied reason="omitted">አ</supplied>ብሔር፡ ለአለመ፡ አለም፡ አሜን፡ ንግባእኬ፡ ኃበ፡ ጥ<supplied reason="omitted">ን</supplied>ተ<supplied reason="omitted">፡</supplied>
                             ነገር፡ ዛቲ፡ መጽሐፍ<supplied reason="omitted">፡</supplied> ዘታበውእ፤ ውስተ<supplied reason="omitted">፡</supplied> ፀባብ፡ አንቀጽ፡ ውስተ፤ ህይወት፨ 
                             ወትወስድ፤ ውስተ<supplied reason="omitted">፡</supplied> መንግሥተ፤ ሰማያት፤ መርኅ፤ ለፃድቃን፤ ወዘንተ፤ ነገራ፡ ክርስቶስ፡ ለማርያም፡ እምድሕረ <supplied reason="omitted">፡</supplied>
-                            <choice><sic>ተወልድ፤</sic><corr resp="bm:GrebTiss1935Codices">ተወልደ፤</corr></choice> 
+                            <choice><sic>ተወልድ፤</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ተወልደ፤</corr></choice> 
                           </explicit>
                         </msItem>
                         <msItem xml:id="ms_i1.2">
@@ -114,14 +114,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <textLang mainLang="gez"/>
                           <incipit xml:lang="gez">
                             በስመ፡ አብ፡ <gap reason="omitted" resp="bm:GrebTiss1935Codices"/> ጸሎተ፡ ዘመንገደ፡ ሰማይ፡ እቀበኒ፡ ክርስቶስ፡ ከመ፡ ኢ<add place="above">ያ</add>እቅፍዋ፡
-                            <choice><sic>ነብፍየ</sic><corr resp="bm:GrebTiss1935Codices">ነፍስየ፡</corr></choice> መላእክተ፡ ጽልመት፡
-                            <choice><sic>ለሐዳሳት፡</sic><corr resp="bm:GrebTiss1935Codices">በሐዳሳት፡</corr></choice> ምኵራብ፡ አመ<supplied reason="omitted">፡</supplied>
+                            <choice><sic>ነብፍየ</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ነፍስየ፡</corr></choice> መላእክተ፡ ጽልመት፡
+                            <choice><sic>ለሐዳሳት፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">በሐዳሳት፡</corr></choice> ምኵራብ፡ አመ<supplied reason="omitted">፡</supplied>
                             ይነግሥ<supplied reason="omitted">፡</supplied> ሎሙ<supplied reason="omitted">፡</supplied> ክቡር፡ ንጉሥ፡ በይእቲ፡ ዕለት፡ መሐረኒ፡
                             </incipit>
                           <explicit xml:lang="gez">
                             ወኢያእምርዋ፡ መላእክት፡ ጸዋጋን፡ ወኢ<supplied reason="omitted">ይ</supplied>ነጽርዋ፡ በመዓት፡ ዕቀብ፡ ዘንተ፡ ቃለ፡ ከመ፡ ይእቀብከ<supplied reason="omitted">፡</supplied>
                             እግዚአብሔር፡ እ<supplied reason="omitted">ም</supplied>ኵሉ፡ እኩይ<supplied reason="omitted">፡</supplied> በደኃሪ፡ መዋ<supplied reason="omitted">ዕ</supplied>ል<supplied reason="omitted">፡</supplied>
-                            ወከማሁ፡ ወኃረኒ፡ <choice><sic>ወተሠሐለኒ፡</sic><corr resp="bm:GrebTiss1935Codices">ወተሣሐለኒ፡</corr></choice> ለ<add resp="#h2">አመትከ፡ 
+                            ወከማሁ፡ ወኃረኒ፡ <choice><sic>ወተሠሐለኒ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ወተሣሐለኒ፡</corr></choice> ለ<add resp="#h2">አመትከ፡ 
                               ወለተ፡ ሕይወት፡</add>
                           </explicit>
                           <note>The name of <persName ref="PRS14664WalattaHe" role="owner">Walatta Ḥǝywat</persName>, presumably an owner, has been added in a secondary hand 
@@ -140,7 +140,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <explicit xml:lang="gez">
                             እስመ፡ እንተ፡ ቀዳማዊ፡ ወአነ<supplied reason="omitted">፡</supplied> ደኃራዊ፡ ኢታርእየኒ፡ እሳተ፡ ገሃነም፡ ዘበልአ<supplied reason="omitted">፡</supplied> 
                             ሥጋየ፡ ወሰትየ፡ ደምየ፡ የሐዩ፡ ዘለዓለም፡ ሕይወተ፡ ሥጋከ። ወ<add resp="#h2" place="below">ለአመትከ፡ ወለተ<supplied reason="omitted">፡</supplied> 
-                              <del rend="effaced">ሕይወት፡</del> <choice><sic>መርያም፡</sic><corr resp="bm:GrebTiss1935Codices">ማርያም፡</corr></choice></add>
+                              <del rend="effaced">ሕይወት፡</del> <choice><sic>መርያም፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ማርያም፡</corr></choice></add>
                           </explicit>
                           <note>A later hand added the name of <persName ref="PRS14665WalattaMa" role="owner">Walatta Māryām</persName> in the concluding supplication formula, 
                             and indicated her as "your servant". 
@@ -247,7 +247,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </desc>                            
                             <q xml:lang="gez">
                               ነፍሣቲሆሙ፡ አእርፍ፡ ለገብርከ፡ ወልደ፡ ክርስቶስ፡ ለአመትከ፡ አብ<supplied reason="omitted">፡</supplied> ከለላ፡ ተስፋ፡ ዮሐንስ፡ ገብረ፡ እግዚአብሔር፡ 
-                              ወለተ፡ ሰንበት፡ መ<surplus>መ</surplus>ንግሥተ፡ ሰማያት፡ <choice><sic>አያስተዋርሰቸው</sic><corr resp="bm:GrebTiss1935Codices">አስተዋርሳቸው፡</corr></choice> 
+                              ወለተ፡ ሰንበት፡ መ<surplus>መ</surplus>ንግሥተ፡ ሰማያት፡ <choice><sic>አያስተዋርሰቸው</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">አስተዋርሳቸው፡</corr></choice> 
                               አሜን፡
                             </q>
                           </item>

--- a/VaticanBAV/et/BAVet202.xml
+++ b/VaticanBAV/et/BAVet202.xml
@@ -41,12 +41,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             በስመ፡ አብ፡ <gap reason="omitted" resp="bm:GrebTiss1935Codices"/> ንጽሕፍ<supplied reason="omitted">፡</supplied> በረድኤተ፡ እግዚአብሔር፡ 
                             መጽሐፈ፡ ልፋፈ፡ ጽድቅ፡ ጸሎተ፡ መድኃኒት፡ ዘጸሐፈ፡ አብ፡ በእደዊሁ፡ ቅዱሳት፡ እም<surplus>፡</surplus>ቅድመ፡ 
                             ይትፈጠሩ፡ ሰማያት፡ ወምድር፡ እም<surplus>፡</surplus>ቅድመ፡ ነፋሳት፡ ወእሳት፡ እም<surplus>፡</surplus>ቅድመ፡ ማያር፡
-                            <choice><sic>ወጸልመት፡</sic><corr resp="bm:GrebTiss1935Codices">ወጽልመት፡</corr></choice> 
+                            <choice><sic>ወጸልመት፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ወጽልመት፡</corr></choice> 
                           </incipit>
                           <note>
                             The text contains several theological observations on the Trinity, among which (<locus from="1r5" to="1r6"/>):
                             <q xml:lang="gez">
-                              አብ፡ ብርሃን፡ ወልድ፡ ብርሃን፡ እስመ፡ <choice><sic>ተወልድ፡</sic><corr resp="bm:GrebTiss1935Codices">ተወልደ፡</corr></choice> 
+                              አብ፡ ብርሃን፡ ወልድ፡ ብርሃን፡ እስመ፡ <choice><sic>ተወልድ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ተወልደ፡</corr></choice> 
                               እም<surplus>፡</surplus>ብርሃን፡ ወመንፈስ፡ ቅዱስ፡ ብርሃን፡ እስመ፡ ሠረፀ፡ እም<surplus>፡</surplus>ብርሃን፡ ወ፫ቲሆሙ፡ ፩ ብርሃን፡
                               ዘኢይጠፍዕ፡ አብ፡ ይቤሎ፡ ለወልዱ፡ ወልድየ፡ ወልድኒ፡ ይቤሎ፡ ለአብ፡ አቡየ፡ ወለመንፈስ፡ ቅዱስኒ፡ ይቤልዎ፡ አብ፡ ወወልድ፡ ሕይወትነ፡
                             </q>.
@@ -63,11 +63,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <textLang mainLang="gez"/>
                           <incipit xml:lang="gez">
                             በስመ፡ አብ፡ <gap reason="omitted" resp="bm:GrebTiss1935Codices"/> ጸሎተ፡ መንገድ፡ ሰማይ፡ በደኃሪት፡ መዋዕል፡ በህየ፡ ይነሥኡ፡
-                            መላእክት፡ ማዕጠንታተ፡ <choice><sic>ወየዓርጉ፡</sic><corr resp="bm:GrebTiss1935Codices">ወያዓርጉ፡</corr></choice> በእንተ፡
+                            መላእክት፡ ማዕጠንታተ፡ <choice><sic>ወየዓርጉ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ወያዓርጉ፡</corr></choice> በእንተ፡
                             ምሕረተ፡ ሰብእ፡ ወያበርህ፡ ማኅቶተ፡
                             </incipit>
                           <explicit xml:lang="gez">
-                            እንዘ፡ ይሰደዱ፨ አጋንንት፨ ወፃዕረ፡ <choice><sic>ሞተ፡</sic><corr resp="bm:GrebTiss1935Codices">ሞት፡</corr></choice>
+                            እንዘ፡ ይሰደዱ፨ አጋንንት፨ ወፃዕረ፡ <choice><sic>ሞተ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ሞት፡</corr></choice>
                             ከማሁ፡ ስድድ፡ ሠራዊተ<supplied reason="omitted">፡</supplied> ዲያብሎስ፡ ፀርየ፡ ለገብርከ፡                            
                           </explicit>
                         </msItem>

--- a/VaticanBAV/et/BAVet203.xml
+++ b/VaticanBAV/et/BAVet203.xml
@@ -40,9 +40,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           ክርስቶስ፡ ሊቀ፡ ካህናት፡ ዘላዕለ፡ ኵሉ፤
                           </incipit>
                         <explicit xml:lang="gez">
-                          ታቦተ፡ ገሢሶሙ፡ ዖሙ፡ <choice><corr resp="bm:GrebTiss1935Codices">ነቂሎሙ፡</corr><sic>ነቀሎሙ፡</sic></choice> አስማተ፡ ገቢሮሙ፡ ይሠአር፡ 
-                          <choice><corr resp="bm:GrebTiss1935Codices">ሥራያቲሆሙ፡</corr><sic>ሥርያቲሆሙ፡</sic></choice> ወይትፈታሕ፡ 
-                          <choice><corr resp="bm:GrebTiss1935Codices">ሥራያቲሆሙ፡</corr><sic>ሥርያቲሆሙ፡</sic></choice> ላዕለ፡ ገብር፡ ወልደ፡ ሰማዕት፡
+                          ታቦተ፡ ገሢሶሙ፡ ዖሙ፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ነቂሎሙ፡</corr><sic>ነቀሎሙ፡</sic></choice> አስማተ፡ ገቢሮሙ፡ ይሠአር፡ 
+                          <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ሥራያቲሆሙ፡</corr><sic>ሥርያቲሆሙ፡</sic></choice> ወይትፈታሕ፡ 
+                          <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ሥራያቲሆሙ፡</corr><sic>ሥርያቲሆሙ፡</sic></choice> ላዕለ፡ ገብር፡ ወልደ፡ ሰማዕት፡
                         </explicit>
                       </msItem>
                       <msItem xml:id="ms_i2">
@@ -51,10 +51,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <textLang mainLang="gez"/>
                         <incipit xml:lang="gez">
                           በስመ፡ አብ፡ <gap reason="ellipsis" extent="unknown" resp="bm:GrebTiss1935Codices"/> ጸሎተ፡ ቅዱስ፡ ቆጵርያኖስ፡ ጽንዕ፡ ለነገሥት<supplied reason="omitted">፡</supplied>
-                          ወስደት፡ ለአጋንንት፡ ወለዓይነ፡ እኩይ፡ <choice><corr resp="bm:GrebTiss1935Codices">ወራእይ፡</corr><sic>ወረአይ፡</sic></choice> እኩይ፡ ወፈታሔ፡
-                          እሱራን፡ <choice><corr resp="bm:GrebTiss1935Codices">ወስደተ፡</corr><sic>ወስደት፡</sic></choice> እስለም፡ እኩያን፡ ጸሎቱ፡ ወበረከቱ፡ የሃሉ፡ ምስለ፡ 
+                          ወስደት፡ ለአጋንንት፡ ወለዓይነ፡ እኩይ፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ወራእይ፡</corr><sic>ወረአይ፡</sic></choice> እኩይ፡ ወፈታሔ፡
+                          እሱራን፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ወስደተ፡</corr><sic>ወስደት፡</sic></choice> እስለም፡ እኩያን፡ ጸሎቱ፡ ወበረከቱ፡ የሃሉ፡ ምስለ፡ 
                           ፍቁሩ፡ ወልደ፡ <space reason="owner"/> አሜን። ስብሐት፡ ለእግዚአብሔር፡ በሰማያት፡ ወሰላም፡ በምድር፡ ሥምረቱ፡ ለሰብእ። በእንተ፡ ሰንበተ፡ እንተ፡ ቅደሳ፡ ወባረካ፡ 
-                          እግዚአብሔር፡ <choice><corr resp="bm:GrebTiss1935Codices">ሰአሬ፡</corr><sic>ሰአሪ፡</sic></choice> ምግባረ፡ እኩይ፡ ወአነ፡ ቆጵርያኖስ፡
+                          እግዚአብሔር፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ሰአሬ፡</corr><sic>ሰአሪ፡</sic></choice> ምግባረ፡ እኩይ፡ ወአነ፡ ቆጵርያኖስ፡
                         </incipit>
                         <explicit xml:lang="gez">
                           ሬው፡ አርሄሊ፡ አዮን፡ ያብሳቲከ፡ ዘኪር፡ ፒስኪር፡ ፀፀፀ፡ ስመ፡ አምላክ፡ ዘተአመነ፡ በጸሎቱ፡ ወበስእለቱ፡ ለቅዱስ፡ ሚካኤል፡ ሊቀ፡ መላእክት፡ ወበስእለታ፡ 
@@ -67,8 +67,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <textLang mainLang="gez"/>
                         <incipit xml:lang="gez">
                           በስመ፡ አብ፡ <gap reason="ellipsis" extent="unknown" resp="bm:GrebTiss1935Codices"/> ጸሎት፡ በእንተ፡ ሥራይ፡ 
-                          <choice><corr resp="bm:GrebTiss1935Codices">ዘቅማንት፡</corr><sic>ዘቅማምት፡</sic></choice> ወዘአምሐራ፡ 
-                          <choice><corr resp="bm:GrebTiss1935Codices">ወዘእደ፡</corr><sic>ወዘእጀ፡</sic></choice> ሰብእ፡ ወጽላ፡ ወጊ፡ ክናንህ፡ ከናንህ፡ ከናንህ፡ ኖኅ፡ ከመያኖኅ፡ 
+                          <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ዘቅማንት፡</corr><sic>ዘቅማምት፡</sic></choice> ወዘአምሐራ፡ 
+                          <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ወዘእደ፡</corr><sic>ወዘእጀ፡</sic></choice> ሰብእ፡ ወጽላ፡ ወጊ፡ ክናንህ፡ ከናንህ፡ ከናንህ፡ ኖኅ፡ ከመያኖኅ፡ 
                           ኖኅ፡ ከመያኖኅ፡ ኖኅ፡ ከመ<surplus>፡</surplus>ያኖኅ። ዮም፡ ትላዮን፡ ዮም፡ ትላዮም፡ ዮም፡ ትላዮም፡
                         </incipit>
                         <explicit xml:lang="gez">
@@ -81,7 +81,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <title type="complete" ref="LIT7272PrayerMouth"/>
                         <textLang mainLang="gez"/>
                         <incipit xml:lang="gez">
-                          <choice><corr resp="bm:GrebTiss1935Codices">ገቢሮ፡</corr><sic>ገቢሩ፡</sic></choice> ቍንዶ፡ በርበሬ፡ ሰሊጥ፡ ጥሬ፡ ጨው፡ ጉረሮ፡ በመመ፡ ጊዜ፡ 
+                          <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ገቢሮ፡</corr><sic>ገቢሩ፡</sic></choice> ቍንዶ፡ በርበሬ፡ ሰሊጥ፡ ጥሬ፡ ጨው፡ ጉረሮ፡ በመመ፡ ጊዜ፡ 
                           የበግ፡ ሐሞት፡ በበሶ፡ ለወስሕ፡ ቅባ፡
                         </incipit>
                       </msItem>                   

--- a/VaticanBAV/et/BAVet206.xml
+++ b/VaticanBAV/et/BAVet206.xml
@@ -88,7 +88,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                              </incipit>
                            <explicit xml:lang="gez">
                              በ፳ወ፬ ካህናተ፡ ሰማይ፡ በ፸ወ፪ አርድእት፡ በ፭፻ ቢጽ፡ በ፫፻፲ወ፰ ርቱዓነ፡ ሃይማኖት፡ መሐረኒ፡ <gap reason="omitted" resp="bm:GrebTiss1935Codices"/> 
-                             በበአስማቲሆሙ፡ <choice><sic>ተመኅፀንኩ፡</sic><corr resp="bm:GrebTiss1935Codices">ተማኅፀንኩ፡</corr></choice> ከመ፡ ትስአሉ፡ በእንቲአነ፡ 
+                             በበአስማቲሆሙ፡ <choice><sic>ተመኅፀንኩ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ተማኅፀንኩ፡</corr></choice> ከመ፡ ትስአሉ፡ በእንቲአነ፡ 
                              በደኃሪ፡ መዋዕል፡ ኀበ፡ ገባሬ፡ መላእክት፡ አበ፡ ኵሉ፡ ለዓለመ፡ ዓለም፡ አሜን፡
                            </explicit>                         
                          </msItem>
@@ -99,7 +99,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            <incipit xml:lang="gez">
                              በስመ፡ አብ፡ <gap reason="omitted" resp="bm:GrebTiss1935Codices"/> ጸሎተ፡ ዘመንገደ<supplied reason="omitted">፡</supplied> ሰማይ፡ ዕቀበኒ፡
                              ክርስቶስ፡ ኢያዕቅፍዋ፡ ለነፍስየ፡ መላእክተ፡ ጽልመት<supplied reason="omitted">፡</supplied> ውስተ፡ ጸባብ፡ አንቀጸ፡ እስእለከ፡ እብል፡ ስረት፡ ሊተ፡ ኵሎ፡
-                             ጊዜ፡ <choice><sic>ጊጋይይ፡</sic><corr resp="bm:GrebTiss1935Codices">ጌጋይየ፡</corr></choice> በሐዳሳተ፡ ሰማይ፡ 
+                             ጊዜ፡ <choice><sic>ጊጋይይ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ጌጋይየ፡</corr></choice> በሐዳሳተ፡ ሰማይ፡ 
                              ወበሐዳ<supplied reason="omitted">ሳ</supplied>ተ፡ ምድር፡
                            </incipit>
                            <explicit xml:lang="gez">
@@ -112,8 +112,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            <textLang mainLang="gez"/>
                            <incipit xml:lang="gez">
                              በስመ፡ አብ<supplied reason="omitted">፡</supplied> <gap reason="omitted" resp="bm:GrebTiss1935Codices"/> ጸሎተ፡ ዘመንገደ፡ ሰማይ፡ በቆቤ፡
-                             <choice><sic>ስም፡</sic><corr resp="bm:GrebTiss1935Codices">ስመ፡</corr></choice> ኃይልከ፡ ወበድቅኤል፡ ስመ፡ ጥምቀትከ፡ 
-                             <choice><sic>በዘአጥመ<add place="above">ቀ</add>ኒ፡</sic><corr resp="bm:GrebTiss1935Codices">በዘአጥመቀከ፡</corr></choice> 
+                             <choice><sic>ስም፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ስመ፡</corr></choice> ኃይልከ፡ ወበድቅኤል፡ ስመ፡ ጥምቀትከ፡ 
+                             <choice><sic>በዘአጥመ<add place="above">ቀ</add>ኒ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">በዘአጥመቀከ፡</corr></choice> 
                              <sic>ዮሓንስ፡</sic>
                            </incipit>
                            <explicit xml:lang="gez">

--- a/VaticanBAV/et/BAVet207.xml
+++ b/VaticanBAV/et/BAVet207.xml
@@ -83,9 +83,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <title type="complete">First prayer for the heavenly journey</title>
                           <textLang mainLang="gez"/>
                           <explicit xml:lang="gez">
-                            <choice><sic>ወለማርያም</sic><corr resp="bm:GrebTiss1935Codices">ወበማርያም፡</corr></choice> ወላዲትከ፡ በ፲ወ፪ ነቢያት፡ በ፲፪ ሐዋርያት፡ 
+                            <choice><sic>ወለማርያም</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ወበማርያም፡</corr></choice> ወላዲትከ፡ በ፲ወ፪ ነቢያት፡ በ፲፪ ሐዋርያት፡ 
                             ወበ፲፻፡ ቢጽ፡ ወ፸ወ፪ አርድእት፡ በ፳ወ፬ ካህናተ፡ ሰማይ፡ ወበ <supplied reason="omitted">፲</supplied>፭ ነቢያት፡ ወ፭፻ ቢጽ፡ ከመ፡ ትምሐረኒ፡ ወትሣሃለኒ፡
-                            <choice><sic>ለአመትኪ</sic><corr resp="bm:GrebTiss1935Codices">ለአመትከ፡</corr></choice> አመተ፡ ማርያም<supplied reason="omitted">፨</supplied>
+                            <choice><sic>ለአመትኪ</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ለአመትከ፡</corr></choice> አመተ፡ ማርያም<supplied reason="omitted">፨</supplied>
                           </explicit>
                         </msItem>
                         <msItem xml:id="ms_i1.7">
@@ -144,13 +144,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <textLang mainLang="gez"/>
                           <incipit xml:lang="gez">
                             በስመ፡ አብ፡ <gap reason="omitted" resp="bm:GrebTiss1935Codices"/> ንጽሕፍ<supplied reason="omitted">፡</supplied> ዜና፡ ሕማማቲሁ፡ 
-                            <choice><sic>ወአምላከነ፡</sic><corr resp="bm:GrebTiss1935Codices">ለአምላክነ</corr></choice> ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡
+                            <choice><sic>ወአምላከነ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ለአምላክነ</corr></choice> ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡
                             ዘ<surplus>ለ<del rend="expunctuated">ዕ</del>ሌከ</surplus>ከሠትከ፡ ሎን፡ ለ፵ አንስት<supplied reason="omitted">፡</supplied> እለ፡ ይሰመያ፡ ሰሎሜ፡ <sic>ወዮሴፍ፤</sic> ወማርያም፡
-                            <choice><sic>መግዊላዊት፡</sic><corr resp="bm:GrebTiss1935Codices">መግደላዊት፡</corr></choice> ወኤልሳቤጥ፡
+                            <choice><sic>መግዊላዊት፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">መግደላዊት፡</corr></choice> ወኤልሳቤጥ፡
                             </incipit>
                           <explicit xml:lang="gez">
                             በቅዱስ፡ ስንዱን፡ ሥጋከ፡ ዘተገንዘ፡ በእደ፡ ዮሴፍ፡ ወኒቆዲሞስ፡ ድኅረ፡ አውረድዎ፡ እመስቀል፡ ሥመር፡ እግዚኦ፡ በርኅራኄከ፡ ወበትንሣኤከ፤ ወበተቀብሮትከ፤
-                            <choice><sic>ዘየሐቱ፤</sic><corr resp="bm:GrebTiss1935Codices">ዘያሐዩ፤</corr></choice> ለዓለመ፡ ዓለም፡ አሜን፡ ለይኩን፡ ለይኩን፡
+                            <choice><sic>ዘየሐቱ፤</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ዘያሐዩ፤</corr></choice> ለዓለመ፡ ዓለም፡ አሜን፡ ለይኩን፡ ለይኩን፡
                             ድሙር፡ ሥቃያቲከ፡ ፼፼ አ<add place="above">ስ</add>ተርአያ፡ ኢየሱስ፡ ለማርያም፡ ፍፃሜሁ፡ ለልፋፈ፡ ጽድቅ፡ ተፈጸመ፡ ልፋፈ፤ ጽድቅ፨
                           </explicit>
                         </msItem>                        
@@ -160,14 +160,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <title type="complete">Narration of the torments suffered by Jesus Christ</title>
                         <textLang mainLang="gez"/>
                         <incipit xml:lang="gez">
-                          ፶፡ ወ፪ ጊዜያተ፡ ሰብሕዎ፡ ወ<supplied reason="omitted">ወ</supplied>ሀብዎ፡  <choice><sic>ባሐብ</sic><corr resp="bm:GrebTiss1935Codices">ባሐከ፡</corr></choice> 
-                          ወነጽይዎ፡ ጽሕሞ፡ ወጸጕረ፡ ርእሱ፡ ወዘበጥዎ፡ <choice><sic>እንግዳሁ፡</sic><corr resp="bm:GrebTiss1935Codices">እንግድኣሁ፡</corr></choice> 
+                          ፶፡ ወ፪ ጊዜያተ፡ ሰብሕዎ፡ ወ<supplied reason="omitted">ወ</supplied>ሀብዎ፡  <choice><sic>ባሐብ</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ባሐከ፡</corr></choice> 
+                          ወነጽይዎ፡ ጽሕሞ፡ ወጸጕረ፡ ርእሱ፡ ወዘበጥዎ፡ <choice><sic>እንግዳሁ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">እንግድኣሁ፡</corr></choice> 
                         </incipit>
                           <explicit xml:lang="gez">
-                            ፲ወ፪ ዘወረቅዎ፡ ምራቀ፡ አይሁድ፡ <choice><sic>ቍስላተ፡</sic><corr resp="bm:GrebTiss1935Codices">ቍስላት፡</corr></choice> ዘነበሩ፡ ቦቱ፡ 
-                            ፲ወ፪<surplus>፱</surplus>፼፳፻<supplied reason="omitted">፡</supplied> <choice><sic>ወእለ</sic><corr resp="bm:GrebTiss1935Codices">ወእለ፡</corr></choice> 
-                            <choice><sic>ይሰሐለቁ</sic><corr resp="bm:GrebTiss1935Codices">ይስሕቁ፡</corr></choice> አንሰ፡ 
-                            <choice><sic>ግመራ፡</sic><corr resp="bm:GrebTiss1935Codices">ግሙራ፡</corr></choice> <choice><sic>ኢይስሐቅ፡</sic><corr resp="bm:GrebTiss1935Codices">ኢይስሕቅ፡</corr></choice> 
+                            ፲ወ፪ ዘወረቅዎ፡ ምራቀ፡ አይሁድ፡ <choice><sic>ቍስላተ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ቍስላት፡</corr></choice> ዘነበሩ፡ ቦቱ፡ 
+                            ፲ወ፪<surplus>፱</surplus>፼፳፻<supplied reason="omitted">፡</supplied> <choice><sic>ወእለ</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ወእለ፡</corr></choice> 
+                            <choice><sic>ይሰሐለቁ</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ይስሕቁ፡</corr></choice> አንሰ፡ 
+                            <choice><sic>ግመራ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ግሙራ፡</corr></choice> <choice><sic>ኢይስሐቅ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ኢይስሕቅ፡</corr></choice> 
                             <sic>ለለርኢ<gap reason="lost"/></sic>
                         </explicit>
                       </msItem>  

--- a/VaticanBAV/et/BAVet209.xml
+++ b/VaticanBAV/et/BAVet209.xml
@@ -77,7 +77,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <textLang mainLang="gez"/>
                           <note>Short prayer, beginning nearly like in <ref type="item" corresp="BAVet115#ms_i1.14.2"/>.</note>
                           <explicit xml:lang="gez">
-                            መሀረኒ፡ ወተሣሃለኒ፡ <surplus>ወ</surplus>ክርስቶስ፡ አምላኪየ፡ ኢየሱስ፡ <choice><sic>ታአስ፡</sic><corr resp="bm:GrebTiss1935Codices">ታኦስ፡</corr></choice> 
+                            መሀረኒ፡ ወተሣሃለኒ፡ <surplus>ወ</surplus>ክርስቶስ፡ አምላኪየ፡ ኢየሱስ፡ <choice><sic>ታአስ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ታኦስ፡</corr></choice> 
                             ሮቤባዊ፡ ታቦራዊ፡ መጽሐፈ፡ ዕዳየ፡ ለገብርከ።
                           </explicit>
                         </msItem>
@@ -88,7 +88,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <note>The prayer begins like in <bibl><ptr target="bm:Budge1929"/>
                             <citedRange unit="page">76 ll. 6-7</citedRange>
                           </bibl>, then it continues like follows: <q xml:lang="gez">ሚካኤል፡ ወገብርኤል፡ ሱራፌል፡ ወኪሩቤል፡ ይትባደሩ፡ ፍጡነ፡
-                            <choice><sic>ወያንሥእዋ፡</sic><corr resp="bm:GrebTiss1935Codices">ወይንሥእዋ፡</corr></choice> ለነፍስየ፡ ወኢያእምርዋ፡ ፀዋጋን፡ መላእክት፡
+                            <choice><sic>ወያንሥእዋ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ወይንሥእዋ፡</corr></choice> ለነፍስየ፡ ወኢያእምርዋ፡ ፀዋጋን፡ መላእክት፡
                             <gap reason="omitted" resp="bm:GrebTiss1935Codices"/> ከመ፡ ያንብብዋ፡ በደኃሪት፡ ዕለት፡ ለዓ<supplied reason="explanation">ለመ፡</supplied>፡ ዓለም፡</q>.
                           </note>                          
                         </msItem>
@@ -98,8 +98,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <textLang mainLang="gez"/>
                           <note>The prayer includes the following invocation:
                             <q xml:lang="gez">
-                              ከመ፡ <choice><sic>ትፈንው</sic><corr resp="bm:GrebTiss1935Codices">ትፈንዉ፡</corr></choice> ሊተ<supplied reason="omitted">፡</supplied> 
-                              ምሕረተክሙ፡ <choice><sic>ወክነፊክሙ፡</sic><corr resp="bm:GrebTiss1935Codices">በክነፊክሙ፡</corr></choice> መላእክተ፡ 
+                              ከመ፡ <choice><sic>ትፈንው</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ትፈንዉ፡</corr></choice> ሊተ<supplied reason="omitted">፡</supplied> 
+                              ምሕረተክሙ፡ <choice><sic>ወክነፊክሙ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">በክነፊክሙ፡</corr></choice> መላእክተ፡ 
                               ምሕረት<supplied reason="omitted">፡ </supplied> <gap reason="omitted" resp="bm:GrebTiss1935Codices"/> ከመ፡ ትምሀረኒ፡ ወትሣሃለኒ፡ 
                               ወትስ<surplus>፡</surplus>ረይ፡ ኃጢአትየ፡ ለገብር፡
                               </q>.
@@ -118,9 +118,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <textLang mainLang="gez"/>
                           <note>The prayer includes the following invocation:
                             <q xml:lang="gez">
-                              ወኢይነፅርዋ፡ በመዓልት፡ ወበሌሊት፡ ወኢያንብርዋ፡ ውስተ፡ ደይን፡ <choice><sic>በደኀረት፡</sic><corr resp="bm:GrebTiss1935Codices">በደኀሪት፡</corr></choice> 
+                              ወኢይነፅርዋ፡ በመዓልት፡ ወበሌሊት፡ ወኢያንብርዋ፡ ውስተ፡ ደይን፡ <choice><sic>በደኀረት፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">በደኀሪት፡</corr></choice> 
                               ዕለት፡ ወይትነሥኡ፡ መላእክት፡ በበ፯ ማዕጠንት<supplied reason="omitted">፡</supplied> ወበበ፯ መዓርጋት፡ ወበበ፯ መናብርት፡
-                              <choice><sic>ወበበጊ</sic><corr resp="bm:GrebTiss1935Codices">ወበበ፯</corr></choice> አፍላጋት፡ ወበበ፯ ሰማያት። ይሴብሑ፡ ወይዜምሩ፡                             
+                              <choice><sic>ወበበጊ</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ወበበ፯</corr></choice> አፍላጋት፡ ወበበ፯ ሰማያት። ይሴብሑ፡ ወይዜምሩ፡                             
                             </q>.
                           </note>
                         </msItem>
@@ -192,7 +192,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             and the scribe <persName ref="PRS14676GabraHe" role="scribe">Gabra Ḥǝywat</persName>.
                           </desc>                        
                           <q xml:lang="gez">
-                            አ<add place="above">ጽ</add><lb/>መ፡ ጊዮርጊ<lb/>ስ፡ ወምስለ፡ <choice><sic>ጸሀ<lb/>ፈሁ፡</sic><corr resp="bm:GrebTiss1935Codices">ጸሀ<lb/>ፊሁ፡</corr></choice> 
+                            አ<add place="above">ጽ</add><lb/>መ፡ ጊዮርጊ<lb/>ስ፡ ወምስለ፡ <choice><sic>ጸሀ<lb/>ፈሁ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ጸሀ<lb/>ፊሁ፡</corr></choice> 
                             ገ<lb/>ብረ፡ ሕ<lb/>ይወት፡ <lb/> ለአለመ<supplied reason="omitted">፡</supplied> አ<lb/>ለም፡ አ<lb/><surplus>አ</surplus>ሜን።
                             </q>
                         </item>

--- a/VaticanBAV/et/BAVet21.xml
+++ b/VaticanBAV/et/BAVet21.xml
@@ -52,7 +52,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                  <sic>ወጸለይ፡</sic>
                                ላዕሌየ፡ ላዕለ፡ <choice>
                                  <sic>ገብርከ፨</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ገብርከ፡</corr>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ገብርከ፡</corr>
                                </choice>
                         እስመ፡ ብዝኀ፡ 
                                  <sic>
@@ -961,7 +961,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <explicit xml:lang="gez">
                            እስመ፡ ዐቢየ፡ ጌገይኩ፡ በቅድሜከ፡ <choice>
                                  <sic>ወኢኮኑ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ወኮንኩ፡</corr></choice>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ወኮንኩ፡</corr></choice>
                                ከመ፡ ኵሉ፡ 
                            ሰብእ፡ ዘስሕትኩ፡ አነ፡ ወአንተ፡ ጻድቅ፡ በነቢብከ፡ ወትመውእ፡ በኵሉ፡ ኵነኔከ፨
                         </explicit>
@@ -1529,7 +1529,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <incipit xml:lang="gez">
                               ጸሎት፡ ለሶበ፡ <choice>
                                  <sic>ይዘክብ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ይሰክብ፡</corr></choice>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ይሰክብ፡</corr></choice>
                                ሰብእ፡ ሰአልናከ፡ መሐሪ፡ ሰአልናከ፡ 
                            ዘኢትከልእ። አንቃዕደውነ፡ ኀቤከ፡
                         </incipit>
@@ -1557,7 +1557,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <explicit xml:lang="gez">
                               አድኅነኒ፡ እምአፈ፡ አናብስት፡ <choice>
                                  <sic>ወአድኅነኒ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ወአኅድረኒ፡</corr></choice>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ወአኅድረኒ፡</corr></choice>
                                ምስለ፡ 
                            ጻድቃኒከ፡ አሜን።
                         </explicit>
@@ -1647,7 +1647,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                  <sic>ውርደአኒ፡</sic>
                               በዕለተ፡ ምንዳቤየ፡ እስመ፡ ኪያከ፡ <choice>
                                  <sic>ተሰፈውከ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ተፈሰውኩ፡</corr></choice>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ተፈሰውኩ፡</corr></choice>
                                
                            ተሰፈውኩ፡ ወበከ፡ ተአመንኩ፡ ወላዕሌከ፡ ተወከልኩ፡ እስከ፡ ለዓለመ፡ ዓለም፡ አሜን።
                         </explicit>

--- a/VaticanBAV/et/BAVet214.xml
+++ b/VaticanBAV/et/BAVet214.xml
@@ -44,7 +44,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </msItem>
                         <msItem xml:id="ms_i1.2">
                           <locus target="#1r"/>
-                          <title type="complete">First prayer for the heavenly journey, entitled ጸሎተ፡ <choice><sic>መንፈሰ፡</sic><corr resp="bm:GrebTiss1935Codices">መንገደ፡</corr></choice> ሰማይ፡</title>
+                          <title type="complete">First prayer for the heavenly journey, entitled ጸሎተ፡ <choice><sic>መንፈሰ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">መንገደ፡</corr></choice> ሰማይ፡</title>
                           <textLang mainLang="gez"/>         
                           <note>The text corresponds to <bibl>
                             <ptr target="bm:Budge1929"/>
@@ -83,8 +83,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <title type="complete">Fifth prayer, entitled ጸሎት፡ ዘመንገድ፡ ሰማይ፡</title>
                           <textLang mainLang="gez"/>  
                           <incipit xml:lang="gez">
-                            ዕቀበኒ፡ ክርስቶስ፡ ከመ፡ ኢያዕቅፍዋ፡ ለነፍስየ፡ መላእክት<supplied reason="omitted">፡</supplied> <choice><sic>ወስተ፡</sic><corr resp="bm:GrebTiss1935Codices">ውስተ፡</corr></choice> 
-                            ጸባብ፡ <choice><sic>አንቀጸ፡</sic><corr resp="bm:GrebTiss1935Codices">አንቀጽ፡</corr></choice> እንዘ፡ ዕብል፡ ስረይ<supplied reason="omitted">፡</supplied> 
+                            ዕቀበኒ፡ ክርስቶስ፡ ከመ፡ ኢያዕቅፍዋ፡ ለነፍስየ፡ መላእክት<supplied reason="omitted">፡</supplied> <choice><sic>ወስተ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ውስተ፡</corr></choice> 
+                            ጸባብ፡ <choice><sic>አንቀጸ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">አንቀጽ፡</corr></choice> እንዘ፡ ዕብል፡ ስረይ<supplied reason="omitted">፡</supplied> 
                             ሊተ፡ ኀጢአት<supplied reason="omitted">የ</supplied> ሱራፌል<supplied reason="omitted">፡</supplied> ይንሥእዋ፡ <sic>በክንፍ፡</sic>
                           </incipit>
                         </msItem>

--- a/VaticanBAV/et/BAVet215.xml
+++ b/VaticanBAV/et/BAVet215.xml
@@ -81,7 +81,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             The entire text is the following:
                           <q xml:lang="gez">
                             ፀዋጋን፡ መሃረኒ፡ ክርስቶስ፡ ወሥረይ፡ ሊተ፡ ኃጢአትየ፡ በዛቲ፡ ዕለት፡ ወሰውረኒ፡ ሊተ፡ እምኵሉ፡ እኩይ፡ ወመንሱት፡ መአልተ፡ ወሌሊተ፡ በእንተ፡ ስምከ፡ ዕቀበኒ፡ 
-                            ሊተ፡ እምኵሉ፡ <choice><sic>ጸናህያን፡</sic><corr resp="bm:GrebTiss1935Codices">ጸናህያነ፡</corr></choice> ፍኖት፡ ግሩማን፡ መላእክት፡
+                            ሊተ፡ እምኵሉ፡ <choice><sic>ጸናህያን፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ጸናህያነ፡</corr></choice> ፍኖት፡ ግሩማን፡ መላእክት፡
                           </q>.</note>
                         </msItem>
                         <msItem xml:id="ms_i1.7">
@@ -90,9 +90,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <note>
                             The entire text is the following:
                             <q xml:lang="gez">
-                              በዛቲ፡ ዕለት፡ ግርምት፡ <choice><sic>አመወት፡</sic><corr resp="bm:GrebTiss1935Codices">እመውት፡</corr></choice> ወትፈልጥ፡ ነፍስየ፡ 
+                              በዛቲ፡ ዕለት፡ ግርምት፡ <choice><sic>አመወት፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">እመውት፡</corr></choice> ወትፈልጥ፡ ነፍስየ፡ 
                               እምሥ<add place="above">ጋ</add>የ፡ አመ፡ ይመጽዑ፡ ግሩማን፡ መላእክት፡ ጽልመት፡ ፈኑ፡ ሊተ፡ መላእ<supplied reason="omitted">ክ</supplied>ት፡ ብርሃን፡
-                              ወያመጽእዋ፡ ኀቤከ፡ መሃራ፡ <choice><sic>ወተሰሃላ፡</sic><corr resp="bm:GrebTiss1935Codices">ወተሳሃላ፡</corr></choice> 
+                              ወያመጽእዋ፡ ኀቤከ፡ መሃራ፡ <choice><sic>ወተሰሃላ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ወተሳሃላ፡</corr></choice> 
                               <supplied reason="omitted">ለነፍስየ፡</supplied> ሊተ፡ ለገብርከ፡ ገብረ፡ ሥላሴ<supplied reason="omitted">።</supplied>
                             </q>.</note>
                         </msItem>
@@ -103,7 +103,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             The entire text is the following:
                             <q xml:lang="gez">
                               ክርስቶስ፡ ኩና፡ አቃቤ፡ <surplus>ኩና፡</surplus> ክርስቶስ፡ ኩና፡ መራሄ፡ ክርስቶስ፡ ኩና፡ ረዳኤ፡ በእድ<surplus>ት</surplus>፡ ልዕልት፡ ከመ፡ 
-                              <choice><sic>ይእቅብዋ፡</sic><corr resp="bm:GrebTiss1935Codices">ኢይእቀብዋ፡</corr></choice> ውስተ፡ ብካይ፡ ወ<del rend="expunctuated">ት</del>ኃቅየ፡
+                              <choice><sic>ይእቅብዋ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ኢይእቀብዋ፡</corr></choice> ውስተ፡ ብካይ፡ ወ<del rend="expunctuated">ት</del>ኃቅየ፡
                               ስነን፡ <supplied reason="omitted">ለ</supplied>መጽሐፈ<supplied reason="omitted">፡</supplied> ዕዳሃ፡ ለነፍ<supplied reason="omitted">ስ</supplied>የ፡ ሊተ፡
                             </q>.</note>
                         </msItem>
@@ -113,7 +113,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <note>
                             The entire text is the following:
                             <q xml:lang="gez">
-                              ንስእለከ፡ <choice><sic>ወናስተበቈአከ፡</sic><corr resp="bm:GrebTiss1935Codices">ወናስተበቍአከ፡</corr></choice> እምፍጥረተ፡ ዓለም፡ ወትፈልጥ፡ እባግአ፡ 
+                              ንስእለከ፡ <choice><sic>ወናስተበቈአከ፡</sic><corr resp="PRS4805Grebaut PRS9530Tisseran">ወናስተበቍአከ፡</corr></choice> እምፍጥረተ፡ ዓለም፡ ወትፈልጥ፡ እባግአ፡ 
                               እምአጣሊ፡ ይእተ፡ አሚረ፡ ተዘከራ፡ እግዚኦ፡ ለነፍስየ፡ <gap reason="omitted" resp="bm:GrebTiss1935Codices"/> እስመ፡ ነቅእ፡ ሕይወት፡ እንተ፡ ዘበአማን፡ ወኵሉ፡
                               ዘሰአለከ፡ ነፍሳት፡ ወሃሤት፡ ኦመሃሪ፡ መሃረኒ፡ <surplus>ዘ</surplus>ሊተ፡
                             </q>.</note>

--- a/VaticanBAV/et/BAVet216.xml
+++ b/VaticanBAV/et/BAVet216.xml
@@ -87,14 +87,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </bibl>. The text is slightly shorter than in Budge's edition.</note>
                         </msItem>
                         <msItem xml:id="ms_i1.7">
-                          <title type="complete">Second prayer for the heavenly journey, entitled ጸሎት፡ ዘ<choice><corr resp="bm:GrebTiss1935Codices">መ</corr><sic>ማ</sic></choice>ንገ<choice resp="AD"><sic>ለ</sic><corr>ደ</corr></choice>፡ ሰማይ፡</title>
+                          <title type="complete">Second prayer for the heavenly journey, entitled ጸሎት፡ ዘ<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">መ</corr><sic>ማ</sic></choice>ንገ<choice resp="AD"><sic>ለ</sic><corr>ደ</corr></choice>፡ ሰማይ፡</title>
                           <textLang mainLang="gez"/>     
                           <incipit xml:lang="gez">
                             በስመ፡ አብ፡ <gap reason="ellipsis" resp="bm:GrebTiss1935Codices"/> ጸሎት፡ 
-                            ዘ<choice><corr resp="bm:GrebTiss1935Codices">መ</corr><sic>ማ</sic></choice>ንገ<choice resp="AD"><sic>ለ</sic><corr>ደ</corr></choice>፡ 
-                            ሰማይ፡ ዕቀበኒ፡ ክርስቶስ፡ ከመ፡ ኢያእ<choice><corr resp="bm:GrebTiss1935Codices">ቅ</corr><sic>ቀ</sic></choice>ፍዋ፡ ለፍስየ፡ 
-                            መ<choice><corr resp="bm:GrebTiss1935Codices">ላ</corr><sic>ለ</sic></choice>እክተ፡ ጽልመት፨ ወከመ፡ ኢይደይዋ፡ ውስተ፡ 
-                            ብ<choice><corr resp="bm:GrebTiss1935Codices">ካ</corr><sic>ከ</sic></choice>ይ፡ ወሐቅየ፡ ስነን፨ ወዘእብል፡ መሐረኒ፡ ክርስቶስ፡ አመ፡ ይነግሥ፡ 
+                            ዘ<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">መ</corr><sic>ማ</sic></choice>ንገ<choice resp="AD"><sic>ለ</sic><corr>ደ</corr></choice>፡ 
+                            ሰማይ፡ ዕቀበኒ፡ ክርስቶስ፡ ከመ፡ ኢያእ<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ቅ</corr><sic>ቀ</sic></choice>ፍዋ፡ ለፍስየ፡ 
+                            መ<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ላ</corr><sic>ለ</sic></choice>እክተ፡ ጽልመት፨ ወከመ፡ ኢይደይዋ፡ ውስተ፡ 
+                            ብ<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ካ</corr><sic>ከ</sic></choice>ይ፡ ወሐቅየ፡ ስነን፨ ወዘእብል፡ መሐረኒ፡ ክርስቶስ፡ አመ፡ ይነግሥ፡ 
                             ሎሙ፡
                           </incipit>
                         </msItem>
@@ -143,7 +143,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <textLang mainLang="gez"/>         
                           <incipit xml:lang="gez">
                             በስመ፡ አብ፡ <gap reason="ellipsis" resp="bm:GrebTiss1935Codices"/> ጸሎት፡ በእንተ፡ ዜና፡ <sic>ሕማማቲከ፡</sic> ለእግዚአብሔር፨ አምላክነ፡ 
-                            ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፨ ሰዶር፡ አላዶር፨ ደናት፨ አ<choice><corr resp="bm:GrebTiss1935Codices">ዴ</corr><sic>ዲ</sic></choice>ራ፡ 
+                            ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፨ ሰዶር፡ አላዶር፨ ደናት፨ አ<choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ዴ</corr><sic>ዲ</sic></choice>ራ፡ 
                             ሮዳስ፡ ወ፭ቅንዋተ፡ መስቀሉ፡ ለእግዚእነ፡ ወመድኃኒነ፡ ኢ<supplied reason="omitted">የ</supplied>ሱስ፡ ክርስቶስ፡ በዝንቱ፨ ሕማምከ፡ ዕቀበኒ፡ ወአድኅነኒ፨ 
                             ለገብርከ።
                           </incipit>

--- a/VaticanBAV/et/BAVet22.xml
+++ b/VaticanBAV/et/BAVet22.xml
@@ -289,7 +289,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         ጸሎተ፡ ሰርክ፡ አምላክነ፡ ዘዲበ፡ ኪሩቤል፡ ይነብር፡ እምኀበ፡ መላእክት፡ ይትዌደስ፡ ወይሴባሕ፡ አንተ፡ ውእቱ፡ ዘከፈልከነ፡ ንባእ፡ ውስተ፡ ቅዱስ፡ 
                         <choice>
                            <sic>ማኅፈድከ።</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ማኅደርከ።</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ማኅደርከ።</corr>
                         </choice>
                      </incipit>
                      <explicit xml:lang="gez">
@@ -430,7 +430,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                   
                                  <choice>
                                     <sic>ማኅፈደ።</sic>
-                                    <corr resp="bm:GrebTiss1935Codices">ማኅደረ።</corr>
+                                    <corr resp="PRS4805Grebaut PRS9530Tisseran">ማኅደረ።</corr>
                                   </choice>
                                  መንፈስ፡ ቅዱስ፡ ረስዮሙ፡ በእግዚእነ፡ ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ። ዘቦቱ፡ ለከ፡ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/>/&gt;</q>. The prayer is written in a different hand than that of the main text. 
                            It is lacking in the litany <ref target="#ms_i3.1"/>.

--- a/VaticanBAV/et/BAVet24.xml
+++ b/VaticanBAV/et/BAVet24.xml
@@ -142,7 +142,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                          ብርሀን፡
                         <choice>
                            <sic>ሰደዮ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ሰደዶ፡</corr></choice>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ሰደዶ፡</corr></choice>
                          ለጽልመት፨ 
                            <sic>መሕቶት፡</sic>
                         
@@ -648,7 +648,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <sic>ተስቆቁ፡</sic>
                            ቅንዋተ፡ <choice>
                               <sic>መእዱ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ወልዳ፡</corr></choice>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ወልዳ፡</corr></choice>
                             ርኢያ፡ 
                               <sic>በልብያ፡</sic>
                            
@@ -1279,7 +1279,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                      <incipit xml:lang="gez">
                         እዌጥን፡ አንሰ፡ ወድሶትኪ፨ <choice>
                            <sic>በአዊክኮ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">በኢዐውክኮ፡</corr></choice>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">በኢዐውክኮ፡</corr></choice>
                         
                         
                            <sic>ወእሴእለኪ፨</sic>

--- a/VaticanBAV/et/BAVet25.xml
+++ b/VaticanBAV/et/BAVet25.xml
@@ -311,7 +311,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                  <sic>ማዓልት።</sic>
                               በ፻፡ ፺፡ ወ፪፡ ዓመተ፡ ምሕረት፡ በመዋዕለ፡ ዮሐንስ፡ ወንጌላዊ። ወዘንተ፡ <choice>
                                  <sic>ዘተዓዲዋ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ዘተዓደዋ፡</corr></choice>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ዘተዓደዋ፡</corr></choice>
                                
                            ወዘደምሰሳ፡ ወዘ፡ መተራ፡ ወዘ፡ 
                                  <sic>ሰራቃ፡</sic>
@@ -332,7 +332,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                  <sic>ክርስተያን፡</sic>
                               ዘሰረቆ፡ ወዘተአገሎ፡ ውስተዝ፡ መጽሐፍ፡ ዘሃለወ፡ ግዘት፡ <choice>
                                  <sic>ይብጽሐ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ይብጽሖ፡</corr></choice>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ይብጽሖ፡</corr></choice>
                                
                            ወይእስሮ፡ አሜን። አሜን፡
                         </q>
@@ -443,7 +443,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                  መፍቀሬ፡ ሰብእ፡ ወልድከ፡ ዋሕድ፡ <supplied reason="omitted">ሎቱ፡</supplied> 
                                  <choice>
                                     <sic>ምስለ፡ አቡከ፡</sic>
-                                    <corr resp="bm:GrebTiss1935Codices">ምስሌከ፡ አብ፡</corr></choice>
+                                    <corr resp="PRS4805Grebaut PRS9530Tisseran">ምስሌከ፡ አብ፡</corr></choice>
                                   
                                  ቀዳማዊ፡ ወምስለ፡ መንፈስከ፡ ቅዱስ፡ ማሕየዊ፡ ስብሐት፡ ወክብር፡ ለዓለመ፡ ዓለም፡ አሜን፡</q>. 
                            The name inserted in the prayer are written in a secondary hand on <locus target="#260va"/> and are barely legible:
@@ -479,7 +479,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <q xml:lang="gez">
                               በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ጸሐፍነ፡ ወሠራዕነ፡ ንሕነ፡ ፈላሲያን፡ ሐበሲ፡ ወዓቃቤ፡ ሰዓት፡ ፍሥሓነ፡ ወምስሌነ፡ እግዚእ። <choice>
                                  <sic>ንብርእድ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ንቡረ፡ እድ፡</corr></choice>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ንቡረ፡ እድ፡</corr></choice>
                                
                               
                                  <sic>ዘጻምዎ፡</sic>

--- a/VaticanBAV/et/BAVet27.xml
+++ b/VaticanBAV/et/BAVet27.xml
@@ -289,7 +289,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               It starts as follows: <q xml:lang="gez">
                                  <choice>
                                     <sic>በ፯፡</sic>
-                                    <corr resp="bm:GrebTiss1935Codices">በ፮፡</corr>
+                                    <corr resp="PRS4805Grebaut PRS9530Tisseran">በ፮፡</corr>
                                  </choice> 
                                  
                                     <sic>ስዓት፡</sic>

--- a/VaticanBAV/et/BAVet29.xml
+++ b/VaticanBAV/et/BAVet29.xml
@@ -613,7 +613,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                   ምስሌነ፤ ወሌሊተ፤ ማእከሌነ፤ አንተ፤ እግዚኦ፤ ኢትርኃቅ፤ እምኔነ፨ 
                                  <choice>
                                     <sic>ሃሊ፡</sic>
-                                    <corr resp="bm:GrebTiss1935Codices">ሃሉ፡</corr></choice>
+                                    <corr resp="PRS4805Grebaut PRS9530Tisseran">ሃሉ፡</corr></choice>
                                   ምስሌነ፤ ረዳኤ፤ 
                                     <sic>ኵነነ፨</sic>
                                   

--- a/VaticanBAV/et/BAVet3.xml
+++ b/VaticanBAV/et/BAVet3.xml
@@ -58,7 +58,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <lb n="2"/>ወአንቅህ፡ ሕሊናየ፡ ከመ፡ እግነይ፡ ሎቱ፡
                            <lb n="3"/>ለልዑል። እጸርሕ፡ እንዘ፡ <choice>
                               <sic>አዐብል፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">እብል፡</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">እብል፡</corr>
                            </choice> ሃሌሉያ።
                         </explicit>
                      </msItem>

--- a/VaticanBAV/et/BAVet38.xml
+++ b/VaticanBAV/et/BAVet38.xml
@@ -85,7 +85,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                          ወምስለ፡ ሥዩማን፡ ካህናት፡ 
                         ወምስለ፡ ፍጹማን፡ መነኮሳት፡ ወያስምዖ፡ ቃለ፡ ማኅሌት፡ ዘሕፃናት፡ ወያብኦ፡ ሀገረ፡ <choice>
                            <sic>ብርህፈ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ብርህተ፡</corr></choice>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ብርህተ፡</corr></choice>
                          
                         አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ እስከ፡ ለዓለመ፡ ዓለም፡ አሜን፨ ወአሜን። 
                            <sic>ለይኵን፨</sic>

--- a/VaticanBAV/et/BAVet39.xml
+++ b/VaticanBAV/et/BAVet39.xml
@@ -80,7 +80,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <explicit xml:lang="gez">
                            <choice>
                               <sic>ወኢይሴወሮ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ወኢይሴውሮ፡</corr></choice>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ወኢይሴውሮ፡</corr></choice>
                             ሌሊት፡ አንተ፡ ዘአቅረብከነ፡ ቅድመ፡
                            ዝንቱ፡ ምሥጢር፡ ለከ፡ ስብሐት፡ ወ
                               <sic>ከብር፡</sic>
@@ -98,15 +98,15 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <explicit xml:lang="gez">
                            ከሠትከ፡ ለነ፡ ለኅፃናት፡ ንኡሳን፡ እለ፡ ቤተ፡ ክርስቲያን፡ ቅድስት። ኦአብ፡ ከመ፡ ዝንቱ፡ ሥምረት፡ ኮነ፡ በቅድሜከ፨ እስመ፡ አንተ፡ መሐሪ፡ ለከ፡ <choice>
                               <sic>ንፈኑ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ንፌኑ፡</corr></choice>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ንፌኑ፡</corr></choice>
                            
                            ውስተ፡ አርያም፨ <choice>
                               <sic>ስብሐት፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ስብሐተ፡</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ስብሐተ፡</corr>
                            </choice>
                            <choice>
                               <sic>ወክብር፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ወክብረ፡</corr></choice>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ወክብረ፡</corr></choice>
                             ይእዜኒ፡ ወዘልፈኒ፡ ወለዓለመ፡ ዓለም፡ አሜን።
                         </explicit>
                      </msItem>
@@ -121,7 +121,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <explicit xml:lang="gez">
                            ወለሴስዮ፡ <choice>
                               <sic>ነግስት፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ነፍሳት፡</corr></choice>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ነፍሳት፡</corr></choice>
                             ወሥጋት፡ ወመናፍስቲሆሙ፡
                            በእግዚእነ፡ ወመድኀኒነ፡ ኢየሱስ፡ 
                               <sic>ከርስቶስ፡</sic>
@@ -144,7 +144,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <choice>
                            
                               <sic>ወይፈጽም፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ይፌጽም፡</corr></choice>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ይፌጽም፡</corr></choice>
                             በከመ፡ ሥርዐቱ፨ ወይብል፡ ተንሥኡ፡
                            በፍርሃተ፡ እግዚአብሔር፡ ከመ፡ ታጽምኡ፡ 
                               <sic>አርኅው፡</sic>

--- a/VaticanBAV/et/BAVet4.xml
+++ b/VaticanBAV/et/BAVet4.xml
@@ -43,7 +43,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <incipit xml:lang="gez">
                            ግጻዌ፡ ሥርዐት፡ ዘኣውሶቢስ፡ ፍልስጢናዊ። ዘመጽሐፈ፡ ዳዊ<supplied reason="lost">ት፡ መዝ</supplied>ሙር፡ ወግጻዌሁ፡ ዘበ፡ ህልው፡ ዘከመ፡ ተጽሕፈ፡ ዘበዕብራይስጥ፡ ወበ
                            <choice><sic>አ</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ከ</corr></choice>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ከ</corr></choice>
                            መሂ፡ አዕለውዎ፡ እለ፡ ኢኮኑ፡ ጽሑፋነ፡ ፲፱፡ ወጽሑፋንሰ። ፻፴፩፡ ለእለ፡ ጽሑፍ፡ ግጻዌሆሙ፡ ዘዳዊት፡ ፸፪ ...
                         </incipit>
                         <explicit xml:lang="gez">
@@ -310,7 +310,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                          ጽባ<supplied reason="omitted">ሕ፡</supplied>
                         <choice>
                            <sic>ከለ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ኵላ፡</corr></choice>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ኵላ፡</corr></choice>
                          ነፍስ፡ ይፈርሆ፡ ለእግዚአብሔር፡
                      </explicit>
                   </msItem>
@@ -342,7 +342,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <locus target="#152r"/>
                         በስመ፡ አብ፡ ወወልደ፡ ወ<supplied reason="omitted">መ</supplied>ንፈስ፡ ቅዱስ፡ <choice>
                            <sic>ጸሎተ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ጸሎት፡</corr></choice>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ጸሎት፡</corr></choice>
                          በበዓለ፡ መስቀል፡ ላዕለ፡ ማይ፡ ዘይትነበብ፡ መዝሙር፡ ዘተሠሀለኒ፡=፡
                         ወድኅሬሁ፡ ዘ፻፲፫፡ አመ፡ ይወፅኡ። ወድኅሬሁ፡ ዘ፷፰።አድኅነኒ፡ እግዚእ፡=፡ ወድኅሬሁ፡ ጳውሎስ፡ ቆሮንቶስ። ዘ፬፡ ነገሩነ፡ በእንቲኣክሙ፡
                      </incipit>
@@ -365,20 +365,20 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                      <locus from="158v" to="160v"/>
                      <title type="complete" ref="LIT3083RepCh363">ርቅየተ፡ ንኡስ፡ <choice>
                            <sic>ክርስስቲያን፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ክርስቲያን፡</corr></choice>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ክርስቲያን፡</corr></choice>
                          ከመ፡ ይትዐወቍ፡ እለ፡ ቦሙ፡ መንፈሰ፡ ነኪር።</title>
                      <incipit xml:lang="gez">
                         <locus target="#158v"/>
                         እግዚኣብሔር፡ ዘብርሃናት፡ እግዚአብሔር፡ ዘአርእስተ፡ መላእክት፡ ዘእምታሕቱ፡ <choice>
                            <sic>እኂዞተከ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">እኂዞትከ፡</corr></choice>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">እኂዞትከ፡</corr></choice>
                         ኵሎ፡ ፍጥረተ፡ ንጉሠ፡ ስብሐት፡ ወለ፡ አጋእዝት፡ <choice>
                            <sic>አምላክ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">አምላከ፡</corr></choice>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">አምላከ፡</corr></choice>
                         
                         <choice>
                            <sic>ቅዱዱሳን፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ቅዱሳን፡</corr></choice>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ቅዱሳን፡</corr></choice>
                          አቡሁ፡ ለእግዚእነ፡ ወመድኀኒነ፡ ኢየሱስ፡ ክርስቶስ፡
                      </incipit>
                      <explicit xml:lang="gez">
@@ -610,7 +610,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               በስመ፡ <supplied reason="omitted">አብ፡</supplied> ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ አሐዱ፡ አምላክ፡ ስሙ፡ ለአብ፡ ማሩየል፡ ወስሙ፡ ለወልድ፡ ምናቴር፡ ወስሙ፡ ለመንፈስ፡ ቅዱስ፡ አብያቴር።
                               በዝንቱ፡ አስማት፡ ተፈጥረ፡ ሰማያት፡ <choice>
                                  <sic>ወምደር፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ወምድር፡</corr></choice>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ወምድር፡</corr></choice>
                                ወኵሉ፡ ተግባር።
                            </q>
                            <q xml:lang="gez">

--- a/VaticanBAV/et/BAVet42.xml
+++ b/VaticanBAV/et/BAVet42.xml
@@ -339,7 +339,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                  ቀድስኒ፡ በቅድስ<supplied reason="omitted">ና</supplied>ኪ፡ <del rend="erasure" extent="two lines"/> 
                                  <choice>
                                     <sic>ኦቡርካት፡</sic>
-                                    <corr resp="bm:GrebTiss1935Codices">ኦቡርክት፡</corr>
+                                    <corr resp="PRS4805Grebaut PRS9530Tisseran">ኦቡርክት፡</corr>
                                  </choice>
                                  
                                     <sic>በርኪኒ፡</sic>

--- a/VaticanBAV/et/BAVet46.xml
+++ b/VaticanBAV/et/BAVet46.xml
@@ -135,7 +135,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <explicit xml:lang="gez">
                            ወይቤ፡ ድኅንኩ፡ በጸሎተ፡ <choice>
                               <sic>በውየ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">አቡየ፡</corr></choice>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">አቡየ፡</corr></choice>
                             ለነኒ፡
                            
                               <sic>ያድኅነ፡</sic>

--- a/VaticanBAV/et/BAVet47.xml
+++ b/VaticanBAV/et/BAVet47.xml
@@ -61,7 +61,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                      <incipit xml:lang="gez">
                         ዝንቱ፡ ስብሐተ፡ ፍቁር፡ <choice>
                            <sic>ዘይትኀሀለሉ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ዘይትመሀለሉ፡</corr></choice>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ዘይትመሀለሉ፡</corr></choice>
                          ቦቱ፡ 
                         
                            <sic>ክርስትያን፡</sic>
@@ -75,7 +75,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <sic>ክርስቶሰዊ፡</sic>
                         ለእመ፡ <choice>
                            <sic>ረከብኪ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ረከብከ፡</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ረከብከ፡</corr>
                         </choice>
                         ቤተ፡ ክርስቲያን፡ ተማህለል፡ ቦቱ፡ በምሥዋዕ፡ ለእመ፡ በጽሐከ፡ ተሰዶ፡ ተማህለል፡ በስደትከ። 
                      </incipit>
@@ -136,11 +136,11 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                          
                          ተመርጕዝየ፡ እምዮርዳኖስ፡ ዘተአንመ፡ <choice>
                            <sic>ንዳነ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ክዳነ፡</corr></choice>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ክዳነ፡</corr></choice>
                          ብርሃን፡ 
                         <choice>
                            <sic>ተአጽየ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ተአጺፍየ።</corr></choice>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ተአጺፍየ።</corr></choice>
                          በጸሎታ፡ 
                            <sic>ወበስዕላተ፡</sic>
                          
@@ -155,11 +155,11 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                          እ<supplied reason="omitted">ም</supplied>ንእስየ፡ 
                         <choice>
                            <sic>አሳከ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">እስከ፡</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">እስከ፡</corr>
                          </choice>
                         <choice>
                            <sic>ርእስ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ርስእየ።</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ርስእየ።</corr>
                         </choice>
                      </explicit>
                      <note/>

--- a/VaticanBAV/et/BAVet48.xml
+++ b/VaticanBAV/et/BAVet48.xml
@@ -40,7 +40,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                      <quote xml:lang="gez">
                         አስማቲሁ፡ <choice>
                            <sic>ለእግሂእነ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ለእግዚእነ፡</corr></choice>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ለእግዚእነ፡</corr></choice>
                          ዘወሀቦ፡ ለጴጥሮስ፡ ከመ፡ ይርከብ፡ 
                         ሞገሰ፡ በቅድመ፡ ነገሥት፡ ወመኳን<add place="inline">
                            <supplied reason="omitted">ን</supplied>

--- a/VaticanBAV/et/BAVet50.xml
+++ b/VaticanBAV/et/BAVet50.xml
@@ -90,7 +90,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <sic>ስብሐተ፡</sic>
                          ለእግዚአ፡ ብሔር፡ ከመ፡ <choice>
                            <sic>ምአ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">እማኦ፡</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">እማኦ፡</corr>
                         </choice> ለሰይጣን።
                      </explicit>
                      <note/>
@@ -193,7 +193,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                          ሰዓት፡ ወቅብኦ፡ ወአጥምቆ፡ ለገብርከ፨ 
                         <del rend="erasure"/> ወይኩን፡ ሎቱ፡ <choice>
                            <sic>ፍትሐ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ፍሥሐ፡</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ፍሥሐ፡</corr>
                         </choice> 
                         ወኀሴተ፡ ወፈውሰ፡ ወመድኀኒተ፡ እምኀበ፡ ኣብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ይእዜኒ፡ ወዘልፈኒ፡ ወለዓለመ፡ ዓለም። አሜን፡ አሜን፡ ወአሜን። ለይኩን፡ ለይኩን፡ ይኩን፨
                      </explicit>

--- a/VaticanBAV/et/BAVet54.xml
+++ b/VaticanBAV/et/BAVet54.xml
@@ -346,7 +346,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               
                            <choice>
                                  <sic>በጋቢት፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">መጋቢት፡</corr>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">መጋቢት፡</corr>
                            </choice>
                               
                                  <sic>በሕቲታ።</sic>

--- a/VaticanBAV/et/BAVet61.xml
+++ b/VaticanBAV/et/BAVet61.xml
@@ -119,7 +119,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                      <incipit xml:lang="gez">
                         <choice>
                            <sic>ያእኵትዎ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ያአኵትዎ፡</corr></choice>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ያአኵትዎ፡</corr></choice>
                          መንፈሳውያን፡ በአሐዱ፡ 
                         
                            <sic>አፈ፡</sic>

--- a/VaticanBAV/et/BAVet62.xml
+++ b/VaticanBAV/et/BAVet62.xml
@@ -175,7 +175,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                      <incipit xml:lang="gez">
                         <choice>
                            <sic>ሱባዔ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ስባሔ፡</corr></choice>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ስባሔ፡</corr></choice>
                          ወኢዝንጋዔ።
                      </incipit>
                     </msItem>

--- a/VaticanBAV/et/BAVet64.xml
+++ b/VaticanBAV/et/BAVet64.xml
@@ -57,7 +57,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                             ፲ወሰሉሱ፡ ለመጋቢት፡ ደብረ፡ ዘይት፡ ፲ወአሚሩ፡ ለሚያዝያ፡ ሖሣእና፡ ፲፰ትንሣኤ፡ አመ፡ ፳፯ለግንቦት፡ እርገት፡ 
                                <choice>
                               <sic>እም</sic>
-                              <corr resp="bm:GrebTiss1935Codices">አመ፡</corr></choice>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">አመ፡</corr></choice>
                            ፯ለሰኔ፡ 
                               <sic>ባል</sic>
                             

--- a/VaticanBAV/et/BAVet74.xml
+++ b/VaticanBAV/et/BAVet74.xml
@@ -108,7 +108,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <title type="complete" ref="LIT1931Mashaf#Neophytes">Supplication for the neophytes</title>
                            <incipit xml:lang="gez">ወካዕበ፡ ናስተበቍዕ፡ በእንተ፡ ንኡስ፡ ክርስቲያን፡ እስመ፡ በፍትወታት፡ ዘተወልደ፡ ብእሲ፡ <choice>
                                  <sic>እግባዕነ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">አግባዕነ፡</corr></choice>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">አግባዕነ፡</corr></choice>
                               
                            ለኪ፡ ወልደ፡ በቅብዓ፡ ዘይት፡ በቅብዕ፡ ቅዱስ፡ ዘተወልደ፡ ዳግመ፡ ንሥኢ፡ ወልደኪ፨</incipit>
                            <explicit xml:lang="gez">ወትብል፡ ሰላም፤ ዕዝል፡ ፈኑ፡ ሰላመ፡ ላዕለ፡ ሕዝብከ፤ ሃሌ፤ ሉያ፤ ሃሌ፤ ሉያ፤ ዘመራህኮሙ፡ ወመጽኡ፡ ኀቤከ፡</explicit>
@@ -166,7 +166,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            ወፈጺማ፡ እግዝእትነ፡ ማርያም፡ ዘንተ፡ ጸሎተ፡ ኖመት፡ ላዕለ፡ ዓራት፨ ተከዲና፡ ሰንዶናተ፡ እንዘ፡ ትሄሊ፡ በልባ፡ ወትብል፡ እምከመ፡ ሞትኩ፡ ይቅብሩኒ፡ ሥጋየ፡ በዝንቱ፡ ሰንዱናት፨
                            <choice>
                               <sic>ወይምህረኒ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ወይመርሀኒ፡</corr></choice>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ወይመርሀኒ፡</corr></choice>
                             እግዚእየ፡ ኢየሱስ፡ ክርስቶስ፡
                            በመንግሥተ፡ ሰማያት፡ በስእለት፡ ለእግዝእትነ፡ ማርያም፡ መሐራ፡ 
                               <sic>ወተሠሃላ፡</sic>
@@ -295,7 +295,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <q xml:lang="gez">
                               <choice>
                                  <sic>አብልስዋጢ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">አብስልዋጢ፡</corr>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">አብስልዋጢ፡</corr>
                               </choice>
                               ፫ጸዋትው፡ ወአንብብ፡ ድርሳናተ፤ ዘሀሎ፡ ጽሑፍ፡ ው<add place="inline">
                                  <supplied reason="omitted">ስ</supplied>
@@ -374,7 +374,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                  <sic>ዘለሐኰ</sic>
                               ሰብአ፤ እምነ፡ መሬት፡ <choice>
                                  <sic>ወአምፃዕከ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ወአውፃዕከ፡</corr>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ወአውፃዕከ፡</corr>
                               </choice>
                               እምኀበ፡ ወኢምንት፨ ወነፋሕከ፡ ላዕሌሁ፡ መንፈሰ፡ ሕይወት፤ ወሶበ፡ ዓለወ፡ ትእዛዘከ፡ 
                                  <sic>አወፃዕኮ፡</sic>
@@ -434,7 +434,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               ወካዕበ፡ ናስተበቍዕ፡ ዘኵሎ፡ ይእኅዝ፡ እግዚአብሔር፡ አብ፡ ለእግዚእ፡ ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ። እግዚአ፡ ሕያዋን፡ ሕይወተ፡ ሙታን፡ ተስፋ፡ ቅቡፃን፡ ረዳኤ፡ ምንዱባን፡ መንሥኤ፡ ኃጥአን።
                               ዘሞተ፡ አጽራዕከ፡ ወማዕሠረ፡ ሰይጣን፡ በቲከከ፡ ሕይወተ፡ ለትዝምደ፡ ሰብእ፡ ጸጎከ፡ ኀቤከ፡ ንስእል፡ ወናስተበቍዕ፡ ዘኢትመውት፡ <choice>
                                  <sic>ዘመዝከበ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ዘመዝገበ፡</corr>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ዘመዝገበ፡</corr>
                               </choice>
                               ሕይወት፡ ለዓለመ፡ ዓለም፡ ኀቤከ፡ ውእቱ፨ በእንተ፡ እለ፡ ኖሙ፡ በሃይማኖት፡ አዕረፉ፡ አበው፡ ቀደምት፨ ሊቃነ፡ ጳጳሳት፡ ጳጳሳት፡ ኤጲስ፡ ቆጶሳት፡ ቀሳውስት፡ ወዲያቆናት፨ አናጕንስጢስ፡ ወመዘምራን፡
                               ደናግል፡ ወመንኮሳት፡ 
@@ -618,7 +618,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                             እንዘ፡ ይሰፍሑ፡ እደኢቅሆሙ፨ ኦአ<supplied reason="omitted">ዕ</supplied>ይንት፡ እለ፡
                            ሥርግዋን፡ በኵሕል፡ <choice>
                               <sic>እመ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">አመ፡</corr></choice>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">አመ፡</corr></choice>
                             ይደፍነክን፡ ሞት፡ እፎ፡ ትከውና፨
                            ኦአፍ፡ ዘተናገርኪ፡ ነገረ፡ ሐሰት፡ እፎ፡ ትከውኒ፨
                         </incipit>
@@ -703,7 +703,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                             ለኵሉ፡ ሰብእ፡ ከመ፡ መዓር፡ ወከመ፡ ፄው፡ ወአልቦ፡ ዘይክለከ፤ ኵሉ፡ ሰብእ፡ ዘመከሩ፡ በልቦሙ፡
                            <choice>
                               <sic>ወትህሉ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ወኢክህሉ፡</corr></choice>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ወኢክህሉ፡</corr></choice>
                             በኃይሎሙ፡ ላዕሌከ፨ እምዝንቱ፡ ኵሉ፡
                            ትድኅን፡ ይቤ፡ ለሊሁ፡ መድኃኒነ፤ ኢየሱስ፡ ክርስቶስ፡ ሎቱ፡ ስብሐት፡ ወክብር፡ ለዓለመ፡ ዓለም፤
                         </explicit>
@@ -839,7 +839,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <incipit xml:lang="gez">
                               እምሥራቀ፡ ፀሐይ፡ እስከ፡ ምዕራብ፡ ይትዓኰት፡ <choice>
                                  <sic>ወሴባሕ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ወይሰባሕ፡</corr>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ወይሰባሕ፡</corr>
                               </choice>
                               ስሙ፡ ለእግዚአብሔር፡ እምደቡብ፡ እስከ፡ ሰሜን፨ ይት<supplied reason="explanation">አኰት</supplied>፤ ወይ<supplied reason="explanation">ሰባሕ</supplied>፤
                               ስሙ፤ ለእግ<supplied reason="explanation">ዚአብሔር</supplied>፨
@@ -1193,7 +1193,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                     <sic>መጽሐፍ፡</sic>
                                  ለፋፈ፡ <choice>
                                     <sic>ቅድቅ፡</sic>
-                                    <corr resp="bm:GrebTiss1935Codices">ጽድቅ፡</corr>
+                                    <corr resp="PRS4805Grebaut PRS9530Tisseran">ጽድቅ፡</corr>
                                  </choice>
                               ዘወሀባ፡ እግዚአብሔር፡ ለእግዝእ<supplied reason="omitted">ት</supplied>ነ፡ ማርያም፡ ወይቤላ፡ ንሥኢ፡</q>,
                               and terminates as follows:
@@ -1219,7 +1219,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                   በይእቲ፡ ዕለት፡ እስመ፡ ግርምት፡ ወዕፅብት፡ ይእቲ፡ ሳዶ፡ አላዶር፡ ዳናት፡ አዴሬ፡ በዝንቱ፡
                                   አስማት፡ ተሰደዱ፡ አጋንንት፡ ወጻዕረ፡ ሞት፡ <choice>
                                     <sic>ወዕላላ፡</sic>
-                                    <corr resp="bm:GrebTiss1935Codices">ላዕለ፡</corr>
+                                    <corr resp="PRS4805Grebaut PRS9530Tisseran">ላዕለ፡</corr>
                                   </choice>
                               ገብርከ፡ ሀብተ፡ ሚካኤል፡</q>.
                               The name of <persName ref="PRS11548HabtaMi">Habta Mikāʾel</persName> is mentioned in the supplication formula at the end of the excerpt.

--- a/VaticanBAV/et/BAVet77.xml
+++ b/VaticanBAV/et/BAVet77.xml
@@ -96,7 +96,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         በስመ፡ አብ፡ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/> ጸሎት፡ በእንተ፡ ሕማመ፡ 
                         <choice>
                            <sic>ቍርፀት፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ቍርጠት፡</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ቍርጠት፡</corr>
                         </choice> ዘተፈነወ፡ እምኀበ፡ ወልድ፡ ዋሕድ፡ ከመ፡ ይርዳእ፡ 
                         ወይቤዙ፡ ውሉደ፡ እጓለ፡ እመሕያው፡ ሸገር፡ ሸገር፡ ሸገር፡
                      </incipit>
@@ -109,7 +109,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         በስመ፡ አብ፡ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/> ጸሎት፡ በእንተ፡ ሕማመ፡ 
                         <choice>
                            <sic>ቍርፀት፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ቍርጠት፡</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ቍርጠት፡</corr>
                         </choice> በከፓኮስ፡ ስምከ፡ በኄርያኖስ፡ ስምከ፡ በዳፌል፡ 
                         ስምከ፡
                      </incipit>
@@ -122,7 +122,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         በስመ፡ አብ፡ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/> ጸሎት፡ በእንተ፡ ሕማመ፡ 
                         <choice>
                            <sic>ውግዓት፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ውጋት፡</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ውጋት፡</corr>
                         </choice> ምድምያስ፡ ምድምያስ፡
                      </incipit>
                      <note/>
@@ -133,7 +133,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                      <incipit xml:lang="gez">
                         ጸሎት፡ በእንተ፡ ሕማመ፡ <supplied reason="omitted">ውጋት፡</supplied> ሰላም፡ ለገቦከ፡ ኵናተ፡ <choice>
                            <sic>ለጊጊሮስ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ለንጊኖስ፡</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ለንጊኖስ፡</corr>
                         </choice> 
                         ዘወግዖ፡
                      </incipit>

--- a/VaticanBAV/et/BAVet8.xml
+++ b/VaticanBAV/et/BAVet8.xml
@@ -127,7 +127,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <incipit xml:lang="gez">በስመ፡ አብ፡ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/> ወእምዝ፡ ንጽሕፍ፡ ተአምሪሃ፡ ለ፡ ማርያም፡ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/>  ወሀሎ፡ በአሐቲ፡ <choice>
                                  <sic>ሀሀገር፡</sic>
                               
-                              <corr resp="bm:GrebTiss1935Codices">ሀገር፡</corr></choice>ሀገር፡ ብእሲ፡ ባዕል፡ ጥቀ፡ 
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ሀገር፡</corr></choice>ሀገር፡ ብእሲ፡ ባዕል፡ ጥቀ፡ 
                                  <sic>ፈድፈድ፨</sic>
                                ወይገብር፡ 
                                  <sic>ተዝከረ፡</sic>
@@ -221,7 +221,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               <choice>
                                  <sic>ሐኀምስቱ፡</sic>
                               
-                              <corr resp="bm:GrebTiss1935Codices">ሐምስቱ፡</corr></choice> 
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ሐምስቱ፡</corr></choice> 
                               
                                  <sic>ታአምሪሐ፡</sic>
                                ለማርያም፡ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/> 
@@ -327,7 +327,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               ለማርያም፡ <choice>
                                     <sic>ድንግግል፡</sic>
                                  
-                                 <corr resp="bm:GrebTiss1935Codices">ድንግል፡</corr></choice> 
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ድንግል፡</corr></choice> 
                                  
                                     <sic>ወለዲተ፡</sic>
                                   መድሕን። ወያሰምዖሙ፡ 
@@ -390,7 +390,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               
                                  <sic>ወለሰመይ፡</sic>
                               
-                              <corr resp="bm:GrebTiss1935Codices">ወለማይ፡</corr></choice> 
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ወለማይ፡</corr></choice> 
                               
                                  <sic>ዘውስት፡</sic>
                                አውደ፡ ምሥ<supplied reason="omitted">ዋ</supplied>ዕ፨
@@ -540,7 +540,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               ዘበህልው፡ ዘከመ፡ ተጽሕፈ፡ ዘበዕብራይስጢ፡ <choice>
                                  <sic>ወወከመሂ፡</sic>
                               
-                              <corr resp="bm:GrebTiss1935Codices">ወከመሂ፡</corr></choice> አዕለውዎ፨ እለ፡ ኢኮኑ፡ 
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ወከመሂ፡</corr></choice> አዕለውዎ፨ እለ፡ ኢኮኑ፡ 
                                  <sic>ጽሑፈን፨</sic>
                                
                               ፴፡ ፪፡ ዘቦ፡ ሃሌሉያ፡ ፱፡ ለእለ፡ 

--- a/VaticanBAV/et/BAVet82.xml
+++ b/VaticanBAV/et/BAVet82.xml
@@ -603,7 +603,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                     <sic>እምአህጕራተ፡</sic>
                                   ግብፅ፡ ዘትሰመይ፡ እስክንድርያ፨ <choice>
                                     <sic>ዘከመ፡</sic>
-                                    <corr resp="bm:GrebTiss1935Codices">ዘስሙ፡</corr></choice>
+                                    <corr resp="PRS4805Grebaut PRS9530Tisseran">ዘስሙ፡</corr></choice>
                                   
                                  ዱራታኦስ፡ ወስመ፡ ብእሲቱ፡ ቴዎብስታ፡ ወ፪ኤሆሙ፡ ፈራህያነ፡ እግዚአብሔር፡
                               </incipit>
@@ -809,7 +809,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <locus target="#147v"/>
                            ዘተጽሐፈ፡ በዘመነ፡ ዮሐንስ፡ በ፲፻<choice>
                               <sic>በ</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ወ</corr></choice>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ወ</corr></choice>
                            ፰፻፹ወ፰፡ ኮነ፡ ዓመተ፡ 
                            ምሕረት፨ ዘአጽሐፎ፡ ራስ፡ መኰንን፡ ወጸሐፊሁኒ፡ ኃጥእ፡ ገብረ፡ ሕይወት፡ ኅቡረ፡ ይምሐሮ<supplied reason="omitted">ሙ</supplied>፡ እግዚአብሔር፡ በመንግሥተ፡ ሰማያት፨ 
                            ለዓለመ፡ ዓለም፡ አሜን፨

--- a/VaticanBAV/et/BAVet84.xml
+++ b/VaticanBAV/et/BAVet84.xml
@@ -147,7 +147,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                               ወይሰርሩ፡ ዲበ፡ መዋግደ፡ ብርሃን፡ ዘዕበይ፡ ምስለ፡ መላእክተ፡ ቅዳሴ፡ እለ፡ ይትሐወኩ፡ በፍጹም፡ ሕይወት፨ በሀገር፡ እንተ፡ መንፈስ፡ ቅዱስ፡ ይከውኖሙ፡ ነፋሰ፡ ሕይወት፡ ለእለ፡ የኀድሩ፡ ውስቴታ፡ አሜን፨ 
                               ዘሎቱ፡ <choice>
                                  <sic>ከብሐት፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ስብሐት፡</corr></choice>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ስብሐት፡</corr></choice>
                                እምአፈ፡ ኵልነ፨ 
                               <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/>  ለዓለመ፡ ዓለም፡ አሜን፨
                            </explicit>
@@ -193,7 +193,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            <incipit xml:lang="gez">
                               ዘሰ፡ ጥዕመ፡ ፍቅረ፡ እግዚአብሔር፡ ያንቅህ፡ <choice>
                                  <sic>ነፍሰ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ነፍሶ፡</corr></choice>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ነፍሶ፡</corr></choice>
                                ከመ፡ 
                               ይትፈሣሕ፡ በጸሎቱ፨ እስመ፡ ይእቲ፡ ትፈደፍድ፡ እምኵሉ፡ ምግባራት፡ ወታቀርብ፡ ኀበ፡ እግዚአብሔር፨
                            </incipit>
@@ -1023,11 +1023,11 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                መንግሥተ፡ ዐረብ፡ ወእምድኅረ፡ ተሰዶ፡ ድዮስቆሮስ፡ ተሰይሙ፡ ፪ጳጳሳት፡ በመንበረ፡ ዚአሁ፡ እንዘ፡ ሀለወ፡ ሕያው፡ አሐዱሰ፡ ስሙ፤ ያይሮስ፡ ዘሴሞ፡ ምርቅያን፡ ወሶበ፡ ተለወ፡ ሃይማኖቶ፡ 
                                <choice>
                                  <sic>ለጉንሥ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ለንጉሥ፡</corr></choice>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ለንጉሥ፡</corr></choice>
                                እምድኅረ፡ ሞተ፡ ንጉሥ፡ ወያይሮስ፡ ሴምዎ፡ 
                                ሕዝብ፡ <choice>
                                  <sic>ለናቴዎስ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">ጢሞቴዎስ፡</corr></choice>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">ጢሞቴዎስ፡</corr></choice>
                                ጳጳስ፡ ዘተለዎ፡ ለድዮስቆሮስ፡ 
                                በዐቂበ፡ ሃይማኖት፡ ወኵሉሰ፡ ድሙር፡ ፲እሙንቱ፡ ሊቃነ፡ 
                                  <sic>ጰጰሳት፡</sic>

--- a/VaticanBAV/et/BAVet87.xml
+++ b/VaticanBAV/et/BAVet87.xml
@@ -269,7 +269,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                                ኵልነ፡ ለዘ፡ 
                               <choice>
                                  <sic>አንቅልነ፡</sic>
-                                 <corr resp="bm:GrebTiss1935Codices">አንቅሀነ፡</corr></choice>
+                                 <corr resp="PRS4805Grebaut PRS9530Tisseran">አንቅሀነ፡</corr></choice>
                                እምንዋም፨
                            </incipit>
                         </msItem>

--- a/VaticanBAV/et/BAVet92.xml
+++ b/VaticanBAV/et/BAVet92.xml
@@ -128,7 +128,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <explicit xml:lang="gez">
                            ይነጽሑ፡ እምሐጢአቶሙ፡ ወኢ<supplied reason="omitted">ይ</supplied>ወድቅ፡ ውስተ፡ ኵነኔ፡ ለእመ፡ <choice>
                               <sic>ይባዎ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ይቤልዎ፡</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ይቤልዎ፡</corr>
                            </choice>
                            ለዝንቱ፡ <add place="below">፯</add>አስማት፡ በበጊዜ፤ እንዘ፡ 
                               <sic>ይብለ፡</sic>
@@ -172,7 +172,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <explicit xml:lang="gez">
                            ኢትመጥወኒ፡ ለእለ፡ ይሣቅዩኒ፡ <choice>
                               <sic>ጽንንሖ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">አጽንዖ፡</corr></choice>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">አጽንዖ፡</corr></choice>
                             ለገብርከ፡ ውስተ፡
                            ሠናይ፡ ወ<supplied reason="omitted">ኢ</supplied>ይትዓገሉኒ፡ ዕቡያን፡ ስብሐት፡ ለአብ፡ ወወልድ፡ ወመንፈ<supplied reason="omitted">ስ</supplied>፡ ቅዱስ፨
                         </explicit>
@@ -213,7 +213,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <explicit xml:lang="gez">
                            ወሀበት፡ ፍሬሃ፡ ወይባርከነ፡ እግዚአብሔር፡ ወይፈርህዎ፡ ኵሎሙ፡ አጽናፈ፡ ምድር፡ <choice>
                               <sic>ኦአምላክ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ለአምላክ፡</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ለአምላክ፡</corr>
                            </choice>
                         </explicit>
                         <note>The name of the owner <persName role="owner" ref="PRS11676GabraSa">Gabra Sanbat</persName> is mentioned in the supplication formula at

--- a/VaticanBAV/et/BAVet97.xml
+++ b/VaticanBAV/et/BAVet97.xml
@@ -133,7 +133,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         <incipit xml:lang="gez">
                            አርእየኒ፡ እግዚኦ፡ በ<gap reason="illegible" unit="chars" quantity="3"/> ዛቲ፡ ዕለት፡ <choice>
                               <sic>ሠናይት፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ሠናይተ፡</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ሠናይተ፡</corr>
                            </choice> 
                            <supplied reason="lost">ስ</supplied>ማዕ፡ ጸሎትየ፡ ወተወከፍ፡ ስእለትየ፤ ወሥረይ፡ ሊተ፡ ኃጢአትየ፡ ወኢትመጥወኒ፡ ውስተ፡ 
                               <sic>እዳ፡</sic>
@@ -172,7 +172,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                             
                            <choice>
                               <sic>ላዕለ፡</sic>
-                              <corr resp="bm:GrebTiss1935Codices">ለእለ፡</corr>
+                              <corr resp="PRS4805Grebaut PRS9530Tisseran">ለእለ፡</corr>
                            </choice> 
                            ይሴፈዉ፡ ኪያከ፡ ነጽር፡ ድካምየ፡ ወትሕትናየ፤ ወስረይ፡ ሊተ፡ አበሳየ፡ ወኃጢአትየ፡                           
                         </incipit>

--- a/VaticanBAV/et/BAVet98.xml
+++ b/VaticanBAV/et/BAVet98.xml
@@ -107,7 +107,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                      <incipit xml:lang="gez">
                         ጸሎት፡ በእን<supplied reason="omitted">ት</supplied>፡ ሕማመ፡ ቍርፀት፡ <choice>
                            <sic>ወመገኛ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ወመጋኛ፡</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ወመጋኛ፡</corr>
                         </choice> 
                         በፓኮስ፡ ስምከ፡ በደፌል፡ ስምከ፡ በሕርዮኖስ፡ ስምከ፡
                      </incipit>
@@ -122,7 +122,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                      <incipit xml:lang="gez">
                         ጸሎት፡ በእንተ፡ ሕማመ፡ ውግዓት፡ ምድምድያም፡ ምድምድያስ፡ <choice>
                            <sic>ምድድምያስ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ምድምድያስ፡</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ምድምድያስ፡</corr>
                         </choice> 
                         የሃቂ፡ የሀቂ፡ የሃቂ፡
                      </incipit>

--- a/VaticanBAV/et/BAVet99.xml
+++ b/VaticanBAV/et/BAVet99.xml
@@ -38,7 +38,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         በስመ፡ አብ፡ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/> ጸሎት፡ በእንተ፡ ሕማመ፡ ልሳነ፡ ሰብእ፡ ናሁ፡
                         ተማኅፀ<supplied reason="omitted">ን</supplied>ኩ፡ <choice>
                            <sic>በኆኅታተ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">በኆኅያተ፡</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">በኆኅያተ፡</corr>
                         </choice>
                         ስምከ፡ ካዊ፡ ወበቀዳማይ፡ ይውጣ፡ ዘጥንተ፡ ፊደሉ፡ አሌፍ፡ ከመ፡ ታድኅነኒ፡ ክርስቶስ፡ እምትሣኤ፡ ልሳን፡ ወአፍ፡
                      </incipit>
@@ -59,7 +59,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         በስመ፡ አብ፡ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/> ጸሎት፡ በእንተ፡ ማ<supplied reason="omitted">እ</supplied>ሠሮሙ፡
                         ለአጋንንት፡ ሰላም፡ ለከ፡ ሰዳዴ፡ አጋንንት፡ ፋኑኤል፡ ለእግዚአብሔር፡ እምጽርሁ፡ ከመ፡ ኢይስክዩ፡ እለ፡ ይኔስሑ፡ <choice>
                            <sic>ለጌጋይ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ለጌጋየ፡</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ለጌጋየ፡</corr>
                         </choice>
                         ዚአሁ፡
                      </incipit>
@@ -93,15 +93,15 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         ወአውገዝኩክሙ፡ አጋንንት፡ ጸዋጋን፡ ወመናፍ<supplied reason="omitted">ስት</supplied>፡ ርኩሳን፡ ከመ፡ ኢትቅረቡ፡ ኀበ፡ ነፍሱ፡ ወሥጋሁ፡ ወኀበ፡ ደቂቁ፡ ወሰብአ፡
                         <choice>
                            <sic>ቢቱ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ቤቱ፡</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ቤቱ፡</corr>
                         </choice>
                         <choice>
                            <sic>ወእንስሳሀ፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">ወእንስሳሁ፡</corr>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">ወእንስሳሁ፡</corr>
                         </choice>
                         ለገብረ፡ <choice>
                            <sic>እግዚአብሒር፡</sic>
-                           <corr resp="bm:GrebTiss1935Codices">እግዚአብሔር፡</corr></choice>
+                           <corr resp="PRS4805Grebaut PRS9530Tisseran">እግዚአብሔር፡</corr></choice>
                          ወልደ፡ እግዚእ፡
                         <add place="interlinear">ኪዳነ፡ ማርያም፡</add>
                      </explicit>


### PR DESCRIPTION
In this PR I have updated all the BAV records by replacing `resp="bm:GrebTiss1935Codices"` with `resp="PRS4805Grebaut PRS9530Tisseran"`, as indicated in https://github.com/BetaMasaheft/Works/pull/1821