### PR TITLE
Create BLorient12913J

### DIFF
--- a/LondonBritishLibrary/orient/BLorient12913J.xml
+++ b/LondonBritishLibrary/orient/BLorient12913J.xml
@@ -39,8 +39,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     Daq (!) ʾƎsṭifānos (<placeName ref="INS0329DE"/>), 
                                     <placeName ref="INS0357Kebran">Kǝbrān Gabrǝʾel</placeName>,
                                     <placeName ref="LOC4970NargaS">Narga Śǝllāse</placeName>,
-                                    ʾUrā Kidāna Mǝhrat (<placeName ref="LOC6307WerraK"/>) and 
-                                    Krǝstos Samrā (<placeName ref="LOC7468KrestosSam"/>).
+                                    <placeName ref="LOC6307WerraK">ʾUrā Kidāna Mǝhrat</placeName> and 
+                                    <placeName ref="LOC7468KrestosSam">Krǝstos Samrā</placeName>.
                                     The letter is addressed to <persName ref="PRS7822Petros">H. B. ʾabuna Ṗeṭros, archbishop of Gondar</persName>,
                                     and <persName ref="PRS6772Marqos">H. B. ʾabuna Mārqos, archbishop of Goǧǧām at Dabra Mārqos</persName>.</note>
                                 <textLang mainLang="am"/>
@@ -113,7 +113,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2025-09-18">Created record.</change>
-            <!-- Add change note after review -->
+            <change when="2025-09-19" who="CH">Updates after reviews by Dorothea Reule and Magdalena Krzyżanowska</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">

--- a/LondonBritishLibrary/orient/BLorient12913J.xml
+++ b/LondonBritishLibrary/orient/BLorient12913J.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng"
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" type="mss" xml:lang="en" xml:id="BLorient12913H">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" type="mss" xml:lang="en" xml:id="BLorient12913J">
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <title>Letter of safe conduct by Emperor Mǝnilǝk to Edward Degen</title>
+                <title>Letter of safe conduct to Mr. Richard Hosking</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
             </titleStmt>
@@ -23,28 +23,26 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <msDesc xml:id="ms">
                     <msIdentifier>
                         <repository ref="INS00001BL"/>
-                        <idno>BL Oriental 12913 H</idno>
-                        <altIdentifier><idno>Or. 12913 H</idno></altIdentifier>
-                        <altIdentifier><idno>Strelcyn 103</idno></altIdentifier>
+                        <idno>BL Oriental 12913 J</idno>
+                        <altIdentifier><idno>Or. 12913 J</idno></altIdentifier>
+                        <altIdentifier><idno>Strelcyn 104</idno></altIdentifier>
                     </msIdentifier>
                     <msContents>
                         <summary/>
                         <msItem xml:id="ms_i1">
                             <locus target="#1r"/>
-                            <title type="complete">Letter of safe conduct by Emperor Mǝnilǝk to Edward Degen</title>
-                            <msItem xml:id="ms_i1.1">
-                                <locus target="#1r"/>
-                                <title type="complete">Letter of safe conduct in Amharic</title>
-                                <note>Letter of safe conduct delivered by <persName ref="PRS7006Menilek"/> to <persName ref="PRS15029Degen"/>
-                                    and his escort in nine lines of Amharic text</note>
+                            <title type="complete">Letter of safe conduct to Mr. Richard Hosking</title>
+                                <note>Typewritten letter of safe conduct by the Chancellery of the Ethiopian Orthodox Church, signed by 
+                                    <persName ref="PRS15032SemenahB"/>, vice-director for relations with foreign churches to 
+                                    <persName ref="PRS15031Hosking"/> of the British Museum to visit the following churches on the
+                                    <placeName ref="LOC5888Tana">lake Ṭānā</placeName> and see the Ethiopic manuscripts preserved there:
+                                    Daq (!) ʾƎsṭifānos (<placeName ref="INS0329DE"/>), 
+                                    <placeName ref="INS0357Kebran">Kǝbrān Gabrǝʾel</placeName>,
+                                    <placeName ref="LOC4970NargaS">Narga Śǝllāse</placeName>,
+                                    ʾUrā Kidāna Mǝhrat (<placeName ref="LOC6307WerraK"/>) and Krǝstos Samrā<!-- I could not identify this site in Bm -->.
+                                    The letter is addressed to <persName ref="PRS7822Petros">H. B. ʾabuna Ṗeṭros, archbishop of Gondar</persName>,
+                                    and <persName ref="PRS6772Marqos">H. B. ʾabuna Mārqos, archbishop of Goǧǧām at Dabra Mārqos</persName>.</note>
                                 <textLang mainLang="am"/>
-                            </msItem>
-                            <msItem xml:id="ms_i1.2">
-                                <locus target="#1r"/>
-                                <title type="complete">English translation</title>
-                                <note>Typewritten English translation of the aforementioned letter following right after.</note>
-                                <textLang mainLang="en"/>
-                            </msItem>
                         </msItem>
                     </msContents>
                     <physDesc>
