### PR TITLE
Create ANLcr47

### DIFF
--- a/Casamari/MNC012.xml
+++ b/Casamari/MNC012.xml
@@ -175,13 +175,11 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                            </desc>
                         </item> 
                         <item xml:id="a2">
-                           <desc type="ProtectivePrayer">ጸሎተ፡ ሥርየት፡</desc>
                            <locus from="2r" to="4r"/>
-                           <desc>The incipit of the text is rubricated. The handwriting deteriorates from <locus target="#2v"/>. 
+                           <desc type="ProtectivePrayer"><ref type="work" corresp="LIT7825SalotaSery"/>; The incipit of the text is rubricated. The handwriting deteriorates from <locus target="#2v"/>. 
                               Some lines have been effaced on <locus target="#3r"/>. 
-                              The prayer begins as follows: 
                               <q xml:lang="gez">
-                                 በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡ ጸሎተ፡ ሥርየት ወመድኃኒተ፡ ሥጋ፡ ወመንጽሔ፡ ኃጢአት።
+                                 በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ፡ ጸሎተ፡ ሥርየት፡ ወመድኃኒተ፡ ሥጋ፡ ወመንጽሔ፡ ኃጢአት። <gap reason="ellipsis"/>
                               </q>.
                             </desc>
                         </item> 
@@ -261,6 +259,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
       </profileDesc>
      <revisionDesc>
         <change who="MV" when="2018-04-27">Created catalogue entry</change>
+        <change when="2026-03-18" who="CH">Added LIT7825SalotaSery to a2</change>
      </revisionDesc>
   </teiHeader>
    <text xml:base="https://betamasaheft.eu/">

--- a/EMIP/1-1000/EMIP00677.xml
+++ b/EMIP/1-1000/EMIP00677.xml
@@ -87,8 +87,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <msItem xml:id="ms_i9"><locus from="123v" to="133r" facs="126"/><title type="complete" ref="LIT2260salota"/>
                   <textLang mainLang="gez">Gǝ‘ǝz</textLang>
                 </msItem>
-                  <msItem xml:id="ms_i10"><locus from="133r" to="135r" facs="135"/><title>Instructions to defeat the charm of the Evil Eye</title><incipit xml:lang="gez">ገቢሩ፡ ጽላ፡ወጊ፡ ቢወጋው፡ ፫ ጊዜ፡ አዙረህ፡ በላዩ፡ አስትዮ፡ ለላዕኩ፡ ሰው፡ ደጊመከ፡ በምድርም፡ በቤትም፡ በላምም፡ በበሬም፡ በድመትም፡ በሸኮኮም፡ በዶሮም፡ ቢደግም፡ ደግመህ፡ ፫ጊዜ፡ አዙረህ፡ አጠጣ፡ <gap reason="omitted"/></incipit>
-                  <textLang mainLang="gez">Gǝ‘ǝz</textLang>
+                 <msItem xml:id="ms_i10"><locus from="133r" to="135r" facs="135"/><title ref="LIT7827GabiruSW"/><incipit xml:lang="gez">ገቢሩ፡ ጽላ፡ ወጊ፡ ቢወጋው፡ ፫ ጊዜ፡ አዙረህ፡ በላዩ፡ አስትዮ፡ ለላዕኩ፡ ሰው፡ ደጊመከ፡ በምድርም፡ በቤትም፡ በላምም፡ በበሬም፡ በድመትም፡ በሸኮ<unclear>ኮ</unclear>ም፡ በዶሮም፡ ቢደግም፡ ደግመህ፡ ፫ጊዜ፡ አዙረህ፡ አጠጣ፡ <gap reason="omitted"/></incipit>
+                  <textLang mainLang="am"/>
                   <note>written in a later hand in red ink</note>
                   <colophon xml:id="coloph1">
                     <locus target="#134v #135r" facs="137"/>
@@ -290,7 +290,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language><language ident="gez">Gǝʿǝz</language></langUsage>
+         <langUsage><language ident="en">English</language><language ident="gez">Gǝʿǝz</language><language ident="am">Amharic</language></langUsage>
       </profileDesc>
       <revisionDesc>
             <change who="PL" when="2018-01-18">Created XML record from EMIP Collection Metadata.xsls</change>

--- a/EMIP/2001-3000/EMIP02023.xml
+++ b/EMIP/2001-3000/EMIP02023.xml
@@ -46,56 +46,56 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   </msItem>
                   <msItem xml:id="ms_i2">
                      <locus from="25r" to="76v" facs="026"/>
-                     <title type="complete" ref="LIT5888AsmatPrayer"> Asmat Prayer for forgiveness of the soul and healing of the flesh, ‎‎<foreign xml:lang="gez">ጸሎተ፡ ሥርየተ፡ ነፍስ፡ ወመድኃኒተ፡ ሥጋ፡</foreign>‎</title>
+                    <title type="complete">Magic prayers</title>
                     <msItem xml:id="ms_i2.1">
                         <locus from="25r" to="29r" facs="026"/>
-                        <title>Prayers for Monday, <foreign xml:lang="gez">ዘሰኑይ፡</foreign>
-                        </title>
+                      <title ref="LIT7825SalotaSery"/>
+                      <note>Indicated as ‘prayers for Monday’, <foreign xml:lang="gez">ዘሰኑይ፡</foreign>.</note>
                         <incipit xml:lang="gez">በስመ፡ አብ፡ ወወልድ፡ <gap reason="omitted"/> ጸሎተ፡ ሥርየተ፡ ነፍስ፡ ወመድኃኒተ፡ ሥጋ፡ ወነፍስ፡ ወመንጽሔ፡ ኃጢአት፡ አፍናኤል፡ አቅናኤል፡ <gap reason="omitted"/>
                         </incipit>
                      </msItem>
                     <msItem xml:id="ms_i2.2">
                         <locus from="29r" to="37v" facs="030"/>
-                        <title>Prayers for Tuesday, <foreign xml:lang="gez">ዘሠሉስ፡</foreign>
-                        </title>
+                      <title>Prayers for Tuesday</title>
+                      <note>Indicated with <foreign xml:lang="gez">ዘሠሉስ፡</foreign>.</note>
                         <incipit xml:lang="gez">: በስመ፡ አብ፡ ወወልድ፡ <gap reason="omitted"/> ወይቤልዎ፡ መላእክት፡ ታስተኃፍሮሙኑ፡ ለእለ፡ ደገምዎ፡ በበ፯ ጊዜ፡ ወይቤሎሙ፡</incipit>
                      </msItem>
                     <msItem xml:id="ms_i2.3">
                         <locus from="37v" to="43v" facs="039"/>
