### PR TITLE
Delete links in PULgarrettEth017

### DIFF
--- a/princeton/PULgarrettEth017.xml
+++ b/princeton/PULgarrettEth017.xml
@@ -31,7 +31,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             4. Folio 66v-67r. Miracle of Saint Marqoryos [sic]
                             5. Folio 68r-75r. Miracles of the Infant Jesus 10 miracles.</summary>
                   <msItem xml:id="ms_i1">
-                     <title>Miracles of Mary</title>
+                     <title ref="LIT2384Taamme">Miracles of Mary</title>
                      <msItem xml:id="ms_i1.1">
                         <title>Introduction</title>
                      </msItem>
@@ -39,7 +39,252 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <title>Prologue</title>
                      </msItem>
                      <msItem xml:id="ms_i1.3">
-                        <title>62 Miracles</title>
+                        <title>Miracles</title>
+                        <note>The first 32 miracles are followed by a stanza of <ref type="work" corresp="LIT4274AkkonuB"/>, making them to <title ref="LIT5673AkkonuColl"></title></note>
+                        <msItem xml:id="ms_i1.3.1">
+                           <locus from="9v">f. 9v-11r, col. 2, line 3</locus>
+                           <title ref="LIT3586Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.2">
+                           <locus from="11r">f. 11r-12r, col. 2, line 17</locus>
+                           <title ref="LIT3589Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.3">
+                           <locus from="12r">f. 12r-12v, col. 2, line 1</locus>
+                           <title ref="LIT3589Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.4">
+                           <locus from="12v">f. 12v-13v, col. 2, line 15</locus>
+                           <title ref="LIT3590Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.5">
+                           <locus from="13v">f. 13v-14v, col. 2, line 4</locus>
+                           <title ref="LIT3591Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.6">
+                           <locus from="14v">f. 14v-15v, col. 2, line 4</locus>
+                           <title ref="LIT3592Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.7">
+                           <locus from="15v">f. 15v-16v, col. 2, line 14</locus>
+                           <title ref="LIT3593Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.8">
+                           <locus from="16v">f. 16v-17v, col. 2, line 8</locus>
+                           <title ref="LIT3594Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.9">
+                           <locus from="17v">f. 17v-18r, col. 2, line 11</locus>
+                           <title ref="LIT3595Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.10">
+                           <locus from="18v">f. 18v-20r, col. 1, line 2</locus>
+                           <title ref="LIT3596Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.11">
+                           <locus from="20r">f. 20r-20v, col. 1, line 9</locus>
+                           <title ref="LIT3597Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.12">
+                           <locus from="20v">f. 20v-21v, col. 2, line 5</locus>
+                           <title ref="LIT3598Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.13">
+                           <locus from="21v">f. 21v-22r, col. 1, line 19</locus>
+                           <title ref="LIT3599Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.14">
+                           <locus from="22r">f. 22r-23r, col. 2, line 10</locus>
+                           <title ref="LIT3600Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.15">
+                           <locus from="23r">f. 23r-24r, col. 2, line 10</locus>
+                           <title ref="LIT3601Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.16">
+                           <locus from="24r">f. 24r-25r, col. 1, line 21</locus>
+                           <title ref="LIT3602Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.17">
+                           <locus from="25r">f. 25r-26r, col. 2, line 14</locus>
+                           <title ref="LIT3603Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.18">
+                           <locus from="26r">f. 26r-26v, col. 2, line 11</locus>
+                           <title ref="LIT3604Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.19">
+                           <locus from="26v">f. 26v-27v, col. 2, line 11</locus>
+                           <title ref="LIT3606Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.20">
+                           <locus from="27v">f. 27v-28r, col. 1, line 12</locus>
+                           <title ref="LIT3605Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.21">
+                           <locus from="28r">f. 28r-29r, col. 1, line 19</locus>
+                           <title ref="LIT3607Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.22">
+                           <locus from="29v">f. 29v-30v, col. 1, line 1</locus>
+                           <title ref="LIT3608Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.23">
+                           <locus from="30v">f. 30v-31r, col. 1, line 15</locus>
+                           <title ref="LIT3609Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.24">
+                           <locus from="31r">f. 31r-32r, col. 2, line 15</locus>
+                           <title ref="LIT3610Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.25">
+                           <locus from="32v">f. 32v-35r, col. 1, line 2</locus>
+                           <title ref="LIT3611Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.26">
+                           <locus from="35r">f. 35r-35v, col. 1, line 9</locus>
+                           <title ref="LIT3612Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.27">
+                           <locus from="36r">f. 36r-36v, col. 1, line 3</locus>
+                           <title ref="LIT3613Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.28">
+                           <locus from="37r">f. 37r-39r, col. 1, line 1</locus>
+                           <title ref="LIT3614Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.29">
+                           <locus from="39r">f. 39r-40v, col. 2, line 12</locus>
+                           <title ref="LIT3615Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.30">
+                           <locus from="40v">f. 40v-41r, col. 2, line 5</locus>
+                           <title ref="LIT3663Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.31">
+                           <locus from="41r">f. 41r-41v, col. 2, line 12</locus>
+                           <title ref="LIT3617Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.32">
+                           <locus from="42r">f. 42r-42v, col. 1, line 9</locus>
+                           <title ref="LIT3618Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.33">
+                           <locus from="42v">f. 42v-44r, col. 2, line 13</locus>
+                           <title ref="LIT3665Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.34">
+                           <locus from="44r">f. 44r-44r, col. 1, line 3</locus>
+                           <title ref="LIT3587Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.35">
+                           <locus from="44r">f. 44r-45r, col. 2, line 16</locus>
+                           <title ref="LIT3647Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.36">
+                           <locus from="45r">f. 45r-46v, col. 2, line 7</locus>
+                           <title ref="LIT5377MiracleKing"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.37">
+                           <locus from="46v">f. 46v-47r, col. 2, line 16</locus>
+                           <title ref="LIT3865Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.38">
+                           <locus from="47r">f. 47r-48r, col. 2, line 6</locus>
+                           <title ref="LIT3866Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.39">
+                           <locus from="48r">f. 48r-49r, col. 1, line 11</locus>
+                           <title ref="LIT3923Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.40">
+                           <locus from="49r">f. 49r-50r, col. 2, line 1</locus>
+                           <title ref="LIT5008MiracleScorpionSwallowed"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.41">
+                           <locus from="50r">f. 50r-51v, col. 1, line 4</locus>
+                           <title ref="LIT3611Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.42">
+                           <locus from="51v">f. 51v-52r, col. 2, line 14</locus>
+                           <title ref="LIT3652Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.43">
+                           <locus from="52r">f. 52r-53v, col. 2, line 19</locus>
+                           <title ref="LIT3658Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.44">
+                           <locus from="53v">f. 53v-54r, col. 1, line 4</locus>
+                           <title ref="LIT3588Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.45">
+                           <locus from="54r">f. 54r-54v, col. 1, line 6</locus>
+                           <title ref="LIT3694Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.46">
+                           <locus from="54v">f. 54v-55v, col. 2, line 15</locus>
+                           <title ref="LIT3926Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.47">
+                           <locus from="55v">f. 55v-56v, col. 2, line 10</locus>
+                           <title ref="LIT3919Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.48">
+                           <locus from="56v">f. 56v-57r, col. 1, line 10</locus>
+                           <title ref="LIT3866Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.49">
+                           <locus from="57r">f. 57r-57v, col. 1, line 12</locus>
+                           <title>Pilgrim to Santiago: Part 1: The bishop for whom the Virgin Mary tailored a new sackcloth sends a penitent pilgrim to Santiago (whole or opening)</title>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.50">
+                           <locus from="57v">f. 57v-58v, col. 2, line 19</locus>
+                           <title ref="LIT3613Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.51">
+                           <locus from="58v">f. 58v-59r, col. 1, line 7</locus>
+                           <title ref="LIT3917Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.52">
+                           <locus from="59r">f. 59r-60r, col. 2, line 20</locus>
+                           <title ref="LIT3918Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.53">
+                           <locus from="60r">f. 60r-61v, col. 1, line 19</locus>
+                           <title ref="LIT3867Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.54">
+                           <locus from="62r">f. 62r-62v, col. 2, line 1</locus>
+                           <title ref="LIT5170MiracleFishermanSnake"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.55">
+                           <locus from="62v">f. 62v-63r, col. 2, line 1</locus>
+                           <title ref="LIT3589Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.56">
+                           <locus from="63r">f. 63r-63v, col. 1, line 15</locus>
+                           <title ref="LIT3919Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.57">
+                           <locus from="63v">f. 63v-64r, col. 2, line 19</locus>
+                           <title ref="LIT3652Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.58">
+                           <locus from="64r">f. 64r-64v, col. 2, line 14</locus>
+                           <title ref="LIT3915Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.59">
+                           <locus from="64v">f. 64v-65r, col. 2, line 8</locus>
+                           <title ref="LIT3590Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.60">
+                           <locus from="65r">f. 65r-65v, col. 2, line 7</locus>
+                           <title ref="LIT5008MiracleScorpionSwallowed"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.61">
+                           <locus from="65v">f. 65v-66v, col. 2, line 14</locus>
+                           <title ref="LIT3636Miracle"/>
+                        </msItem>
                      </msItem>
                   </msItem>
                   <msItem xml:id="ms_i2">