@@ -54,48 +52,27 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <material key="paper"/>
                                 </support>
                                 <extent>
-                                    <measure unit="leaf" quantity="2">2</measure>
+                                    <measure unit="leaf" quantity="1">1</measure>
                                     <dimensions type="inner" unit="mm">
-                                        <height>274</height>
-                                        <width>212</width>
+                                        <height>280</height>
+                                        <width>220</width>
                                     </dimensions>
                                 </extent>
                                 <condition key="good"/>
                             </supportDesc>
                         </objectDesc>
-                        <handDesc>
-                            <handNote xml:id="h1" script="Ethiopic">
-                                <desc>Large fluent handwriting</desc>
-                                <date from="1902"/>
-                            </handNote>
-                        </handDesc>
                         <additions>
                             <list>
-                                <item xml:id="a1">
-                                    <locus target="#2r"/>
-                                    <desc type="GuestText">Copy of the typewritten English translation of the letter (<ref target="#ms_i1.2"/>).</desc>
-                                </item>
                                 <item xml:id="e1">
                                     <locus target="#1r"/>
-                                    <desc type="StampExlibris">Round seal of <persName ref="PRS7006Menilek"/></desc>
-                                </item>
-                                <item xml:id="e2">
-                                    <locus target="#1r"/>
-                                    <desc type="StampExlibris">Small rectangular stamp by a later owner</desc>
-                                    <q xml:lang="en">SOLL. SHERBORN</q>
-                                </item>
-                                <item xml:id="e3">
-                                    <locus target="#2v"/>
-                                    <desc type="StampExlibris">Seal of <persName ref="PRS15030Sherborn"/>.</desc>
-                                    <q xml:lang="en">C. Davies Sherborn. 49, Peterborough Road, Fulham, London, S. W.</q>
+                                    <desc type="StampExlibris">Seal of the chancellery of the Ethiopian Orthodox Church.</desc>
                                 </item>
                             </list>
                         </additions>
                     </physDesc>
                     <history>
                         <origin>Dated to <placeName ref="LOC1216AddisA"/>, 
-                            <origDate when="1902-07-02" when-custom="1894-10-25" calendar="ethiopian">25 Sane 1894 E.E. (= A.D. 2 July 1902)</origDate></origin>
-                        <provenance>Owned by <persName ref="PRS15030Sherborn"/>.</provenance>
+                            <origDate when="1966-04-15" when-custom="1894-10-25" calendar="ethiopian">7 Miyāzyā 1958 E.E. (= A.D. 15 April 1966)</origDate></origin>
                     </history>
                     <additional>
                         <adminInfo>
@@ -104,7 +81,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <listBibl type="catalogue">
                                         <bibl>
                                             <ptr target="bm:Strelcyn1978BritishLibrary"/>
-                                            <citedRange unit="page">157</citedRange>
+                                            <citedRange unit="page">158</citedRange>
                                         </bibl>
                                     </listBibl>
                                 </source>
@@ -134,9 +111,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </langUsage>
         </profileDesc>
         <revisionDesc>
-            <change who="CH" when="2025-09-17">Created record.</change>
-            <change when="2025-09-18" who="CH">Corrections after reviews by Dorothea Reule and Magdalena Krzyżanowska</change>
-            <change when="2025-09-18" who="CH">Corrected xml:id</change>
+            <change who="CH" when="2025-09-18">Created record.</change>
+            <!-- Add change note after review -->
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">

--- a/LondonBritishLibrary/orient/BLorient12913J.xml
+++ b/LondonBritishLibrary/orient/BLorient12913J.xml
@@ -39,7 +39,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     Daq (!) ʾƎsṭifānos (<placeName ref="INS0329DE"/>), 
                                     <placeName ref="INS0357Kebran">Kǝbrān Gabrǝʾel</placeName>,
                                     <placeName ref="LOC4970NargaS">Narga Śǝllāse</placeName>,
-                                    ʾUrā Kidāna Mǝhrat (<placeName ref="LOC6307WerraK"/>) and Krǝstos Samrā<!-- I could not identify this site in Bm -->.
+                                    ʾUrā Kidāna Mǝhrat (<placeName ref="LOC6307WerraK"/>) and 
+                                    Krǝstos Samrā (<placeName ref="LOC7468KrestosSam"/>).
                                     The letter is addressed to <persName ref="PRS7822Petros">H. B. ʾabuna Ṗeṭros, archbishop of Gondar</persName>,
                                     and <persName ref="PRS6772Marqos">H. B. ʾabuna Mārqos, archbishop of Goǧǧām at Dabra Mārqos</persName>.</note>
                                 <textLang mainLang="am"/>


### PR DESCRIPTION
I created a record für BLorient12913J, even though this is a typewritten letter and therefore not a manuscript in a stricter sense.

I corrected the xml:id in BLorient12913H.