-                        <title>Prayers for Wednesday,  <foreign xml:lang="gez">ዘረቡዕ፡</foreign>
-                        </title>
+                        <title>Prayers for Wednesday</title>
+                      <note>Indicated with <foreign xml:lang="gez">ዘረቡዕ፡</foreign>.</note>
                         <incipit xml:lang="gez">: በስመ፡ አብ፡ ወወልድ፡ <gap reason="omitted"/> ይቀድሰኒ፡ አስማቲሁ፡ ለክርስቶስ፡ ሴድላዊ፡ በድጋዊ፡ ቄድሎ፡</incipit>
                      </msItem>
                     <msItem xml:id="ms_i2.4">
                         <locus from="43v" to="52r" facs="045"/>
-                        <title>Prayers for Thursday, <foreign xml:lang="gez">ዘሐሙስ፡</foreign>
-                        </title>
+                        <title>Prayers for Thursday</title>
+                      <note>Indicated with <foreign xml:lang="gez">ዘሐሙስ፡</foreign>.</note>
                         <incipit xml:lang="gez">: በስመ፡ አብ፡ ወወልድ፡ <gap reason="omitted"/> ‎ሥርየተ፡ እምነቶሙ፡ ለሐዋርያት፡ ወለኵሎሙ፤ ፸ወ፪አርድእት፡ ከማሁ፡ ይቤሎሙ፡</incipit>
                      </msItem>
                     <msItem xml:id="ms_i2.5">
                         <locus from="52r" to="66r" facs="053"/>
-                        <title>Prayers for Friday, <foreign xml:lang="gez">ዘዓርብ፡</foreign>
-                        </title>
+                        <title>Prayers for Friday</title>
+                      <note>Indicated with <foreign xml:lang="gez">ዘዓርብ፡</foreign>.</note>
                         <incipit xml:lang="gez">: በስመ፡ አብ፡ ወወልድ፡ <gap reason="omitted"/> ጸሎተ፡ ሥርየተ፡ ኃጢአት፡ ዘሰዓሉ፡ ሐዋርያት፡ ኀበ፡ እግዚአብሔር፡ እግዚኦሙ፡ <gap reason="omitted"/>
                         </incipit>
                      </msItem>
                     <msItem xml:id="ms_i2.6">
                         <locus from="66r" to="73r" facs="067"/>
-                        <title>Prayers for Saturday, <foreign xml:lang="gez">ዘቀዳሚት፡</foreign>
-                        </title>
+                        <title>Prayers for Saturday</title>
+                      <note>Indicated with <foreign xml:lang="gez">ዘቀዳሚት፡</foreign>.</note>
                         <incipit xml:lang="gez">:  በስመ፡ አብ፡ ወወልድ፡ <gap reason="omitted"/> ጸሎት፡ ዘእግዝእትነ፡ ማርያም፡ ወላዲተ፡ አምላክ፡ ዘሀሎ፡ ውስተ፡ ንዑሰ፡ ወንጌል፡ ዘውእቱ፡ ነገረ፡ማርያም፡ <gap reason="omitted"/>
                         </incipit>
                      </msItem>
                     <msItem xml:id="ms_i2.7">
                         <locus from="73r" to="73v" facs="074"/>
                         <locus from="76r" to="76v" facs="077"/>
-                        <title>Sunday Reading, <foreign xml:lang="gez">ዘእሁድ፡</foreign>
-                        </title>
+                        <title>Sunday Reading</title>
+                      <note>Indicated with <foreign xml:lang="gez">ዘእሁድ፡</foreign>.</note>
                         <incipit xml:lang="gez">: በስመ፡ አብ፡ ወወልድ፡ <gap reason="omitted"/> ጸሎተ፡ ሥርየተ፡ ኃጢአት፡ ዘሰዓሉ፡ ሐዋርያት፡ ኀበ፡ እግዚአብሔር፡ እግዚኦሙ፡ <gap reason="omitted"/>
                         </incipit>
                      </msItem>
                     <note>
-                        <locus from="74r" to="75v" facs="075"/> is a misplaced sheet elsewhere within the asmat prayers
+                        <locus from="74r" to="75v" facs="075"/> is a misplaced sheet elsewhere within the ʾasmāt prayers
                       </note>
                   </msItem>
                </msContents>
@@ -326,6 +326,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <change when="2020-02-26" who="RL">Added quire image links</change>
          <change when="2020-04-17" who="RL">corrected ǝ character</change>
          <change when="2020-05-21" who="RL">Added Asmat prayer as work</change>
+        <change when="2026-03-18" who="CH">Added LIT7825SalotaSery to ms_i2.1</change>
   </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">

--- a/RomeALincei/ANLcr47.xml
+++ b/RomeALincei/ANLcr47.xml
@@ -409,7 +409,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </msItem>
                                 <msItem xml:id="p2_i1.10">
                                     <locus from="118vb"/>
-                                    <title type="incomplete" ref="LIT7826GabiruSela">Beginning of a magic receipt against Ṣǝlā wagi</title><!-- Issue #3279 -->
+                                    <title type="incomplete" ref="LIT7826GabiruSela">Beginning of a magic receipt against Ṣǝlā Wagi</title><!-- Issue #3279 -->
                                     <incipit xml:lang="gez">ገቢሩ፡ ጽላ፡ ወጊ፡ ቢወጋው፡ ፫ ጊዜ፡ አዙር፡ ለሥራይ፡ ፯ ዘቢብ፡ 
                                         ፯ ቁ<supplied reason="omitted" resp="PRS8999Strelcyn">ን</supplied>ዶ፡ በርበሬ፡ ያሞሌ፡ 
                                         ጨ<supplied reason="omitted" resp="PRS8999Strelcyn">ው</supplied>፡ የወርካ፡</incipit>

--- a/RomeALincei/ANLcr47.xml
+++ b/RomeALincei/ANLcr47.xml
@@ -35,8 +35,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <support>
                                     <material key="parchment"/></support>
                                 <extent>
-                                    <measure unit="leaf" quantity="118" cert="low">118</measure><note>The number of leaves is not explicitly 
-                                        noted in the catalogue</note>
+                                    <measure unit="leaf" quantity="118" cert="low">118</measure><note>The number of leaves is not 
+                                        noted in the catalogue.</note>
                                     <measure unit="page" type="blank">3</measure><locus target="#2 #2v #72v"/>
                                     <dimensions type="outer" unit="mm">
                                         <height unit="mm">117</height>
@@ -68,7 +68,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <origin>
                             <origDate notBefore="1800" notAfter="1899">19th century</origDate>
                         </origin>
-                        <provenance>Two names, which belong presumably to two subsequent owners appear on <locus target="#4r"/> 
+                        <provenance>Two names, which belong presumably to two subsequent owners, appear on <locus target="#4r"/> 
                             (<persName ref="PRS15325MabaGigar">Mabʾa Gigār</persName>) and on <locus target="#92ra"/> 
                             (<persName ref="PRS15326TaklaMadh">Takla Madḫǝn</persName>).</provenance>
                     </history>
@@ -108,7 +108,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <msItem xml:id="p1_i2.1">
                                     <locus from="6va" to="14rb"/>
                                     <title ref="LIT4668Prayer#Monday"/>