@@ -73,7 +318,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                   <origin>
                      <origDate notBefore="1800" notAfter="1809">between 1800 and 1809</origDate>
                   </origin>
-                  <provenance>Former owners: Kenfa Māryām, also Kenfa Mikāʻēl and Zarʻa Krestos, donated by Robert Garrett</provenance>
+                  <provenance>Former owners: Kenfa Māryām, also Kenfa Mikāʻēl and Zarʻa Krestos, donated by Robert Garrett. This manuscript's last known location in Ethiopia was Galab, Eritrea</provenance>
                </history>
                <additional>
                   <adminInfo>
@@ -108,12 +353,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       </profileDesc>
       <revisionDesc>
          <change when="2024-04-22" who="ES">created stub</change>
+         <change when="2022-05-05" who="SG">catalogued the stories for PEMM</change>
          <change when="2026-04-15" who="CH">deleted dead facsimile links</change>
+         <change when="2026-04-15" who="ES">imported content from PEMM</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
       <body>
-         <ab/>
+         <div type="bibliography"><listRelation><relation name="skos:exactMatch" active="PULgarrettEth017" passive="https://pemm.princeton.edu/en-us/manuscripts/PGE17"></relation></listRelation></div>
+         
       </body>
    </text>
 </TEI>

--- a/princeton/PULgarrettEth017.xml
+++ b/princeton/PULgarrettEth017.xml
@@ -31,7 +31,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             4. Folio 66v-67r. Miracle of Saint Marqoryos [sic]
                             5. Folio 68r-75r. Miracles of the Infant Jesus 10 miracles.</summary>
                   <msItem xml:id="ms_i1">
