### PR TITLE
Create ANLcr51.xml

### DIFF
--- a/RomeALincei/ANLcr51.xml
+++ b/RomeALincei/ANLcr51.xml
@@ -145,6 +145,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 <citedRange unit="page">149</citedRange>
                                             </bibl>
                                         </listBibl>
+                                        <listBibl type="secondary">
+                                            <bibl>
+                                                <ptr target="bm:ContiRossini1903Ricordi"/>
+                                                <citedRange unit="chapter">VI, II, Tradizioni degli Algheden</citedRange>
+                                                <citedRange unit="page">71–73</citedRange>
+                                            </bibl>
+                                            <bibl>
+                                                <ptr target="bm:ContiRossini1903Tigre"/><citedRange>23–27</citedRange>
+                                            </bibl>
+                                        </listBibl>
                                     </source>
                                 </recordHist>
                                 <custodialHist>
@@ -165,12 +175,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <title>Tigre texts</title>
                             <msItem xml:id="p2_i1.1">
                                 <locus from="2r"/>
-                                <title>Dǝgm ǧǝmʿ wad galāydos mǝn ʿad takles</title>
+                                <title>Dǝgm ǧǝmʿ wad Galāydos mǝn ʿad Takles</title>
                                 <incipit xml:lang="tig">ድግም፡ ጅምዕ፡ ወድ፡ ገላይዶስ፡ ምን፡ ዐድ፡ ተክሌስ።</incipit>
                             </msItem>
                             <msItem xml:id="p2_i1.2">
                                 <locus from="3v"/>
-                                <title>Dǝgm sab ḥabāb</title>
+                                <title>Dǝgm sab Ḥabāb</title>
                                 <incipit xml:lang="tig">ድግም፡ ሰብ፡ ሐባብ።</incipit>
                             </msItem>
                             <msItem xml:id="p2_i1.3">
@@ -180,17 +190,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </msItem>
                             <msItem xml:id="p2_i1.4">
                                 <locus from="4v"/>
-                                <title>Dǝgm ʾǝb ḥamde</title>
+                                <title>Dǝgm ʾǝb Ḥamde</title>
                                 <incipit xml:lang="tig">ድግም፡ እብ፡ ሐምዴ።</incipit>
                             </msItem>
                             <msItem xml:id="p2_i1.5">
                                 <locus from="4v"/>
-                                <title>Dǝgm sab badir</title>
+                                <title>Dǝgm sab Badir</title>
                                 <incipit xml:lang="tig">ድግም፡ ሰብ፡ በዲር።</incipit>
                             </msItem>
                             <msItem xml:id="p2_i1.6">
                                 <locus from="12r"/>
-                                <title>Dǝgm kǝlʾot ḥāw sab badir</title>
+                                <title>Dǝgm kǝlʾot ḥāw sab Badir</title>
                                 <incipit xml:lang="tig">ድግም፡ ክልኦት፡ ሓው፡ ሰብ፡ በዲር።</incipit>
                              </msItem>
                         </msItem>
@@ -258,12 +268,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <title>Tigre texts</title>
                                 <msItem xml:id="p3_i1.1">
                                     <locus from="2r"/>
-                                    <title>Dǝgm ʾǝnās badir</title>
+                                    <title>Dǝgm ʾǝnās Badir</title>
                                     <incipit xml:lang="tig">ድግም፡ እናስ፡ በዲር፡</incipit>
                                 </msItem>
                                 <msItem xml:id="p3_i1.2">
                                     <locus from="3v"/>
-                                    <title>Dǝgm ʿad ǧamil</title>
+                                    <title>Dǝgm ʿad Ǧamil</title>
                                     <incipit xml:lang="tig">ድግም፡ ዐድ፡ ጀሚል።</incipit>
                                 </msItem>
                                 <msItem xml:id="p3_i1.3">
@@ -273,7 +283,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </msItem>
                                 <msItem xml:id="p3_i1.4">
                                     <locus from="4r"/>
-                                    <title>Dǝgm bǝyḥo sab badir</title>
+                                    <title>Dǝgm Bǝyḥo sab Badir</title>
                                     <note>=Littmann I, 16</note>
                                     <note>The text was edited in Enno Littmann, Publications of the Princeton Expedition to 
                                         Abyssinia, vol. 1 - Tales, Customs ...: Tigre Text, Leiden 1910, no. 16; and translated in vol. 2 - Translations.</note>
@@ -286,7 +296,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </msItem>
                                 <msItem xml:id="p3_i1.6">
                                     <locus from="11r"/>
-                                    <title>Dǝgm wǝrs salas ḥaw karā maḥamad</title>
+                                    <title>Dǝgm wǝrs salas ḥaw karā Maḥamad</title>
                                     <incipit xml:lang="tig">ድግም፡ ውርስ፡ ሰለስ፡ ሐው፡ ከራ፡ መሐመድ።</incipit>
                                 </msItem>
                                 <msItem xml:id="p3_i1.7">
@@ -441,7 +451,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <msContents><summary/>
                         <msItem xml:id="p5_i1">
                             <locus from="1r" to="5r"/><locus from="6r" to="6v"/>