-                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎቱ፡ ለጴጥሮስ፡ ዝውቱ፡ ዘየዓቢ፡ እምሐዋር<cb n="6vb"/>ያቲሁ፡ 
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎቱ፡ ለጴጥሮስ፡ 
+                                        ዝው<supplied reason="omitted" resp="CH">እ</supplied>ቱ፡ ዘየዓቢ፡ እምሐዋር<cb n="6vb"/>ያቲሁ፡ 
                                         ዘኃረዮ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ክርስቶስ፡ 
                                         <gap reason="ellipsis"/><cb n="9vb"/><gap reason="ellipsis"/> ሀበኒ፡ ዘንተ፡ ጸሎተ፡ ዘወጽአ፡ እምአፉከ፡ ይኩን፡ ቅዱስ፡ 
                                         ወ<cb n="10ra"/>ፈውሰ፡ ለኵሎሙ፡ ሕሙማን<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ወድውያን፡ 
@@ -302,7 +303,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <handDesc>
                                 <handNote xml:id="h1" script="Ethiopic">
                                     <seg type="script">Nineteenth-century script.</seg>
-                                    <seg type="ink">Black and red ink</seg>
+                                    <seg type="ink">Black and red ink.</seg>
                                     <date notBefore="1800" notAfter="1899" evidence="lettering">19th century</date>
                                     <desc>Regular handwriting by the scribe 
                                         <persName ref="PRS15328SayfaMik" role="scribe">Sayfa Mikāʾel</persName>.</desc>
@@ -312,10 +313,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <list>
                                     <item xml:id="e2">
                                         <locus target="#22vb #34r #48vb"/>
-                                        <desc>The text of <ref target="#p1_i2"/> is divided to the days of the week, but yet alone the readings for 
+                                        <desc>The text of <ref target="#p1_i2"/> is divided according to the days of the week, but only the readings for 
                                             Wednesday (<foreign xml:lang="gez">ዘረቡዕ፡</foreign>, <locus target="#22vb"/>),
                                             Thursday (<foreign xml:lang="gez">ዘሐሙስ፡</foreign>, <locus target="#34r"/>) and
-                                            Saturday (<foreign xml:lang="gez">ዘቀዳሚት፡</foreign>, <locus target="#48vb"/>), are indicated.</desc>
+                                            Saturday (<foreign xml:lang="gez">ዘቀዳሚት፡</foreign>, <locus target="#48vb"/>) are indicated.</desc>
                                     </item>
                                 </list>
                             </additions>
@@ -408,7 +409,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </msItem>
                                 <msItem xml:id="p2_i1.10">
                                     <locus from="118vb"/>
-                                    <title type="incomplete" ref="LIT7826GabiruSela">Beginning of a magic receipt against ṣǝlā wagi</title><!-- Issue #3279 -->
+                                    <title type="incomplete" ref="LIT7826GabiruSela">Beginning of a magic receipt against Ṣǝlā wagi</title><!-- Issue #3279 -->
                                     <incipit xml:lang="gez">ገቢሩ፡ ጽላ፡ ወጊ፡ ቢወጋው፡ ፫ ጊዜ፡ አዙር፡ ለሥራይ፡ ፯ ዘቢብ፡ 
                                         ፯ ቁ<supplied reason="omitted" resp="PRS8999Strelcyn">ን</supplied>ዶ፡ በርበሬ፡ ያሞሌ፡ 
                                         ጨ<supplied reason="omitted" resp="PRS8999Strelcyn">ው</supplied>፡ የወርካ፡</incipit>
@@ -435,7 +436,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <handDesc>
                                 <handNote xml:id="h2" script="Ethiopic">
                                     <seg type="script">Nineteenth-century script.</seg>
-                                    <seg type="ink">Black and red ink</seg>
+                                    <seg type="ink">Black and red ink.</seg>
                                     <date notBefore="1800" notAfter="1899" evidence="lettering">19th century</date>
                                     <desc>Regular handwriting, larger than <ref target="h1"/>.</desc>
                                 </handNote>
@@ -502,7 +503,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2026-03-12">Created record</change>
-            <!--  -->
+            <change when="2026-03-19" who="CH">Updated after review by Magdalena Krzyżanowska</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">

--- a/RomeALincei/ANLcr47.xml
+++ b/RomeALincei/ANLcr47.xml
@@ -396,7 +396,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <msItem xml:id="p2_i1.8">
                                     <locus from="107vb"/>
                                     <title ref="LIT7830Algum"/><!-- Issue #3282 -->
-                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ መፍትሔ፡ ሥራይ፡ ወአልጉም፡ ወእጅ፡ ሰብእ፡ 
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ መፍትሔ፡ ሥራይ፡ ወአልጉም፡ ወእጀ፡ ሰብእ፡ 
                                         ዝንቱ፡ <pb n="108ra"/> አስማት፡ በእንተ፡ አቤ፡ እቤ እቤ፡ ሸር፡ አፍእጅ፡</incipit>
                                     <textLang mainLang="gez"/>
                                 </msItem>