-                     <title>Miracles of Mary</title>
+                     <title ref="LIT2384Taamme">Miracles of Mary</title>
                      <msItem xml:id="ms_i1.1">
                         <title>Introduction</title>
                      </msItem>
@@ -39,7 +39,252 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <title>Prologue</title>
                      </msItem>
                      <msItem xml:id="ms_i1.3">
-                        <title>62 Miracles</title>
+                        <title>Miracles</title>
+                        <note>The first 32 miracles are followed by a stanza of <ref type="work" corresp="LIT4274AkkonuB"/>, making them to <title ref="LIT5673AkkonuColl"></title></note>
+                        <msItem xml:id="ms_i1.3.1">
+                           <locus from="9v">f. 9v-11r, col. 2, line 3</locus>
+                           <title ref="LIT3586Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.2">
+                           <locus from="11r">f. 11r-12r, col. 2, line 17</locus>
+                           <title ref="LIT3589Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.3">
+                           <locus from="12r">f. 12r-12v, col. 2, line 1</locus>
+                           <title ref="LIT3589Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.4">
+                           <locus from="12v">f. 12v-13v, col. 2, line 15</locus>
+                           <title ref="LIT3590Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.5">
+                           <locus from="13v">f. 13v-14v, col. 2, line 4</locus>
+                           <title ref="LIT3591Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.6">
+                           <locus from="14v">f. 14v-15v, col. 2, line 4</locus>
+                           <title ref="LIT3592Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.7">
+                           <locus from="15v">f. 15v-16v, col. 2, line 14</locus>
+                           <title ref="LIT3593Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.8">
+                           <locus from="16v">f. 16v-17v, col. 2, line 8</locus>
+                           <title ref="LIT3594Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.9">
+                           <locus from="17v">f. 17v-18r, col. 2, line 11</locus>
+                           <title ref="LIT3595Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.10">
+                           <locus from="18v">f. 18v-20r, col. 1, line 2</locus>
+                           <title ref="LIT3596Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.11">
+                           <locus from="20r">f. 20r-20v, col. 1, line 9</locus>
+                           <title ref="LIT3597Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.12">
+                           <locus from="20v">f. 20v-21v, col. 2, line 5</locus>
+                           <title ref="LIT3598Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.13">
+                           <locus from="21v">f. 21v-22r, col. 1, line 19</locus>
+                           <title ref="LIT3599Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.14">
+                           <locus from="22r">f. 22r-23r, col. 2, line 10</locus>
+                           <title ref="LIT3600Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.15">
+                           <locus from="23r">f. 23r-24r, col. 2, line 10</locus>
+                           <title ref="LIT3601Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.16">
+                           <locus from="24r">f. 24r-25r, col. 1, line 21</locus>
+                           <title ref="LIT3602Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.17">
+                           <locus from="25r">f. 25r-26r, col. 2, line 14</locus>
+                           <title ref="LIT3603Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.18">
+                           <locus from="26r">f. 26r-26v, col. 2, line 11</locus>
+                           <title ref="LIT3604Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.19">
+                           <locus from="26v">f. 26v-27v, col. 2, line 11</locus>
+                           <title ref="LIT3606Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.20">
+                           <locus from="27v">f. 27v-28r, col. 1, line 12</locus>
+                           <title ref="LIT3605Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.21">
+                           <locus from="28r">f. 28r-29r, col. 1, line 19</locus>
+                           <title ref="LIT3607Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.22">
+                           <locus from="29v">f. 29v-30v, col. 1, line 1</locus>
+                           <title ref="LIT3608Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.23">
+                           <locus from="30v">f. 30v-31r, col. 1, line 15</locus>
+                           <title ref="LIT3609Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.24">
+                           <locus from="31r">f. 31r-32r, col. 2, line 15</locus>
+                           <title ref="LIT3610Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.25">
+                           <locus from="32v">f. 32v-35r, col. 1, line 2</locus>
+                           <title ref="LIT3611Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.26">
+                           <locus from="35r">f. 35r-35v, col. 1, line 9</locus>
+                           <title ref="LIT3612Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.27">
+                           <locus from="36r">f. 36r-36v, col. 1, line 3</locus>
+                           <title ref="LIT3613Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.28">
+                           <locus from="37r">f. 37r-39r, col. 1, line 1</locus>
+                           <title ref="LIT3614Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.29">
+                           <locus from="39r">f. 39r-40v, col. 2, line 12</locus>
+                           <title ref="LIT3615Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.30">
+                           <locus from="40v">f. 40v-41r, col. 2, line 5</locus>
+                           <title ref="LIT3663Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.31">
+                           <locus from="41r">f. 41r-41v, col. 2, line 12</locus>
+                           <title ref="LIT3617Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.32">
+                           <locus from="42r">f. 42r-42v, col. 1, line 9</locus>
+                           <title ref="LIT3618Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.33">
+                           <locus from="42v">f. 42v-44r, col. 2, line 13</locus>
+                           <title ref="LIT3665Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.34">
+                           <locus from="44r">f. 44r-44r, col. 1, line 3</locus>
+                           <title ref="LIT3587Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.35">
+                           <locus from="44r">f. 44r-45r, col. 2, line 16</locus>
+                           <title ref="LIT3647Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.36">
+                           <locus from="45r">f. 45r-46v, col. 2, line 7</locus>
+                           <title ref="LIT5377MiracleKing"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.37">
+                           <locus from="46v">f. 46v-47r, col. 2, line 16</locus>
+                           <title ref="LIT3865Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.38">
+                           <locus from="47r">f. 47r-48r, col. 2, line 6</locus>
+                           <title ref="LIT3866Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.39">
+                           <locus from="48r">f. 48r-49r, col. 1, line 11</locus>
+                           <title ref="LIT3923Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.40">
+                           <locus from="49r">f. 49r-50r, col. 2, line 1</locus>
+                           <title ref="LIT5008MiracleScorpionSwallowed"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.41">
+                           <locus from="50r">f. 50r-51v, col. 1, line 4</locus>
+                           <title ref="LIT3611Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.42">
+                           <locus from="51v">f. 51v-52r, col. 2, line 14</locus>
+                           <title ref="LIT3652Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.43">
+                           <locus from="52r">f. 52r-53v, col. 2, line 19</locus>
+                           <title ref="LIT3658Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.44">
+                           <locus from="53v">f. 53v-54r, col. 1, line 4</locus>
+                           <title ref="LIT3588Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.45">
+                           <locus from="54r">f. 54r-54v, col. 1, line 6</locus>
+                           <title ref="LIT3694Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.46">
+                           <locus from="54v">f. 54v-55v, col. 2, line 15</locus>
+                           <title ref="LIT3926Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.47">
+                           <locus from="55v">f. 55v-56v, col. 2, line 10</locus>
+                           <title ref="LIT3919Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.48">
+                           <locus from="56v">f. 56v-57r, col. 1, line 10</locus>
+                           <title ref="LIT3866Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.49">
+                           <locus from="57r">f. 57r-57v, col. 1, line 12</locus>
+                           <title ref="LIT4997MiracleBishopPhiloteus">Pilgrim to Santiago: Part 1: The bishop for whom the Virgin Mary tailored a new sackcloth sends a penitent pilgrim to Santiago (whole or opening)</title>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.50">
+                           <locus from="57v">f. 57v-58v, col. 2, line 19</locus>
+                           <title ref="LIT3613Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.51">
+                           <locus from="58v">f. 58v-59r, col. 1, line 7</locus>
+                           <title ref="LIT3917Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.52">
+                           <locus from="59r">f. 59r-60r, col. 2, line 20</locus>
+                           <title ref="LIT3918Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.53">
+                           <locus from="60r">f. 60r-61v, col. 1, line 19</locus>
+                           <title ref="LIT3867Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.54">
+                           <locus from="62r">f. 62r-62v, col. 2, line 1</locus>
+                           <title ref="LIT5170MiracleFishermanSnake"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.55">
+                           <locus from="62v">f. 62v-63r, col. 2, line 1</locus>
+                           <title ref="LIT3589Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.56">
+                           <locus from="63r">f. 63r-63v, col. 1, line 15</locus>
+                           <title ref="LIT3919Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.57">
+                           <locus from="63v">f. 63v-64r, col. 2, line 19</locus>
+                           <title ref="LIT3652Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.58">
+                           <locus from="64r">f. 64r-64v, col. 2, line 14</locus>
+                           <title ref="LIT3915Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.59">
+                           <locus from="64v">f. 64v-65r, col. 2, line 8</locus>
+                           <title ref="LIT3590Miracle"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.60">
+                           <locus from="65r">f. 65r-65v, col. 2, line 7</locus>
+                           <title ref="LIT5008MiracleScorpionSwallowed"/>
+                        </msItem>
+                        <msItem xml:id="ms_i1.3.61">
+                           <locus from="65v">f. 65v-66v, col. 2, line 14</locus>
+                           <title ref="LIT3636Miracle"/>
+                        </msItem>
                      </msItem>
                   </msItem>
                   <msItem xml:id="ms_i2">