-                            <title>Dǝgm mansāʿ</title>
+                            <title>Dǝgm Mansāʿ</title>
                             <note>The original text runs up to <locus target="#5r"/>. The final chapter is written on <locus from="6r" to="6v"/>, 
                                 which was taken from <ref target="p4"/> and inserted in this place. It is entitled 
                                 <foreign xml:lang="tig">ድግም፡ ወለት፡ ሐጸይ፡ እት፡ ምድር፡ መንሳዕ፡</foreign> and comparable to fol. 17r (18r according to 
@@ -615,19 +625,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 includes prefaces to the poems that are missing from this manuscript.</note>
                             <msItem xml:id="p7_i1.1">
                                 <locus from="2r"/>
-                                <title>ʾAmir wad gabāh ʾǝgl maḥamad wad ǧāwǧ laḥalayā</title>
+                                <title>ʾAmir wad Gabāh ʾǝgl Maḥamad wad Ǧāwǝǧ laḥalayā</title>
                                 <incipit xml:lang="tig" type="inscriptio">አሚር፡ ወድ፡ ገባህ፡ እግል፡ መሐመድ፡ ወድ፡ ጃውጅ፡ ለሐለያ።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.2">
                                 <locus from="2v"/>
-                                <title>ʾAmir wad gabāh ʾǝgl kantebay ǧāwǧ laḥalayā</title>
+                                <title>ʾAmir wad Gabāh ʾǝgl Kantebay Ǧāwǝǧ laḥalayā</title>
                                 <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">486</citedRange></bibl>.
                                         </note>
                                 <incipit xml:lang="tig" type="inscriptio">አሚር፡ ወድ፡ ገባህ፡ እግል፡ ከንቴበይ፡ ጃውጅ፡ ለሐለያ።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.3">
                                 <locus from="3v"/>
-                                <title>Ḥǝlāyat hǝbtes wad nawradin (mǝn ʿad takles)</title>
+                                <title>Ḥǝlāyat Hǝbtes wad Nawradin (mǝn ʿad Takles)</title>
                                 <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">550</citedRange></bibl>.
                                         </note>
                                 <incipit xml:lang="tig" type="inscriptio">ሕላየት፡ ህብቴስ፡ ወድ፡ ነውረዲን፡ 
@@ -635,7 +645,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </msItem>
                             <msItem xml:id="p7_i1.4">
                                 <locus from="4r"/>
-                                <title>Ḥǝlāyat ʾǝyāsu wad hǝbtes (mǝn ʿad hǝbtes)</title>
+                                <title>Ḥǝlāyat ʾƎyāsu wad Hǝbtes (mǝn ʿAd Hǝbtes)</title>
                                 <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">515</citedRange></bibl>.
                                         </note>
                                 <incipit xml:lang="tig" type="inscriptio">ሕላየት፡ እያሱ፡ ወድ፡ ህብቴስ፡ 
@@ -643,45 +653,45 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </msItem>
                             <msItem xml:id="p7_i1.5">
                                 <locus from="6r"/>
-                                <title>Wad gǝrmit ʾǝgl ʾǝzāz wad ǧamil laḥalayā ʿad taklesay</title>
+                                <title>Wad Gǝrmit ʾǝgl ʾƎzāz wad Gamil laḥalayā ʿAd Taklesay</title>
                                 <incipit xml:lang="tig" type="inscriptio">ወድ፡ ግርሚት፡ እግል፡ እዛዝ፡ ወድ፡ ጀሚል፡ ለሐለያ፡ ዐድ፡ ተክሌሰይ።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.6">
                                 <locus from="6v"/>
-                                <title>Wad gǝrmit ʾǝgl galāydos laḥalayā</title>
+                                <title>Wad Gǝrmit ʾǝgl Galāydos laḥalayā</title>
                                 <incipit xml:lang="tig" type="inscriptio">ወድ፡ ግርሚት፡ እግል፡ ገላይዶስ፡ ለሐለያ።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.7">
                                 <locus from="7r"/>
-                                <title>ʾƎzāz wad ǧamil ʾǝgl ḥazan laḥalayā</title>
+                                <title>ʾƎzāz wad Ǧamil ʾǝgl Ḥazan laḥalayā</title>
                                 <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">548</citedRange></bibl>.
                                         </note>
                                 <incipit xml:lang="tig" type="inscriptio">እዛዝ፡ ወድ፡ ጀሚል፡ እግል፡ ሐዘን፡ ለሐለያ።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.8">
                                 <locus from="7v"/>
-                                <title>ʾƎzāz wad fǝdel laḥalayā ʾǝgl mansāʿ kaʾafo kǝm ʿalat</title>
+                                <title>ʾƎzāz wad Fǝdel laḥalayā ʾǝgl Mansāʿ kaʾafo kǝm ʿalat</title>
                                 <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">226</citedRange></bibl>.
                                         </note>
                                 <incipit xml:lang="tig" type="inscriptio">እዛዝ፡ ወድ፡ ፍዴል፡ ለሐለያ፡ እግል፡ መንሳዕ፡ ከአፎ፡ ክም፡ ዐለት።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.9">
                                 <locus from="9v"/>
-                                <title>ʾƎkd wad fǝdel labelā</title>
+                                <title>ʾƎkkǝd wad Fǝdel labellā</title>
                                 <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">227</citedRange></bibl>.
                                       </note>
                                 <incipit xml:lang="tig" type="inscriptio">እክድ፡ ወድ፡ ፍዴል፡ ለቤላ።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.10">
                                 <locus from="10r"/>
-                                <title>ʿAli ʾǝgl dabab laḥalayā</title>
+                                <title>ʿAli ʾǝgl Dabab laḥalayā</title>
                                 <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">394</citedRange></bibl>.
                                         </note>
                                 <incipit xml:lang="tig" type="inscriptio">ዐሊ፡ እግል፡ ደበብ፡ ለሐለያ።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.11">
                                 <locus from="10v"/>
-                                <title>ʿAli ʾǝgl dabab laḥalayā</title>
+                                <title>ʿAli ʾǝgl Dabab laḥalayā</title>
                                 <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">395</citedRange></bibl>.
                                         </note>
                                 <incipit xml:lang="tig" type="inscriptio">ዐሊ፡ እግል፡ ደበብ፡ ለሐለያ።</incipit>
@@ -702,105 +712,109 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </msItem>
                             <msItem xml:id="p7_i1.14">
                                 <locus from="12r"/>
-                                <title>ʾElos wad tedros betǧukay dib sanḥit laḥalayā</title>
+                                <title>ʾElos wad Tedros betǧukay dib sanḥit laḥalayā</title>
                                 <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">311</citedRange></bibl>.
                                         </note>
                                 <incipit xml:lang="tig" type="inscriptio">ኤሎስ፡ ወድ፡ ቴድሮስ፡ ቤትጁከይ፡ ዲብ፡ ሰንሒት፡ ለሐለያ።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.15">
                                 <locus from="12v"/>
-                                <title>ʿƎmrān wad karam bazḥ ʾǝgl ǧahāǧ waǧ ʿagabā labelā</title>
-                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">75</citedRange></bibl>.
-                                        </note>
-                                <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ እግል፡ ጀሃጅ፡ ወጅ፡ ዐገባ፡ ለቤላ።</incipit>
+                                <title>ʿƎmrān wad Karam Bazzǝḥ ʾǝgl Ǧahāǧ waǧ ʿAggabā labellā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">75</citedRange></bibl>, 
+                                    where the title is inscribed as <foreign xml:lang="tig">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ እግል፡ <sic>ጀሃድ፡</sic> <sic>ወድ፡</sic>
+                                        ዐገባ፡ ለቤላ።</foreign>.</note>
+                                <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም–በዝሕ። እግል፡ ጀሃጅ፡ ወጅ፡ ዐገባ፡ ለቤላ።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.16">
                                 <locus from="16r"/>
-                                <title>ʿƎmrān wad karam bazḥ ʾǝgl ǧahāǧ waǧ ʿagabā labelā</title>
-                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">76</citedRange></bibl>.
-                                        </note>
+                                <title>ʿƎmrān wad Karam Bazzǝḥ ʾǝgl Ǧahāǧ waǧ ʿAggabā labellā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">76</citedRange></bibl>,
+                                    where the title is inscribed as <foreign xml:lang="tig">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ እግል፡ <sic>ጀሃድ፡</sic> <sic>ወድ፡</sic>
+                                        ዐገባ፡ <sic>ሀዬ፡</sic> ለቤላ።</foreign>.</note>
                                 <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ እግል፡ ጀሃጅ፡ ወጅ፡ ዐገባ፡ ለቤላ።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.17">
                                 <locus from="17r"/>
-                                <title>ʿƎmrān wad karam bazḥ ʾǝgl ǧahāǧ waǧ ʿagabā labelā</title>
-                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">77</citedRange></bibl>.
-                                        </note>
+                                <title>ʿƎmrān wad Karam Bazzǝḥ ʾǝgl Ǧahāǧ waǧ ʿAggabā labellā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">77</citedRange></bibl>,
+                                    where the title is inscribed as <foreign xml:lang="tig">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ እግል፡ <sic>ጀሃድ፡</sic> <sic>ወድ፡</sic>
+                                        ዐገባ፡ <sic>ሀዬ፡</sic> ለቤላ።</foreign>.</note>
                                 <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ እግል፡ ጀሃጅ፡ ወጅ፡ ዐገባ፡ ለቤላ።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.18">
                                 <locus from="18r"/>
-                                <title>ʿƎmrān wad karam bazḥ ʾǝgl ǧahāǧ waǧ ʿagabā labelā</title>
-                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">78</citedRange></bibl>.
-                                        </note>
+                                <title>ʿƎmrān wad Karam Bazzǝḥ ʾǝgl Ǧahāǧ waǧ ʿAggabā labellā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">78</citedRange></bibl>,
+                                    where the title is inscribed as <foreign xml:lang="tig">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ እግል፡ <sic>ጀሃድ፡</sic> <sic>ወድ፡</sic>
+                                        ዐገባ፡ <sic>ሀዬ፡</sic> ለቤላ።</foreign>.</note>
                                 <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ እግል፡ ጀሃጅ፡ ወጅ፡ ዐገባ፡ ለቤላ።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.19">
                                 <locus from="18v"/>
-                                <title>ʿƎmrān wad karam bazḥ ʾǝgl ʿad tasfāč̣on labelā</title>
+                                <title>ʿƎmrān wad Karam Bazzǝḥ ʾǝgl ʿAd Tasfāč̣on labellā</title>
                                 <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">79</citedRange></bibl>.
                                         </note>
                                 <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ እግል፡ ዐድ፡ ተስፋጮን፡ ለቤላ።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.20">
                                 <locus from="21r"/>
-                                <title>ʿƎmrān wad karam bazḥ ʾǝt badā ʾazān tagarit mansāʿ wamot sab gǝdri labelā</title>
+                                <title>ʿƎmrān wad Karam Bazzǝḥ ʾǝt badā ʾazān tagarit Mansāʿ wamot sab gǝdri labellā</title>
                                 <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">80</citedRange></bibl>.
                                         </note>
                                 <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ እት፡ በዳ፡ አዛን፡ ተገሪት፡ መንሳዕ፡ ወሞት፡ ሰብ፡ ግድሪ፡ ለቤላ።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.21">
                                 <locus from="23v"/>
-                                <title>ʿƎmrān wad karam bazḥ ʾaḥa ʿatmāryām ʾet mǝdr mansāʿ mǝn ʿerat labelā</title>
-                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">81</citedRange></bibl>.
-                                        </note>
+                                <title>ʿƎmrān wad Karam Bazzǝḥ ʾaḥa ʿAtmāryām ʾet mǝdr Mansāʿ mǝn ʿerat labellā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">81</citedRange></bibl>,
+                                    where the people are indicated as <foreign xml:lang="tig">ዐድ–ትማርያም፡</foreign>.</note>
                                 <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ አሐ፡ ዐትማርያም፡ እት፡ ምድር፡ መንሳዕ፡ ምን፡ ዔረት፡ ለቤላ።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.22">
                                 <locus from="24v"/>
-                                <title>ʿƎmrān wad karam bazḥ ʾǝgl rorā ʾagʿara labelā</title>
-                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">83</citedRange></bibl>.
-                                        </note>
+                                <title>ʿƎmrān wad Karam Bazzǝḥ ʾǝgl rorā ʾAgʿara labellā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">83</citedRange></bibl>,
+                                    where the land is called <foreign xml:lang="tig">ሮራ፡ አግዐሮ፡</foreign>.</note>
                                 <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ እግል፡ ሮራ፡ አግዐረ፡ ለቤላ።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.23">
                                 <locus from="26r"/>
-                                <title>ʿƎmrān wad karam bazḥ ʾǝt zamāte ʾagʿaro waʾǝtā ʾǝt lamotaw sab labelā</title>
+                                <title>ʿƎmrān wad Karam Bazzǝḥ ʾǝt zamāte ʾAgʿaro waʾǝtā ʾǝt lamotaw sab labellā</title>
                                 <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">84</citedRange></bibl>.
                                         </note>
                                 <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ እት፡ ዘማቴ፡ አግዐሮ፡ ወእታ፡ እት፡ ለሞተው፡ ሰብ፡ ለቤላ።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.24">
                                 <locus from="27r"/>
-                                <title>ʿƎmrān wad karam bazḥ labelā</title>
+                                <title>ʿƎmrān wad Karam Bazzǝḥ labellā</title>
                                 <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">85</citedRange></bibl>.
                                      </note>
                                 <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ ለቤላ።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.25">
                                 <locus from="27v"/>
-                                <title>ʿƎmrān wad karam bazḥ labelā</title>
+                                <title>ʿƎmrān wad Karam Bazzǝḥ labellā</title>
                                 <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">86</citedRange></bibl>.
                                       </note>
                                 <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ ለቤላ።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.26">
                                 <locus from="28r"/>
-                                <title>ʿƎmrān wad karam bazḥ labelā</title>
+                                <title>ʿƎmrān wad Karam Bazzǝḥ labellā</title>
                                 <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">87</citedRange></bibl>.
                                         </note>
                                 <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ ለቤላ።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.27">
                                 <locus from="28v"/>
-                                <title>ʾAwʿalā wad maḥamud ʾǝgl ǧahad wad ʿagabā labelā</title>
+                                <title>ʾAwʿalā wad Maḥamud ʾǝgl Ǧahād wad ʿAggabā labellā</title>
                                 <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">1</citedRange></bibl>.
                                         </note>
                                 <incipit xml:lang="tig" type="inscriptio">አውዐላ፡ ወድ፡ መሐሙድ፡ እግል፡ ጀሃድ፡ ወድ፡ ዐገባ፡ ለቤላ።</incipit>
                             </msItem>
                             <msItem xml:id="p7_i1.28">
                                 <locus from="29r"/>
-                                <title>ʾAwʿalā wad maḥamud ʾǝgl kantebay tedros wakantebay bǝʾǝmnat labelā</title>
+                                <title>ʾAwʿalā wad Maḥamud ʾǝgl Kantebay Tedros wa-Kantebay Bǝʾǝmnat labellā</title>
                                 <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">3</citedRange></bibl>.
                                         </note>
                                 <incipit xml:lang="tig" type="inscriptio">አውዐላ፡ ወድ፡ መሐሙድ፡ እግል፡ ከንቴበይ፡ ቴድሮስ፡ ወከንቴበይ፡ ብእምነት፡ ለቤላ።</incipit>
@@ -841,6 +855,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 <citedRange unit="page">150–152</citedRange>
                                             </bibl>
                                         </listBibl>
+                                        <listBibl type="secondary">
+                                            <bibl><ptr target="bm:Littmann1913Tigre"/></bibl>
+                                            <bibl><ptr target="bm:Littmann1913Tigre_IV_A"/></bibl><!-- Consult: AAI 9: M:Lit 4,A/1383  and SUB-->
+                                            <bibl><ptr target="bm:Littmann1915Tigre_IV_B"/></bibl><!-- Consult: AAI 9: M:Lit 4,B/1810 and SUB -->
+                                        </listBibl>
                                     </source>
                                 </recordHist>
                                 <custodialHist>
@@ -872,7 +891,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <locus from="1v" to="3v"/>
                                 <title>History of the prophet Salomon</title>
                                 <note>Written by the hand of <persName ref="PRS3182ContiRo"/> and edited and translated in
-                                    <bibl><ptr target="bm:ContiRossini1903Tigre"/><citedRange unit="page">17–20</citedRange></bibl>.</note><!-- Add zotero bibl ref -->
+                                    <bibl><ptr target="bm:ContiRossini1903Tigre"/><citedRange unit="page">17–20</citedRange></bibl>.</note>
                             </msItem>
                         </msContents>
                         <physDesc>
@@ -910,6 +929,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 <citedRange unit="page">152</citedRange>
                                             </bibl>
                                         </listBibl>
+                                        <listBibl type="secondary">
+                                            <bibl>
+                                                <ptr target="bm:ContiRossini1903Tigre"/>
+                                                <citedRange unit="page">17–20</citedRange>
+                                            </bibl>
+                                        </listBibl>
                                     </source>
                                 </recordHist>
                                 <custodialHist>
@@ -933,81 +958,81 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     </note>
                             <msItem xml:id="p9_i1.1">
                                 <locus from="1r"/>
-                                <title>Šalāy ḥakin</title>
+                                <title>Šalāy Ḥakin</title>
                                 <incipit xml:lang="tig"><locus from="1ra"/> ሸላይ። ሐኪን፡</incipit>
                                 <incipit xml:lang="am"><locus from="1rb"/> የሐኪን፡ ውዳሴ።</incipit>
                             </msItem>
                             <msItem xml:id="p9_i1.2">
                                 <locus from="1r"/>
-                                <title>Nāy daǧǧāč ḥadga ʾanba(sā) šalāy</title>
+                                <title>Nāy daǧǧāč Ḥadga ʾAnba(sā) šalāy</title>
                                 <incipit xml:lang="tig"><locus from="1ra"/> ናይ፡ ደጃች፡ ሐድገ፡ 
                                     አንበ<supplied reason="omitted" resp="PRS8999Strelcyn">ሳ፡</supplied> ሸላይ።</incipit>
                                 <incipit xml:lang="am"><locus from="1rb"/> የደጃች፡ ሐድገ፡ አንበሳ፡ ውዳሴ።</incipit>
                             </msItem>
                             <msItem xml:id="p9_i1.3">
                                 <locus from="2v"/>
-                                <title>Nāy daǧǧāč ḥadga ʾanba(sā) šalāy</title>
+                                <title>Nāy daǧǧāč Ḥadga ʾAnba(sā) šalāy</title>
                                 <incipit xml:lang="tig"><locus from="2va"/> ናይ፡ ደጃች፡ ሐድገ፡ 
                                     አንበ<supplied reason="omitted" resp="PRS8999Strelcyn">ሳ፡</supplied> ሸላይ።</incipit>
                                 <incipit xml:lang="am"><locus from="2vb"/> የደጃች፡ ሐድገ፡ አንበሳ፡ ውዳሴ።</incipit>
                             </msItem>
                             <msItem xml:id="p9_i1.4">
                                 <locus from="4r"/>
-                                <title>Ḥǝlāy<!-- transcription unclear --> kantibā walda gābr</title>
+                                <title>Ḥǝlāy kantibā Walda Gābr</title>
                                 <incipit xml:lang="tig"><locus from="4ra"/> 𞟥ላይ፡ ከንቲባ፡ ወልደ፡ ጋብር።</incipit>
                                 <incipit xml:lang="am"><locus from="4rb"/> የከንቲባ፡ ወልደ፡ ጋብር፡ ውዳሴ።</incipit>
                             </msItem>
                             <msItem xml:id="p9_i1.5">
                                 <locus from="4v"/>
-                                <title>Nāy madin wad zarʾay šalāy</title>
+                                <title>Nāy madin wad Zarʾay šalāy</title>
                                 <incipit xml:lang="tig"><locus from="4va"/> ናይ፡ መዲን፡ ወድ፡ ዘርአይ፡ ሸላይ።</incipit>
                                 <incipit xml:lang="am"><locus from="4vb"/> የመዲን፡ የዘርአይ፡ ልጅ፡ ውዳሴ።</incipit>
                             </msItem>
                             <msItem xml:id="p9_i1.6">
                                 <locus from="4v"/>
-                                <title>Ḥǝlāy<!-- transcription unclear --> ḥamǝd zamāt</title>
+                                <title>Ḥǝlāy Ḥamǝd zamāt</title>
                                 <incipit xml:lang="tig"><locus from="4va"/> 𞟥ላይ፡ ሐምድ፡ ዘማት።</incipit>
                                 <incipit xml:lang="am"><locus from="4vb"/>የሐምድ፡ ዘማት፡ ውዳሴ።</incipit>
                             </msItem>
                             <msItem xml:id="p9_i1.7">
                                 <locus from="5r"/>
-                                <title>Ḥǝlāy<!-- transcription unclear --> ʾarʾadom wad ʾaǧāǧ</title>
+                                <title>Ḥǝlāy ʾarʾadom wad ʾAǧāǧ</title>
                                 <incipit xml:lang="tig"><locus from="5ra"/> 𞟥ላይ፡ አርአዶም፡ ወድ፡ አጃጃ።</incipit>
                                 <incipit xml:lang="am"><locus from="5rb"/>የአርአዶም፡ የአጃጅ፡ ልጅ፡ ውዳሴ።</incipit>
                             </msItem>
                             <msItem xml:id="p9_i1.8">
                                 <locus from="6v"/>
-                                <title>Ḥǝlāy<!-- transcription unclear --> raṭi wad zamāt</title>
+                                <title>Ḥǝlāy raṭi wad zamāt</title>
                                 <incipit xml:lang="tig"><locus from="6va"/> 𞟥ላይ፡ ረጢ፡ ወድ፡ ዘማት።</incipit>
                                 <incipit xml:lang="am"><locus from="6vb"/> የረጢ፡ የዘማት፡ ልጅ፡ ውዳሴ።</incipit>
                             </msItem>
                             <msItem xml:id="p9_i1.9">
                                 <locus from="6v"/>
-                                <title>Ḥǝlāy<!-- transcription unclear --> ḥakin wad madin</title>
+                                <title>Ḥǝlāy Ḥakin wad Madin</title>
                                 <incipit xml:lang="tig"><locus from="6va"/> 𞟥ላይ፡ ሐኪን፡ ወድ፡ መዲን።</incipit>
                                 <incipit xml:lang="am"><locus from="6vb"/> የሐኪን፡ የመዲን፡ ልጅ፡ ውዳሴ።</incipit>
                             </msItem>
                             <msItem xml:id="p9_i1.10">
                                 <locus from="7v"/>
-                                <title>Ḥǝlāy<!-- transcription unclear --> māḥmud wad ʾazāz</title>
+                                <title>Ḥǝlāy Māḥmud wad ʾAzāz</title>
                                 <incipit xml:lang="tig"><locus from="7va"/> 𞟥ላይ፡ ማሕሙድ፡ ወድ፡ እዛዝ።</incipit>
                                 <incipit xml:lang="am"><locus from="7vb"/> የማሕሙድ፡ የእዛዝ፡ ልጅ፡ ውዳሴ።</incipit>
                             </msItem>
                             <msItem xml:id="p9_i1.11">
                                 <locus from="8r"/>
-                                <title>Ḥǝlāy<!-- transcription unclear --> ḥǝmadin wad ʾǝǧl</title>
+                                <title>Ḥǝlāy Ḥǝmadin wad ʾǝǧl</title>
                                 <incipit xml:lang="tig"><locus from="8ra"/> 𞟥ላይ፡ ሕመዲን፡ ወድ፡ እጅል።</incipit>
                                 <incipit xml:lang="am"><locus from="8rb"/> የሕመዲን፡ የእጅል፡ ልጅ፡ ውዳሴ።</incipit>
                             </msItem>
                             <msItem xml:id="p9_i1.12">
                                 <locus from="8v"/>
-                                <title>Ḥǝlāy<!-- transcription unclear --> ḥǝmad wad māḥmud</title>
+                                <title>Ḥǝlāy Ḥǝmad wad Māḥmud</title>
                                 <incipit xml:lang="tig"><locus from="8va"/> 𞟥ላይ፡ ወድ፡ ማሕሙድ።</incipit>
                                 <incipit xml:lang="am"><locus from="8vb"/>የሕመድ፡ የማሕሙድ፡ ልጅ፡ ውዳሴ።</incipit>
                             </msItem>
                             <msItem xml:id="p9_i1.13">
                                 <locus from="9r"/>
-                                <title>Ḥǝlāy<!-- transcription unclear --> ʾelos wad tedros</title>
+                                <title>Ḥǝlāy ʾElos wad Tedros</title>
                                 <note>Edited and translated in 
                                     <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">258</citedRange></bibl>.</note>
                                 <incipit xml:lang="tig"><locus from="9ra"/> 𞟥ላይ፡ ወድ፡ ቴድሮስ።</incipit>
@@ -1015,13 +1040,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </msItem>
                             <msItem xml:id="p9_i1.14">
                                 <locus from="10r"/>
-                                <title>Ḥǝlāy<!-- transcription unclear --> daǧāč ḥadga ʾambasā</title>
+                                <title>Ḥǝlāy daǧǧāč Ḥadga ʾAmbasā</title>
                                 <incipit xml:lang="tig"><locus from="10ra"/> 𞟥ላይ፡ ደጃች፡ ሐድገ፡ አምበሳ።</incipit>
                                 <incipit xml:lang="am"><locus from="10rb"/>የደጃች፡ ሐድገ፡ አንበሳ፡ ውዳሴ።</incipit>
                             </msItem>
                             <msItem xml:id="p9_i1.15">
                                 <locus from="10v"/>
-                                <title>Ḥǝlāy<!-- transcription unclear --> maḥamad nur</title>
+                                <title>Ḥǝlāy Maḥamad Nur</title>
                                 <incipit xml:lang="tig"><locus from="10va"/> 𞟥ላይ፡ ሐመድ፡ ኑር።</incipit>
                                 <incipit xml:lang="am"><locus from="10vb"/>የመሐመድ፡ ኑር፡ ውዳሴ።</incipit>
                             </msItem>
@@ -1062,6 +1087,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 <ptr target="bm:Strelcyn1976Catalogue"/>
                                                 <citedRange unit="page">152–153</citedRange>
                                             </bibl>
+                                        </listBibl>
+                                        <listBibl type="secondary">
+                                            <bibl><ptr target="bm:Littmann1913Tigre"/></bibl>
                                         </listBibl>
                                     </source>
                                 </recordHist>

--- a/RomeALincei/ANLcr51.xml
+++ b/RomeALincei/ANLcr51.xml
@@ -226,7 +226,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </objectDesc>  
                             <handDesc>
                                 <handNote xml:id="h2" script="Ethiopic">                                     
-                                    <seg type="script">19th or 20th-century script.</seg>
+                                    <seg type="script">Nineteenth or Twentieth-century script.</seg>
                                     <seg type="ink">Black</seg>
                                 </handNote>
                             </handDesc>
@@ -284,9 +284,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <msItem xml:id="p3_i1.4">
                                     <locus from="4r"/>
                                     <title>Dǝgm Bǝyḥo sab Badir</title>
-                                    <note>=Littmann I, 16</note>
-                                    <note>The text was edited in Enno Littmann, Publications of the Princeton Expedition to 
-                                        Abyssinia, vol. 1 - Tales, Customs ...: Tigre Text, Leiden 1910, no. 16; and translated in vol. 2 - Translations.</note>
+                                    <note>The text was edited in <bibl><ptr target="bm:Littmann1910Tigre_I"/><citedRange unit="item">16</citedRange></bibl> and
+                                        translated <bibl><ptr target="bm:Littmann1910Tigre_II"/></bibl>.</note>
                                     <incipit xml:lang="tig">ድግም፡ ብይሖ፡ ሰብ፡ በዲር፡</incipit>
                                 </msItem>
                                 <msItem xml:id="p3_i1.5">
@@ -365,6 +364,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                                 <ptr target="bm:Strelcyn1976Catalogue"/>
                                                 <citedRange unit="page">149–150</citedRange>
                                             </bibl>
+                                        </listBibl>
+                                        <listBibl type="secondary">
+                                            <bibl><ptr target="bm:Littmann1910Tigre_I"/></bibl> 
+                                            <bibl><ptr target="bm:Littmann1910Tigre_II"/></bibl>
                                         </listBibl>
                                     </source>
                                 </recordHist>
@@ -622,7 +625,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <bibl><ptr target="bm:Littmann1913Tigre_IV_A"/></bibl> and 
                                 <bibl><ptr target="bm:Littmann1915Tigre_IV_B"/></bibl>. However, the texts in this manuscript differ
                                 particularly in terms of spelling from those published by Littmann. Furthermore, Littmann’s edition sometimes 
-                                includes prefaces to the poems that are missing from this manuscript.</note>
+                                includes prefaces to the poems that are missing in this manuscript.</note>
                             <msItem xml:id="p7_i1.1">
                                 <locus from="2r"/>
                                 <title>ʾAmir wad Gabāh ʾǝgl Maḥamad wad Ǧāwǝǧ laḥalayā</title>
@@ -856,9 +859,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             </bibl>
                                         </listBibl>
                                         <listBibl type="secondary">
-                                            <bibl><ptr target="bm:Littmann1913Tigre"/></bibl><!-- AAI 9: M:Lit 3/1384  and SUB-->
-                                            <bibl><ptr target="bm:Littmann1913Tigre_IV_A"/></bibl><!-- AAI 9: M:Lit 4,A/1383  and SUB-->
-                                            <bibl><ptr target="bm:Littmann1915Tigre_IV_B"/></bibl><!-- AAI 9: M:Lit 4,B/1810 and SUB -->
+                                            <bibl><ptr target="bm:Littmann1913Tigre"/></bibl>
+                                            <bibl><ptr target="bm:Littmann1913Tigre_IV_A"/></bibl>
+                                            <bibl><ptr target="bm:Littmann1915Tigre_IV_B"/></bibl>
                                         </listBibl>
                                     </source>
                                 </recordHist>
@@ -1014,7 +1017,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </msItem>
                             <msItem xml:id="p9_i1.10">
                                 <locus from="7v"/>
-                                <title>Ḥǝlāy Māḥmud wad ʾAzāz</title>
+                                <title>Ḥǝlāy Māḥmud wad ʾƎzāz</title>
                                 <incipit xml:lang="tig"><locus from="7va"/> 𞟥ላይ፡ ማሕሙድ፡ ወድ፡ እዛዝ።</incipit>
                                 <incipit xml:lang="am"><locus from="7vb"/> የማሕሙድ፡ የእዛዝ፡ ልጅ፡ ውዳሴ።</incipit>
                             </msItem>

--- a/RomeALincei/ANLcr51.xml
+++ b/RomeALincei/ANLcr51.xml
@@ -856,9 +856,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             </bibl>
                                         </listBibl>
                                         <listBibl type="secondary">
-                                            <bibl><ptr target="bm:Littmann1913Tigre"/></bibl>
-                                            <bibl><ptr target="bm:Littmann1913Tigre_IV_A"/></bibl><!-- Consult: AAI 9: M:Lit 4,A/1383  and SUB-->
-                                            <bibl><ptr target="bm:Littmann1915Tigre_IV_B"/></bibl><!-- Consult: AAI 9: M:Lit 4,B/1810 and SUB -->
+                                            <bibl><ptr target="bm:Littmann1913Tigre"/></bibl><!-- AAI 9: M:Lit 3/1384  and SUB-->
+                                            <bibl><ptr target="bm:Littmann1913Tigre_IV_A"/></bibl><!-- AAI 9: M:Lit 4,A/1383  and SUB-->
+                                            <bibl><ptr target="bm:Littmann1915Tigre_IV_B"/></bibl><!-- AAI 9: M:Lit 4,B/1810 and SUB -->
                                         </listBibl>
                                     </source>
                                 </recordHist>
@@ -964,21 +964,21 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </msItem>
                             <msItem xml:id="p9_i1.2">
                                 <locus from="1r"/>
-                                <title>Nāy daǧǧāč Ḥadga ʾAnba(sā) šalāy</title>
+                                <title>Nāy Daǧǧāč Ḥadga ʾAnba(sā) šalāy</title>
                                 <incipit xml:lang="tig"><locus from="1ra"/> ናይ፡ ደጃች፡ ሐድገ፡ 
                                     አንበ<supplied reason="omitted" resp="PRS8999Strelcyn">ሳ፡</supplied> ሸላይ።</incipit>
                                 <incipit xml:lang="am"><locus from="1rb"/> የደጃች፡ ሐድገ፡ አንበሳ፡ ውዳሴ።</incipit>
                             </msItem>
                             <msItem xml:id="p9_i1.3">
                                 <locus from="2v"/>
-                                <title>Nāy daǧǧāč Ḥadga ʾAnba(sā) šalāy</title>
+                                <title>Nāy Daǧǧāč Ḥadga ʾAnba(sā) šalāy</title>
                                 <incipit xml:lang="tig"><locus from="2va"/> ናይ፡ ደጃች፡ ሐድገ፡ 
                                     አንበ<supplied reason="omitted" resp="PRS8999Strelcyn">ሳ፡</supplied> ሸላይ።</incipit>
                                 <incipit xml:lang="am"><locus from="2vb"/> የደጃች፡ ሐድገ፡ አንበሳ፡ ውዳሴ።</incipit>
                             </msItem>
                             <msItem xml:id="p9_i1.4">
                                 <locus from="4r"/>
-                                <title>Ḥǝlāy kantibā Walda Gābr</title>
+                                <title>Ḥǝlāy Kantibā Walda Gābr</title>
                                 <incipit xml:lang="tig"><locus from="4ra"/> 𞟥ላይ፡ ከንቲባ፡ ወልደ፡ ጋብር።</incipit>
                                 <incipit xml:lang="am"><locus from="4rb"/> የከንቲባ፡ ወልደ፡ ጋብር፡ ውዳሴ።</incipit>
                             </msItem>
@@ -996,13 +996,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </msItem>
                             <msItem xml:id="p9_i1.7">
                                 <locus from="5r"/>
-                                <title>Ḥǝlāy ʾarʾadom wad ʾAǧāǧ</title>
+                                <title>Ḥǝlāy ʾArʾadom wad ʾAǧāǧ</title>
                                 <incipit xml:lang="tig"><locus from="5ra"/> 𞟥ላይ፡ አርአዶም፡ ወድ፡ አጃጃ።</incipit>
                                 <incipit xml:lang="am"><locus from="5rb"/>የአርአዶም፡ የአጃጅ፡ ልጅ፡ ውዳሴ።</incipit>
                             </msItem>
                             <msItem xml:id="p9_i1.8">
                                 <locus from="6v"/>
-                                <title>Ḥǝlāy raṭi wad zamāt</title>
+                                <title>Ḥǝlāy Raṭi wad Zamāt</title>
                                 <incipit xml:lang="tig"><locus from="6va"/> 𞟥ላይ፡ ረጢ፡ ወድ፡ ዘማት።</incipit>
                                 <incipit xml:lang="am"><locus from="6vb"/> የረጢ፡ የዘማት፡ ልጅ፡ ውዳሴ።</incipit>
                             </msItem>
@@ -1040,7 +1040,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </msItem>
                             <msItem xml:id="p9_i1.14">
                                 <locus from="10r"/>
-                                <title>Ḥǝlāy daǧǧāč Ḥadga ʾAmbasā</title>
+                                <title>Ḥǝlāy Daǧǧāč Ḥadga ʾAmbasā</title>
                                 <incipit xml:lang="tig"><locus from="10ra"/> 𞟥ላይ፡ ደጃች፡ ሐድገ፡ አምበሳ።</incipit>
                                 <incipit xml:lang="am"><locus from="10rb"/>የደጃች፡ ሐድገ፡ አንበሳ፡ ውዳሴ።</incipit>
                             </msItem>

--- a/RomeALincei/ANLcr51.xml
+++ b/RomeALincei/ANLcr51.xml
@@ -1,0 +1,1128 @@
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="ANLcr51" xml:lang="en" type="mss">
+    <teiHeader xml:base="https://betamasaheft.eu/">
+        <fileDesc>
+            <titleStmt>
+                <title>Tigre texts</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine
+                    multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS0335ANL"/>
+                        <idno>Conti Rossini 51</idno>
+                    </msIdentifier>
+                    <msContents>
+                        <summary/>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Other">
+                            <supportDesc>
+                                <support>
+                                    <material key="paper">Lined paper</material></support>
+                                <extent>
+                                    <measure unit="leaf" quantity="144">142</measure>
+                                    <dimensions type="outer" unit="mm">
+                                        <height unit="mm">200–215</height>
+                                        <width unit="mm">145–160</width>
+                                    </dimensions>
+                                </extent>   
+                                <collation>Nine unbound quires.</collation>
+                            </supportDesc>
+                            <layoutDesc><layout writtenLines="20 22"/></layoutDesc>
+                        </objectDesc>
+                        <additions>
+                            <list>
+                                <item xml:id="e1">
+                                    <desc>Note in red pencil concerning the content of the entire collection on <locus target="#1r"/> of 
+                                        <ref target="#p1"/>.</desc>
+                                    <q xml:id="it">Testi tigrè della Missione Svedense</q>
+                                </item>
+                            </list>
+                        </additions>
+                        <bindingDesc>
+                            <binding>
+                                <decoNote xml:id="b1">No binding.</decoNote>
+                            </binding>
+                        </bindingDesc>
+                    </physDesc>
+                    <history>
+                        <origin>The items originate largely from the environments of the Swedish Evangelical Mission to Eritrea, 
+                            as indicated by a signature by <persName ref="PRS8170Roden"/> on <locus target="#16r"/> of 
+                            <ref target="#p2"/>. They were therefore produced at the
+                            <origDate notBefore="1880" notAfter="1910">end of the 19th or beginning of the 20th century</origDate>.
+                        </origin>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1976Catalogue"/>
+                                            <citedRange unit="item">51</citedRange>
+                                            <citedRange unit="page">149–153</citedRange>
+                                        </bibl>
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                            <custodialHist>
+                                <custEvent type="restorations" subtype="none"/>
+                            </custodialHist>
+                        </adminInfo>
+                    </additional>
+                    <msPart xml:id="p1">
+                        <msIdentifier>
+                            <altIdentifier>
+                                <idno>Quire 1</idno>
+                            </altIdentifier>
+                        </msIdentifier>
+                        <msContents><summary/>
+                        <msItem xml:id="p1_i1">
+                            <locus from="5r" to="8v"/>
+                            <title>History of ʾAlgaden</title>
+                            <note>Annotated by <persName ref="PRS3182ContiRo"/> and edited in 
+                                <bibl><ptr target="bm:ContiRossini1903Ricordi"/>
+                                    <citedRange unit="chapter">VI, II, Tradizioni degli Algheden</citedRange>
+                                        <citedRange unit="page">71–73</citedRange></bibl>, as well as translated in 
+                                <bibl><ptr target="bm:ContiRossini1903Tigre"/><citedRange>23–27</citedRange></bibl>.
+                                    </note>
+                            <incipit type="inscriptio" xml:lang="tig">ድግም፡ ሰብ፡ አልገዴን።</incipit>
+                        </msItem>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Other">
+                                <supportDesc>
+                                    <support><material key="paper">Lined paper</material></support>
+                                    <extent>
+                                        <measure unit="leaf" quantity="8">8</measure>
+                                        <measure unit="page" type="blank">7</measure><locus from="1v" to="4v"/>
+                                        <measure unit="quire" quantity="1">1</measure>
+                                        <dimensions type="outer" unit="mm">
+                                            <height unit="mm">210</height>
+                                            <width unit="mm">155</width>
+                                        </dimensions>
+                                    </extent>
+                                    <foliation>Paginated by <persName ref="PRS3182ContiRo"/>.</foliation>
+                                    <condition key="good"/>
+                                </supportDesc> 
+                            </objectDesc>  
+                            <handDesc>
+                                <handNote xml:id="h1" script="Ethiopic">
+                                    <ab type="script"/>
+                                    <seg type="script">19th or 20th-century script.</seg>
+                                    <seg type="ink">Black</seg>
+                                </handNote>
+                            </handDesc>
+                            <additions>
+                                <list>
+                                    <item xml:id="e2">
+                                        <desc>Annotations by <persName ref="PRS3182ContiRo"/>.</desc>
+                                    </item>
+                                </list>
+                            </additions>
+                        </physDesc>
+                        <additional>
+                            <adminInfo>
+                                <recordHist>
+                                    <source>
+                                        <listBibl type="catalogue">
+                                            <bibl>
+                                                <ptr target="bm:Strelcyn1976Catalogue"/>
+                                                <citedRange unit="page">149</citedRange>
+                                            </bibl>
+                                        </listBibl>
+                                    </source>
+                                </recordHist>
+                                <custodialHist>
+                                    <custEvent type="restorations" subtype="none"/>
+                                </custodialHist>
+                            </adminInfo>
+                        </additional>
+                    </msPart>
+                    <msPart xml:id="p2">
+                        <msIdentifier>
+                            <altIdentifier>
+                                <idno>Quire 2</idno>
+                            </altIdentifier>
+                        </msIdentifier>
+                        <msContents><summary/>
+                        <msItem xml:id="p2_i1">
+                            <locus from="2r" to="15v"/>
+                            <title>Tigre-texts</title>
+                            <msItem xml:id="p2_i1.1">
+                                <locus from="2r"/>
+                                <title>Dǝgm ǧǝmʿ wad galāydos mǝn ʿad takles</title>
+                                <incipit xml:lang="tig">ድግም፡ ጅምዕ፡ ወድ፡ ገላይዶስ፡ ምን፡ ዐድ፡ ተክሌስ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p2_i1.2">
+                                <locus from="3v"/>
+                                <title>Dǝgm sab ḥabāb</title>
+                                <incipit xml:lang="tig">ድግም፡ ሰብ፡ ሐባብ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p2_i1.3">
+                                <locus from="4r"/>
+                                <title>Dǝgm šedom</title>
+                                <incipit xml:lang="tig">ድግም፡ ሼዶም፡</incipit>
+                            </msItem>
+                            <msItem xml:id="p2_i1.4">
+                                <locus from="4v"/>
+                                <title>Dǝgm ʾǝb ḥamde</title>
+                                <incipit xml:lang="tig">ድግም፡ እብ፡ ሐምዴ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p2_i1.5">
+                                <locus from="4v"/>
+                                <title>Dǝgm sab badir</title>
+                                <incipit xml:lang="tig">ድግም፡ ሰብ፡ በዲር።</incipit>
+                            </msItem>
+                            <msItem xml:id="p2_i1.6">
+                                <locus from="12r"/>
+                                <title>Dǝgm kǝlʾot ḥāw sab badir</title>
+                                <incipit xml:lang="tig">ድግም፡ ክልኦት፡ ሓው፡ ሰብ፡ በዲር።</incipit>
+                             </msItem>
+                        </msItem>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Other">
+                                <supportDesc>
+                                    <support><material key="paper">Lined paper</material></support>
+                                    <extent>
+                                        <measure unit="leaf" quantity="16">16</measure>
+                                        <measure unit="leaf" type="blank">2</measure><locus target="#1 #16"/>
+                                        <measure unit="quire" quantity="1">1</measure>
+                                        <dimensions type="outer" unit="mm">
+                                            <height unit="mm">215</height>
+                                            <width unit="mm">160</width>
+                                        </dimensions>
+                                    </extent>
+                                    <foliation>Paginated with blank pages skipped from pagination and continued in <ref target="#p3"/>.</foliation>
+                                    <collation></collation>
+                                    <condition key="good"/>
+                                </supportDesc> 
+                            </objectDesc>  
+                            <handDesc>
+                                <handNote xml:id="h2" script="Ethiopic">
+                                    <ab type="script"/>                                    
+                                    <seg type="script">19th or 20th-century script.</seg>
+                                    <seg type="ink">Black</seg>
+                                </handNote>
+                            </handDesc>
+                            <additions>
+                                <list>
+                                    <item xml:id="e3">
+                                        <desc>Annotations by <persName ref="PRS3182ContiRo"/> in the first pages.</desc>
+                                    </item>
+                                </list>
+                            </additions>
+                        </physDesc>
+                        <additional>
+                            <adminInfo>
+                                <recordHist>
+                                    <source>
+                                        <listBibl type="catalogue">
+                                            <bibl>
+                                                <ptr target="bm:Strelcyn1976Catalogue"/>
+                                                <citedRange unit="page">149–150</citedRange>
+                                            </bibl>
+                                        </listBibl>
+                                    </source>
+                                </recordHist>
+                                <custodialHist>
+                                    <custEvent type="restorations" subtype="none"/>
+                                </custodialHist>
+                            </adminInfo>
+                        </additional>
+                    </msPart>
+                    <msPart xml:id="p3">
+                        <msIdentifier>
+                            <altIdentifier>
+                                <idno>Quire 3</idno>
+                            </altIdentifier>
+                        </msIdentifier>
+                        <msContents><summary/>
+                            <msItem xml:id="p3_i1">
+                                <locus from="2r" to="15v"/>
+                                <title>Tigre-texts</title>
+                                <msItem xml:id="p3_i1.1">
+                                    <locus from="2r"/>
+                                    <title>Dǝgm ʾǝnās Badir</title>
+                                    <incipit xml:lang="tig">ድግም፡ እናስ፡ በዲር፡</incipit>
+                                </msItem>
+                                <msItem xml:id="p3_i1.2">
+                                    <locus from="3v"/>
+                                    <title>Dǝgm ʿad Ǧamil</title>
+                                    <incipit xml:lang="tig">ድግም፡ ዐድ፡ ጀሚል።</incipit>
+                                </msItem>
+                                <msItem xml:id="p3_i1.3">
+                                    <locus from="4r"/>
+                                    <title>Dǝgm ʿƎyot</title>
+                                    <incipit xml:lang="tig">ድግም፡ ዕዮት።</incipit>
+                                </msItem>
+                                <msItem xml:id="p3_i1.4">
+                                    <locus from="4r"/>
+                                    <title>Dǝgm bǝyḥo sab Badir</title>
+                                    <note>=Littmann I, 16</note>
+                                    <note>The text was edited in Enno Littmann, Publications of the Princeton Expedition to 
+                                        Abyssinia, vol. 1 - Tales, Customs ...: Tigre Text, Leiden 1910, no. 16; and translated in vol. 2 - Translations.</note>
+                                    <incipit xml:lang="tig">ድግም፡ ብይሖ፡ ሰብ፡ በዲር፡</incipit>
+                                </msItem>
+                                <msItem xml:id="p3_i1.5">
+                                    <locus from="9r"/>
+                                    <title>Dǝgm kǝlʾot ḥaw</title>
+                                    <incipit xml:lang="tig">ድግም፡ ክልኦት፡ ሐው።</incipit>
+                                </msItem>
+                                <msItem xml:id="p3_i1.6">
+                                    <locus from="11r"/>
+                                    <title>Dǝgm wǝrs salas ḥaw karā Maḥamad</title>
+                                    <incipit xml:lang="tig">ድግም፡ ውርስ፡ ሰለስ፡ ሐው፡ ከራ፡ መሐመድ።</incipit>
+                                </msItem>
+                                <msItem xml:id="p3_i1.7">
+                                    <locus from="13v"/>
+                                    <title>Dǝgm ʾaflagǝd</title>
+                                    <incipit xml:lang="tig">ድግም፡ አፍለግድ።</incipit>
+                                </msItem>
+                                <msItem xml:id="p3_i1.8">
+                                    <locus from="14v"/>
+                                    <title>Dǝgm ḥarmāz wa-wad ḥašil</title>
+                                    <incipit xml:lang="tig">ድግም፡ ሐርማዝ፡ ወወድ፡ ሐሺል፡</incipit>
+                                </msItem>
+                                <msItem xml:id="p3_i1.9">
+                                    <locus from="15r"/>
+                                    <title>Dǝgm ʿad gazirat</title>
+                                    <incipit xml:lang="tig">ድግም፡ ዐድ፡ ገዚረት።</incipit>
+                                </msItem>
+                            </msItem>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Other">
+                                <supportDesc>
+                                    <support><material key="paper">Lined paper</material></support>
+                                    <extent>
+                                        <measure unit="leaf" quantity="16">16</measure>
+                                        <measure unit="page" type="blank">2</measure><locus target="#1v #16v"/>
+                                        <measure unit="quire" quantity="1">1</measure>
+                                        <dimensions type="outer" unit="mm">
+                                            <height unit="mm">205–215</height>
+                                            <width unit="mm">145–160</width>
+                                        </dimensions>
+                                    </extent>
+                                    <foliation>Pagination continued from <ref target="#p2"/> ending up in 56.</foliation>
+                                    <collation></collation>
+                                    <condition key="good"/>
+                                </supportDesc> 
+                            </objectDesc>  
+                            <handDesc>
+                                <handNote xml:id="h3" script="Ethiopic">
+                                    <ab type="script"/>
+                                    <seg type="script">19th or 20th-century script.</seg>
+                                    <desc>Possibly identical to <ref target="#h2"/>.</desc>
+                                    <seg type="ink">Black</seg>
+                                </handNote>
+                            </handDesc>
+                            <additions>
+                                <list>
+                                    <item xml:id="e4">
+                                        <locus target="#1r"/>
+                                        <desc>Note</desc>
+                                        <q xml:lang="it">Racconti in Tigrè II</q>
+                                    </item> 
+                                    <item xml:id="e5">
+                                        <locus target="#16r"/>
+                                        <desc>Note by <persName ref="PRS8170Roden"/>.</desc>
+                                        <q xml:lang="it">Mando col tempo anche dei cantici et proverbi come III o IV quaderno</q>
+                                    </item>
+                                </list>
+                            </additions>
+                        </physDesc>
+                        <additional>
+                            <adminInfo>
+                                <recordHist>
+                                    <source>
+                                        <listBibl type="catalogue">
+                                            <bibl>
+                                                <ptr target="bm:Strelcyn1976Catalogue"/>
+                                                <citedRange unit="page">149–150</citedRange>
+                                            </bibl>
+                                        </listBibl>
+                                    </source>
+                                </recordHist>
+                                <custodialHist>
+                                    <custEvent type="restorations" subtype="none"/>
+                                </custodialHist>
+                            </adminInfo>
+                        </additional>
+                    </msPart>
+                    <msPart xml:id="p4">
+                        <msIdentifier>
+                            <altIdentifier>
+                                <idno>Quire 4</idno>
+                            </altIdentifier>
+                        </msIdentifier>
+                        <msContents>
+                            <summary>Histoire des Mansāʿ</summary>
+                            <msItem xml:id="p4_i1">
+                                <locus from="1r" to="17r"/>
+                                <title>Dǝgm Mansāʿ</title>
+                                <note>The text was altered (e.g. <locus target="#6v"/>) and completed for the pages <locus from="15r" to="17r"/>
+                                    (fol. 16r to 18r according to Strelcyn’s numbering in <bibl><ptr target="bm:Strelcyn1976Catalogue"/>
+                                    <citedRange unit="page">150</citedRange></bibl>) by the hand of <persName ref="PRS3182ContiRo"/>.</note>
+                            </msItem>
+                            <msItem xml:id="p4_i2">
+                                <locus target="#17r"/>
+                                <title>Table of contents of the following quire 5</title>
+                                <note>Table of contents of the following quire (<ref target="#p5"/>), presumably on <locus target="#17r"/>
+                                    (which is fol. 18r according to <bibl><ptr target="bm:Strelcyn1976Catalogue"/>
+                                    <citedRange unit="page">150</citedRange></bibl>).</note>
+                                <!-- Not clear to me from the description in Strelcyn. -->
+                            </msItem>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Other">
+                                <supportDesc>
+                                    <support><material key="paper">Lined paper</material></support>
+                                    <extent>
+                                        <measure unit="leaf" quantity="17">17</measure>
+                                        <measure unit="page" type="blank">1</measure><locus target="#17v"/>
+                                        <measure unit="quire" quantity="1">1</measure>
+                                        <dimensions type="outer" unit="mm">
+                                            <height unit="mm">210</height>
+                                            <width unit="mm">150</width>
+                                        </dimensions>
+                                    </extent>
+                                    <foliation>Paginated in blue pencil from 1 to 33.</foliation>
+                                    <collation>One folio (after page 28 and before page 29) is misplaced and can be found in <ref target="#p5"/>.
+                                            </collation>
+                                    <condition key="good"/>
+                                </supportDesc> 
+                            </objectDesc>  
+                            <handDesc>
+                                <handNote xml:id="h4" script="Ethiopic">
+                                    <ab type="script"/>
+                                    <seg type="script">19th or 20th-century script.</seg>
+                                    <seg type="ink">Black</seg>
+                                </handNote>
+                            </handDesc>
+                        </physDesc>
+                        <additional>
+                            <adminInfo>
+                                <recordHist>
+                                    <source>
+                                        <listBibl type="catalogue">
+                                            <bibl>
+                                                <ptr target="bm:Strelcyn1976Catalogue"/>
+                                                <citedRange unit="page">150</citedRange>
+                                            </bibl>
+                                        </listBibl>
+                                    </source>
+                                </recordHist>
+                                <custodialHist>
+                                    <custEvent type="restorations" subtype="none"/>
+                                </custodialHist>
+                            </adminInfo>
+                        </additional>
+                    </msPart>
+                    <msPart xml:id="p5">
+                        <msIdentifier>
+                            <altIdentifier>
+                                <idno>Quire 5</idno>
+                            </altIdentifier>
+                        </msIdentifier>
+                        <msContents><summary/>
+                        <msItem xml:id="p5_i1">
+                            <locus from="1r" to="5r"/><locus from="6r" to="6v"/>
+                            <title>Dǝgm mansāʿ</title>
+                            <note>The original text runs up to <locus target="#5r"/>. The final chapter is written on <locus from="6r" to="6v"/>, 
+                                which was taken from <ref target="p4"/> and inserted in this place, is entitled 
+                                <foreign xml:lang="tig">ድግም፡ ወለት፡ ሐጸይ፡ እት፡ ምድር፡ መንሳዕ፡</foreign> and comparable to fol. 17r (18r according to 
+                                <bibl><ptr target="bm:Strelcyn1976Catalogue"/><citedRange unit="page">150</citedRange></bibl>) of
+                                <ref target="#p4"/>. The first eight lines of the front page (<locus target="#6r"/>) have been written by the hand of
+                                <persName ref="PRS3182ContiRo"/>.</note>
+                        </msItem>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Other">
+                                <supportDesc>
+                                    <support><material key="paper">Lined paper</material></support>
+                                    <extent>
+                                        <measure unit="leaf" quantity="14">14</measure>
+                                        <measure unit="page" type="blank">17</measure><locus target="#5v"/><locus from="7r" to="14v"/>
+                                        <measure unit="quire" quantity="1">1</measure>
+                                        <dimensions type="outer" unit="mm">
+                                            <height unit="mm">210–215</height>
+                                            <width unit="mm">135–155</width>
+                                        </dimensions>
+                                        <!-- Strelcyn 1976: Suite et fin du cahier n. 4 correspondant au texte ajouté de la main de CCR aux ff. 16 r-18 r du prccedent cahier. Le texte primitif s'arrete au f. 5 r.
+Un chapitre final, intitulé ድግም፡ ወለት፡ ሐጸይ፡ እት፡ ምድር፡ መንሳዕ፡ (cp. CCR, cahier n. 4, f. r8 r) a été ajouté sur le premier feuillet d'un bifolio en papier non ligne (ff. 6-7), de 2rox 135 mm.  -->
+                                    </extent>
+                                    <collation>One bifolio with unligned paper of smaller size (210 x 135 mm) was added (<locus from="6" to="7"/>) 
+                                        to the notebook.</collation>
+                                    <condition key="good"/>
+                                </supportDesc> 
+                            </objectDesc>  
+                            <handDesc>
+                                <handNote xml:id="h5" script="Ethiopic">
+                                    <ab type="script"/>
+                                    
+                                    <seg type="script">19th or 20th-century script.</seg>
+                                    <desc></desc>
+                                    <seg type="ink">Black</seg>
+                                </handNote>
+                                <handNote xml:id="h6" script="Ethiopic">
+                                    <ab type="script"/>
+                                    <locus from="6r1" to="6r8"/>
+                                    <seg type="script">19th or 20th-century script.</seg>
+                                    <desc>According to <bibl><ptr target="bm:Strelcyn1976Catalogue"/>
+                                        <citedRange unit="page">150</citedRange></bibl>, hand of <persName ref="PRS3182ContiRo"/>.</desc>
+                                    <seg type="ink">Black</seg>
+                                </handNote>
+                            </handDesc>
+                        </physDesc>
+                        <additional>
+                            <adminInfo>
+                                <recordHist>
+                                    <source>
+                                        <listBibl type="catalogue">
+                                            <bibl>
+                                                <ptr target="bm:Strelcyn1976Catalogue"/>
+                                                <citedRange unit="page">150</citedRange>
+                                            </bibl>
+                                        </listBibl>
+                                    </source>
+                                </recordHist>
+                                <custodialHist>
+                                    <custEvent type="restorations" subtype="none"/>
+                                </custodialHist>
+                            </adminInfo>
+                        </additional>
+                    </msPart>
+                    <msPart xml:id="p6">
+                        <msIdentifier>
+                            <altIdentifier>
+                                <idno>Quire 6</idno>
+                            </altIdentifier>
+                        </msIdentifier>
+                        <msContents><summary/>
+                        <msItem xml:id="p6_i1">
+                            <locus from="2r" to="11r"/>
+                            <title>Proverbs and riddles</title>
+                            <note>Notes in red ink by the hand of <persName ref="PRS3182ContiRo"/> in the margins and
+                                interlinear spaces. Some of the proverbs and riddles are edited in 
+                                <bibl><ptr target="bm:ContiRossini1903Tigre"/><citedRange>1–14</citedRange></bibl>, 
+                                with a note on page 1, indicating that these texts were provided to him by the Swedish Mission to 
+                                <placeName ref="LOC3197Galab"/>.</note>
+                            <msItem xml:id="p6_i1.1">
+                                <locus from="2r" to="7r"/>
+                                <title>Proverbs</title>
+                                <incipit xml:lang="tig" type="inscriptio">አምሳላት።</incipit>
+                            </msItem>
+                            <msItem xml:id="p6_i1.2">
+                                <locus from="8r" to="11r"/>
+                                <title>Riddles</title>
+                                <incipit xml:lang="tig" type="inscriptio">እንቅርቅራ፡ ተክላ።</incipit>
+                            </msItem>
+                        </msItem>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Other">
+                                <supportDesc>
+                                    <support><material key="paper">Lined paper</material></support>
+                                    <extent>
+                                        <measure unit="leaf" quantity="16">16</measure>
+                                        <measure unit="page" type="blank">13</measure><locus target="#1v #7v"/><locus from="11v" to="16v"/>
+                                        <measure unit="quire" quantity="1">1</measure>
+                                        <dimensions type="outer" unit="mm">
+                                            <height unit="mm">210</height>
+                                            <width unit="mm">160</width>
+                                        </dimensions>
+                                    </extent>
+                                    <condition key="good"/>
+                                </supportDesc> 
+                            </objectDesc>  
+                            <handDesc>
+                                <handNote xml:id="h7" script="Ethiopic">
+                                    <ab type="script"/>
+                                    <seg type="script">19th or 20th-century script.</seg>
+                                    <seg type="ink">Black</seg>
+                                </handNote>
+                            </handDesc>
+                                <additions>
+                                    <list>
+                                        <item xml:id="e6">
+                                            <locus target="#1r"/>
+                                            <desc>Signature of <persName ref="PRS3182ContiRo"/>.</desc>
+                                        </item>
+                                        <item xml:id="e7">
+                                            <locus target="#2r"/>
+                                            <desc>Title of the first part in Italian</desc>
+                                            <q xml:lang="it">I. Proverbi</q>
+                                        </item>
+                                        <item xml:id="e8">
+                                            <locus target="#7r"/>
+                                            <desc>Note in Italian indicating the end of the text</desc>
+                                            <q xml:lang="gez">Finis della piccola raccolta di proverbi</q>
+                                        </item>
+                                        <item xml:id="e9">
+                                            <locus target="#8r"/>
+                                            <desc>Note in Italian on the content of the text</desc>
+                                            <q xml:lang="it">Enimme ed indovinelli colle risposte</q>
+                                        </item>
+                                        <item xml:id="e10">
+                                            <locus target="#11r"/>
+                                            <desc>Note in Italian indicating the end of the text and the beginning of another</desc>
+                                            <q xml:lang="it">Finis delle enimme da noi raccolte. Segue un altro quaderno di cantici</q>
+                                        </item>
+                                    </list>
+                                </additions>
+                        </physDesc>
+                        <additional>
+                            <adminInfo>
+                                <recordHist>
+                                    <source>
+                                        <listBibl type="catalogue">
+                                            <bibl>
+                                                <ptr target="bm:Strelcyn1976Catalogue"/>
+                                                <citedRange unit="page">150</citedRange>
+                                            </bibl>
+                                        </listBibl>
+                                    </source>
+                                </recordHist>
+                                <custodialHist>
+                                    <custEvent type="restorations" subtype="none"/>
+                                </custodialHist>
+                            </adminInfo>
+                        </additional>
+                    </msPart>
+                    <msPart xml:id="p7">
+                        <msIdentifier>
+                            <altIdentifier>
+                                <idno>Quire 7</idno>
+                            </altIdentifier>
+                        </msIdentifier>
+                        <msContents><summary/>
+                        <msItem xml:id="p7_i1">
+                            <locus from="2r"/>
+                            <title>Collection of 28 Tigre-poems</title>
+                            <note>Some of the poems are annotated by <persName ref="PRS3182ContiRo"/>. The greater part of the poems 
+                                is edited in <bibl><ptr target="bm:Littmann1913Tigre"/></bibl>; a German translation of which is published in
+                                <bibl><ptr target="bm:Littmann1913Tigre_IV_A"/></bibl> and 
+                                <bibl><ptr target="bm:Littmann1915Tigre_IV_B"/></bibl>. However, the texts in this manuscript differ
+                                particularly in terms of spelling from those published by Littmann. Furthermore, Littmann’s edition sometimes 
+                                includes prefaces to the poems that are missing from our manuscript.</note>
+                            <msItem xml:id="p7_i1.1">
+                                <locus from="2r"/>
+                                <title>ʾAmir wad gabāh ʾǝgl maḥamad wad ǧāwǧ laḥalayā</title>
+                                <incipit xml:lang="tig" type="inscriptio">አሚር፡ ወድ፡ ገባህ፡ እግል፡ መሐመድ፡ ወድ፡ ጃውጅ፡ ለሐለያ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.2">
+                                <locus from="2v"/>
+                                <title>ʾAmir wad gabāh ʾǝgl kantebay ǧāwǧ laḥalayā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">486</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">አሚር፡ ወድ፡ ገባህ፡ እግል፡ ከንቴበይ፡ ጃውጅ፡ ለሐለያ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.3">
+                                <locus from="3v"/>
+                                <title>Ḥǝlāyat hǝbtes wad nawradin (mǝn ʿad takles)</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">550</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">ሕላየት፡ ህብቴስ፡ ወድ፡ ነውረዲን፡ 
+                                    <supplied resp="PRS8999Strelcyn" reason="explanation">ምን፡ ዐድ፡ ተክሌስ።</supplied></incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.4">
+                                <locus from="4r"/>
+                                <title>Ḥǝlāyat ʾǝyāsu wad hǝbtes (mǝn ʿad hǝbtes)</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">515</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">ሕላየት፡ እያሱ፡ ወድ፡ ህብቴስ፡ 
+                                    <supplied resp="PRS8999Strelcyn" reason="explanation">ምን፡ ዐድ፡ ህብቴስ።</supplied></incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.5">
+                                <locus from="6r"/>
+                                <title>Wad gǝrmit ʾǝgl ʾǝzāz wad ǧamil laḥalayā ʿad taklesay</title>
+                                <incipit xml:lang="tig" type="inscriptio">ወድ፡ ግርሚት፡ እግል፡ እዛዝ፡ ወድ፡ ጀሚል፡ ለሐለያ፡ ዐድ፡ ተክሌሰይ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.6">
+                                <locus from="6v"/>
+                                <title>Wad gǝrmit ʾǝgl galāydos laḥalayā</title>
+                                <incipit xml:lang="tig" type="inscriptio">ወድ፡ ግርሚት፡ እግል፡ ገላይዶስ፡ ለሐለያ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.7">
+                                <locus from="7r"/>
+                                <title>ʾƎzāz wad ǧamil ʾǝgl ḥazan laḥalayā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">548</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">እዛዝ፡ ወድ፡ ጀሚል፡ እግል፡ ሐዘን፡ ለሐለያ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.8">
+                                <locus from="7v"/>
+                                <title>ʾƎzāz wad fǝdel laḥalayā ʾǝgl mansāʿ kaʾafo kǝm ʿalat</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">226</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">እዛዝ፡ ወድ፡ ፍዴል፡ ለሐለያ፡ እግል፡ መንሳዕ፡ ከአፎ፡ ክም፡ ዐለት።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.9">
+                                <locus from="9v"/>
+                                <title>ʾƎkd wad fǝdel labelā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">227</citedRange></bibl>.
+                                      </note>
+                                <incipit xml:lang="tig" type="inscriptio">እክድ፡ ወድ፡ ፍዴል፡ ለቤላ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.10">
+                                <locus from="10r"/>
+                                <title>ʿAli ʾǝgl dabab laḥalayā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">394</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">ዐሊ፡ እግል፡ ደበብ፡ ለሐለያ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.11">
+                                <locus from="10v"/>
+                                <title>ʿAli ʾǝgl dabab laḥalayā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">395</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">ዐሊ፡ እግል፡ ደበብ፡ ለሐለያ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.12">
+                                <locus from="11r"/>
+                                <title>ʿAli laḥalayā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">401</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">ዐሊ፡ ለሐለያ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.13">
+                                <locus from="11v"/>
+                                <title>ʿAli laḥalayā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">404</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">ዐሊ፡ ለሐለያ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.14">
+                                <locus from="12r"/>
+                                <title>ʾElos wad tedros betǧukay dib sanḥit laḥalayā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">311</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">ኤሎስ፡ ወድ፡ ቴድሮስ፡ ቤትጁከይ፡ ዲብ፡ ሰንሒት፡ ለሐለያ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.15">
+                                <locus from="12v"/>
+                                <title>ʿƎmrān wad karam bazḥ ʾǝgl ǧahāǧ waǧ ʿagabā labelā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">75</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ እግል፡ ጀሃጅ፡ ወጅ፡ ዐገባ፡ ለቤላ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.16">
+                                <locus from="16r"/>
+                                <title>ʿƎmrān wad karam bazḥ ʾǝgl ǧahāǧ waǧ ʿagabā labelā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">76</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ እግል፡ ጀሃጅ፡ ወጅ፡ ዐገባ፡ ለቤላ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.17">
+                                <locus from="17r"/>
+                                <title>ʿƎmrān wad karam bazḥ ʾǝgl ǧahāǧ waǧ ʿagabā labelā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">77</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ እግል፡ ጀሃጅ፡ ወጅ፡ ዐገባ፡ ለቤላ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.18">
+                                <locus from="18r"/>
+                                <title>ʿƎmrān wad karam bazḥ ʾǝgl ǧahāǧ waǧ ʿagabā labelā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">78</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ እግል፡ ጀሃጅ፡ ወጅ፡ ዐገባ፡ ለቤላ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.19">
+                                <locus from="18v"/>
+                                <title>ʿƎmrān wad karam bazḥ ʾǝgl ʿad tasfāč̣on labelā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">79</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ እግል፡ ዐድ፡ ተስፋጮን፡ ለቤላ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.20">
+                                <locus from="21r"/>
+                                <title>ʿƎmrān wad karam bazḥ ʾǝt badā ʾazān tagarit mansāʿ wamot sab gǝdri labelā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">80</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ እት፡ በዳ፡ አዛን፡ ተገሪት፡ መንሳዕ፡ ወሞት፡ ሰብ፡ ግድሪ፡ ለቤላ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.21">
+                                <locus from="23v"/>
+                                <title>ʿƎmrān wad karam bazḥ ʾaḥa ʿatmāryām ʾet mǝdr mansāʿ mǝn ʿerat labelā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">81</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ አሐ፡ ዐትማርያም፡ እት፡ ምድር፡ መንሳዕ፡ ምን፡ ዔረት፡ ለቤላ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.22">
+                                <locus from="24v"/>
+                                <title>ʿƎmrān wad karam bazḥ ʾǝgl rorā ʾagʿara labelā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">83</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ እግል፡ ሮራ፡ አግዐረ፡ ለቤላ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.23">
+                                <locus from="26r"/>
+                                <title>ʿƎmrān wad karam bazḥ ʾǝt zamāte ʾagʿaro waʾǝtā ʾǝt lamotaw sab labelā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">84</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ እት፡ ዘማቴ፡ አግዐሮ፡ ወእታ፡ እት፡ ለሞተው፡ ሰብ፡ ለቤላ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.24">
+                                <locus from="27r"/>
+                                <title>ʿƎmrān wad karam bazḥ labelā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">85</citedRange></bibl>.
+                                     </note>
+                                <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ ለቤላ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.25">
+                                <locus from="27v"/>
+                                <title>ʿƎmrān wad karam bazḥ labelā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">86</citedRange></bibl>.
+                                      </note>
+                                <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ ለቤላ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.26">
+                                <locus from="28r"/>
+                                <title>ʿƎmrān wad karam bazḥ labelā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">87</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">ዕምራን፡ ወድ፡ ከረም፡ በዝሕ፡ ለቤላ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.27">
+                                <locus from="28v"/>
+                                <title>ʾAwʿalā wad maḥamud ʾǝgl ǧahad wad ʿagabā labelā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">1</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">አውዐላ፡ ወድ፡ መሐሙድ፡ እግል፡ ጀሃድ፡ ወድ፡ ዐገባ፡ ለቤላ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p7_i1.28">
+                                <locus from="29r"/>
+                                <title>ʾAwʿalā wad maḥamud ʾǝgl kantebay tedros wakantebay bǝʾǝmnat labelā</title>
+                                <note>Edited in <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">3</citedRange></bibl>.
+                                        </note>
+                                <incipit xml:lang="tig" type="inscriptio">አውዐላ፡ ወድ፡ መሐሙድ፡ እግል፡ ከንቴበይ፡ ቴድሮስ፡ ወከንቴበይ፡ ብእምነት፡ ለቤላ።</incipit>
+                            </msItem>
+                        </msItem>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Other">
+                                <supportDesc>
+                                    <support><material key="paper">Lined paper</material></support>
+                                    <extent>
+                                        <measure unit="leaf" quantity="30">30</measure>
+                                        <measure unit="page" type="blank">1</measure><locus target="#30v"/>
+                                        <measure unit="quire" quantity="1">1</measure>
+                                        <dimensions type="outer" unit="mm">
+                                            <height unit="mm">200</height>
+                                            <width unit="mm">150</width>
+                                        </dimensions>
+                                    </extent>
+                                    <condition key="deficient">The notebook shows signs of scorching.</condition>
+                                </supportDesc> 
+                            </objectDesc>  
+                            <handDesc>
+                                <handNote xml:id="h8" script="Ethiopic">
+                                    <ab type="script"/>
+                                    <seg type="script">19th or 20th-century script.</seg>
+                                    <desc><locus from="16v" to="18r"/> are written in green ink.</desc>
+                                    <seg type="ink">Black, green</seg>
+                                </handNote>
+                            </handDesc>
+                        </physDesc>
+                        <additional>
+                            <adminInfo>
+                                <recordHist>
+                                    <source>
+                                        <listBibl type="catalogue">
+                                            <bibl>
+                                                <ptr target="bm:Strelcyn1976Catalogue"/>
+                                                <citedRange unit="page">150–152</citedRange>
+                                            </bibl>
+                                        </listBibl>
+                                    </source>
+                                </recordHist>
+                                <custodialHist>
+                                    <custEvent type="restorations" subtype="none"/>
+                                </custodialHist>
+                            </adminInfo>
+                        </additional>
+                    </msPart>
+                    <msPart xml:id="p8">
+                        <msIdentifier>
+                            <altIdentifier>
+                                <idno>Quire 8</idno>
+                            </altIdentifier>
+                        </msIdentifier>
+                        <msContents><summary/>
+                        <msItem xml:id="p8_i1">
+                            <locus from="1r"/>
+                            <title>ʿAd ʾǝt qabat gazirat</title>
+                            <note>Written by the hand of <persName ref="PRS3182ContiRo"/>.</note>
+                            <incipit xml:lang="tig">ዐድ፡ እት፡ ቀበት፡ ገዚረት፡ ዐላ፡ ወሹሙ፡ ጀር፡ ልቡሉ፡ ወእሊ፡ ሹም፡ እግላ፡ ዐድ፡ እትሕድ፡ ሐዘዩ፡ ወበረዩ፡ ወህቱ፡ ክእና፡ ክምወዳ፡ 
+                                ሐየት፡ ወአልማ፡ ሀዬ፡ ትሰለጠውውቱ።</incipit>
+                        </msItem>
+                            <msItem xml:id="p8_i2">
+                                <title>Tigre-story</title>
+                                <note>Written by the hand of <persName ref="PRS3182ContiRo"/>.</note>
+                                <incipit xml:lang="tig"></incipit>
+                            </msItem>
+                            <msItem xml:id="p8_i3">
+                                <locus from="1v" to="3v"/>
+                                <title>History of the prophet Salomon</title>
+                                <note>Written by the hand of <persName ref="PRS3182ContiRo"/> and edited and translated in
+                                    <bibl><ptr target="bm:ContiRossini1903Tigre"/><citedRange unit="page">17–20</citedRange></bibl>.</note><!-- Add zotero bibl ref -->
+                            </msItem>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Other">
+                                <supportDesc>
+                                    <support><material key="paper">Lined paper</material></support>
+                                    <extent>
+                                        <measure unit="leaf" quantity="14">14</measure>
+                                        <measure unit="leaf" type="blank">10</measure><locus from="4" to="14"/>
+                                        <measure unit="quire" quantity="1">1</measure>
+                                        <dimensions type="outer" unit="mm">
+                                            <height unit="mm">205</height>
+                                            <width unit="mm">150</width>
+                                        </dimensions>
+                                    </extent>
+                                    <collation></collation>
+                                    <condition key="good">The quire exhibits significant signs of burning.</condition>
+                                </supportDesc> 
+                            </objectDesc>  
+                            <handDesc>
+                                <handNote xml:id="h9" script="Ethiopic">
+                                    <ab type="script"/>
+                                    <seg type="script">19th or 20th-century script.</seg>
+                                    <desc>Hand of <persName ref="PRS3182ContiRo"/>.</desc>
+                                    <seg type="ink">Red</seg>
+                                </handNote>
+                            </handDesc>
+                        </physDesc>
+                        <additional>
+                            <adminInfo>
+                                <recordHist>
+                                    <source>
+                                        <listBibl type="catalogue">
+                                            <bibl>
+                                                <ptr target="bm:Strelcyn1976Catalogue"/>
+                                                <citedRange unit="page">152</citedRange>
+                                            </bibl>
+                                        </listBibl>
+                                    </source>
+                                </recordHist>
+                                <custodialHist>
+                                    <custEvent type="restorations" subtype="none"/>
+                                </custodialHist>
+                            </adminInfo>
+                        </additional>
+                    </msPart>
+                    <msPart xml:id="p9">
+                        <msIdentifier>
+                            <altIdentifier>
+                                <idno>Quire 9</idno>
+                            </altIdentifier>
+                        </msIdentifier>
+                        <msContents><summary/>
+                        <msItem xml:id="p9_i1">
+                            <locus from="1r"/>
+                            <title>Tigre poems with Amharic translations</title>
+                            <note>The left column on each page contain the Tigre-text of each poem, while the right provides an Amharic translation.
+                                Except for <ref target="#p9_i1.13"/>, the poems are not included in <bibl><ptr target="bm:Littmann1913Tigre"/></bibl>.
+                                    </note>
+                            <msItem xml:id="p9_i1.1">
+                                <locus from="1r"/>
+                                <title>Šalāy ḥakin</title>
+                                <incipit xml:lang="tig"><locus from="1ra"/> ሸላይ። ሐኪን፡</incipit>
+                                <incipit xml:lang="am"><locus from="1rb"/> የሐኪን፡ ውዳሴ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p9_i1.2">
+                                <locus from="1r"/>
+                                <title>Nāy daǧāč ḥadga ʾanba(sā) šalāy</title>
+                                <incipit xml:lang="tig"><locus from="1ra"/> ናይ፡ ደጃች፡ ሐድገ፡ 
+                                    አንበ<supplied reason="omitted" resp="PRS8999Strelcyn">ሳ፡</supplied> ሸላይ።</incipit>
+                                <incipit xml:lang="am"><locus from="1rb"/> የደጃች፡ ሐድገ፡ አንበሳ፡ ውዳሴ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p9_i1.3">
+                                <locus from="2v"/>
+                                <title>Nāy daǧāč ḥadga ʾanba(sā) šalāy</title>
+                                <incipit xml:lang="tig"><locus from="2va"/> ናይ፡ ደጃች፡ ሐድገ፡ 
+                                    አንበ<supplied reason="omitted" resp="PRS8999Strelcyn">ሳ፡</supplied> ሸላይ።</incipit>
+                                <incipit xml:lang="am"><locus from="2vb"/> የደጃች፡ ሐድገ፡ አንበሳ፡ ውዳሴ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p9_i1.4">
+                                <locus from="4r"/>
+                                <title>Ḥǝlāy<!-- transcription unclear --> kantibā walda gābr</title>
+                                <incipit xml:lang="tig"><locus from="4ra"/> 𞟥ላይ፡ ከንቲባ፡ ወልደ፡ ጋብር።</incipit>
+                                <incipit xml:lang="am"><locus from="4rb"/> የከንቲባ፡ ወልደ፡ ጋብር፡ ውዳሴ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p9_i1.5">
+                                <locus from="4v"/>
+                                <title>Nāy madin wad zarʾay šalāy</title>
+                                <incipit xml:lang="tig"><locus from="4va"/> ናይ፡ መዲን፡ ወድ፡ ዘርአይ፡ ሸላይ።</incipit>
+                                <incipit xml:lang="am"><locus from="4vb"/> የመዲን፡ የዘርአይ፡ ልጅ፡ ውዳሴ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p9_i1.6">
+                                <locus from="4v"/>
+                                <title>Ḥǝlāy<!-- transcription unclear --> ḥamǝd zamāt</title>
+                                <incipit xml:lang="tig"><locus from="4va"/> 𞟥ላይ፡ ሐምድ፡ ዘማት።</incipit>
+                                <incipit xml:lang="am"><locus from="4vb"/>የሐምድ፡ ዘማት፡ ውዳሴ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p9_i1.7">
+                                <locus from="5r"/>
+                                <title>Ḥǝlāy<!-- transcription unclear --> ʾarʾadom wad ʾaǧāǧ</title>
+                                <incipit xml:lang="tig"><locus from="5ra"/> 𞟥ላይ፡ አርአዶም፡ ወድ፡ አጃጃ።</incipit>
+                                <incipit xml:lang="am"><locus from="5rb"/>የአርአዶም፡ የአጃጅ፡ ልጅ፡ ውዳሴ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p9_i1.8">
+                                <locus from="6v"/>
+                                <title>Ḥǝlāy<!-- transcription unclear --> raṭi wad zamāt</title>
+                                <incipit xml:lang="tig"><locus from="6va"/> 𞟥ላይ፡ ረጢ፡ ወድ፡ ዘማት።</incipit>
+                                <incipit xml:lang="am"><locus from="6vb"/> የረጢ፡ የዘማት፡ ልጅ፡ ውዳሴ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p9_i1.9">
+                                <locus from="6v"/>
+                                <title>Ḥǝlāy<!-- transcription unclear --> ḥakin wad madin</title>
+                                <incipit xml:lang="tig"><locus from="6va"/> 𞟥ላይ፡ ሐኪን፡ ወድ፡ መዲን።</incipit>
+                                <incipit xml:lang="am"><locus from="6vb"/> የሐኪን፡ የመዲን፡ ልጅ፡ ውዳሴ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p9_i1.10">
+                                <locus from="7v"/>
+                                <title>Ḥǝlāy<!-- transcription unclear --> māḥmud wad ʾazāz</title>
+                                <incipit xml:lang="tig"><locus from="7va"/> 𞟥ላይ፡ ማሕሙድ፡ ወድ፡ እዛዝ።</incipit>
+                                <incipit xml:lang="am"><locus from="7vb"/> የማሕሙድ፡ የእዛዝ፡ ልጅ፡ ውዳሴ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p9_i1.11">
+                                <locus from="8r"/>
+                                <title>Ḥǝlāy<!-- transcription unclear --> ḥǝmadin wad ʾǝǧl</title>
+                                <incipit xml:lang="tig"><locus from="8ra"/> 𞟥ላይ፡ ሕመዲን፡ ወድ፡ እጅል።</incipit>
+                                <incipit xml:lang="am"><locus from="8rb"/> የሕመዲን፡ የእጅል፡ ልጅ፡ ውዳሴ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p9_i1.12">
+                                <locus from="8v"/>
+                                <title>Ḥǝlāy<!-- transcription unclear --> ḥǝmad wad māḥmud</title>
+                                <incipit xml:lang="tig"><locus from="8va"/> 𞟥ላይ፡ ወድ፡ ማሕሙድ።</incipit>
+                                <incipit xml:lang="am"><locus from="8vb"/>የሕመድ፡ የማሕሙድ፡ ልጅ፡ ውዳሴ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p9_i1.13">
+                                <locus from="9r"/>
+                                <title>Ḥǝlāy<!-- transcription unclear --> ʾelos wad tedros</title>
+                                <note>Edited and translated in 
+                                    <bibl><ptr target="bm:Littmann1913Tigre"/><citedRange unit="item">258</citedRange></bibl>.</note>
+                                <incipit xml:lang="tig"><locus from="9ra"/> 𞟥ላይ፡ ወድ፡ ቴድሮስ።</incipit>
+                                <incipit xml:lang="am"><locus from="9rb"/>የኤሎስ፡ የቴድሮስ፡ ልጅ፡ ውዳሴ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p9_i1.14">
+                                <locus from="10r"/>
+                                <title>Ḥǝlāy<!-- transcription unclear --> daǧāč ḥadga ʾambasā</title>
+                                <incipit xml:lang="tig"><locus from="10ra"/> 𞟥ላይ፡ ደጃች፡ ሐድገ፡ አምበሳ።</incipit>
+                                <incipit xml:lang="am"><locus from="10rb"/>የደጃች፡ ሐድገ፡ አንበሳ፡ ውዳሴ።</incipit>
+                            </msItem>
+                            <msItem xml:id="p9_i1.15">
+                                <locus from="10v"/>
+                                <title>Ḥǝlāy<!-- transcription unclear --> maḥamad nur</title>
+                                <incipit xml:lang="tig"><locus from="10va"/> 𞟥ላይ፡ ሐመድ፡ ኑር።</incipit>
+                                <incipit xml:lang="am"><locus from="10vb"/>የመሐመድ፡ ኑር፡ ውዳሴ።</incipit>
+                            </msItem>
+                        </msItem>
+                        </msContents>
+                        <physDesc>
+                            <objectDesc form="Other">
+                                <supportDesc>
+                                    <support><material key="paper"/></support>
+                                    <extent>
+                                        <measure unit="leaf" quantity="11">11</measure>
+                                        <measure unit="quire" quantity="1">1</measure>
+                                        <dimensions type="outer" unit="mm">
+                                            <height unit="mm">210</height>
+                                            <width unit="mm">155</width>
+                                        </dimensions>
+                                    </extent>
+                                    <foliation><locus from="1" to="5"/> paginated in Ethiopian numbers (<foreign xml:lang="gez">፩</foreign>
+                                        to <foreign xml:lang="gez">፭</foreign>).</foliation>
+                                    <condition key="deficient">The quire is severely damaged by fire with partial text losses on the left side at the bottom
+                                        of <locus target="#1 #2 #9 #20"/>; <locus from="11ra1" to="11ra12"/> are completely or partly detoriated.</condition>
+                                </supportDesc> 
+                                <layoutDesc><layout writtenLines="18" columns="2"/></layoutDesc>
+                            </objectDesc>  
+                            <handDesc>
+                                <handNote xml:id="h10" script="Ethiopic">
+                                    <ab type="script"/>
+                                    <seg type="script">19th or 20th-century script.</seg>
+                                    <desc></desc>
+                                    <seg type="ink">Black</seg>
+                                </handNote>
+                            </handDesc>
+                        </physDesc>
+                        <additional>
+                            <adminInfo>
+                                <recordHist>
+                                    <source>
+                                        <listBibl type="catalogue">
+                                            <bibl>
+                                                <ptr target="bm:Strelcyn1976Catalogue"/>
+                                                <citedRange unit="page">152–153</citedRange>
+                                            </bibl>
+                                        </listBibl>
+                                    </source>
+                                </recordHist>
+                                <custodialHist>
+                                    <custEvent type="restorations" subtype="none"/>
+                                </custodialHist>
+                            </adminInfo>
+                        </additional>
+                    </msPart>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+                <xi:fallback>
+                    <p>Definitions of prefixes used.</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="Vocabulary"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="it">Italian</language>
+                <language ident="tig">Tigre</language>
+                <language ident="gez">Gǝʿǝz</language>
+                <language ident="am">Amharic</language>
+                <language ident="sv">Swedish</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2026-04-21">Created record</change>
+            <!--  -->
+        </revisionDesc>
+    </teiHeader>
+    <text xml:base="https://betamasaheft.eu/">
+        <body>
+            <ab/>
+        </body>
+    </text>
+</TEI>

--- a/RomeALincei/ANLcr51.xml
+++ b/RomeALincei/ANLcr51.xml
@@ -122,15 +122,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </supportDesc> 
                             </objectDesc>  
                             <handDesc>
-                                <handNote xml:id="h1" script="Ethiopic">
-                                    <ab type="script"/>
-                                    <seg type="script">19th or 20th-century script.</seg>
+                                <handNote xml:id="h1" script="Ethiopic"> 
+                                    <seg type="script">Nineteenth or twentieth-century script.</seg>
                                     <seg type="ink">Black</seg>
                                 </handNote>
                             </handDesc>
                             <additions>
                                 <list>
-                                    <item xml:id="e2">
+                                    <item xml:id="a1">
                                         <desc>Annotations by <persName ref="PRS3182ContiRo"/>.</desc>
                                     </item>
                                 </list>
@@ -163,7 +162,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <msContents><summary/>
                         <msItem xml:id="p2_i1">
                             <locus from="2r" to="15v"/>
-                            <title>Tigre-texts</title>
+                            <title>Tigre texts</title>
                             <msItem xml:id="p2_i1.1">
                                 <locus from="2r"/>
                                 <title>Dǝgm ǧǝmʿ wad galāydos mǝn ʿad takles</title>
@@ -209,22 +208,22 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <width unit="mm">160</width>
                                         </dimensions>
                                     </extent>
-                                    <foliation>Paginated with blank pages skipped from pagination and continued in <ref target="#p3"/>.</foliation>
+                                    <foliation>Blank pages have been skipped from pagination. The pagination is continued in 
+                                        <ref target="#p3"/> and ends up at 56.</foliation>
                                     <collation></collation>
                                     <condition key="good"/>
                                 </supportDesc> 
                             </objectDesc>  
                             <handDesc>
-                                <handNote xml:id="h2" script="Ethiopic">
-                                    <ab type="script"/>                                    
+                                <handNote xml:id="h2" script="Ethiopic">                                     
                                     <seg type="script">19th or 20th-century script.</seg>
                                     <seg type="ink">Black</seg>
                                 </handNote>
                             </handDesc>
                             <additions>
                                 <list>
-                                    <item xml:id="e3">
-                                        <desc>Annotations by <persName ref="PRS3182ContiRo"/> in the first pages.</desc>
+                                    <item xml:id="a2">
+                                        <desc>Annotations by <persName ref="PRS3182ContiRo"/> on the first pages.</desc>
                                     </item>
                                 </list>
                             </additions>
@@ -256,25 +255,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <msContents><summary/>
                             <msItem xml:id="p3_i1">
                                 <locus from="2r" to="15v"/>
-                                <title>Tigre-texts</title>
+                                <title>Tigre texts</title>
                                 <msItem xml:id="p3_i1.1">
                                     <locus from="2r"/>
-                                    <title>Dǝgm ʾǝnās Badir</title>
+                                    <title>Dǝgm ʾǝnās badir</title>
                                     <incipit xml:lang="tig">ድግም፡ እናስ፡ በዲር፡</incipit>
                                 </msItem>
                                 <msItem xml:id="p3_i1.2">
                                     <locus from="3v"/>
-                                    <title>Dǝgm ʿad Ǧamil</title>
+                                    <title>Dǝgm ʿad ǧamil</title>
                                     <incipit xml:lang="tig">ድግም፡ ዐድ፡ ጀሚል።</incipit>
                                 </msItem>
                                 <msItem xml:id="p3_i1.3">
                                     <locus from="4r"/>
-                                    <title>Dǝgm ʿƎyot</title>
+                                    <title>Dǝgm ʿǝyot</title>
                                     <incipit xml:lang="tig">ድግም፡ ዕዮት።</incipit>
                                 </msItem>
                                 <msItem xml:id="p3_i1.4">
                                     <locus from="4r"/>
-                                    <title>Dǝgm bǝyḥo sab Badir</title>
+                                    <title>Dǝgm bǝyḥo sab badir</title>
                                     <note>=Littmann I, 16</note>
                                     <note>The text was edited in Enno Littmann, Publications of the Princeton Expedition to 
                                         Abyssinia, vol. 1 - Tales, Customs ...: Tigre Text, Leiden 1910, no. 16; and translated in vol. 2 - Translations.</note>
@@ -287,7 +286,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </msItem>
                                 <msItem xml:id="p3_i1.6">
                                     <locus from="11r"/>
-                                    <title>Dǝgm wǝrs salas ḥaw karā Maḥamad</title>
+                                    <title>Dǝgm wǝrs salas ḥaw karā maḥamad</title>
                                     <incipit xml:lang="tig">ድግም፡ ውርስ፡ ሰለስ፡ ሐው፡ ከራ፡ መሐመድ።</incipit>
                                 </msItem>
                                 <msItem xml:id="p3_i1.7">
@@ -327,20 +326,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </objectDesc>  
                             <handDesc>
                                 <handNote xml:id="h3" script="Ethiopic">
-                                    <ab type="script"/>
-                                    <seg type="script">19th or 20th-century script.</seg>
-                                    <desc>Possibly identical to <ref target="#h2"/>.</desc>
+                                    <seg type="script">Nineteenth or twentieth-century script.</seg>
+                                    <desc>Possibly identical or the same to <ref target="#h2"/>.</desc>
                                     <seg type="ink">Black</seg>
                                 </handNote>
                             </handDesc>
                             <additions>
                                 <list>
-                                    <item xml:id="e4">
+                                    <item xml:id="e2">
                                         <locus target="#1r"/>
                                         <desc>Note</desc>
                                         <q xml:lang="it">Racconti in Tigrè II</q>
                                     </item> 
-                                    <item xml:id="e5">
+                                    <item xml:id="e3">
                                         <locus target="#16r"/>
                                         <desc>Note by <persName ref="PRS8170Roden"/>.</desc>
                                         <q xml:lang="it">Mando col tempo anche dei cantici et proverbi come III o IV quaderno</q>
@@ -377,9 +375,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <msItem xml:id="p4_i1">
                                 <locus from="1r" to="17r"/>
                                 <title>Dǝgm Mansāʿ</title>
-                                <note>The text was altered (e.g. <locus target="#6v"/>) and completed for the pages <locus from="15r" to="17r"/>
-                                    (fol. 16r to 18r according to Strelcyn’s numbering in <bibl><ptr target="bm:Strelcyn1976Catalogue"/>
-                                    <citedRange unit="page">150</citedRange></bibl>) by the hand of <persName ref="PRS3182ContiRo"/>.</note>
+                                <note>The text was amended by <persName ref="PRS3182ContiRo"/> (e.g. <locus target="#6v"/>) and expanded 
+                                    by him to include pages <locus from="15r" to="17r"/> (fol. 16r to 18r according to Strelcyn’s numbering in 
+                                    <bibl><ptr target="bm:Strelcyn1976Catalogue"/><citedRange unit="page">150</citedRange></bibl>).</note>
                             </msItem>
                             <msItem xml:id="p4_i2">
                                 <locus target="#17r"/>
@@ -411,8 +409,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             </objectDesc>  
                             <handDesc>
                                 <handNote xml:id="h4" script="Ethiopic">
-                                    <ab type="script"/>
-                                    <seg type="script">19th or 20th-century script.</seg>
+                                    <seg type="script">Nineteenth or twentieth-century script.</seg>
                                     <seg type="ink">Black</seg>
                                 </handNote>
                             </handDesc>
@@ -446,7 +443,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <locus from="1r" to="5r"/><locus from="6r" to="6v"/>
                             <title>Dǝgm mansāʿ</title>
                             <note>The original text runs up to <locus target="#5r"/>. The final chapter is written on <locus from="6r" to="6v"/>, 
-                                which was taken from <ref target="p4"/> and inserted in this place, is entitled 
+                                which was taken from <ref target="p4"/> and inserted in this place. It is entitled 
                                 <foreign xml:lang="tig">ድግም፡ ወለት፡ ሐጸይ፡ እት፡ ምድር፡ መንሳዕ፡</foreign> and comparable to fol. 17r (18r according to 
                                 <bibl><ptr target="bm:Strelcyn1976Catalogue"/><citedRange unit="page">150</citedRange></bibl>) of
                                 <ref target="#p4"/>. The first eight lines of the front page (<locus target="#6r"/>) have been written by the hand of
@@ -465,26 +462,21 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             <height unit="mm">210–215</height>
                                             <width unit="mm">135–155</width>
                                         </dimensions>
-                                        <!-- Strelcyn 1976: Suite et fin du cahier n. 4 correspondant au texte ajouté de la main de CCR aux ff. 16 r-18 r du prccedent cahier. Le texte primitif s'arrete au f. 5 r.
-Un chapitre final, intitulé ድግም፡ ወለት፡ ሐጸይ፡ እት፡ ምድር፡ መንሳዕ፡ (cp. CCR, cahier n. 4, f. r8 r) a été ajouté sur le premier feuillet d'un bifolio en papier non ligne (ff. 6-7), de 2rox 135 mm.  -->
                                     </extent>
-                                    <collation>One bifolio with unligned paper of smaller size (210 x 135 mm) was added (<locus from="6" to="7"/>) 
+                                    <collation>One bifolium of unligned paper, smaller in size (210 x 135 mm), was added (<locus from="6" to="7"/>) 
                                         to the notebook.</collation>
                                     <condition key="good"/>
                                 </supportDesc> 
                             </objectDesc>  
                             <handDesc>
                                 <handNote xml:id="h5" script="Ethiopic">
-                                    <ab type="script"/>
-                                    
-                                    <seg type="script">19th or 20th-century script.</seg>
+                                    <seg type="script">Nineteenth or twentieth-century script.</seg>
                                     <desc></desc>
                                     <seg type="ink">Black</seg>
                                 </handNote>
                                 <handNote xml:id="h6" script="Ethiopic">
-                                    <ab type="script"/>
                                     <locus from="6r1" to="6r8"/>
-                                    <seg type="script">19th or 20th-century script.</seg>
+                                    <seg type="script">Nineteenth or twentieth-century script.</seg>
                                     <desc>According to <bibl><ptr target="bm:Strelcyn1976Catalogue"/>
                                         <citedRange unit="page">150</citedRange></bibl>, hand of <persName ref="PRS3182ContiRo"/>.</desc>
                                     <seg type="ink">Black</seg>
@@ -554,33 +546,32 @@ Un chapitre final, intitulé ድግም፡ ወለት፡ ሐጸይ፡ እት፡ �
                             </objectDesc>  
                             <handDesc>
                                 <handNote xml:id="h7" script="Ethiopic">
-                                    <ab type="script"/>
-                                    <seg type="script">19th or 20th-century script.</seg>
+                                    <seg type="script">Nineteenth or twentieth-century script.</seg>
                                     <seg type="ink">Black</seg>
                                 </handNote>
                             </handDesc>
                                 <additions>
                                     <list>
-                                        <item xml:id="e6">
+                                        <item xml:id="e4">
                                             <locus target="#1r"/>
                                             <desc>Signature of <persName ref="PRS3182ContiRo"/>.</desc>
                                         </item>
-                                        <item xml:id="e7">
+                                        <item xml:id="e5">
                                             <locus target="#2r"/>
                                             <desc>Title of the first part in Italian</desc>
                                             <q xml:lang="it">I. Proverbi</q>
                                         </item>
-                                        <item xml:id="e8">
+                                        <item xml:id="e6">
                                             <locus target="#7r"/>
                                             <desc>Note in Italian indicating the end of the text</desc>
                                             <q xml:lang="gez">Finis della piccola raccolta di proverbi</q>
                                         </item>
-                                        <item xml:id="e9">
+                                        <item xml:id="e7">
                                             <locus target="#8r"/>
                                             <desc>Note in Italian on the content of the text</desc>
                                             <q xml:lang="it">Enimme ed indovinelli colle risposte</q>
                                         </item>
-                                        <item xml:id="e10">
+                                        <item xml:id="e8">
                                             <locus target="#11r"/>
                                             <desc>Note in Italian indicating the end of the text and the beginning of another</desc>
                                             <q xml:lang="it">Finis delle enimme da noi raccolte. Segue un altro quaderno di cantici</q>
@@ -615,13 +606,13 @@ Un chapitre final, intitulé ድግም፡ ወለት፡ ሐጸይ፡ እት፡ �
                         <msContents><summary/>
                         <msItem xml:id="p7_i1">
                             <locus from="2r"/>
-                            <title>Collection of 28 Tigre-poems</title>
-                            <note>Some of the poems are annotated by <persName ref="PRS3182ContiRo"/>. The greater part of the poems 
-                                is edited in <bibl><ptr target="bm:Littmann1913Tigre"/></bibl>; a German translation of which is published in
+                            <title>Collection of 28 Tigre poems</title>
+                            <note>Some of the poems are annotated by <persName ref="PRS3182ContiRo"/>. Most of the poems have been 
+                                edited in <bibl><ptr target="bm:Littmann1913Tigre"/></bibl>; a German translation of which is published in
                                 <bibl><ptr target="bm:Littmann1913Tigre_IV_A"/></bibl> and 
                                 <bibl><ptr target="bm:Littmann1915Tigre_IV_B"/></bibl>. However, the texts in this manuscript differ
                                 particularly in terms of spelling from those published by Littmann. Furthermore, Littmann’s edition sometimes 
-                                includes prefaces to the poems that are missing from our manuscript.</note>
+                                includes prefaces to the poems that are missing from this manuscript.</note>
                             <msItem xml:id="p7_i1.1">
                                 <locus from="2r"/>
                                 <title>ʾAmir wad gabāh ʾǝgl maḥamad wad ǧāwǧ laḥalayā</title>
@@ -829,13 +820,12 @@ Un chapitre final, intitulé ድግም፡ ወለት፡ ሐጸይ፡ እት፡ �
                                             <width unit="mm">150</width>
                                         </dimensions>
                                     </extent>
-                                    <condition key="deficient">The notebook shows signs of scorching.</condition>
+                                    <condition key="deficient">The quire shows signs of scorching.</condition>
                                 </supportDesc> 
                             </objectDesc>  
                             <handDesc>
                                 <handNote xml:id="h8" script="Ethiopic">
-                                    <ab type="script"/>
-                                    <seg type="script">19th or 20th-century script.</seg>
+                                    <seg type="script">Nineteenth or twentieth-century script.</seg>
                                     <desc><locus from="16v" to="18r"/> are written in green ink.</desc>
                                     <seg type="ink">Black, green</seg>
                                 </handNote>
@@ -874,7 +864,7 @@ Un chapitre final, intitulé ድግም፡ ወለት፡ ሐጸይ፡ እት፡ �
                                 ሐየት፡ ወአልማ፡ ሀዬ፡ ትሰለጠውውቱ።</incipit>
                         </msItem>
                             <msItem xml:id="p8_i2">
-                                <title>Tigre-story</title>
+                                <title>Tigre story</title>
                                 <note>Written by the hand of <persName ref="PRS3182ContiRo"/>.</note>
                                 <incipit xml:lang="tig"></incipit>
                             </msItem>
@@ -904,8 +894,7 @@ Un chapitre final, intitulé ድግም፡ ወለት፡ ሐጸይ፡ እት፡ �
                             </objectDesc>  
                             <handDesc>
                                 <handNote xml:id="h9" script="Ethiopic">
-                                    <ab type="script"/>
-                                    <seg type="script">19th or 20th-century script.</seg>
+                                    <seg type="script">Nineteenth or twentieth-century script.</seg>
                                     <desc>Hand of <persName ref="PRS3182ContiRo"/>.</desc>
                                     <seg type="ink">Red</seg>
                                 </handNote>
@@ -939,7 +928,7 @@ Un chapitre final, intitulé ድግም፡ ወለት፡ ሐጸይ፡ እት፡ �
                         <msItem xml:id="p9_i1">
                             <locus from="1r"/>
                             <title>Tigre poems with Amharic translations</title>
-                            <note>The left column on each page contain the Tigre-text of each poem, while the right provides an Amharic translation.
+                            <note>The left column on each page contain the Tigre text of each poem, while the right provides an Amharic translation.
                                 Except for <ref target="#p9_i1.13"/>, the poems are not included in <bibl><ptr target="bm:Littmann1913Tigre"/></bibl>.
                                     </note>
                             <msItem xml:id="p9_i1.1">
@@ -950,14 +939,14 @@ Un chapitre final, intitulé ድግም፡ ወለት፡ ሐጸይ፡ እት፡ �
                             </msItem>
                             <msItem xml:id="p9_i1.2">
                                 <locus from="1r"/>
-                                <title>Nāy daǧāč ḥadga ʾanba(sā) šalāy</title>
+                                <title>Nāy daǧǧāč ḥadga ʾanba(sā) šalāy</title>
                                 <incipit xml:lang="tig"><locus from="1ra"/> ናይ፡ ደጃች፡ ሐድገ፡ 
                                     አንበ<supplied reason="omitted" resp="PRS8999Strelcyn">ሳ፡</supplied> ሸላይ።</incipit>
                                 <incipit xml:lang="am"><locus from="1rb"/> የደጃች፡ ሐድገ፡ አንበሳ፡ ውዳሴ።</incipit>
                             </msItem>
                             <msItem xml:id="p9_i1.3">
                                 <locus from="2v"/>
-                                <title>Nāy daǧāč ḥadga ʾanba(sā) šalāy</title>
+                                <title>Nāy daǧǧāč ḥadga ʾanba(sā) šalāy</title>
                                 <incipit xml:lang="tig"><locus from="2va"/> ናይ፡ ደጃች፡ ሐድገ፡ 
                                     አንበ<supplied reason="omitted" resp="PRS8999Strelcyn">ሳ፡</supplied> ሸላይ።</incipit>
                                 <incipit xml:lang="am"><locus from="2vb"/> የደጃች፡ ሐድገ፡ አንበሳ፡ ውዳሴ።</incipit>
@@ -1050,18 +1039,16 @@ Un chapitre final, intitulé ድግም፡ ወለት፡ ሐጸይ፡ እት፡ �
                                             <width unit="mm">155</width>
                                         </dimensions>
                                     </extent>
-                                    <foliation><locus from="1" to="5"/> paginated in Ethiopian numbers (<foreign xml:lang="gez">፩</foreign>
+                                    <foliation><locus from="1" to="5"/> paginated in Ethiopian numbers (from <foreign xml:lang="gez">፩</foreign>
                                         to <foreign xml:lang="gez">፭</foreign>).</foliation>
                                     <condition key="deficient">The quire is severely damaged by fire with partial text losses on the left side at the bottom
-                                        of <locus target="#1 #2 #9 #20"/>; <locus from="11ra1" to="11ra12"/> are completely or partly detoriated.</condition>
+                                        of <locus target="#1 #2 #9 #20"/>; <locus from="11ra1" to="11ra12"/> are completely or partly destroyed.</condition>
                                 </supportDesc> 
                                 <layoutDesc><layout writtenLines="18" columns="2"/></layoutDesc>
                             </objectDesc>  
                             <handDesc>
-                                <handNote xml:id="h10" script="Ethiopic">
-                                    <ab type="script"/>
-                                    <seg type="script">19th or 20th-century script.</seg>
-                                    <desc></desc>
+                                <handNote xml:id="h10" script="Ethiopic">    
+                                    <seg type="script">Nineteenth or twentieth-century script.</seg>
                                     <seg type="ink">Black</seg>
                                 </handNote>
                             </handDesc>
@@ -1117,7 +1104,7 @@ Un chapitre final, intitulé ድግም፡ ወለት፡ ሐጸይ፡ እት፡ �
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2026-04-21">Created record</change>
-            <!--  -->
+            <change who="CH" when="2026-05-08">Updated after reviews by Magdalena Krzyżanowska and Elizaveta Shvartz</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">


### PR DESCRIPTION
This record describes a number of materials of the Tigre language. Strelcyn describes each item as 'cahier'. I equated it with 'Quire' rather than 'Notebook', because I assume, that each of them is an unbound quire which is possibly placed in box.

I was confused about the description of quire 4 and 5. I hope that I managed to understand Strelcyns explanations correctly and found the most probable solution for encoding.

<img width="922" height="473" alt="grafik" src="https://github.com/user-attachments/assets/1e60f167-bb24-4e33-bf91-b665d5542921" />

I wanted to quote the Tigre titles of various stories and poems in various msItems. Since I have no command in Tigre, I could not make any judgements on šwa-vowels or double consonants apart from guessing. Similarly, I could not well distingish between personal names and the ordinary lexicon in cases, which are not obvious. Therefore, I decided to transscribe all texts in a strict transliteration without capitalisation (except for beginning of a phrase), no intensification of consonants and no šwa-vowels, except for neccesary cases. Do you agree to this strategy or do you think, the transcriptions need to be improved?