--- a/RomeALincei/ANLcr47.xml
+++ b/RomeALincei/ANLcr47.xml
@@ -1,0 +1,513 @@
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="ANLcr47" xml:lang="en" type="mss">
+    <teiHeader xml:base="https://betamasaheft.eu/">
+        <fileDesc>
+            <titleStmt>
+                <title>Magic prayers</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine
+                    multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS0335ANL"/>
+                        <idno>Conti Rossini 47</idno>
+                    </msIdentifier>
+                    <msContents>
+                        <summary/>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Codex">
+                            <supportDesc>
+                                <support>
+                                    <material key="parchment"/></support>
+                                <extent>
+                                    <measure unit="leaf" quantity="118" cert="low">118</measure><note>The number of leaves is not explicitly 
+                                        noted in the catalogue</note>
+                                    <measure unit="page" type="blank">3</measure><locus target="#2 #2v #72v"/>
+                                    <dimensions type="outer" unit="mm">
+                                        <height unit="mm">117</height>
+                                        <width unit="mm">82</width>
+                                    </dimensions>
+                                </extent>
+                                <collation>Four protective leaves (<locus from="1" to="4"/>).</collation>
+                                <condition key="good"/>
+                            </supportDesc>
+                        </objectDesc>
+                        <additions>
+                            <list>
+                            <item xml:id="e1">
+                                <locus target="#1r #1v #2r #4r #4v"/>
+                                <desc>Graffiti in black pencil and purple carbon pencil.</desc>
+                            </item>
+                            </list>
+                        </additions>
+                        <bindingDesc>
+                            <binding>
+                                <decoNote xml:id="b1"/>
+                                <decoNote xml:id="b2" type="Boards">Wooden boards</decoNote>
+                                <decoNote xml:id="b3" type="Cover">Covered with multicoloured canvas</decoNote>
+                                <decoNote xml:id="b4" type="bindingMaterial"><material key="wood"/><material key="textile"/></decoNote>
+                            </binding>
+                        </bindingDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1800" notAfter="1899">19th century</origDate>
+                        </origin>
+                        <provenance>Two names, which belong presumably to two subsequent owners appear on <locus target="#4r"/> 
+                            (<persName ref="PRS15325MabaGigar">Mabʾa Gigār</persName>) and on <locus target="#92ra"/> 
+                            (<persName ref="PRS15326TaklaMadh">Takla Madḫǝn</persName>).</provenance>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1976Catalogue"/>
+                                            <citedRange unit="page">140–144</citedRange>
+                                        </bibl>
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                            <custodialHist>
+                                <custEvent type="restorations" subtype="none"/>
+                            </custodialHist>
+                        </adminInfo>
+                    </additional>
+                    <msPart xml:id="p1">
+                        <msIdentifier/>
+                        <msContents><summary/>
+                            <msItem xml:id="p1_i1">
+                                <locus from="5ra" to="6va"/>
+                                <title ref="LIT7825SalotaSery"/><!-- Issue #3269 -->
+                                <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎተ፡ ሥርየት፡ መድኃኒተ፡ ሥጋ፡ ወነፍስ፡ ወመንጽሔ፡ 
+                                    ኃጢአት<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> አፍናኤል፡ አቅናኤል፡ በስሙ፡ ድፋኤል፡ <gap reason="ellipsis"/>
+                                    <cb n="5rb"/><gap reason="ellipsis"/> አኅርው፡ ለአጋንንተ፡ ሌጌዎን፡ አሐኖኤል፡ ወደሰድድ፡ 
+                                    ሕማመ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ነፍስ፡ ድክምት፡ በስመ፡ ድፍቃኤል፡ 
+                                    <gap reason="ellipsis"/><cb n="6rb"/><gap reason="ellipsis"/> በዝንቱ፡ አስማቲከ፡ ኢይምጽአኒ፡ ሞት፡ ዘእንበለ፡ ጊዜየ፡</incipit>
+                                <textLang mainLang="gez"/>
+                            </msItem>
+                            <msItem xml:id="p1_i2">
+                                <locus from="6va"/>
+                                <title type="incomplete" ref="LIT4668Prayer"/>
+                                <msItem xml:id="p1_i2.1">
+                                    <locus from="6va" to="14rb"/>
+                                    <title ref="LIT4668Prayer#Monday"/>
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎቱ፡ ለጴጥሮስ፡ ዝውቱ፡ ዘየዓቢ፡ እምሐዋር<cb n="6vb"/>ያቲሁ፡ 
+                                        ዘኃረዮ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ክርስቶስ፡ 
+                                        <gap reason="ellipsis"/><cb n="9vb"/><gap reason="ellipsis"/> ሀበኒ፡ ዘንተ፡ ጸሎተ፡ ዘወጽአ፡ እምአፉከ፡ ይኩን፡ ቅዱስ፡ 
+                                        ወ<cb n="10ra"/>ፈውሰ፡ ለኵሎሙ፡ ሕሙማን<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ወድውያን፡ 
+                                        ወይ<supplied reason="omitted" resp="PRS8999Strelcyn">ሰ</supplied>ደዱ፡ ሰይጣናት፡ 
+                                        ወሌጌዎን<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ወሥራይ፡ ወዘጸለዩ፡ ቦቱ፡ በዝንቱ፡ 
+                                        ጸሎት<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ለኵሉ፡ 
+                                        ምድር<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> እመሂ፡ 
+                                        በቤተ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ክርስቲያን፡ ይኩኖሙ፡ ለበረከት፡ ወለመድኃኒተ፡ ነፍሶሙ፡
+                                        <gap reason="ellipsis"/><pb n="10va"/>ኤሎሄ፡ ኤሎሄ፡ ኤሎሄ፡ ኢየሱስ፡ ክርስቶስ፡ ሕያው፡ <unclear>ሕያው፡</unclear><!-- (bis)? --></incipit>
+                                    <textLang mainLang="gez"/>
+                                </msItem>
+                                <msItem xml:id="p1_i2.2">
+                                    <locus from="14rb" to="22va"/>
+                                    <title ref="LIT4668Prayer#Tuesday"/>
+                                    <msItem xml:id="p1_i2.2.1">
+                                        <locus from="14rb" to="18rb"/>
+                                        <title ref="LIT4668Prayer#Tuesday1"/>
+                                        <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ መልከ፡ ጼዴቅ፡ ወበእንተ፡ ጰራቅሊጦስ፡ መንፈሰ፡ 
+                                            ጽድቅ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied><pb n="14va"/> ወጸሎት፡ በእንተ፡ 
+                                            <surplus>እንተ፡</surplus> እግዚአብሔር፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ። ክርስቶስ፡ አዕትት፡ እምነፍስየ፡ ሕማመ፡ እግዚኦ፡ ተሣሃለኒ፡ በጸጋሁ፡
+                                            ለእግዚአብሔር፡ ወበእንተ፡ ሕዝበ፡ ክርስቲያን። ወበእንተ፡ ጳጳሳት<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied>
+                                            <cb n="14vb"/><gap reason="ellipsis"/><pb n="15ra"/> አማኑኤል፡ ስሙ፡ ለመድኃኒነ፡ በዝንቱ፡ አስማት፡ ዘእምነ፡ ይድኃን፡ ወኢይትኳንን፡
+                                            በደይን፡ ለዓለመ፡ ዓለም፡ አሜን<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ወለእመ፡ ዓቀብክሙ፡ ዘንተ፡ 
+                                            አስማተ፡ ዘይነብር፡ ከመ፡ ማይ፡ ውኂዝ፡ ወይጸርይ፡ ማዮ። <gap reason="ellipsis"/><pb n="15va"/> ወበቀዳማይ፡ ስሙ፡ አላፑን፡ ወበሣልሣይ፡ ስመ፡
+                                            ኅቡዓቲከ፡</incipit>
+                                        <textLang mainLang="gez"/>
+                                    </msItem>
+                                    <msItem xml:id="p1_i2.2.2">
+                                        <locus from="18rb" to="20rb"/>
+                                        <title ref="LIT4668Prayer#Tuesday2"/>
+                                        <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/><pb n="18va"/><gap reason="ellipsis"/> ጸሎተ፡ 
+                                            ምሕረት<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ዘጸለዩ፡ መላእክት፡
+                                            ወሰማዕታት<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ጳጳሳት፡ ወካህናት፡ 
+                                            ወመነኮሳት<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ዕድ፡ ወአንስት፡ <gap reason="ellipsis"/>
+                                            በዝንቱ፡ አስማቲከ፡ አቱደናብጥል፡ <cb n="18vb"/> አርፌል፡ ወርኤል፡</incipit>
+                                        <textLang mainLang="gez"/>
+                                    </msItem>
+                                    <msItem xml:id="p1_i2.2.3">
+                                        <locus from="20rb" to="20vb"/>
+                                        <title ref="LIT4668Prayer#Tuesday3"/>
+                                        <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/><pb n="20va"/> በዘኢይቀርበከ፡ ሰይጣን፡ 
+                                            ዘንተ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ድግም፡ 
+                                            ወበል<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> በአስናኤል፡ በአቅናኤል፡ አማኑኤል፡</incipit>
+                                        <textLang mainLang="gez"/>
+                                    </msItem>
+                                    <msItem xml:id="p1_i2.2.4">
+                                        <locus from="20vb" to="22va"/>
+                                        <title ref="LIT4668Prayer#Tuesday4"/>
+                                        <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/><pb n="21ra"/><gap reason="ellipsis"/> ክርስቶስ፡ መሐረኒ፡ ክርስቶስ፡
+                                            ተሣሃለኒ፡ <gap reason="ellipsis"/> አንተ፡ ውእቱ፡ ዘትመይጥ፡ ምክሮሙ፡ ለመላእክት፡ በክስብኤል፡ በአካዕ፡ በቤቃ፡ ወበሴቃ፡ 
+                                            <gap reason="ellipsis"/> ር<cb n="21rb"/>ድአኒ፡ ወአድኅነኒ፡ ወአርስእ፡ ምክሮሙ፡ ለፀርየ፡ ወለጸላዕትየ፡</incipit>
+                                        <textLang mainLang="gez"/>
+                                    </msItem>
+                                </msItem>
+                                <msItem xml:id="p1_i2.3">
+                                    <locus from="22vb" to="27rb"/>
+                                    <title ref="LIT4668Prayer#Wednesday"/>
+                                    <msItem xml:id="p1_i2.3.1">
+                                        <locus from="22vb" to="27rb"/>
+                                        <title ref="LIT4668Prayer#Wednesday1"/>
+                                        <note>Indicated here as <term key="Asmat">magic names</term> revealed to St Thomas.</note>
+                                        <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> 
+                                            ጸሎተ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> መድኃኒት፡ አስማተ፡ 
+                                            ኃይላት<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ዘወረደ፡ እምሰማያት፡ ዘወሀቦ፡ ለቶማስ፡ ረድዕ፡ ለዘክሮቱ፡
+                                            ይደሉ፡ ስብሐት፡ ጸሎቱ፡ ወበረከቱ፡ <gap reason="ellipsis"/> ኢያ<pb n="23ra"/>ኤል፡ 
+                                            አፍናኤል<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> አትናኤል፡</incipit>
+                                        <textLang mainLang="gez"/>
+                                    </msItem>
+                                    <msItem xml:id="p1_i2.3.2">
+                                        <locus from="27rb"/>
+                                        <title ref="LIT4668Prayer#Wednesday2"/>
+                                        <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ወይቤልዎ፡ መ<pb n="27va"/>ላእክት፡ ታስተኃፍሮሙ፡ መኑ፡ ለአመ፡ 
+                                            ደገምዎ፡ ለዝንቱ፡ አስማት፡ በበ፯ቱ፡ ወይቤሎሙ፡ እመ፡ ኢያፍቅርክምዎ፡ እስመ፡ 
+                                            ኢከሠቱኒ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied>ሎቱ፡ <gap reason="ellipsis"/>
+                                            <cb n="27vb"/><gap reason="ellipsis"/> ይጸርሑ፡ በስመ፡ አደጋዴ፡ በአውልፍሌን። <pb n="28ra"/> ወይቤ፡ ዲያብሎስ፡ ንግረኒ፡ 
+                                            መዋቅሕተ፡ አድማስ፡ ዘአሠረኒ፡ እንዘ፡ ይብል፡ ዓውድ፡ አውላላአአኤል፡ ወይቤላሁ፡ መዋቅሕተ፡ አድማስ፡ ለእግዚእ፡ ኢትመጥወኒ፡ ለግሙራ፡</incipit>
+                                        <textLang mainLang="gez"/>
+                                    </msItem>
+                                </msItem>
+                                <msItem xml:id="p1_i2.4">
+                                    <locus from="34ra" to="40rb"/>
+                                    <title ref="LIT4668Prayer#Thursday"/>
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ለነ፡ ሐዋርያ፡ ወሀበነ፡ ዘንተ፡ 
+                                        አስማተ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> በደብረ፡ ወምስሌነ፡ እሙ፡ አመ፡ እለተ፡ ዕርገቱ፡ ውስተ፡ 
+                                        ሰማያት፡ በስብሐቲሁ፡ በሰረገላ፡ ብርሃን፡ <gap reason="ellipsis"/> ወይቤ<cb n="34rb"/>ለነ፡ ንሥኡ፡ 
+                                        ዘንተ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ንሥኡ፡ 
+                                        ዘንተ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> አስማተ። ይኩንክሙ፡ ጽንዓ፡ ኀበ፡ ተሐውሩ፡ 
+                                        <gap reason="ellipsis"/><cb n="34vb"/><gap reason="ellipsis"/> 
+                                        ወኢኃረየክሙ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ለእኅርው፡ ከለባት፡ 
+                                        ዘይቤ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ይመስሉ፡ ክርስቲያነ፡ ወኢገብረ፡ ግብረ፡ አረሚ፡ 
+                                        እሙንቱ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> በአልባሰ፡ አባግዕ፡ 
+                                        ውስጦሙ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ተኵላ፡ ወመሰጥ፡ ሐያድያን፡ ወአማጽያን፡ ወገባርያነ፡ 
+                                        ሥራይ፡ ወዘማውያ<pb n="35ra"/>ን፡ ወቀታልያን፡ <gap reason="omitted"/><cb n="36vb"/><gap reason="omitted"/> 
+                                        አካኤል፡ ፍኑኤል፡ ጋኑኤል፡ <pb n="37ra"/> ዳትኤል፡ ኤፍድኤል፡</incipit>
+                                    <textLang mainLang="gez"/>
+                                </msItem>
+                                <msItem xml:id="p1_i2.5">
+                                    <locus from="40va" to="48va"/>
+                                    <title ref="LIT4668Prayer#Friday"/>
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ይቀድሰነ፡ አስማቲሁ፡ ለክርስቶስ፡ ሴድላዊ፡ 
+                                        ቤድጋዊ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ቲድሮፋ፡ <gap reason="ellipsis"/> መኑ፡ 
+                                        አንተ፡ <supplied reason="omitted" resp="PRS8999Strelcyn">ፀሐይ፡</supplied> ብሩህ፡ አነ፡ 
+                                        ውእቱ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied><cb n="40vb"/> በዝኅ፡ ከለካኤል፡ ድብተ፡ 
+                                        ፈላፍላኤል፡ መኑ፡ አንተ፡ ኮከበ፡ ጽባሕ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> አነ፡ ውእቱ፡ በራፍራኤል፡ 
+                                        ቀድላካኤል፡ <gap reason="ellipsis"/><pb n="41va"/><gap reason="ellipsis"/> ዘአሠርክዎሙ፡ ለመርአየ፡ አኅርው፡ ወለአጋንንተ፡ 
+                                        ሌጌዎን፡ ከማሁ፡ አስጥሞሙ፡ ለፀርየ፡ እለ፡ ይገብሩ፡ እኩየ፡ በላእ<cb n="41vb"/>ሌየ፡</incipit>
+                                    <textLang mainLang="gez"/>
+                                </msItem>
+                                <msItem xml:id="p1_i2.6">
+                                    <locus from="48vb" to="56ra"/>
+                                    <title ref="LIT4668Prayer#Saturday"/>
+                                    <msItem xml:id="ms_i2.6.1">
+                                        <locus from="48vb" to="56ra"/>
+                                        <title ref="LIT4668Prayer#Saturday1"/>
+                                        <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎተ፡ ሥርየት፡ እምነቶሙ፡ 
+                                            ለሐዋርያት<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ወለኵሎሙ፡ ፸ወ፪ አርድዕት፡ ከመ፡ ይቤሎሙ፡ 
+                                            እግዚእ፡ ለአርዳኢሁ፡ አንትሙ፡ አርዳዕየ፡ አንትሙ፡ አዕርክትየ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> 
+                                            ወይቤሎ፡ ለጴጥሮስ፡ አንተ፡ ስም<pb n="49ra"/>ዖን፡ ወልደ፡ 
+                                            ዮና<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ወልደ፡
+                                            ርግብ፡ አንተ፡ ርእሰ፡ ሐዋርያት፡ ወአንተ፡ እንድርያስ፡ <gap reason="ellipsis"/> 
+                                            በዝንቱ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ስምየ፡ 
+                                            ቆርዮስ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ሲናጲሳዮስ፡ <gap reason="ellipsis"/>
+                                            <cb n="49rb"/><gap reason="ellipsis"/> በዝንቱ፡ አስማተ፡ ኃይል፡ ከመ፡ ይድኃኑ፡ እምኵሉ፡ መቅሠፍት፡ ዘይመጽኡ፡ ውስተ፡ ዓለም፡
+                                        </incipit>
+                                        <textLang mainLang="gez"/>
+                                    </msItem>
+                                </msItem>
+                                <msItem xml:id="p1_i2.7">
+                                    <locus from="56rb" to="60ra"/>
+                                    <title ref="LIT4668Prayer#Sunday"/>
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> 
+                                        ብርናኤል<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> አጕደ፡ አግፍላላኤል፡ ዘንተ፡ አስማተ፡ 
+                                        ዘወሀቦሙ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> እግዚአብሔር፡ ለአናንያ፡ ወአዛርያ፡ ወሚሳኤል፡ እንዘ፡
+                                        ይትናገሮሙ፡ ሚካኤል<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ቀዊሞ፡ ማዕከለ፡ እቶነ፡ እሳት፡</incipit>
+                                    <textLang mainLang="gez"/>
+                                </msItem>
+                                <msItem xml:id="p1_i2.8">
+                                    <locus from="60ra" to="64vb"/>
+                                    <title ref="LIT4668Prayer#Andrew"/>
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/><cb n="60rb"/><gap reason="ellipsis"/> አስማት፡ ዘነገሮ፡ እግዚእነ፡ 
+                                        ለቅዱስ፡ እንድርያስ፡ ሐዋርያ፡ ወሰማዕት<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied>
+                                        <gap reason="ellipsis"/> ወይቤሎ፡ ሑር<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ሀገረ፡ በላዕተ፡ 
+                                        ሰብእ፡ ኀበ፡ ሀሎ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ማትያስ፡ 
+                                        እኁከ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> <pb n="60va"/> ከመ፡ ታውጽኦ፡ እምቤተ፡ ሞቅሕ፡</incipit>
+                                    <textLang mainLang="gez"/>
+                                </msItem>
+                                <msItem xml:id="p1_i2.9">
+                                    <locus from="65ra" to="71ra"/>
+                                    <title ref="LIT4668Prayer#Daily"/>
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ተማኅፀንኩ፡ ከመ፡ ኢይሙት፡ ዘእንበለ፡ 
+                                        ጊዜየ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ከመ፡ ሠራቄ፡ ሌሊት፡ ወከመ፡ ቀታሌ፡ መዓልት፡ ወሌሊት፡
+                                        <gap reason="ellipsis"/><cb n="65rb"/><gap reason="ellipsis"/> ሞርሞራ፡ ሞርሞራ፡ ሞርሞራ፡ ወመጽአ፡ ቃል፡ እምሰማይ፡ እምደመና፡
+                                        ዘይብል<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ዝንቱ፡ ውእቱ፡ ወልድየ፡ ዘአፈቅር።</incipit>
+                                    <textLang mainLang="gez"/>
+                                </msItem>
+                            </msItem>
+                            <msItem xml:id="p1_i3">
+                                <locus from="73ra" to="88rb"/>
+                                <title ref="LIT2246salotz"/>
+                                <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ዛቲ፡ ጸሎት፡ ዘእግዝእትነ፡ ማርያም፡ ወላዲተ፡ አምላክ፡ እንተ፡ ጸሐፋ፡ አብሮኮሮስ፡
+                                    ረድአ፡ ዮሐንስ፡ <gap reason="ellipsis"/><cb n="73rb"/><gap reason="ellipsis"/> ጸሎት፡ ዘጸለየት፡ ባቲ፡ እግዝእትነ፡ ማርያም፡ ወላዲተ፡
+                                    አምላክ፡ አመ፡ ፳ወ፩ ለወርኃ፡ ሰኔ፡ በደብረ፡ ጐልጐታ፡ ዘውእቱ፡ መቃብረ፡ እግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ እንዘ፡ ትብል፡</incipit>
+                                <textLang mainLang="gez"/>
+                            </msItem>
+                            <msItem xml:id="p1_i4">
+                                <locus from="88va" to="92ra"/>
+                                <title ref="LIT2295Sayfam"/>
+                                <incipit xml:lang="gez">በስመ፡ እግዚአብሔር፡ ቀዳማዊ፡ ዘእንበለ፡ ትማልም፡ ወማዕከላዊ፡ ዘእንበለ፡ ዮም። ወደሐራዊ፡ ዘእንበለ፡ ጌሠም፡ 
+                                    <gap reason="ellipsis"/><pb n="89rb"/><gap reason="ellipsis"/> ነዓ፡ ኀቤየ፡ እግዚእየ፡ ኢየሱስ፡ ክርስቶስ፡ 
+                                    <gap reason="ellipsis"/><cb n="89va"/><gap reason="ellipsis"/> መብረቀ፡ መለኮት፡ መደንግጽ፡ ፍሕመ፡ መለኮት፡ ብቍፅ፡ ሐጸ፡ 
+                                    መለኮት፡ ርውጽ። እሳተ፡ መለኮት፡ ውዑይ፡ ነደ፡ መለኮት፡ ውኩይ፡ ፀሐየ፡ መለኮት፡ ልሁይ፡</incipit>
+                                <textLang mainLang="gez"/>
+                            </msItem>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Codex">
+                                <supportDesc>
+                                    <support>
+                                        <material key="parchment"/></support>
+                                    <extent>
+                                        <measure unit="leaf" quantity="92" cert="medium">92</measure>
+                                        <dimensions type="outer" unit="mm">
+                                            <height unit="mm">117</height>
+                                            <width unit="mm">82</width>
+                                        </dimensions>
+                                    </extent>
+                                    <condition key="good"/>
+                                </supportDesc>
+                                <layoutDesc><layout columns="2" writtenLines="15"/></layoutDesc>
+                            </objectDesc>
+                            <handDesc>
+                                <handNote xml:id="h1" script="Ethiopic">
+                                    <seg type="script">Nineteenth-century script.</seg>
+                                    <seg type="ink">Black and red ink</seg>
+                                    <date notBefore="1800" notAfter="1899" evidence="lettering">19th century</date>
+                                    <desc>Regular handwriting by the scribe 
+                                        <persName ref="PRS15328SayfaMik" role="scribe">Sayfa Mikāʾel</persName>.</desc>
+                                </handNote>
+                            </handDesc>
+                            <additions>
+                                <list>
+                                    <item xml:id="e2">
+                                        <locus target="#22vb #34r #48vb"/>
+                                        <desc>The text of <ref target="#p1_i2"/> is divided to the days of the week, but yet alone the readings for 
+                                            Wednesday (<foreign xml:lang="gez">ዘረቡዕ፡</foreign>, <locus target="#22vb"/>),
+                                            Thursday (<foreign xml:lang="gez">ዘሐሙስ፡</foreign>, <locus target="#34r"/>) and
+                                            Saturday (<foreign xml:lang="gez">ዘቀዳሚት፡</foreign>, <locus target="#48vb"/>), are indicated.</desc>
+                                    </item>
+                                </list>
+                            </additions>
+                        </physDesc>
+                        <history>
+                            <origin>The manuscript was written for <persName role="patron" ref="PRS15327HabtaGab">Habta Gabrǝʾel</persName> 
+                                (<locus target="6va"/> et passim) by <persName ref="PRS15328SayfaMik" role="scribe">Sayfa Mikāʾel</persName> 
+                                (<locus target="73ra"/>) in the <origDate notBefore="1800" notAfter="1899">19th century</origDate>. 
+                            </origin>
+                        </history>
+                        <additional>
+                            <adminInfo>
+                                <recordHist>
+                                    <source>
+                                        <listBibl type="catalogue">
+                                            <bibl>
+                                                <ptr target="bm:Strelcyn1976Catalogue"/>
+                                                <citedRange unit="page">140–144</citedRange>
+                                            </bibl>
+                                        </listBibl>
+                                    </source>
+                                </recordHist>
+                                <custodialHist>
+                                    <custEvent type="restorations" subtype="none"/>
+                                </custodialHist>
+                            </adminInfo>
+                        </additional>
+                    </msPart>
+                    <msPart xml:id="p2">
+                        <msIdentifier/>
+                        <msContents><summary/>
+                            <msItem xml:id="p2_i1">
+                                <locus from="93ra" to="118vb"/>
+                                <title ref="LIT1824Mafteh">Collection of prayers for loosening of charms (Maftǝḥe śǝrāy)</title>
+                                <msItem xml:id="p2_i1.1">
+                                    <locus from="93ra"/>
+                                    <title ref="LIT7270PrayerUCh"/>
+                                    <note>Unlike the text attested in <ref type="mss" corresp="BAVet203"/>, this text does not contain an Arabic name 
+                                        for the Holy Spirit at the beginning.</note>
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ መርእስክ፡ 
+                                        ዘ<cb n="93rb"/>ስሙ<add place="below">ር</add>፡ አብቋሉ፡ ሳዶር፡</incipit>
+                                    <textLang mainLang="gez"/>
+                                </msItem>
+                                <msItem xml:id="p2_i1.2">
+                                    <locus from="98vb"/>
+                                    <title ref="LIT7799PrayerDeath"/>
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ሸሾር፡ አኮናሸር፡ ለእመ፡ ወድቀ፡ በድነ፡ ሥጋሁ፡ በእጀ፡ ሰብእ፡ ወጽላወጊ፡</incipit>
+                                    <textLang mainLang="gez"/>
+                                </msItem>
+                                <msItem xml:id="p2_i1.3">
+                                    <locus from="100rb"/>
+                                    <title ref="LIT7801PrayerCharms"/>
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ መፍትሔ፡ ሥራይ፡ ይትፈታሕ፡ ሥራየ፡ አረሚ፡ ወአምሐራ፡ ወዠራ፡
+                                        ይትፈታሕ፡ ስራየ፡ ጋላ፡ ወሻንቅላ፡</incipit>
+                                    <textLang mainLang="gez"/>
+                                </msItem>
+                                <msItem xml:id="p2_i1.4">
+                                    <locus from="101rb"/>
+                                    <title ref="LIT7802PPrayer"/>
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ መፍትሔ፡ ሥራይ፡ አክምና፡ ፫ ፍታሕ፡</incipit>
+                                    <textLang mainLang="gez"/>
+                                </msItem>
+                                <msItem xml:id="p2_i1.5">
+                                    <locus from="102va"/>
+                                    <title ref="LIT7828Nafseya"/><!-- Issue #3280 -->
+                                        <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ መፍትሔ፡ ሥራይ፡ ነፍስየ፡ ወሐጁን፡ ነፍስየ፡ ዋሕያ፡ ወማልዱ፡
+                                            </incipit>
+                                    <textLang mainLang="gez"/>
+                                </msItem>
+                                <msItem xml:id="p2_i1.6">
+                                    <locus from="105ra"/>
+                                    <title ref="LIT7829Radani"/><!-- Issue #3281 -->
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ሸአድ፡ አሌፍ፡ አልቦ፡ ሔር፡ ዘ<cb n="105rb"/>እንበላ፡ እግዚአብሔር፡ 
+                                        ርድአኒ፡ ወእቀበኒ፡ ወእምኵሉ፡ ጽላወጊ፡ ወአልጉም፡</incipit>
+                                    <textLang mainLang="gez"/>
+                                </msItem>
+                                <msItem xml:id="p2_i1.8">
+                                    <locus from="107vb"/>
+                                    <title ref="LIT7830Algum"/><!-- Issue #3282 -->
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ መፍትሔ፡ ሥራይ፡ ወአልጉም፡ ወእጅ፡ ሰብእ፡ 
+                                        ዝንቱ፡ <pb n="108ra"/> አስማት፡ በእንተ፡ አቤ፡ እቤ እቤ፡ ሸር፡ አፍእጅ፡</incipit>
+                                    <textLang mainLang="gez"/>
+                                </msItem>
+                                <msItem xml:id="p2_i1.9">
+                                    <locus from="109vb"/>
+                                    <title ref="LIT7271PrayerCharms"/><!-- Issue #3283 -->
+                                    <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ መፍት<pb n="110ra"/>ሔ፡ ሥራይ፡ ወጽላወጊ፡
+                                        ወዘቅማ<surplus>ም</surplus>ንት፡ ወዘአምሐራ፡ ወዘእጅ፡ ሰብእ፡ ካህናንህ፡ ካህናንህ፡ ካህናንህ፡ ካህናንህ፡ ካህናንህ፡ ካህናንህ፡ ካህናንህ፡</incipit>
+                                    <textLang mainLang="gez"/>
+                                </msItem>
+                                <msItem xml:id="p2_i1.10">
+                                    <locus from="118vb"/>
+                                    <title type="incomplete" ref="LIT7826GabiruSela">Beginning of a magic receipt against ṣǝlā wagi</title><!-- Issue #3279 -->
+                                    <incipit xml:lang="gez">ገቢሩ፡ ጽላ፡ ወጊ፡ ቢወጋው፡ ፫ ጊዜ፡ አዙር፡ ለሥራይ፡ ፯ ዘቢብ፡ 
+                                        ፯ ቁ<supplied reason="omitted" resp="PRS8999Strelcyn">ን</supplied>ዶ፡ በርበሬ፡ ያሞሌ፡ 
+                                        ጨ<supplied reason="omitted" resp="PRS8999Strelcyn">ው</supplied>፡ የወርካ፡</incipit>
+                                    <textLang mainLang="am"/>
+                                </msItem>
+                            </msItem>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Codex">
+                                <supportDesc>
+                                    <support>
+                                        <material key="parchment"/></support>
+                                    <extent>
+                                        <measure unit="leaf" quantity="92" cert="medium">92</measure>
+                                        <dimensions type="outer" unit="mm">
+                                            <height unit="mm">117</height>
+                                            <width unit="mm">82</width>
+                                        </dimensions>
+                                    </extent>
+                                    <condition key="good"/>
+                                </supportDesc>
+                                <layoutDesc><layout columns="2"/></layoutDesc>
+                            </objectDesc>
+                            <handDesc>
+                                <handNote xml:id="h2" script="Ethiopic">
+                                    <seg type="script">Nineteenth-century script.</seg>
+                                    <seg type="ink">Black and red ink</seg>
+                                    <date notBefore="1800" notAfter="1899" evidence="lettering">19th century</date>
+                                    <desc>Regular handwriting, larger than <ref target="h1"/>.</desc>
+                                </handNote>
+                            </handDesc>
+                            <additions>
+                                
+                            </additions>
+                        </physDesc>
+                        <history>
+                            <origin>
+                                <origDate notBefore="1800" notAfter="1899">19th century</origDate>
+                            </origin>
+                        </history>
+                        <additional>
+                            <adminInfo>
+                                <recordHist>
+                                    <source>
+                                        <listBibl type="catalogue">
+                                            <bibl>
+                                                <ptr target="bm:Strelcyn1976Catalogue"/>
+                                                <citedRange unit="page">143–144</citedRange>
+                                            </bibl>
+                                        </listBibl>
+                                    </source>
+                                </recordHist>
+                                <custodialHist>
+                                    <custEvent type="restorations" subtype="none"/>
+                                </custodialHist>
+                            </adminInfo>
+                        </additional>
+                    </msPart>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+                <xi:fallback>
+                    <p>Definitions of prefixes used.</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Prayers"/>
+                    <term key="Liturgy"/>
+                    <term key="Asmat"/>
+                    <term key="demon"/>
+                    <term key="Medicine"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2026-03-12">Created record</change>
+            <!--  -->
+        </revisionDesc>
+    </teiHeader>
+    <text xml:base="https://betamasaheft.eu/">
+        <body>
+            <ab/>
+        </body>
+    </text>
+</TEI>