@@ -73,7 +318,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                   <origin>
                      <origDate notBefore="1800" notAfter="1809">between 1800 and 1809</origDate>
                   </origin>
-                  <provenance>Former owners: Kenfa Māryām, also Kenfa Mikāʻēl and Zarʻa Krestos, donated by Robert Garrett</provenance>
+                  <provenance>Former owners: Kenfa Māryām, also Kenfa Mikāʻēl and Zarʻa Krestos. 
+                     This manuscript's last known location in Ethiopia was Galab, Eritrea</provenance>
+                  <acquisition>Donated by <persName ref="PRS4530Garrett"/>.</acquisition>
                </history>
                <additional>
                   <adminInfo>
@@ -107,13 +354,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
          </langUsage>
       </profileDesc>
       <revisionDesc>
+         <change when="2022-05-05" who="SG">catalogued the stories for PEMM</change>
          <change when="2024-04-22" who="ES">created stub</change>
          <change when="2026-04-15" who="CH">deleted dead facsimile links</change>
+         <change when="2026-04-15" who="ES">imported content from PEMM</change>
       </revisionDesc>
    </teiHeader>
+   <facsimile>
+      <graphic url="https://dpul.princeton.edu/msstreasures/catalog/4t64gr70w"></graphic>
+   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>
-         <ab/>
+         <div type="bibliography"><listRelation><relation name="skos:exactMatch" active="PULgarrettEth017" passive="https://pemm.princeton.edu/en-us/manuscripts/PGE17"></relation></listRelation></div>
       </body>
    </text>
 </TEI>

--- a/princeton/PULgarrettEth017.xml
+++ b/princeton/PULgarrettEth017.xml
@@ -235,7 +235,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </msItem>
                         <msItem xml:id="ms_i1.3.49">
                            <locus from="57r">f. 57r-57v, col. 1, line 12</locus>
-                           <title>Pilgrim to Santiago: Part 1: The bishop for whom the Virgin Mary tailored a new sackcloth sends a penitent pilgrim to Santiago (whole or opening)</title>
+                           <title ref="LIT4997MiracleBishopPhiloteus">Pilgrim to Santiago: Part 1: The bishop for whom the Virgin Mary tailored a new sackcloth sends a penitent pilgrim to Santiago (whole or opening)</title>
                         </msItem>
                         <msItem xml:id="ms_i1.3.50">
                            <locus from="57v">f. 57v-58v, col. 2, line 19</locus>

--- a/princeton/PULgarrettEth017.xml
+++ b/princeton/PULgarrettEth017.xml
@@ -355,7 +355,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       </profileDesc>
       <revisionDesc>
          <change when="2022-05-05" who="SG">catalogued the stories for PEMM</change>
-         <change when="2024-04-22" who="ES">created stub</change>
+         <change when="2024-04-22" who="ES">created bm ID for images</change>
          <change when="2026-04-15" who="CH">deleted dead facsimile links</change>
          <change when="2026-04-15" who="ES">imported content from PEMM</change>
       </revisionDesc>

--- a/princeton/PULgarrettEth017.xml
+++ b/princeton/PULgarrettEth017.xml
@@ -103,19 +103,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       <profileDesc>
          <langUsage>
             <language ident="en">English</language>
-            <language ident="gez"/>
+            <language ident="gez">Gǝʿǝz</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>
          <change when="2024-04-22" who="ES">created stub</change>
+         <change when="2026-04-15" who="CH">deleted dead facsimile links</change>
       </revisionDesc>
    </teiHeader>
-   <facsimile>
-      <graphic url=""/>
-   </facsimile>
-   <facsimile>
-      <graphic url="https://dpul.princeton.edu/msstreasures/catalog/4t64gr70w"></graphic>
-   </facsimile>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <ab/>


### PR DESCRIPTION
I found that "Link to images" existed twice on https://betamasaheft.eu/manuscripts/PULgarrettEth017/main, but none worked (while clicking on "Images" works well). I think, it is therefore necessary either to update the links in facsimile or to delete them. I found that images are distributed on https://catalog.princeton.edu/catalog/99123667053506421, which is quoted in listBibl, but I am not sure about the link that would fit into facsimile. Therefore I suggest to delete the links in facsimile.