--- a/RomeALincei/ANLcr47.xml
+++ b/RomeALincei/ANLcr47.xml
@@ -35,8 +35,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <support>
                                     <material key="parchment"/></support>
                                 <extent>
-                                    <measure unit="leaf" quantity="118" cert="low">118</measure><note>The number of leaves is not 
-                                        noted in the catalogue.</note>
+                                    <measure unit="leaf" quantity="118" cert="low">118</measure><note>The number of leaves is not explicitly
+                                        provided in the catalogue.</note>
                                     <measure unit="page" type="blank">3</measure><locus target="#2 #2v #72v"/>
                                     <dimensions type="outer" unit="mm">
                                         <height unit="mm">117</height>

--- a/RomeALincei/ANLcr47.xml
+++ b/RomeALincei/ANLcr47.xml
@@ -68,9 +68,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <origin>
                             <origDate notBefore="1800" notAfter="1899">19th century</origDate>
                         </origin>
-                        <provenance>Two names, which belong presumably to two subsequent owners, appear on <locus target="#4r"/> 
-                            (<persName ref="PRS15325MabaGigar">Mabʾa Gigār</persName>) and on <locus target="#92ra"/> 
-                            (<persName ref="PRS15326TaklaMadh">Takla Madḫǝn</persName>).</provenance>
+                        <provenance>Two names of presumably two subsequent owners appear: 
+                            <persName ref="PRS15325MabaGigar">Mabʾa Gigār</persName> on <locus target="#4r"/> and 
+                            <persName ref="PRS15326TaklaMadh">Takla Madḫǝn</persName> on <locus target="#92ra"/>.</provenance>
                     </history>
                     <additional>
                         <adminInfo>
@@ -170,7 +170,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <msItem xml:id="p1_i2.3.1">
                                         <locus from="22vb" to="27rb"/>
                                         <title ref="LIT4668Prayer#Wednesday1"/>
-                                        <note>Indicated here as <term key="Asmat">magic names</term> revealed to St Thomas.</note>
+                                        <note>Indicated here as <term key="Asmat">magic names</term> revealed to 
+                                            <persName ref="PRS9496Thomas">St Thomas</persName>.</note>
                                         <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> 
                                             ጸሎተ<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> መድኃኒት፡ አስማተ፡ 
                                             ኃይላት<supplied reason="omitted" resp="PRS8999Strelcyn">፡</supplied> ዘወረደ፡ እምሰማያት፡ ዘወሀቦ፡ ለቶማስ፡ ረድዕ፡ ለዘክሮቱ፡


### PR DESCRIPTION
I created a record for ANLcr47. I created new LIT ID for several magic texts,
 cf. https://github.com/BetaMasaheft/Documentation/issues/3282, 
https://github.com/BetaMasaheft/Documentation/issues/3283,
https://github.com/BetaMasaheft/Documentation/issues/3281, 
https://github.com/BetaMasaheft/Documentation/issues/3280, 
https://github.com/BetaMasaheft/Documentation/issues/3279, 
https://github.com/BetaMasaheft/Documentation/issues/3270, 
https://github.com/BetaMasaheft/Documentation/issues/3269 
as well as PRS records for the persons involved in https://github.com/BetaMasaheft/Persons/pull/1339.

I updated three other manuscript records to insert the newly developed CAe.