### PR TITLE
Deco desc d16

### DIFF
--- a/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
@@ -1587,7 +1587,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                is written on <locus target="#2ra"/> on a previously erased name.
                                The involvement of a certain <persName ref="PRS15405Zamalakot"><roleName type="title">ʾAbuna</roleName>
                                    Zamalakot</persName> is evidenced by the mention of his name, written in the main hand in the miniature on <locus target="#56v"/>. 
-                               The latter is possibly identical to the abbot of the monastery of <placeName ref="INS0329DE">Dāgā ʾƎsṭifānos</placeName>, who was in tenure in the early eighteenth century. This suggests that the manuscript has some connections to <placeName ref="INS0329DE">Dāgā ʾƎsṭifānos</placeName>. 
+                               The latter is possibly identical to <roleName type="title">Mamhǝr</roleName> Zamalakot, who was the abbot of the monastery of 
+                               <placeName ref="INS0329DE">Dāgā ʾƎsṭifānos</placeName> in the early eighteenth century 
+                               (cp. <bibl><ptr target="bm:Dombrowski1983TanaseeB"/><citedRange unit="page">256, 307</citedRange></bibl>). 
+                               This suggests that the manuscript has some connections to <placeName ref="INS0329DE">Dāgā ʾƎsṭifānos</placeName>. 
                                At a certain time in its history, the manuscript came into the possession of the church of <placeName ref="INS0101MadhaneAlam">Maqdala Madḫāne ʿĀlam</placeName> (see <ref target="#a1">Additional note 1</ref>).
                                The manuscript was then brought to <placeName ref="wd:Q21">England</placeName> after the 1868 expedition by <persName ref="PRS7484Napier">Napier</persName>. The subsequent owners are unknown in detail.
                                At some time the book entered <persName ref="PRS13956Kevork"/>’s private collection, as indicated on one of the white stickers glued

--- a/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
@@ -363,8 +363,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                            <locus target="#9v"/>
                                            <desc>God the Father binds the angels in Hell.
                                              <q xml:lang="gez">እግዚአብሔር።</q>
-                                             <q xml:lang="gez">ገጸ፡ ሰብእ፡ / ገጸ፡ ንስር። /
-                                               ገጸ፡ አንበሳ። / ገጸ፡ ላህም።</q>
+                                             <q xml:lang="gez">ገጸ፡ ሰብእ፡</q>
+                                               <q xml:lang="gez">ገጸ፡ ንስር።</q>
+                                               <q xml:lang="gez">ገጸ፡ አንበሳ።</q>
+                                               <q xml:lang="gez">ገጸ፡ ላህም።</q>
                                                <q xml:lang="gez">አጋንንት</q>
                                            </desc>
                                         </decoNote>
@@ -375,7 +377,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                             God the Father creates <persName ref="PRS1386Adam">Adam</persName> in his likeness.
                                             <q xml:lang="gez">እግዚአብሔር።</q>
                                             <q xml:lang="gez"><persName ref="PRS1386Adam">አዳም፡</persName></q>
-                                            <q xml:lang="gez">እሳት። / ነፋስ። / መሬት። / ማይ።</q>
+                                            <q xml:lang="gez">እሳት<supplied reason="omitted">፡</supplied></q>
+                                              <q xml:lang="gez">ነፋስ<supplied reason="omitted">፡</supplied></q>
+                                              <q xml:lang="gez">መሬት፡</q>
+                                              <q xml:lang="gez">ማይ።</q>
                                           </desc>
                                              </decoNote>
 
@@ -397,7 +402,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                           <persName ref="PRS1386Adam">Adam</persName> share the forbidden fruit taken from a fig tree with the serpent coiled around it (left); the pair are cast out of Eden by an angel (right).                                       
                                           <q xml:lang="gez">ከይሲ፡</q>
                                           <q xml:lang="gez"><persName ref="PRS1386Adam">አዳም።</persName></q>
-                                          <q xml:lang="gez"><persName ref="PRS3926Eve">ሔዋን፡</persName></q>
+                                            <q xml:lang="gez"><persName ref="PRS3926Eve">ሔዋን፤</persName></q>
                                           <q xml:lang="gez">መልአክ፡</q>
                                       </desc>
                                      </decoNote>
@@ -408,9 +413,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <desc> God the Father looks down upon <persName ref="PRS1386Adam">Adam</persName> and
                                      <persName ref="PRS3926Eve">Eve</persName>, who are shown ashamed of their nakedness to the left and clothed to the right.
                                      <q xml:lang="gez">ዘከመ፡ ተዓርቁ፡ እምልብስ፡
-                                    <persName ref="PRS1386Adam">አዳም፡</persName> ወ<persName ref="PRS3926Eve">ሔዋን</persName></q>
-                                     <q xml:lang="gez"><persName ref="PRS1386Adam">አዳም።</persName></q>
-                                     <q xml:lang="gez"><persName ref="PRS3926Eve">ሔዋን፡</persName></q>
+                                         <persName ref="PRS1386Adam">አዳም፡</persName> ወ<persName ref="PRS3926Eve">ሔዋን።</persName></q>
+                                       <q xml:lang="gez"><persName ref="PRS1386Adam">አዳም፡</persName></q>
+                                       <q xml:lang="gez"><persName ref="PRS3926Eve">ሔዋን።</persName></q>
                                  </desc>
                                 </decoNote>
 
@@ -420,11 +425,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <persName ref="PRS2984Cain">Cain</persName> and <persName ref="PRS1230Abel">Abel</persName> offer gifts to God (above);
                                     <persName ref="PRS2984Cain">Cain</persName> kills
                                     his brother (bottom left); he encounters a crow while wandering (bottom right).
-                                    <q xml:lang="gez"><persName ref="PRS1230Abel">አቤል፡</persName> / መሥዋዕት፡ / እሳት፡</q>
-                                    <q xml:lang="gez"><persName ref="PRS2984Cain">ቃየል</persName></q>
-                                    <q xml:lang="gez">ዘከመ፡ ቀተሎ፡ ቃየል፡ ለአቤል።</q>
-                                    <q xml:lang="gez"><persName ref="PRS1230Abel">አቤል፡</persName></q>
-                                    <q xml:lang="gez"><persName ref="PRS2984Cain">ቃየል</persName> / ቋዕ፡</q>
+                                      <q xml:lang="gez"><persName ref="PRS1230Abel">አቤል፡</persName></q>
+                                      <q xml:lang="gez">መሥዋዕት፡</q>
+                                      <q xml:lang="gez">እሳት፡</q>
+                                      <q xml:lang="gez"><persName ref="PRS2984Cain">ቃየል</persName></q>
+                                      <q xml:lang="gez">ዘከመ፡ ቀተሎ፡ ቃየል፡ ለአቤል።</q>
+                                      <q xml:lang="gez"><persName ref="PRS1230Abel">አቤል፡</persName></q>
+                                      <q xml:lang="gez"><persName ref="PRS2984Cain">ቃየል</persName></q>
+                                      <q xml:lang="gez">ቋዕ፡</q>
                                 </desc>
                                </decoNote>
 
@@ -434,8 +442,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <persName ref="PRS8782Seth">Seth</persName> looks at the recumbent body of his dead brother
                                    <persName ref="PRS1230Abel">Abel</persName>.
                                    <q xml:lang="gez">እግዚአብሔር።</q>
-                                    <q xml:lang="gez"><persName ref="PRS3814Enoch">ሄኖክ፡</persName></q>
-                                    <q xml:lang="gez"><persName ref="PRS8782Seth">ሴት፤</persName></q>
+                                     <q xml:lang="gez"><persName ref="PRS3814Enoch">ሄኖክ።</persName></q>
+                                     <q xml:lang="gez"><persName ref="PRS8782Seth">ሴት፡</persName></q>
                                     <q xml:lang="gez"><persName ref="PRS1230Abel">አቤል፡</persName></q>
                                </desc>
                                </decoNote>
@@ -455,15 +463,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <locus target="#13v"/>
                                  <desc>God, who sits on a cloak that symbolizes his blessing,
                                      addresses <persName ref="PRS3814Enoch">Enoch</persName> in a garden with trees and flowers.
-                                     <q xml:lang="gez"><persName ref="PRS3814Enoch">ሄኖክ፡</persName> / እግዚአብሔር። / መልአክ።</q>
+                                     <q xml:lang="gez"><persName ref="PRS3814Enoch">ሄኖክ፡</persName></q>
+                                     <q xml:lang="gez">እግዚአብሔር።</q>
+                                     <q xml:lang="gez">መልአክ።</q>
                                </desc>
                               </decoNote>
 
                               <decoNote type="miniature" xml:id="d13">
                                   <locus target="#14r"/>
-                                <desc>God, who holds a gold orb, grants a long life to Methuselah who prays towards him
-                                  with a group of elders, presumably his children.
-                                  <q xml:lang="gez">ማቱሳላ፡ / እግዚአብሔር፡ / መላእክት፤</q>
+                                <desc>God, who holds a gold orb, grants a long life to Methuselah who prays towards him with a group of elders, presumably his children.
+                                    <q xml:lang="gez">ማቱሳላ፡</q>
+                                    <q xml:lang="gez">መላእክት፤</q>
+                                    <q xml:lang="gez">አበው፡</q>
+                                    <q xml:lang="gez">እግዚአብሔር፡</q>                                  
                               </desc>
                              </decoNote>
 
@@ -472,7 +484,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                  <desc>The Ark of <persName ref="PRS7594Noah">Noah</persName> described as a <hi
                                      rendition="simple:italic">tābot</hi>
                                and filled with humans, cattle, horses, domesticated animals, and wild beasts. A second group of people are drowning.
-                               <q xml:lang="gez"><persName ref="PRS7594Noah">ኖኅ።</persName> / እግዚአብሔር፡ / ታቦት፤ / ሰብእ። / እንስሳ። አራዊት፤</q>
+                                     <q xml:lang="gez"><persName ref="PRS7594Noah">ኖኅ።</persName></q>
+                                     <q xml:lang="gez">እግዚአብሔር፡</q>
+                                     <q xml:lang="gez">ታቦት፤</q>
+                                     <q xml:lang="gez">ሰብእ።</q>
+                                     <q xml:lang="gez">እንስሳ። አራዊት፤</q>
                                <q xml:lang="gez">ማየ፡ አይኅ።</q>
                              </desc>
                             </decoNote>
@@ -482,9 +498,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                               <desc>God decides to dwell in the house of <persName ref="PRS8819Shem">Shem</persName>, which is represented like a tent,
                               rather than in that of <persName ref="PRS5673Japheth">Japhet</persName> or
                               <persName ref="PRS5038Ham">Ham</persName>.
-                              <q xml:lang="gez"><persName ref="PRS5038Ham">ካም፡</persName> / <persName ref="PRS5673Japheth">ያፌት፤</persName> / ብእሲቱ <persName ref="PRS8819Shem">ሴም፡</persName></q>
-                              <q xml:lang="gez">እግዚአብሔር።</q>
-                              <q xml:lang="gez">ሐይመት፡</q>
+                                  <q xml:lang="gez"><persName ref="PRS5038Ham">ካም፡</persName></q>
+                                  <q xml:lang="gez"><persName ref="PRS5673Japheth">ያፌት፤</persName></q>
+                                  <q xml:lang="gez">ብእሲቱ <persName ref="PRS8819Shem">ሴም፡</persName></q>
+                                  <q xml:lang="gez">እግዚአብሔር።</q>
+                                  <q xml:lang="gez">ሐይመት፡</q>
                             </desc>
                            </decoNote>
 
@@ -509,7 +527,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#16v"/>
                                <desc>God calls <persName ref="PRS1267Abraham"/>, who is accompanied by his wife <persName ref="PRS8533Sarah"/>,
                                    to the land of <placeName ref="LOC2109Canaan"/>, which is populated with trees and located between two rivers.
-                                   <q xml:lang="gez"><persName ref="PRS8533Sarah">ሳራ፡</persName> / <persName ref="PRS1267Abraham">አብርሃም፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS8533Sarah">ሳራ፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS1267Abraham">አብርሃም፡</persName></q>
                                    <q xml:lang="gez">እግዚአብሔር።</q>
                                    <q xml:lang="gez">፪ቱ፡ አፍላግ።</q>
                                </desc>
@@ -520,10 +539,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <desc>God, placed between the two columns of text, looks at
                                    the five cities of the plain engulfed by fires (above); <persName ref="PRS6357Lot">Lot</persName> and his daughters and wife, who turns back, 
                                    are guided away by the two angels (below).
-                                   <q xml:lang="gez">እግዚአብሔር።</q>
-                                   <q xml:lang="gez"><persName ref="PRS6357Lot">ሎት፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS6357Lot">ሎጥ፡</persName></q>
                                    <q xml:lang="gez">ዘከመ፡ ኮነት፡ ብእሲቱ፡ ሐውልተ፡ ፄው፡ ሶበ፡ ተመይጠት፡ ድኅሬሃ፡</q>
-                                   <q xml:lang="gez"><persName ref="PRS6357Lot">ሎት፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS6357Lot">ሎጥ፡</persName></q>
                                    <q xml:lang="gez">፪ኤ፡ አዋልዲሁ፡</q>
                                    <q xml:lang="gez">ዘከመ፡ መርህዎ፡ መላእክት።</q>
                                </desc>
@@ -534,9 +552,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <desc>Two scenes: <persName ref="PRS8533Sarah"/> gives one of her slaves to <persName ref="PRS1267Abraham"/> (left);
                                    the pair look at the newly born <persName ref="PRS5578Isaac">Isaac</persName> (right).
                                    <q xml:lang="gez">እግዚአብሔር።</q>
-                                   <q xml:lang="gez"><persName ref="PRS8533Sarah">ሳራ፡</persName> / <persName ref="PRS1267Abraham">አብርሃም፡</persName></q>
-                                   <q xml:lang="gez"><persName ref="PRS8533Sarah">ሳራ፡</persName> / <persName ref="PRS5578Isaac">ይስሐቅ።</persName> / 
-                                       <persName ref="PRS1267Abraham">አብርሃም፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS8533Sarah">ሳራ፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS1267Abraham">አብርሃም፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS8533Sarah">ሳራ፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS5578Isaac">ይስሐቅ።</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS1267Abraham">አብርሃም፡</persName></q>
                                    <q xml:lang="gez">ንብቲራ፡</q>
                                </desc>
                            </decoNote>
@@ -548,7 +568,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez"><persName ref="PRS1267Abraham">አብርሃም፡</persName></q>
                                    <q xml:lang="gez"><persName ref="PRS5578Isaac">ይስሐቅ።</persName></q>
                                    <q xml:lang="gez">በግዕ፡</q>
-                                   <q xml:lang="gez">ዕፀ፡ ስቤቅ፡</q>
+                                   <q xml:lang="gez">ዕፀ፡ ሳቤቅ፡</q>
                                    <q xml:lang="gez"><persName ref="PRS1267Abraham">አብርሃም፡</persName></q>
                                    <q xml:lang="gez"><persName ref="PRS5578Isaac">ይስሐቅ።</persName></q>
                                </desc>
@@ -564,8 +584,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez"><persName ref="PRS3863Esau">ኤሳው።</persName></q>
                                    <q xml:lang="gez"><persName ref="PRS6122Laban">ላባ፡</persName></q>
                                    <q xml:lang="gez">ሐይመት።</q>
-                                   <q xml:lang="gez">ራሔል / <persName ref="PRS5650Jacob">ያዕቆብ</persName> / ለያ</q>
-                                   <q xml:lang="gez">አፍራስ / አግማል፡ / አባግዕ፡ / አድግት፡</q>
+                                   <q xml:lang="gez">ራሔል<supplied reason="omitted">፡</supplied></q>
+                                   <q xml:lang="gez"><persName ref="PRS5650Jacob">ያዕቆብ</persName><supplied reason="omitted">፡</supplied></q>
+                                   <q xml:lang="gez">ለያ<supplied reason="omitted">፡</supplied></q>
+                                   <q xml:lang="gez">አፍራስ<supplied reason="omitted">፡</supplied></q>
+                                   <q xml:lang="gez">አግማል፡</q>
+                                   <q xml:lang="gez">አባግዕ፡</q>
+                                   <q xml:lang="gez">ዕድግት፡</q>
                                </desc>
                            </decoNote>
 
@@ -573,11 +598,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="19r#"/>
                                <desc>The devil tests <persName ref="PRS5691Job">Job</persName>.
                                    <q xml:lang="gez">እግዚአብሔር።</q>
-                                   <q xml:lang="gez"><persName ref="PRS5691Job">ኢዮብ፡</persName></q>
-                                   <q xml:lang="gez"><persName ref="PRS11330Devil">ሰይጣን፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS11330Devil">ሰይጣን፡</persName></q> <!-- twice -->
                                    <q xml:lang="gez">ብእሲቱ፡ ለኢዮብ፤</q>
                                    <q xml:lang="gez">ሕማሙ፡ ለኢዮብ፡</q>
-                                   <q xml:lang="gez">ጎፍር፡ ኤልፉዝ፡ በልዳዶስ።</q>
+                                   <q xml:lang="gez">ሳፍር፡ ኤልፋዝ፡ በልዳዶስ።</q>
                                </desc>
                            </decoNote>
 
@@ -598,7 +622,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#20r"/>
                                <desc>To the left God encounters <persName ref="PRS7181MosesM">Moses</persName> on a mountain with his flock of sheep. To the right the latter sets off towards Egypt.
                                    <q xml:lang="gez">እግዚአብሔር፤</q>
-                                   <q xml:lang="gez"><persName ref="PRS7181MosesM">ሙሴ፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS7181MosesM">ሙሴ፡</persName></q> <!-- twice -->
                                    <q xml:lang="gez">አባግዕ።</q>
                                </desc>
                            </decoNote>
@@ -613,9 +637,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d27">
                                <locus target="#21r"/>
-                               <desc><persName ref="PRS7181MosesM">Moses</persName> confronts the Pharaoh and his officials. His staff has become a snake that swallows the snake conjured from a staff 
-                                   by two magicians. In the bottom right corner, the livestock of the Egyptians are dead because of the fifth plague.                                   
-                                   <q xml:lang="gez">መላክ፤</q>
+                               <desc><persName ref="PRS7181MosesM">Moses</persName> confronts the Pharaoh and his officials. 
+                                   His staff has become a snake that swallows the snake conjured from a staff by two magicians. 
+                                   In the bottom right corner, the livestock of the Egyptians are dead because of the fifth plague.                                   
+                                   <q xml:lang="gez">መልአክ፤</q>
                                    <q xml:lang="gez">ፈርዖን</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez"><persName ref="PRS7181MosesM">ሙሴ፡</persName></q>
@@ -674,9 +699,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#23v"/>
                                <desc>A priest holding a torch and <persName ref="PRS1002Aaron">Aaron</persName> holding the budded staff and a censer stand before God while 
                                    <persName ref="PRS6053Korah">Korah</persName> and his followers burn in an underground fire.                                   
-                                   <q xml:lang="gez"><persName ref="PRS1002Aaron">ኣሮን፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS1002Aaron">አሮን፡</persName></q>
                                    <q xml:lang="gez">እግዚአብሔር።</q>
-                                   <q xml:lang="gez">በከመ፡ አውዕዮ፡ ለቆራ፡ ምስለ፡ ህዝቡ፡</q>
+                                   <q xml:lang="gez">በከመ፡ አውዓዮ፡ ለቆራ፡ ምስለ፡ ሕዝቡ፡</q>
                                </desc>
                            </decoNote>                           
                            
@@ -694,7 +719,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">እስራኤል፡</q>
                                    <q xml:lang="gez"><placeName ref="LOC3959Jordan">ዮርዳኖስ።</placeName></q>
-                                   <q xml:lang="gez"><persName ref="PRS5773Joshua">ኢያሱ።</persName></q>                                   
+                                   <q xml:lang="gez"><persName ref="PRS5773Joshua"><sic>ኤያሱ።</sic></persName></q>                                   
                                </desc>
                            </decoNote>                           
 
@@ -703,7 +728,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <desc>The fall of <placeName ref="LOC3956Jerich">Jericho</placeName>.                                   
                                    <q xml:lang="gez">እግዚአብሔር።</q>
                                    <q xml:lang="gez">እስራኤል፡</q>
-                                   <q xml:lang="gez">ሰብአ <placeName ref="LOC3956Jerich">ኤሪኮ፡</placeName></q>
+                                   <q xml:lang="gez">ሰብአ፡ <placeName ref="LOC3956Jerich"><sic>ኤሪኮ፡</sic></placeName></q>
                                    <q xml:lang="en">Fall of <placeName ref="LOC3956Jerich">Jericho</placeName></q>
                                </desc>
                            </decoNote>
@@ -714,15 +739,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">እግዚአብሔር።</q>
                                    <q xml:lang="gez">ራአብ፡ ዘማ፡</q>
                                    <q xml:lang="gez">እስራኤል፡</q>
-                                   <q xml:lang="gez">ሰብአ፡ <placeName ref="LOC3956Jerich">ኤሪኮ</placeName></q>
+                                   <q xml:lang="gez">ሰብአ፡ <placeName ref="LOC3956Jerich">ኢያሪኮ<supplied reason="omitted">፡</supplied></placeName></q>
                                </desc>
                            </decoNote>                           
                            
                            <decoNote type="miniature" xml:id="d37">
                                <locus target="#26r"/>
-                               <desc>Two scenes: <persName ref="PRS5773Joshua">Joshua</persName> makes peace with the people of Gibeon (above); and the sun stands still for him and his army (below).
+                               <desc>Two scenes: <persName ref="PRS5773Joshua">Joshua</persName> makes peace with the people of Gibeon (above); 
+                                   and the sun stands still for him and his army (below).
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">በከመ፡ ቆመ፡ ፀሓይ፡ ለ<persName ref="PRS5773Joshua">ኢያሱ።</persName></q>
+                                   <q xml:lang="gez">በከመ፡ ቆመ፡ ፀሐይ፡ ለ<persName ref="PRS5773Joshua">ኢያሱ።</persName></q>
                                    <q xml:lang="gez">እስራኤል፡</q>
                                </desc>
                            </decoNote>                           
@@ -754,20 +780,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">ኢያዔል፡</q>
                                    <q xml:lang="gez">ሲሳራ፡</q>
                                </desc>
-                           </decoNote>
-                           
+                           </decoNote>                           
                            
                            <decoNote type="miniature" xml:id="d40">
                                <locus target="#27v"/>
-                               <desc>Three scenes showing military leaders: Jephthah sacrifices his daughter who had come out to meet him (upper left); Gideon defeats the Midianites (bottom left);
-                                   and <persName ref="PRS8469Samson">Samson</persName> defeats the Philistines brandishing the donkey jaw.  
+                               <desc>Three scenes showing military leaders: Jephthah sacrifices his daughter who had come out to meet him (upper left); 
+                                   Gideon defeats the Midianites (bottom left); and <persName ref="PRS8469Samson">Samson</persName> defeats the Philistines brandishing the donkey jaw.  
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ዮፍታሒ፡</q> 
                                    <q xml:lang="gez">መንከሰ፡ ዓድግ፡</q>
-                                   <q xml:lang="gez">ጊዴዎን፡</q> 
-                                   <q xml:lang="gez">ሰብአ፡ ጊዴዎን፡</q>
+                                   <q xml:lang="gez">ጌዴዎን፡</q> 
+                                   <q xml:lang="gez">ሰብአ፡ ጌዴዎን፡</q>
                                    <q xml:lang="gez">ሰብአ፡ ምድያም፡</q>
-                                   <q xml:lang="gez"><persName ref="PRS8469Samson">ሳምሶን፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS8469Samson">ሶምሶን፡</persName></q>
                                    <q xml:lang="gez">ሰብአ፡ ኢሎፍሊ፡</q>
                                </desc>
                            </decoNote>                           
@@ -776,7 +801,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#28r"/>
                                <desc>Four scenes: <persName ref="PRS8478Samuel">Samuel</persName> addresses the Israelites after the death of Eli (upper left); 
                                    the five Philistine kings send the Ark of the Covenant back to Israel (bottom left); 
-                                   King <persName ref="PRS8567Saul">Saul</persName> addresses an armed man, probably his son (upper right); and the Israelites defeat the Philistines (bottom right).
+                                   king <persName ref="PRS8567Saul">Saul</persName> addresses an armed man, probably his son (upper right); 
+                                   and the Israelites defeat the Philistines (bottom right).
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez"><persName ref="PRS8478Samuel">ሳሙኤል፡</persName></q>
                                    <q xml:lang="gez">እስራኤል፡</q>
@@ -808,8 +834,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#29r"/>
                                <desc>Five scenes: <persName ref="PRS3417David">David</persName> interacts with two unidentified men (his courtiers or soldiers); Uriah dies in battle; 
                                    <persName ref="PRS3417David">David</persName> marries <persName ref="PRS2558Bathsheb">Batsheba</persName>; 
-                                   <persName ref="PRS13685Nathan">Nathan</persName> reproaches the King for his behaviour; 
-                                   and <persName ref="PRS3417David">David</persName> lays on the ground to seek forgiveness.                                 
+                                   <persName ref="PRS13685Nathan">Nathan</persName> reproaches the king for his behaviour; 
+                                   and <persName ref="PRS3417David">David</persName> lies on the ground to seek forgiveness.                                 
                                    <q xml:lang="gez"><persName ref="PRS3417David">ዳዊት፡</persName></q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ኦርዮ፡</q>
@@ -823,7 +849,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d44">
                                <locus target="#29v"/>
-                               <desc> Solomon is appointed king over the four kings of the world.
+                               <desc> Solomon is appointed king over the kings of the world.
                                    <q xml:lang="gez">እግዚአብሔር።</q>
                                    <q xml:lang="gez"><persName ref="PRS8925Solomon">ሰሎሞን፡</persName></q>
                                    <q xml:lang="gez">ነገሥተ፡ ምድር፡</q>                                   
@@ -843,7 +869,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <desc>The Prophets of Israel have visions with the just in Paradise and the sinners in Hell.
                                    <q xml:lang="gez">ነቢያት፡</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">ጻድቃን፡</q>
+                                   <q xml:lang="gez">ጻድቃን፤</q>
                                    <q xml:lang="gez">ኃጥአን፡</q>
                                    <q xml:lang="gez">ገሃነመ፡ እሳት፡</q>
                                </desc>
@@ -853,17 +879,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#31r"/>
                                <desc>Three scenes: King Ahab asks for Naboth’s vineyard; the latter is killed; and dogs devour the decapitated body of the king’s wife Jezebel. 
                                    <q xml:lang="gez">እግዚአብሔር።</q>
-                                   <q xml:lang="gez">አከዓብ፡</q>
-                                   <q xml:lang="gez">ኤልዛቤል፡</q>
+                                   <q xml:lang="gez">አክዓብ፡</q>
+                                   <q xml:lang="gez">ኤልዛቤል፡</q> <!-- twice -->
+                                   <q xml:lang="gez">ናቡቴ፡</q>
                                </desc>
                            </decoNote>
                            
                            <decoNote type="miniature" xml:id="d48">
                                <locus target="#31v"/>
-                               <desc>Three scenes: God instructs <persName ref="PRS3721Elijah">Elijah </persName>; the prophet confronts King Ahab; the king, who has now aged, sits afraid outside the city walls.
+                               <desc>Three scenes: God instructs <persName ref="PRS3721Elijah">Elijah </persName>; the prophet confronts King Ahab; 
+                                   the king, who has now aged, sits afraid outside the city walls.
                                    <q xml:lang="gez">እግዚአብሔር።</q>
                                    <q xml:lang="gez"><persName ref="PRS3721Elijah">ኤልያስ፡</persName></q>
-                                   <q xml:lang="gez">አከዓብ፡ <gap reason="illegible"/> ኤልያስ፡</q> 
+                                   <q xml:lang="gez">አክዓብ፡ <gap reason="illegible"/> ኤልያስ፡</q> 
                                    <q xml:lang="gez">ዘከመ፡ ደንገፀ፡ ከዓብ።</q> 
                                </desc>
                            </decoNote>
@@ -871,10 +899,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            <decoNote type="miniature" xml:id="d49">
                                <locus target="#32r"/>
                                <desc>Three scenes: <persName ref="PRS3721Elijah">Elijah </persName> in the wilderness speaks to God and is aided by an angel;
-                                   <persName ref="PRS3721Elijah">Elijah</persName> appoints <persName ref="PRS3723Elisha">Elisha</persName> as his disciple; the Aramean soldiers are unable to seize
+                                   <persName ref="PRS3721Elijah">Elijah</persName> appoints <persName ref="PRS3723Elisha">Elisha</persName> as his disciple; 
+                                   the Aramean soldiers are unable to seize
                                    <persName ref="PRS3723Elisha">Elisha</persName>.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">መልአክ፡</q>
+                                   <q xml:lang="gez">ኤ<gap reason="illegible"></gap></q>
                                </desc>
                            </decoNote>
                            
@@ -917,7 +947,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d53">
                                <locus target="#34r"/>
-                               <desc><persName ref="PRS6644Manasseh">Manasseh</persName> prays to God and is restored to his Kingdom.                                   
+                               <desc><persName ref="PRS6644Manasseh">Manasseh</persName> prays to God and is restored to his kingdom.                                   
                                    <q xml:lang="gez">ዘከመ፡ ጸለየ፡ <persName ref="PRS6644Manasseh">ምናሴ።</persName></q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ዘከመ፡ ተሞቅሐ፡</q>
@@ -932,17 +962,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">ጒጠት፡</q>
                                    <q xml:lang="gez"><persName ref="PRS5584Isaiah"> ኢሳይያስ፡</persName></q>
                                    <q xml:lang="gez">መልአክ፡</q>
-                                   <q xml:lang="gez">መልአክ፡</q>
                                </desc>
                            </decoNote>
                            
                            <decoNote type="miniature" xml:id="d55">
                                <locus target="#35r"/>
-                               <desc><persName ref="PRS5774Josiah"> Josiah</persName> celebrates the Passover by having lambs and cattle skinned and by burning offerings to God.
+                               <desc><persName ref="PRS5774Josiah"> Josiah</persName> celebrates the Passover by having lambs and cattle sacrificed and by burning offerings to God.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez"><persName ref="PRS5774Josiah">ኢዮሰያስ።</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS5774Josiah">ኢዮስያስ።</persName></q>
                                    <q xml:lang="gez">እሳት፡</q>
-                                   <q xml:lang="gez">መሥዋዕተ፡ አባግዕ፡ ወዋልህምት።</q>
+                                   <q xml:lang="gez">መሥዋዕተ፡ አባግዕ፡ ወአልህምት።</q>
                                </desc>
                            </decoNote>
                            
@@ -982,7 +1011,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS4377Gabriel">ገብርኤል፡</persName></q>
                                    <q xml:lang="gez"><persName ref="PRS11373Nebuc">ናቡከደነ፡ ጻር፡</persName></q>
                                    <q xml:lang="gez"><persName ref="PRS11288AnAzMi">፫ ደቂቅ፡</persName></q>
-                                   <q xml:lang="gez">እሳት፡</q>
+                                   <q xml:lang="gez">እቶነ፡ <supplied reason="lost">እ</supplied>ሳት፡</q>
                                    <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS4377Gabriel">ገብርኤል፡</persName></q>
                                </desc>
                            </decoNote>
@@ -993,7 +1022,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez"><persName ref="PRS11373Nebuc">ናቡከደነ፡ ጻር፡</persName></q>
                                    <q xml:lang="gez">መልአክ።</q>
-                                   <q xml:lang="gez">ዘከመ፡ <gap reason="illegible"/></q>
+                                   <q xml:lang="gez">ዘከመ፡ <gap reason="illegible"/> ሐራውያ፡</q>
                                </desc>
                            </decoNote>
                            
@@ -1001,11 +1030,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#37v"/>
                                <desc>Two scenes: God turns King <persName ref="PRS11373Nebuc">Nebuchadnezzar</persName> back into a human being; and the king is crowned and enthroned and
                                    attended by several courtiers including <persName ref="PRS3337Daniel">Daniel</persName> and the <persName ref="PRS11288AnAzMi">Three Youths</persName>.
-                                   <q xml:lang="gez"><persName ref="PRS11373Nebuc">ናቡከደነ፡ ጻር፡</persName> ዘይቤ፡ መንግሥቱ፡ ዘለዓም። ወምኵናኑኒ፡ ለትውልደ፡ ትውልድ።</q>
+                                   <q xml:lang="gez"><persName ref="PRS11373Nebuc">ናቡከደነ፡ ጻር፡</persName> ዘይቤ፡ መንግሥቱ፡ ዘለዓለም። ወምኵናኑኒ፡ ለትውልደ፡ ትውልድ።</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez"><persName ref="PRS3337Daniel">ዳንኤል፡</persName></q>
-                                   <q xml:lang="gez"><persName ref="PRS11373Nebuc">ናቡከደነ፡ ጻር፡</persName></q>
-                                   <q xml:lang="gez"><persName ref="PRS11288AnAzMi"><supplied reason="lost">፫</supplied> ደ<supplied reason="lost">ቂቅ፡</supplied></persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS11373Nebuc">ናቡከደነጻር፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS11288AnAzMi">፫ ደቂቅ፡</persName></q>
                                </desc>
                            </decoNote>
                            
@@ -1016,7 +1045,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    and the two elders are stoned to death for their lies.                                    
                                    <q xml:lang="gez"><persName ref="PRS3337Daniel">ዳንኤል፡</persName></q>
                                    <q xml:lang="gez">ረበናት፡</q>
-                                   <q xml:lang="gez"><persName ref="PRS11599Susanna">ሶሰና፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS11599Susanna">ሶስና፡</persName></q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ዘከመ፡ ወገርዎሙ፡ ለረበናት<supplied reason="omitted">፡</supplied></q>
                                </desc>
@@ -1028,10 +1057,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS7049Michael">ሚካኤል፡</persName></q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS4377Gabriel">ገብርኤል፡</persName></q>
-                                   <q xml:lang="gez">ዘከመ፡ ወደይዎ፡ ለ<persName ref="PRS3337Daniel">ዳንኤል፡</persName> ውስተ፡ <add place="interlinear">ግበ፡</add> አናብከት።</q>
+                                   <q xml:lang="gez">ዘከመ፡ ወደይዎ፡ ለ<persName ref="PRS3337Daniel">ዳንኤል፡</persName> ውስተ፡ <add place="interlinear">ግበ፡</add> አናብስት።</q>
                                    <q xml:lang="gez">መልአክ፡ ቅዱስ፡ <persName ref="PRS7049Michael">ሚካኤል።</persName></q>
                                    <q xml:lang="gez">ግብ፡</q>
-                                   <q xml:lang="gez">አንብስት፡</q>
+                                   <q xml:lang="gez">አናብስት፡</q>
                                </desc>
                            </decoNote>
                            
@@ -1065,16 +1094,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d65">
                                <locus target="#40r"/>
-                               <desc>Two scenes: a group of three prophets, including <persName ref="PRS3814Enoch">Enoch</persName>, <persName ref="PRS3721Elijah">Elijah</persName>, 
-                                   and <persName ref="PRS3943Ezra">Ezra</persName>, converses before God; Ezra writes his book, an additional empty sheet of parchment at his side is represented 
-                                   as an empty rectangle.
+                               <desc>Two scenes: a group of three prophets, including <persName ref="PRS3814Enoch">Enoch</persName>, 
+                                   <persName ref="PRS3721Elijah">Elijah</persName>, and <persName ref="PRS3943Ezra">Ezra</persName>, converses before God; 
+                                   Ezra writes his book, an additional empty sheet of parchment at his side is represented as an empty rectangle.
                                    <q xml:lang="gez"><persName ref="PRS7049Michael">ቅዱስ፡ ሚካኤል፡</persName></q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez"><persName ref="PRS4377Gabriel">ቅዱስ፡ ገብርኤል፡</persName></q>
                                    <q xml:lang="gez"><persName ref="PRS3814Enoch">ሄኖክ፡</persName></q>
                                    <q xml:lang="gez"><persName ref="PRS3721Elijah">ኤልያስ፡</persName></q>
                                    <q xml:lang="gez"><persName ref="PRS3943Ezra">እዝራ፡</persName></q>
-                                   <q xml:lang="gez">ዘከመ፡ ጸሐፈ፡ <persName ref="PRS3943Ezra">እዝራ፡</persName> መጽሕፍተ፡ ነቢያት። እምድኅረ፡ አውዓይዎሙ በእሳት።</q>
+                                   <q xml:lang="gez">ዘከመ፡ ጸሐፈ፡ <persName ref="PRS3943Ezra">እዝራ፡</persName> <sic>መጽሕፍተ፡</sic> ነቢያት። እምድኅረ፡ አውዓይዎሙ በእሳት።</q>
                                </desc>
                            </decoNote>
                            
@@ -1086,22 +1115,22 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">ሰብአ፡ ባቢሎን፡</q>
                                    <q xml:lang="gez">ኢኮንያን፡</q>
                                    <q xml:lang="gez">ኤዎልማሮዴቅ፡</q>
-                                   <q xml:lang="gez">ዘከመ፡ ሞተ፡ <gap reason="illegible"/>ክደ<gap reason="illegible"/>ር፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ ሞተ፡ <gap reason="illegible"/>ከደነ፡ ጾር፡</q>
                                </desc>
                            </decoNote>
                            
                            <decoNote type="miniature" xml:id="d67">
                                <locus target="#41r"/>
-                               <desc> <!-- Four of five scenes? Parts of this miniature are confusing to me, first we have the hand of the angel of god writing a prophecy about the imminent death of Belshazzar, next, I presume we see his beheaded body, as it’s mentioned in the main text (but what are the sources for this? It’s not in the Bible)  and someone bringing his head, to the middle left we have Daniel being made king? Cannot make out the inscriptions below, are these the servants bringing wine to the King? Are some extra biblical references included that it would be worth mentioning?
-                                   
-                               MV: Belshazzar’s death is described in Daniel 5, but there is no mention of his beheading; this detail probably comes from another source that I am not familiar with. Belshazzar organises a grand banquet for his dignitaries and his wives. During the banquet, cups are brought, among which God's holy cup (ጽዋዓ፡ እግዚአብሔር፡), from which the women drink. Mysterious words appear written by a hand on the wall (the words ማኔ፡ ቴቄል፡ ፉሬስ።). The king is afraid. Daniel, who could notoriously interpret dreams, is summoned to decipher the meaning of the mysterious writing on the wall, and he predicts the imminent end of Belshazzar’s reign. I can't find the biblical place in which Belshazzar's head is shown/given to the people of Israel.     -->
+                               <desc>Five scenes: the hand of the angel of god writes a prophecy about the imminent death of Belshazzar during the banquet at the later’s court;
+                                   Belshazzar’s dignitaries and wives participate in the banquet; the cup of God is brought to the banquet; Belshazzar’s beheaded body;
+                                   Belshazzar’s head is shown to the people of Israel.
                                    <q xml:lang="gez">መልአክ፡</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">ዘከመ፡ ጸሐፈ፡ እደ፡ መልአክ፡ ወይቤ፡ ማኔ፡ ቴቄል፡ ፉሬስ።</q>
+                                   <q xml:lang="gez">ዘከመ፡ ጸሐፈ፡ እደ፡ መልአክ፡ ወይቤ፡ ማኔ፡ ቴቄል፡ ፋሬስ።</q>
                                    <q xml:lang="gez">ብላጣሶር።</q>
-                                   <q xml:lang="gez">ብእሲቱ፡ ዘከመ፡ አኅዘተ፡ ጽዋዓ፡ እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ብእሲቱ፡ ዘከመ፡ አኀዘተ፡ ጽዋዓ፡ እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ዘከመ፡ ወሀቦሙ፡ ርእሶ፡ ለእስራኤል፡ ወዓለሁ፡</q>
-                                   <q xml:lang="gez">ዘከመ፡ አምሰሐ፡ መኳንንቲሁ፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ አምስሐ፡ መኳንንቲሁ፡</q>
                                    <q xml:lang="gez">ዘከመ፡ መጠዋ፡ ጽዋዓ፡</q>
                                    <q xml:lang="gez">ዘከመ፡ ፈከረ፡ ሎቱ፡ ዳንኤል፡ ሕልማ፡</q>
                                </desc>
@@ -1109,7 +1138,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d68">
                                <locus target="#41v"/>
-                               <desc>King <persName ref="PRS3264CyrusII">Cyrus</persName> announces to the Israelites that they may return home, one of his officers plays a drum.
+                               <desc>King <persName ref="PRS3264CyrusII">Cyrus</persName> announces to the Israelites that they may return home; one of his officers plays a drum.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">እስራኤል፡</q>
                                    <q xml:lang="gez"><persName ref="PRS3264CyrusII">ቂሮስ</persName></q>
@@ -1149,8 +1178,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d72">
                                <locus target="#43v"/>
-                               <desc>Three scenes: an unidentified man, possibly Haman, addresses two attendants; Mordecai tells Queen Esther about a plot to kill the Israelites; Haman is hung on a forked pole;
-                                   and King Ashasuerus praises Mordechai. 
+                               <desc>Three scenes: an unidentified man, possibly Haman, and two attendants, among whom possibly Mordecai refusing to bow before him; 
+                                   Mordecai tells Queen Esther about a plot to kill the Israelites; Haman is hung on a forked pole;
+                                   and King Ashasuerus praises Mordecai. 
                                    <q xml:lang="gez">አስቴር።</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">መርዶክዮስ፡</q>
@@ -1178,16 +1208,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">እስክንድር፡</q>
                                    <q xml:lang="gez">ሠራዊተ፡ <gap reason="illegible"/></q>
-                                   <q xml:lang="gez">ዘከመ፡ ሰገደ፡ እስክ<supplied reason="omitted">ን</supplied>ድር፡ ለሊቀ፡ ካህና<gap reason="illegible"/></q>
+                                   <q xml:lang="gez">ዘከመ፡ ሰገደ፡ እስክ<supplied reason="omitted">ን</supplied>ድር፡ ለሊቀ፡ ካህና<gap reason="illegible"/> ምስለ፡ አምኃ፡</q>
                                    <q xml:lang="gez">ካህናት፡</q>
-                                   <q xml:lang="gez">ምስለ፡ አምኃ፡</q> 
                                </desc>
                            </decoNote>                           
                            
                            <decoNote type="miniature" xml:id="d75">
                                <locus target="#45r"/>
-                               <desc>Two scenes: <persName ref="PRS7984Ptolemy">Ptolemy II</persName> is inspired by God to commission the translation of the Bible into Greek; an angel stops 
-                                   <persName ref="PRS8854Simeon">Simeon</persName> from changing the text of Isaiah that claims a Virgin will bear a son.
+                               <desc>Two scenes: <persName ref="PRS7984Ptolemy">Ptolemy II</persName> is inspired by God to commission the translation of the Bible into Greek;
+                                   an angel stops <persName ref="PRS8854Simeon">Simeon</persName> from changing the text of Isaiah that claims a Virgin will bear a son.
                                    <q xml:lang="gez"><persName ref="PRS7984Ptolemy">በጥሊሞስ፡</persName></q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">መልአክ፡</q>
@@ -1214,6 +1243,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ደቂቀ፡ አልዓዛር፡</q>
                                    <q xml:lang="gez">አልዓዛር፡</q>
+                                   <q xml:lang="gez">መስብር፡</q>
                                </desc>
                            </decoNote>                           
                            
@@ -1222,14 +1252,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <desc>An angel brings heavenly bread to <persName ref="PRS6819Mary">Mary</persName> in a basket. 
                                    <q xml:lang="gez">ቤተ፡ መቅደስ።</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">ዘከመ፡ ወሀበ፡ መልአክ፡ ለእግዝእትነ፡ ኅብስተ፡ ሰማያዊ።</q>
+                                   <q xml:lang="gez">ዘከመ፡ ወሀባ፡ መልአክ፡ ለእግዝእትነ፡ ኅብስተ፡ ሰማያዌ።</q>
                                </desc>
                            </decoNote>                           
                            
                            <decoNote type="miniature" xml:id="d79">
                                <locus target="#47r"/>
-                               <desc>The Annunciation of <persName ref="PRS4377Gabriel">Gabriel</persName>to <persName ref="PRS6819Mary">Mary</persName> who is reading the  Book of Isaiah.
-                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም።</persName></q>
+                               <desc>The Annunciation of <persName ref="PRS4377Gabriel">Gabriel</persName>to <persName ref="PRS6819Mary">Mary</persName> 
+                                   who is reading the Book of Isaiah.
+                                   <q xml:lang="gez">እግዝእትነ፡ <persName ref="PRS6819Mary">ማርያም።</persName></q>
                                    <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS4377Gabriel">ገብርኤል።</persName></q>
                                    <q xml:lang="gez">መጽሐፈ፡ ኢሳይያስ፡</q>
                                </desc>
@@ -1237,14 +1268,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d80">
                                <locus target="#47v"/>
-                               <desc>A Nativity scene with shepherds playing the Ethiopian game of Genna and a donor in proskynesis.
+                               <desc>A Nativity scene with shepherds playing the Ethiopian game of <hi rend="italics">gannā</hi> and a donor in proskynesis.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">ዘከመ፡ ተውልደ፡ መድኃኒነ፡ ውስተ፡ ጎል፡</q>
-                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም።</persName></q>
+                                   <q xml:lang="gez">ዘከመ፡ ተወልደ፡ መድኃኒነ፡ ውስተ፡ ጎል፡</q>
+                                   <q xml:lang="gez">እግዝእትነ፡ <persName ref="PRS6819Mary">ማርያም።</persName></q>
                                    <q xml:lang="gez">በከመ፡ ተማኅፀነት፡ ወለተ፡ ጽዮን፡</q>
                                    <q xml:lang="gez">ዮሴፍ፡</q>
                                    <q xml:lang="gez">ላህ<supplied reason="lost">ም፡</supplied></q>
-                                   <q xml:lang="gez">ዕድዓቅ፡</q>
+                                   <q xml:lang="gez">ሰሎሜ፡</q>
+                                   <q xml:lang="gez">መድኃኒነ።</q>
+                                   <q xml:lang="gez">ዕድግት፡</q>
                                    <q xml:lang="gez">ኖሎት፡</q>
                                </desc>
                            </decoNote>
@@ -1255,8 +1288,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS7049Michael">ሚካኤል፡</persName></q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS4377Gabriel">ገብርኤል።</persName></q>
-                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS8417Salome">ሳሎሜ።</persName></q>
-                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም።</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS8417Salome">ሰሎሜ።</persName></q>
+                                   <q xml:lang="gez">እግዝእትነ፡ <persName ref="PRS6819Mary">ማርያም።</persName></q>
                                    <q xml:lang="gez"><persName ref="PRS5684JesusCh">መድኃኒነ፡</persName></q>
                                </desc>
                            </decoNote>
@@ -1265,8 +1298,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#48v"/>
                                <desc>The adoration of the Magi.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም፡</persName></q>
-                                   <q xml:lang="gez">ዘከመ፡ ወሀብዎ፡ ለእቅዚእነ፡ አምኃ፡ ነግሥተ፡ ፋርስ። እንዘ፡ ይሰግዱ፡ ሎቱ፡</q>
+                                   <q xml:lang="gez">እግዝእትነ፡ <persName ref="PRS6819Mary">ማርያም፡</persName></q>
+                                   <q xml:lang="gez">ዘከመ፡ ወሀብዎ፡ ለእግዚእነ፡ አምኃ፡ ነገሥተ፡ ፋርስ። እንዘ፡ ይሰግዱ፡ ሎቱ።</q>
                                </desc>
                            </decoNote>                           
                            
@@ -1274,10 +1307,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#49r"/>
                                <desc>The Flight into Egypt.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">ዘከመ፡ ዜነዎ፡ መልአክ፡ በሕልም፡ ለ<persName ref="PRS5764Joseph">ዮሴፍ</persName></q>
-                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS8417Salome">ሳሎሜ፡</persName></q>
+                                   <q xml:lang="gez">ዘከመ፡ ዜነዎ፡ መልአክ፡ በሕልም፡ ለ<persName ref="PRS5764Joseph">ዮሴፍ፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS8417Salome">ሰሎሜ<supplied reason="omitted">፡</supplied></persName></q>
                                    <q xml:lang="gez"><persName ref="PRS5764Joseph">ዮሴፍ፡</persName></q>
-                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም፡</persName> ምስለ፡ ፍቁር፡ <persName ref="PRS5684JesusCh">ወልዳ።</persName></q>
+                                   <q xml:lang="gez">እግዝእትነ፡ <persName ref="PRS6819Mary">ማርያም፡</persName> ምስለ፡ ፍቁር፡ <persName ref="PRS5684JesusCh">ወልዳ።</persName></q>
                                </desc>
                            </decoNote>
                            
@@ -1326,7 +1359,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <desc>The Agony in the Garden.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">መልአክ፡ ዘወሀቦ፡ መስቀለ፡ ምስለ፡ ጽዋዕ።</q>
-                                   <q xml:lang="gez"><persName ref="PRS5684JesusCh">እግዚእ፡ነ</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS5684JesusCh">እግዚእነ</persName></q>
                                    <q xml:lang="gez">"><persName ref="PRS5695John">ዮሐንስ፡</persName> ፍቁረ፡ እግዚእነ፡</q>
                                    <q xml:lang="gez"><persName ref="PRS5662James">ያዕቆብ፡</persName> ወልደ፡ ዘብዴዎስ።</q>
                                    <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS7805Peter">ጴጥሮስ፡</persName></q>
@@ -1335,9 +1368,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d89">
                                <locus target="#52r"/>
-                               <desc> A combination of the Anastasis and Resurrection of <persName ref="PRS5684JesusCh">Jesus</persName>.
+                               <desc>A combination of the Anastasis and Resurrection of <persName ref="PRS5684JesusCh">Jesus</persName>.
                                    <q xml:lang="gez">መላእክት፡</q>
-                                   <q xml:lang="gez"><persName ref="PRS5684JesusCh">እግዚእነ</persName>፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS5684JesusCh">እግዚእነ<supplied reason="omitted">፡</supplied></persName></q>
                                    <q xml:lang="gez">መላእክት፡</q>
                                    <q xml:lang="gez">ዓቀብተ፡ መቃብር።</q>
                                </desc>
@@ -1348,7 +1381,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <desc>The Ascension of <persName ref="PRS5684JesusCh">Jesus</persName>.
                                    <q xml:lang="gez"><persName ref="PRS5684JesusCh">እግዚእነ</persName>፡</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም፡</persName></q>
+                                   <q xml:lang="gez">እግዝእትነ፡ <persName ref="PRS6819Mary">ማርያም፡</persName></q>
                                    <q xml:lang="gez">ሐዋርያት። እለ፡ ነጸሩ፡ ዕርገተ፡ እግዚእነ፡</q>
                                </desc>
                            </decoNote>                           
@@ -1358,7 +1391,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <desc>Pentecost.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ርደተ፡ ጰራቅሊጦስ፡ በአምሳለ፡ እሳት፡ ላዕለ፡ ሐዋርያት፡</q>
-                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም፡</persName></q>
+                                   <q xml:lang="gez">እግዝእትነ፡ <persName ref="PRS6819Mary">ማርያም፡</persName></q>
                                </desc>
                            </decoNote>
                            
@@ -1366,9 +1399,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#53v"/>
                                <desc>The Second Coming of <persName ref="PRS5684JesusCh">Jesus</persName>
                                    <q xml:lang="gez">ጻድቃን፡</q>
-                                   <q xml:lang="gez">ተእምርተ፡ ኵናት፡</q>
+                                   <q xml:lang="gez">ትእምርተ፡ ኵናት፡</q>
                                    <q xml:lang="gez"><persName ref="PRS5684JesusCh">እግዚእነ፡</persName></q>
-                                   <q xml:lang="gez">ተእምርተ፡ መስቀል፡</q>
+                                   <q xml:lang="gez">ትእምርተ፡ መስቀል፡</q>
                                    <q xml:lang="gez">ጻድቃን፡</q>
                                    <q xml:lang="gez">ኃጥአን።</q>
                                </desc>
@@ -1376,7 +1409,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d93">
                                <locus target="#54r"/>
-                               <desc>The Last Judgment (in this miniature Christ is identified with the title that is elsewhere reserved for the Father).
+                               <desc>The Last Judgment (in this miniature Christ is identified with the title ‘ʾƎgziʾabǝḥer’ that is elsewhere reserved for the Father).
                                    <q xml:lang="gez">መላእክት፡</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">መላእክት፡</q>
@@ -1391,10 +1424,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <desc>The Trinity and a donor in proskynesis. The caption has been partially erased.
                                    <q xml:lang="gez">ሥላሴ፡ ቅዱስ።</q>
                                    <q xml:lang="gez">ገጸ፡ ሰብእ፡</q>
-                                   <q xml:lang="gez">ገጸ፡ ንስር</q>
+                                   <q xml:lang="gez">ገጸ፡ ንስር፡</q>
                                    <q xml:lang="gez">ገጸ፡ አንበሳ፡</q>
                                    <q xml:lang="gez">ገጸ፡ ላህም፡</q>
-                                   <q xml:lang="gez">በ<del rend="effaced"/> <persName ref="PRS13954TaklaMa" role="owner">ትክለ፡ ማርያም፡</persName> <gap reason="illegible"/></q>
+                                   <q xml:lang="gez">በ<del rend="effaced"/> <persName ref="PRS13954TaklaMa" role="owner">ተክለ፡ ማርያም፡</persName> <gap reason="illegible"/></q>
                                </desc>
                            </decoNote>
                                                       
@@ -1415,7 +1448,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">ጻድቃን፡</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">አቡነ፡ ገብረ፡ መንፈስ፡ ቅዱስ፡</q>
-                                   <q xml:lang="gez">ስማዕታት፡</q>
+                                   <q xml:lang="gez">ሰማዕታት፡</q>
                                    <q xml:lang="gez">ቅዱስ፡ ጊዮርጊስ፡</q>
                                </desc>
                            </decoNote>                           
@@ -1428,7 +1461,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS4377Gabriel">ገብርኤል።</persName></q>
                                    <q xml:lang="gez">አናብስት፡</q>
                                    <q xml:lang="gez">ሰማዕት፡ ወጻድቃን።</q>
-                                   <q xml:lang="gez">አሳት፡</q>
+                                   <q xml:lang="gez">እሳት፡</q>
                                </desc>
                            </decoNote>                           
                            
@@ -1439,11 +1472,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    The caption has been partially erased.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ገጸ፡ ሰብእ፡</q>
-                                   <q xml:lang="gez">ገጸ፡ ንስር</q>
+                                   <q xml:lang="gez">ገጸ፡ ንስር፡</q>
                                    <q xml:lang="gez">ገጸ፡ አንበሳ፡</q>
                                    <q xml:lang="gez">ገጸ፡ ላህም፡</q>
                                    <q xml:lang="gez">በከመ፡ ከሠተ፡ ሎቱ፡ ዘንተ፡ ድርሳነ፡ ለአቡነ፡ <persName ref="PRS15405Zamalakot">ዘመለኮት።</persName></q>
-                                   <q xml:lang="gez">በመ፡ <del rend="effaced"/> <persName ref="PRS13954TaklaMa" role="owner">ትክለ፡ ማርያም፡</persName> <del rend="effaced"/></q>
+                                   <q xml:lang="gez">በከመ፡ <del rend="effaced"/> <persName ref="PRS13954TaklaMa" role="owner">ተክለ፡ ማርያም፡</persName> <del rend="effaced"/></q>
                                </desc>
                            </decoNote>
                        </decoDesc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
@@ -316,18 +316,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         
 
                        <decoDesc>
-                           <summary>Almost every page in this lavishly decorated manuscript features an illumination. In most of them, God the Father is shown intervening in episodes from the Old and New Testaments and arranged in loose chronological order.                               
-                               The images found in this volume bear comparison with those found in another illustrated copy of the same text kept at the British Library (MS <ref type="mss" corresp="BLorient590">London, British Library Or. 590</ref>). The two manuscripts were painted by different hands, but many of the images are almost identical in terms of layout and iconography, though there are a number of exceptions. For instance, the giants that appear on <locus target="#13r"/> appear to be female in this copy and male in the British Library copy; and in this manuscript the scene of the Binding of Isaac (<locus target="#18r"/>) is less detailed than in the British Library example, where Abraham is shown riding a donkey. Likewise, the tent on <locus target="#18v"/> is closed in this manuscript, but open in the one from the British Library. At times the images in the Bodleian Libraries manuscript have more details, whereas in other cases it is the opposite. In the Bodleian example, a donor is present beneath a representation of the Trinity, whereas in British Library example there is no donor and God is represented alone. The choice of images also varies: the British Library copy features representations of the Crucifixion and Descent into Hell that are not present in the Bodleian copy. Finally, the images in the latter manuscript do not have captions, whereas in this piece they are numerous and added next to the figures by the main hand that wrote titles for each poem in red ink on the upper margin of each folio.
+                           <summary>Almost every page in this lavishly decorated manuscript features an illumination. In most of them, God the Father is shown intervening in episodes from the Old and New Testaments arranged in loose chronological order.                               
+                               The images found in this volume bear comparison with those found in another illustrated copy of the same text kept at the British Library (MS <ref type="mss" corresp="BLorient590">London, British Library, Or. 590</ref>). The two manuscripts were painted by different hands, but many of the images are almost identical in terms of layout and iconography, though there are a number of exceptions. For instance, the giants that appear on <locus target="#13r"/> appear to be female in this copy and male in the British Library copy; and in this manuscript the scene of the Binding of Isaac (<locus target="#18r"/>) is less detailed than in the British Library example, where Abraham is shown riding a donkey. Likewise, the tent on <locus target="#18v"/> is closed in this manuscript, but open in the one from the British Library. At times the images in the Bodleian Libraries manuscript have more details, whereas in other cases it is the opposite. In the Bodleian example, a donor is present beneath a representation of the Trinity, whereas in the British Library example there is no donor and God is represented alone. The choice of images also varies: the British Library copy features representations of the Crucifixion and Descent into Hell that are not present in the Bodleian copy. Finally, the images in the British Library manuscript do not have captions, whereas in this piece they are numerous and added next to the figures by the main hand that wrote titles for each poem in red ink on the upper margin of each folio.
                                God the Father appears in almost all of the miniatures. As shown by  <bibl>
                                    <ptr target="bm:Mercier2000LArcheEthiopienne"/>
                                    <citedRange unit="page">174–177</citedRange>
                                </bibl>, 
                                several images in these manuscripts were inspired by European prints or paintings. Many other details evoke local customs and material traditions, such as the prayer stick on <locus target="#17r"/>, the drum on <locus target="#22r"/>, the warriors wearing leopard skins and headbands on <locus target="#25v"/>, the king riding a caparisoned mule with bells on its bridle and accompanied by a page bearing an umbrella on <locus target="#26r"/>, the butchering of animals on <locus target="#35r"/>, the presence of what appears to be a mottled cow hide on a tent on <locus target="#43r"/>, and the bread basket on <locus target="#46v"/>.
-                               Particularly interesting is the representation of the miraculous sleep of Ebed-Melech (Abimelech) the Ethiopian on <locus target="#36r"/>, which offers a reference to 4Baruch that is only canonical in the Ethiopic tradition, since the episode is not mentioned in the text that the image accompanies and to Ethiopian Maccabees on <locus from="45v" to="46r"/>. This scene is absent in the British Library copy. On <locus target="#45r"/>, we see a reference to the translation of the Bible into Greek mentioned in the Ethiopian Synaxarion; the artist showcases his familiarity with the story and expands on the text of the Wisest of the Wise by including a reference to the angel that stops Simeon from changing the words of the Bible. 
+                               Particularly interesting is the representation of the miraculous sleep of Ebed-Melech (Abimelech) the Ethiopian on <locus target="#36r"/>, which offers a reference to 4 Baruch that is only canonical in the Ethiopic tradition, since the episode is not mentioned in the text that the image accompanies and to Ethiopian Maccabees on <locus from="45v" to="46r"/>. This scene is absent in the British Library copy. On <locus target="#45r"/>, we see a reference to the translation of the Bible into Greek mentioned in the Ethiopian Synaxarion; the artist showcases his familiarity with the story and expands on the text of the Wisest of the Wise by including a reference to the angel that stops Simeon from changing the words of the Bible. 
                                In another instance, on  <locus target="#36r"/>, both text and image rely on non-biblical sources when they refer to Alexander the Great as presenting offerings to the High Priest of the Israelites. Alexander is shown presenting a chest, a detail possibly inspired by the Josippon (<bibl>
                                    <ptr target="bm:Budge1896AlexanderTranslation"/>
                                    <citedRange unit="page">409–410</citedRange>
-                               </bibl>). Noteworthy is also the decision of the artists to represent King <persName ref="PRS11373Nebuc"> Nebuchadnezzar</persName> as a wild boar when is he transformed into a beast by God, a detail that is not mentioned in the Bible and recalls the transformation of Tiridates III of Armenia.
+                               </bibl>). Noteworthy is also the decision of the artists to represent King <persName ref="PRS11373Nebuc"> Nebuchadnezzar</persName> as a wild boar when he is transformed into a beast by God, a detail that is not mentioned in the Bible and recalls the transformation of Tiridates III of Armenia.
                                Some motifs on the clothes of prominent figures in the illustrations may provide evidence of the circulation of particular patterns on textiles. The ones that appear on <locus target="#26r"/>, for example, seem to be inspired by contemporary Indian woven silks, as a sign of their prestige, whereas the fabric that covers the altar behind them could have been inspired by a block-printed Gujarati textile. Relatedly, the attire of Goliath on <locus target="#28v"/> may have been inspired by chainmail armour and a pointed helmet in use in the Islamicate world. Many scenes feature details inspired by the biblical texts that inspired the verses.
                            </summary>
                            
@@ -586,7 +586,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <desc>Three episodes: <persName ref="PRS5763Joseph">Joseph</persName> is sold by his brothers (above);
                                    his brothers depart with grain in their sacks as well as the objects placed there by his men and are chased by one of his stewards (bottom left);
                                    <persName ref="PRS5763Joseph">Joseph</persName> confronts his brothers.                                   
-                                   <q xml:lang="gez">ዘከመ፡ ሤጥዎ፡ ለዮሴፍ፡ እኃዊሁ</q>	
+                                   <q xml:lang="gez">ዘከመ፡ ሤጥዎ፡ ለዮሴፍ፡ አኃዊሁ፡</q>	
                                    <q xml:lang="gez">እግዚአብሔር።</q>	
                                    <q xml:lang="gez">አግማል፡</q>		
                                    <q xml:lang="gez">ዕድግት፡</q>
@@ -616,7 +616,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <desc><persName ref="PRS7181MosesM">Moses</persName> confronts the Pharaoh and his officials. His staff has become a snake that swallows the snake conjured from a staff 
                                    by two magicians. In the bottom right corner, the livestock of the Egyptians are dead because of the fifth plague.                                   
                                    <q xml:lang="gez">መላክ፤</q>
-                                   <q xml:lang="gez">ፈራዖን።</q>
+                                   <q xml:lang="gez">ፈርዖን</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez"><persName ref="PRS7181MosesM">ሙሴ፡</persName></q>
                                    <q xml:lang="gez">ግብጻውያን።</q>
@@ -628,7 +628,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#21v"/>
                                <desc>The Crossing of the Red Sea.                                   
                                    <q xml:lang="gez">ዘከመ፡ አስጠሞ፡ ለፈርዖን፡ ምስለ፡ ሠራዊቱ።</q>
-                                   <q xml:lang="gez">ፈራዖን።</q>
+                                   <q xml:lang="gez">ፈርዖን</q>
                                    <q xml:lang="gez">እግዚአብሔር።</q>
                                    <q xml:lang="gez">እስራኤል፡</q>
                                    <q xml:lang="gez">ኤርትራ፡</q>                                   
@@ -1114,7 +1114,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">እስራኤል፡</q>
                                    <q xml:lang="gez"><persName ref="PRS3264CyrusII">ቂሮስ</persName></q>
                                    <q xml:lang="gez">እስራኤል፡</q>
-                                   <q xml:lang="gez">ዘከመ፡ ዜነወ፡ ቃለ፡ <!-- One word is missing here: HELP? --> ሚጠቶሙ፡ ለእስራኤል፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ ዜነወ፡ ቃለ፡ ዓዋዲ፡ ሚጠቶሙ፡ ለእስራኤል፡</q>
                                </desc>
                            </decoNote>
                            
@@ -1203,7 +1203,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">ሥዕለ፡ ፀሐይ፡</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">አንጥያኮስ፡</q>
-                                   <q xml:lang="gez">ዘከመ፡ አዘዞሙ፡ ይ<gap reason="illegible"/>ሥዋዕተ፡ ጣዖት፡</q><!-- I can't decipher the verb: HELP? -->
+                                   <q xml:lang="gez">ዘከመ፡ አዘዞሙ፡ ይሡዑ፡ <supplied reason="omitted">መ</supplied>ሥዋዕተ፡ ጣዖት፡</q>
                                    <q xml:lang="gez">እስራኤል፡</q>
                                </desc>
                            </decoNote>                           

--- a/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
@@ -316,14 +316,24 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         
 
                        <decoDesc>
-                    <summary><!--The sentence "Captions of the miniatures are added in the main hand in red
-                       ink on the upper margin of each folio" might be inserted either in decoDesc or under "extra" below. (MV 09.12.2022)-->
-                    </summary>
-
+                           <summary>Almost every page in this lavishly decorated manuscript features an illumination. In most of them, God the Father is shown intervening in episodes from the Old and New Testaments and arranged in loose chronological order.                               
+                               The images found in this volume bear comparison with those found in another illustrated copy of the same text kept at the British Library (MS <ref type="mss" corresp="BLorient590">London, British Library Or. 590</ref>). The two manuscripts were painted by different hands, but many of the images are almost identical in terms of layout and iconography, though there are a number of exceptions. For instance, the giants that appear on <locus target="#13r"/> appear to be female in this copy and male in the British Library copy; and in this manuscript the scene of the Binding of Isaac (<locus target="#18r"/>) is less detailed than in the British Library example, where Abraham is shown riding a donkey. Likewise, the tent on <locus target="#18v"/> is closed in this manuscript, but open in the one from the British Library. At times the images in the Bodleian Libraries manuscript have more details, whereas in other cases it is the opposite. In the Bodleian example, a donor is present beneath a representation of the Trinity, whereas in British Library example there is no donor and God is represented alone. The choice of images also varies: the British Library copy features representations of the Crucifixion and Descent into Hell that are not present in the Bodleian copy. Finally, the images in the latter manuscript do not have captions, whereas in this piece they are numerous and added next to the figures by the main hand that wrote titles for each poem in red ink on the upper margin of each folio.
+                               God the Father appears in almost all of the miniatures. As shown by  <bibl>
+                                   <ptr target="bm:Mercier2000LArcheEthiopienne"/>
+                                   <citedRange unit="page">174–177</citedRange>
+                               </bibl>, 
+                               several images in these manuscripts were inspired by European prints or paintings. Many other details evoke local customs and material traditions, such as the prayer stick on <locus target="#17r"/>, the drum on <locus target="#22r"/>, the warriors wearing leopard skins and headbands on <locus target="#25v"/>, the king riding a caparisoned mule with bells on its bridle and accompanied by a page bearing an umbrella on <locus target="#26r"/>, the butchering of animals on <locus target="#35r"/>, the presence of what appears to be a mottled cow hide on a tent on <locus target="#43r"/>, and the bread basked on <locus target="#46v"/>.
+                               Particularly interesting is the representation of the miraculous sleep of Ebed-Melech (Abimelech) the Ethiopian on <locus target="#36r"/>, which offers a reference to 4Baruch that is only canonical in the Ethiopic tradition, since the episode is not mentioned in the text that the image accompanies and to Ethiopian Maccabees on <locus from="45v" to="46r"/>. This scene is absent in the British Library copy. On <locus target="#45r"/>, we see a reference to the translation of the Bible into Greek mentioned in the Ethiopian Synaxarium; the artist showcases his familiarity with the story and expands on the text of the Wisest of the Wise by including a reference to the angel that stops Simeon from changing the words of the Bible. 
+                               In another instance, on  <locus target="#36r"/>, both text and image rely on non-biblical sources when they refer to Alexander the Great as presenting offerings to the High Priest of the Israelites. Alexander is shown presenting a chest, a detail possibly inspired by the Josippon (<bibl>
+                                   <ptr target="bm:Budge1896AlexanderTranslation"/>
+                                   <citedRange unit="page">409–410</citedRange>
+                               </bibl>). Noteworthy is also the decision of the artists to represent King <persName ref="PRS11373Nebuc"> Nebuchadnezzar</persName> as a wild boar when is he transformed into a beast by God, a detail that is not mentioned in the Bible and recalls the transformation of Tiridates III of Armenia.
+                               Some motifs on the clothes of prominent figures in the illustrations may provide evidence of the circulation of particular patterns on textiles. The ones that appear on <locus target="#26r"/>, for example, seem to be inspired by contemporary Indian woven silks, as a sign of their prestige, whereas the fabric that covers the altar behind them could have been inspired by a block-printed Gujarati textile. Relatedly, the attire of Goliath on <locus target="#28v"/> may have been inspired by chainmail armour and a pointed helmet in use in the Islamicate world. Many scenes feature details inspired by the Biblical texts that inspired the verses.
+                           </summary>
+                           
                     <decoNote type="miniature" xml:id="d1">
                             <locus target="#8r"/>
                             <desc>God the Father.
-
                               <q xml:lang="gez">እግዚአብሔር።</q>
                             </desc>
                          </decoNote>
@@ -331,21 +341,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                          <decoNote type="miniature" xml:id="d2">
                                  <locus target="#8v"/>
                                  <desc>
-                                   God creates life and the elements of the world
-                                   (fire; water; earth; air) as angels praise him.
-
+                                   God creates life and the elements of the world (fire, water, earth, air) as angels praise him.
                                    <q xml:lang="gez">እግዚአብሔር።</q>
-                                   <q xml:lang="gez">ሰማይ። / እሳት። / ነፍስ። / መሬት። / ማይ።</q>
+                                   <q xml:lang="gez">ሰማይ። እሳት። ነፍስ። መሬት። ማይ።</q>
                                  </desc>
                               </decoNote>
 
                           <decoNote type="miniature" xml:id="d3">
                                       <locus target="#9r"/>
                                       <desc>
-                                        God the Father, flanked by Michael and Gabriel, casts the
-                                        <persName ref="PRS11330Devil">devil</persName>
+                                        God the Father, flanked by Michael and Gabriel, casts the <persName ref="PRS11330Devil">devil</persName>
                                         out of heaven and binds him.
-
                                         <q xml:lang="gez">እግዚአብሔር።</q>
                                         <q xml:lang="gez"><persName ref="PRS7049Michael">ቅዱስ፡ ሚካኤል፡</persName>
                                         <persName ref="PRS4377Gabriel">ቅዱስ፡ ገብርኤል።</persName></q>
@@ -356,7 +362,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            <decoNote type="miniature" xml:id="d4">
                                            <locus target="#9v"/>
                                            <desc>God the Father binds the angels in Hell.
-
                                              <q xml:lang="gez">እግዚአብሔር።</q>
                                              <q xml:lang="gez">ገጸ፡ ሰብእ፡ / ገጸ፡ ንስር። /
                                                ገጸ፡ አንበሳ። / ገጸ፡ ላህም።</q>
@@ -368,34 +373,29 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <locus target="#10r"/>
                                           <desc>
                                             God the Father creates <persName ref="PRS1386Adam">Adam</persName> in his likeness.
-
                                             <q xml:lang="gez">እግዚአብሔር።</q>
                                             <q xml:lang="gez"><persName ref="PRS1386Adam">አዳም፡</persName></q>
                                             <q xml:lang="gez">እሳት። / ነፋስ። / መሬት። / ማይ።</q>
                                           </desc>
                                              </decoNote>
 
-                         <decoNote type="miniature" xml:id="d6">
+                           <decoNote type="miniature" xml:id="d6">
                                 <locus target="10v#"/>
                                            <desc>
                                              God the Father creates <persName ref="PRS3926Eve">Eve</persName> from
-                                             <persName ref="PRS1386Adam">Adam</persName>'s rib in a garden with flowers.
-
+                                               <persName ref="PRS1386Adam">Adam</persName>’s rib in a garden with flowers.
                                              <q xml:lang="gez"><persName ref="PRS1386Adam">አዳም፡</persName></q>
                                              <q xml:lang="gez"><persName ref="PRS3926Eve">ሔዋን፡</persName></q>
                                              <q xml:lang="gez">እግዚአብሔር።</q>
                                          </desc>
                                         </decoNote>
 
-
                                     <decoNote type="miniature" xml:id="d7">
                                         <locus target="#11r"/>
                                         <desc>Two scenes:
                                           <persName ref="PRS3926Eve">Eve</persName> and
-                                          <persName ref="PRS1386Adam">Adam</persName> share the forbidden taken from
-                                          a fig tree with the serpent coiled around it (left); the pair are
-                                          cast out of Eden by an angel (right).
-
+                                          <persName ref="PRS1386Adam">Adam</persName> share the forbidden taken from a fig tree with the serpent coiled around it (left); the pair are cast out of Eden by an angel (right).
+                                            <!-- MV 18.05.2026 : Is something missing in the sentence "Eve and Adam share the forbidden taken from a fig tree" ? Is "forbidden" ok alone? -->
                                           <q xml:lang="gez">ከይሲ፡</q>
                                           <q xml:lang="gez"><persName ref="PRS1386Adam">አዳም።</persName></q>
                                           <q xml:lang="gez"><persName ref="PRS3926Eve">ሔዋን፡</persName></q>
@@ -406,11 +406,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                                  <decoNote type="miniature" xml:id="d8">
                                      <locus target="#11v"/>
-                                   <desc> God the Father looks down upon
-                                     <persName ref="PRS1386Adam">Adam</persName> and
-                                     <persName ref="PRS3926Eve">Eve</persName>, who are shown ashamed
-                                     of their nakedness to the left and clothed to the right.
-
+                                   <desc> God the Father looks down upon <persName ref="PRS1386Adam">Adam</persName> and
+                                     <persName ref="PRS3926Eve">Eve</persName>, who are shown ashamed of their nakedness to the left and clothed to the right.
                                      <q xml:lang="gez">ዘከመ፡ ተዓርቁ፡ እምልብስ፡
                                     <persName ref="PRS1386Adam">አዳም፡</persName> ወ<persName ref="PRS3926Eve">ሔዋን</persName></q>
                                      <q xml:lang="gez"><persName ref="PRS1386Adam">አዳም።</persName></q>
@@ -421,11 +418,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 <decoNote type="miniature" xml:id="d9">
                                     <locus target="#12r"/>
                                   <desc>Three episodes from top left to bottom right:
-                                    <persName ref="PRS2984Cain">Cain</persName> and
-                                    <persName ref="PRS1230Abel">Abel</persName> offer gifts to god (above);
+                                    <persName ref="PRS2984Cain">Cain</persName> and <persName ref="PRS1230Abel">Abel</persName> offer gifts to God (above);
                                     <persName ref="PRS2984Cain">Cain</persName> kills
-                                    his brother (bottom left); he encounters a crow while wondering (bottom right).
-
+                                    his brother (bottom left); he encounters a crow while wandering (bottom right).
                                     <q xml:lang="gez"><persName ref="PRS1230Abel">አቤል፡</persName> / መሥዋዕት፡ / እሳት፡</q>
                                     <q xml:lang="gez"><persName ref="PRS2984Cain">ቃየል</persName></q>
                                     <q xml:lang="gez">ዘከመ፡ ቀተሎ፡ ቃየል፡ ለአቤል።</q>
@@ -436,10 +431,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                                <decoNote type="miniature" xml:id="d10">
                                    <locus target="#12v"/>
-                                 <desc>God instructs <persName ref="PRS3814Enoch"/> on how to invoke his name as
-                                   <persName ref="PRS8782Seth"/> looks at the recumbent body of his dead brother
-                                   <persName ref="PRS1230Abel"/>.
-
+                                 <desc>God instructs <persName ref="PRS3814Enoch">Enoch</persName> on how to invoke his name as
+                                   <persName ref="PRS8782Seth">Seth</persName> looks at the recumbent body of his dead brother
+                                   <persName ref="PRS1230Abel">Abel</persName>.
                                    <q xml:lang="gez">እግዚአብሔር።</q>
                                     <q xml:lang="gez"><persName ref="PRS3814Enoch">ሄኖክ፡</persName></q>
                                     <q xml:lang="gez"><persName ref="PRS8782Seth">ሴት፤</persName></q>
@@ -451,7 +445,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <locus target="#13r"/>
                                    <desc><persName ref="PRS14025Jared">Jared</persName> and his children are shown above, while below the children of Seth descend
                                    from the Mount of the Treasures to meet the wives of Cain, one of whom is a giant.
-
                                      <q xml:lang="gez"><persName ref="PRS14025Jared">ያሬድ።</persName></q>
                                    <q xml:lang="gez">እግዚአብሔር።</q>
                                    <q xml:lang="gez">ዘከመ፡ ወረዱ፡ ደቂቀ፡ ሴት፡ እምደብር።</q>
@@ -463,7 +456,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <locus target="#13v"/>
                                  <desc>God, who sits on a cloak that symbolizes his blessing,
                                      addresses <persName ref="PRS3814Enoch">Enoch</persName> in a garden with trees and flowers.
-
                                      <q xml:lang="gez"><persName ref="PRS3814Enoch">ሄኖክ፡</persName> / እግዚአብሔር። / መልአክ።</q>
                                </desc>
                               </decoNote>
@@ -472,7 +464,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                   <locus target="#14r"/>
                                 <desc>God, who holds a gold orb, grants a long life to Methuselah who prays towards him
                                   with a group of elders, presumably his children.
-
                                   <q xml:lang="gez">ማቱሳላ፡ / እግዚአብሔር፡ / መላእክት፤</q>
                               </desc>
                              </decoNote>
@@ -481,9 +472,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                  <locus target="#14v"/>
                                  <desc>The Ark of <persName ref="PRS7594Noah">Noah</persName> described as a <hi
                                      rendition="simple:italic">tābot</hi>
-                               and filled with humans, cattle, horses, domesticated animals, and wild beasts. A second group of
-                               people are drowning.
-
+                               and filled with humans, cattle, horses, domesticated animals, and wild beasts. A second group of people are drowning.
                                <q xml:lang="gez"><persName ref="PRS7594Noah">ኖኅ።</persName> / እግዚአብሔር፡ / ታቦት፤ / ሰብእ። / እንስሳ። አራዊት፤</q>
                                <q xml:lang="gez">ማየ፡ አይኅ።</q>
                              </desc>
@@ -494,7 +483,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                               <desc>God decides to dwell in the house of <persName ref="PRS8819Shem">Shem</persName>, which is represented like a tent,
                               rather than in that of <persName ref="PRS5673Japheth">Japhet</persName> or
                               <persName ref="PRS5038Ham">Ham</persName>.
-
                               <q xml:lang="gez"><persName ref="PRS5038Ham">ካም፡</persName> / <persName ref="PRS5673Japheth">ያፌት፤</persName> / ብእሲቱ <persName ref="PRS8819Shem">ሴም፡</persName></q>
                               <q xml:lang="gez">እግዚአብሔር።</q>
                               <q xml:lang="gez">ሐይመት፡</q>
@@ -504,7 +492,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            <decoNote type="miniature" xml:id="d16">
                                <locus target="#15v"/>
                              <desc>God entrusts Adam’s tomb to <persName ref="PRS6988Melchize">Melchizedek</persName> and appoints him as a priest.
-
                              <q xml:lang="gez"> <persName ref="PRS6988Melchize">መልከ፡ ጼዴቅ።</persName></q>
                              <q xml:lang="gez">እግዚአብሔር።</q>
                              <q xml:lang="gez">መቃብረ፡ አዳም።</q>
@@ -514,134 +501,955 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           <decoNote type="miniature" xml:id="d17">
                               <locus target="#16r"/>
                             <desc>God readies himself to scatter the people who are building the Tower of Babel.
-
                               <q xml:lang="gez">ጥቅመ፡ ስናዖር።</q>
                               <q xml:lang="gez">እግዚአብሔር።</q>
                           </desc>
                          </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d18">
+                               <locus target="#16v"/>
+                               <desc>God calls <persName ref="PRS1267Abraham"/>, who is accompanied by his wife <persName ref="PRS8533Sarah"/>,
+                                   to the land of <placeName ref="LOC2109Canaan"/>, which is populated with trees and located between two rivers.
+                                   <q xml:lang="gez"><persName ref="PRS8533Sarah">ሳራ፡</persName> / <persName ref="PRS1267Abraham">አብርሃም፡</persName></q>
+                                   <q xml:lang="gez">እግዚአብሔር።</q>
+                                   <q xml:lang="gez">፪ቱ፡ አፍላግ።</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d19">
+                               <locus target="#17r"/>
+                               <desc>God, placed between the two columns of text, looks at
+                                   the five cities of the plain engulfed by fires (above); <persName ref="PRS6357Lot">Lot</persName> and his daughters and wife, who turns back, 
+                                   are guided away by the two angels (below).
+                                   <q xml:lang="gez">እግዚአብሔር።</q>
+                                   <q xml:lang="gez"><persName ref="PRS6357Lot">ሎት፡</persName></q>
+                                   <q xml:lang="gez">ዘከመ፡ ኮነት፡ ብእሲቱ፡ ሐውልት፡ ፄው፡ ሶበ፡ ተመይጠት፡ ድኅሬሃ፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS6357Lot">ሎት፡</persName></q>
+                                   <q xml:lang="gez">፪ኤ፡ አዋልዲሁ፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ መርህዎ፡ መላእክት።</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d20">
+                               <locus target="#17v"/>
+                               <desc>Two scenes: <persName ref="PRS8533Sarah"/> gives one of her slaves to <persName ref="PRS1267Abraham"/> (left);
+                                   the pair look at the newly born <persName ref="PRS5578Isaac">Isaac</persName> (right).
+                                   <q xml:lang="gez">እግዚአብሔር።</q>
+                                   <q xml:lang="gez"><persName ref="PRS8533Sarah">ሳራ፡</persName> / <persName ref="PRS1267Abraham">አብርሃም፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS8533Sarah">ሳራ፡</persName> / <persName ref="PRS5578Isaac">ይስሐቅ።</persName> / 
+                                       <persName ref="PRS1267Abraham">አብርሃም፡</persName></q>
+                                   <q xml:lang="gez">ንብቲራ፡</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d21">
+                               <locus target="#18r"/>
+                               <desc>The Binding of <persName ref="PRS5578Isaac">Isaac</persName>.
+                                   <q xml:lang="gez">እግዚአብሔር።</q>
+                                   <q xml:lang="gez"><persName ref="PRS1267Abraham">አብርሃም፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS5578Isaac">ይስሐቅ።</persName></q>
+                                   <q xml:lang="gez">በግዕ፡</q>
+                                   <q xml:lang="gez">ዕፀ፡ ስቤቅ፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS1267Abraham">አብርሃም፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS5578Isaac">ይስሐቅ።</persName></q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d22">
+                               <locus target="#18v"/>
+                               <desc>Through the intervention of <persName ref="PRS7049Michael">Michael the Archangel</persName>
+                                   neither <persName ref="PRS3863Esau">Esau</persName> nor <persName ref="PRS6122Laban">Laban</persName>
+                                   harm <persName ref="PRS5650Jacob">Jacob</persName>, who is depicted in front of a tent, together with his
+                                   two wives and his large flock of animals.
+                                   <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS7049Michael">ሚካኤል።</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS3863Esau">ኤሳው።</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS6122Laban">ላባ፡</persName></q>
+                                   <q xml:lang="gez">ሐይመት።</q>
+                                   <q xml:lang="gez">ራሔል / <persName ref="PRS5650Jacob">ያዕቆብ</persName> / ለያ</q>
+                                   <q xml:lang="gez">አፍራስ / አግማል፡ / አባግዕ፡ / አድግት፡</q>
+                               </desc>
+                           </decoNote>
 
-                         <decoNote type="miniature" xml:id="d18">
-                             <locus target="#16v"/>
-                           <desc>God calls <persName ref="PRS1267Abraham"/>, who is accompanied by his wife <persName ref="PRS8533Sarah"/>,
-                           to the land of <placeName ref="LOC2109Canaan"/>, which is populated with trees and located between two rivers.
+                           <decoNote type="miniature" xml:id="d23">
+                               <locus target="19r#"/>
+                               <desc>The devil tests <persName ref="PRS5691Job">Job</persName>.
+                                   <q xml:lang="gez">እግዚአብሔር።</q>
+                                   <q xml:lang="gez"><persName ref="PRS5691Job">ኢዮብ፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS11330Devil">ሰይጣን፡</persName></q>
+                                   <q xml:lang="gez">ብእሲቱ፡ ለኢዮብ፤</q>
+                                   <q xml:lang="gez">ሕማሙ፡ ለኢዮብ፡</q>
+                                   <q xml:lang="gez">ጎፍር፡ ኤልፉዝ፡ በልዳዶስ።</q>
+                               </desc>
+                           </decoNote>
 
-                             <q xml:lang="gez"><persName ref="PRS8533Sarah">ሳራ፡</persName> / <persName ref="PRS1267Abraham">አብርሃም፡</persName></q>
-                             <q xml:lang="gez">እግዚአብሔር።</q>
-                             <q xml:lang="gez">፪ቱ፡ አፍላግ።</q>
+                           <decoNote type="miniature" xml:id="d24">
+                               <locus target="#19v"/>
+                               <desc>Three episodes: <persName ref="PRS5763Joseph">Joseph</persName> is sold by his brothers (above);
+                                   his brothers depart with grain in their sacks as well as the objects placed there by his men and are chased by one of his stewards (bottom left);
+                                   <persName ref="PRS5763Joseph">Joseph</persName> confronts his brothers.                                   
+                                   <q xml:lang="gez">ዘከመ፡ ሤጥዎ፡ለዮሴፍ፡ እኃዊሁ</q>	
+                                   <q xml:lang="gez">እግዚአብሔር።</q>	
+                                   <q xml:lang="gez">አግማል፡</q>		
+                                   <q xml:lang="gez">ዕድግት፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS5763Joseph">ዮሴፍ፡</persName></q>
+                               </desc>
+                           </decoNote>
 
-                         </desc>
-                        </decoNote>
+                           <decoNote type="miniature" xml:id="d25">
+                               <locus target="#20r"/>
+                               <desc>To the left God encounters <persName ref="PRS7181MosesM">Moses</persName> on a mountain with his flock of sheep. To the right the latter sets off towards Egypt.
+                                   <q xml:lang="gez">እግዚአብሔር፤</q>
+                                   <q xml:lang="gez"><persName ref="PRS7181MosesM">ሙሴ፡</persName></q>
+                                   <q xml:lang="gez">አባግዕ።</q>
+                               </desc>
+                           </decoNote>
 
-                        <decoNote type="miniature" xml:id="d19">
-                            <locus target="#17r"/>
-                          <desc>God, placed between the two columns of text, looks at
-                            the five cities of the plain engulfed by fires (above); <persName ref="PRS6357Lot">Lot</persName>
-                             and his daughters and wife, who turns back, are guided away by the
-                            two angels (below).
+                           <decoNote type="miniature" xml:id="d26">
+                               <locus target="#20v"/>
+                               <desc>God observers the suffering of the Israelites and listens to their pleas.
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">እስራኤል፤</q>	                                   
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d27">
+                               <locus target="#21r"/>
+                               <desc><persName ref="PRS7181MosesM">Moses</persName> confronts the Pharaoh and his officials. His staff has become a snake that swallows the snake conjured from a staff 
+                                   by two magicians. In the bottom right corner, the livestock of the Egyptians are dead because of the fifth plague.                                   
+                                   <q xml:lang="gez">መላክ፤</q>
+                                   <q xml:lang="gez">ፈራዖን።</q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS7181MosesM">ሙሴ፡</persName></q>
+                                   <q xml:lang="gez">ግብጻውያን።</q>
+                                   <q xml:lang="gez">ከይሲ፡</q>                                   
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d28">
+                               <locus target="#21v"/>
+                               <desc>The Crossing of the Red Sea.                                   
+                                   <q xml:lang="gez">ዘከመ፡ አስጠሞ፡ ለፈርዖን፡ ምስለ፡ ሠራዊቱ።</q>
+                                   <q xml:lang="gez">ፈራዖን።</q>
+                                   <q xml:lang="gez">እግዚአብሔር።</q>
+                                   <q xml:lang="gez">እስራኤል፡</q>
+                                   <q xml:lang="gez">ኤርትራ፡</q>                                   
+                               </desc>
+                           </decoNote>
 
-                            <q xml:lang="gez">እግዚአብሔር።</q>
-                            <q xml:lang="gez"><persName ref="PRS6357Lot">ሎት፡</persName></q>
-                            <q xml:lang="gez">ዘከመ፡ ኮነት፡ ብእሲቱ፡ ሐውልት፡ ፄው፡ ሶበ፡ ተመይጠት፡ ድኅሬሃ፡</q>
-                            <q xml:lang="gez"><persName ref="PRS6357Lot">ሎት፡</persName></q>
-                            <q xml:lang="gez">፪ኤ፡ አዋልዲሁ፡</q>
-                            <q xml:lang="gez">ዘከመ፡ መርህዎ፡ መላእክት።</q>
+                           <decoNote type="miniature" xml:id="d29">
+                               <locus target="#22r"/>                                   
+                                   <desc>The people of Israel celebrate the Pharaoh’s defeat by singing while <persName ref="PRS11610Miriam">Miriam</persName> beats a drum before her brothers.
+                                       <q xml:lang="gez"><persName ref="PRS7181MosesM">ሙሴ፡</persName></q>
+                                       <q xml:lang="gez"><persName ref="PRS7049Michael">ቅዱስ፡ ሚካኤል፡</persName></q>
+                                       <q xml:lang="gez">እግዚአብሔር፡</q>
+                                       <q xml:lang="gez">እስራኤል።</q>
+                                       <q xml:lang="gez">ከበሮ፡</q>
+                                       <q xml:lang="gez">እኅተ፡ <persName ref="PRS7181MosesM">ሙሴ።</persName></q>
+                                   </desc>
+                           </decoNote>                          
+                           
+                           <decoNote type="miniature" xml:id="d30">
+                               <locus target="#22v"/>
+                               <desc>God creates clouds to shield the Israelites from the heat of the sun.                                   
+                                   <q xml:lang="gez">ደመና፡</q>
+                                   <q xml:lang="gez">እግዚአብሔር።</q>
+                                   <q xml:lang="gez">እስራኤል፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS7181MosesM">ሙሴ፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS7049Michael">ቅዱስ፡ ሚካኤል።</persName></q>
+                               </desc>
+                           </decoNote>
 
-                            <q xml:lang="gez"></q>
-                        </desc>
-                       </decoNote>
+                           <decoNote type="miniature" xml:id="d31">
+                               <locus target="#23r"/>
+                               <desc>The Israelites eat Manna and drink the water that miraculously pours out from two mountains.                                   
+                                   <q xml:lang="gez"><persName ref="PRS7181MosesM">ሙሴ፡</persName></q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ኰኵሐ፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS7181MosesM">ሙሴ፡</persName></q>
+                                   <q xml:lang="gez">ማይ፡</q>
+                                   <q xml:lang="gez">እስራኤል፡</q>
+                               </desc>
+                           </decoNote>
+                                                      
+                           <decoNote type="miniature" xml:id="d32">
+                               <locus target="#23v"/>
+                               <desc>A priest holding a torch and <persName ref="PRS1002Aaron">Aaron</persName> holding the budded staff and a censer stand before God while 
+                                   <persName ref="PRS6053Korah">Korah</persName> and his followers burn in an underground fire.                                   
+                                   <q xml:lang="gez"><persName ref="PRS1002Aaron">ኣሮን፡</persName></q>
+                                   <q xml:lang="gez">እግዚአብሔር።</q>
+                                   <q xml:lang="gez">በከመ፡ አውዕዮ፡ ለቆራ፡ ምስለ፡ ህዝቡ፡</q>
+                               </desc>
+                           </decoNote>                           
+                           
+                           <decoNote type="miniature" xml:id="d33">
+                               <locus target="#24r"/>
+                               <desc>An unidentified individual, probably <persName ref="PRS5773Joshua">Joshua</persName>, guides the leaders of the Israelites across the Promised Land.                                   
+                                   <q xml:lang="gez">እግዚአብሔር።</q>
+                                   <q xml:lang="gez">እስራኤል፡</q>
+                               </desc>
+                           </decoNote>                           
+                           
+                           <decoNote type="miniature" xml:id="d34">
+                               <locus target="#24v"/>
+                               <desc>The crossing of the <placeName ref="LOC3959Jordan">Jordan</placeName> River.  
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">እስራኤል፡</q>
+                                   <q xml:lang="gez"><placeName ref="LOC3959Jordan">ዮርዳኖስ።</placeName></q>
+                                   <q xml:lang="gez"><persName ref="PRS5773Joshua">ኢያሱ።</persName></q>                                   
+                               </desc>
+                           </decoNote>                           
 
-                       <decoNote type="miniature" xml:id="d20">
-                           <locus target="#17v"/>
-                         <desc>Two scenes: <persName ref="PRS8533Sarah"/> gives one of her slaves to <persName ref="PRS1267Abraham"/> (left);
-                          the pair look at the newly born <persName ref="PRS5578Isaac">Isaac</persName> (right).
+                           <decoNote type="miniature" xml:id="d35">
+                               <locus target="#25r"/>
+                               <desc>The fall of <placeName ref="LOC3956Jerich">Jericho</placeName>.                                   
+                                   <q xml:lang="gez">እግዚአብሔር።</q>
+                                   <q xml:lang="gez">እስራኤል፡</q>
+                                   <q xml:lang="gez">ሰብአ <placeName ref="LOC3956Jerich">ኤሪኮ</placeName></q>
+                                   <!--There is an English Caption “Fall of Jericho, include?
+                                   MV: Jacopo, what do you mean with this comment?-->
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d36">
+                               <locus target="#25v"/>
+                               <desc>The prostitute Rahab <!--Pers name Rahab to be encoded? --> looks at the Israelites killing the men and rulers or Jericho.                                   
+                                   <q xml:lang="gez">እግዚአብሔር።</q>
+                                   <q xml:lang="gez">ራአብ፡ ዘማ፡</q><!--Pers name Rahab to be encoded? -->
+                                   <q xml:lang="gez">እስራኤል፡</q>
+                                   <q xml:lang="gez">ሰብአ፡ <placeName ref="LOC3956Jerich">ኤሪኮ</placeName></q>
+                               </desc>
+                           </decoNote>                           
+                           
+                           <decoNote type="miniature" xml:id="d37">
+                               <locus target="#26r"/>
+                               <desc>Two scenes: <persName ref="PRS5773Joshua">Joshua</persName> makes peace with the people of Gibeon (above); and the sun stands still for him and his army (below).
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">በከመ፡ ቆመ፡ ፀሓይ፡ ለ<persName ref="PRS5773Joshua">ኢያሱ።</persName></q>
+                                   <q xml:lang="gez">እስራኤል፡</q>
+                               </desc>
+                           </decoNote>                           
+                           
+                           <decoNote type="miniature" xml:id="d38">
+                               <locus target="#26v"/>
+                               <desc>Two scenes: <persName ref="PRS2394Balaam">Balaam</persName> and the angel (left); 
+                                   and Phinehas raises his spear to kill an Israelite man who is copulating with a Midianite woman before a golden idol, while another one performs a sacrifice below (right).
+                                   <q xml:lang="gez">እስራኤል፡</q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS2394Balaam">በለዓም፡</persName></q>
+                                   <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS7049Michael">ሚካኤል።</persName></q>
+                                   <q xml:lang="gez">ዕድግት፡</q>
+                                   <q xml:lang="gez">ፊንሐስ፡ ዘምሪ</q> <!--Pers names to be encoded: Phinehas and Zimri, cf. Numbers 25:14 -->
+                                   <q xml:lang="gez">ከስቢ፡</q><!-- Pers name to be encoded: Kozbi, cf. Numbers 25:15-->
+                                   <q xml:lang="gez">ጣዖት፡</q>	
+                                   <q xml:lang="gez">መሥዋዕተ፡ ጣዖት፡</q>	
+                               </desc>
+                           </decoNote>
 
-                           <q xml:lang="gez">እግዚአብሔር።</q>
-                           <q xml:lang="gez"><persName ref="PRS8533Sarah">ሳራ፡</persName> / <persName ref="PRS1267Abraham">አብርሃም፡</persName></q>
-                           <q xml:lang="gez"><persName ref="PRS8533Sarah">ሳራ፡</persName> / <persName ref="PRS5578Isaac">ይስሐቅ።</persName> / <persName ref="PRS1267Abraham">አብርሃም፡</persName></q>
-                           <q xml:lang="gez">ንብቲራ፡</q>
-                       </desc>
-                       </decoNote>
-
-                       <decoNote type="miniature" xml:id="d21">
-                           <locus target="#18r"/>
-                         <desc>The Binding of <persName ref="PRS5578Isaac">Isaac</persName>.
-
-                            <q xml:lang="gez">እግዚአብሔር።</q>
-                            <q xml:lang="gez"><persName ref="PRS1267Abraham">አብርሃም፡</persName></q>
-                            <q xml:lang="gez"><persName ref="PRS5578Isaac">ይስሐቅ።</persName></q>
-                            <q xml:lang="gez">በግዕ፡</q>
-                            <q xml:lang="gez">ዕፀ፡ ስቤቅ፡</q>
-                            <q xml:lang="gez"><persName ref="PRS1267Abraham">አብርሃም፡</persName></q>
-                            <q xml:lang="gez"><persName ref="PRS5578Isaac">ይስሐቅ።</persName></q>
-                       </desc>
-                       </decoNote>
-
-                       <decoNote type="miniature" xml:id="d22">
-                           <locus target="#18v"/>
-                         <desc>Through the intervention of <persName ref="PRS7049Michael">Michael the Archangel</persName>
-                         neither <persName ref="PRS3863Esau">Esau</persName> nor <persName ref="PRS6122Laban">Laban</persName>
-                         harm <persName ref="PRS5650Jacob">Jacob</persName>, who is depicted in front of a tent, together with his
-                         two wives and his large flock of animals.
-
-
-                         <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS7049Michael">ሚካኤል።</persName></q>
-                         <q xml:lang="gez"><persName ref="PRS3863Esau">ኤሳው።</persName></q>
-                         <q xml:lang="gez"><persName ref="PRS6122Laban">ላባ፡</persName></q>
-                         <q xml:lang="gez">ሐይመት።</q>
-                         <q xml:lang="gez">ራሔል / <persName ref="PRS5650Jacob">ያዕቆብ</persName> / ለያ</q>
-                         <q xml:lang="gez">አፍራስ / አግማል፡ / አባግዕ፡ / አድግት፡</q>
-                       </desc>
-                       </decoNote>
-
-                       <decoNote type="miniature" xml:id="d23">
-                           <locus target="19r#"/>
-                         <desc>The devil tests <persName ref="PRS5691Job">Job</persName>.
-
-                          <q xml:lang="gez">እግዚአብሔር።</q>
-                          <q xml:lang="gez"><persName ref="PRS5691Job">ኢዮብ፡</persName></q>
-                          <q xml:lang="gez"><persName ref="PRS11330Devil">ሰይጣን፡</persName></q>
-                          <q xml:lang="gez">ብእሲቱ፡ ለኢዮብ፤</q>
-                          <q xml:lang="gez">ሕማሙ፡ ለኢዮብ፡</q>
-                          <q xml:lang="gez">ጎፍር፡ ኤልፉዝ፡ በልዳዶስ።</q>
-                       </desc>
-                       </decoNote>
-
-                       <decoNote type="miniature" xml:id="d24">
-                           <locus target="#19v"/>
-                         <desc>Three episodes: <persName ref="PRS5763Joseph">Joseph</persName> is sold by his brothers (above);
-                           his brothers depart with grain in their sacks as well as the objects placed there by his men
-                           and are chased by one of his stewards (bottom left);
-                           <persName ref="PRS5763Joseph">Joseph</persName> confronts his brothers.
-
-                           <q xml:lang="gez"></q>
-                       </desc>
-                       </decoNote>
-
-                       <decoNote type="miniature" xml:id="d25">
-                           <locus target="#"/>
-                         <desc>
-
-                           <q xml:lang="gez"></q>
-                       </desc>
-                       </decoNote>
-
-                       <decoNote type="miniature" xml:id="d26">
-                           <locus target="#"/>
-                         <desc>
-
-                           <q xml:lang="gez"></q>
-                       </desc>
-                       </decoNote>
-
-                       <decoNote type="miniature" xml:id="d27">
-                           <locus target="#"/>
-                         <desc>
-
-                           <q xml:lang="gez"></q>
-                       </desc>
-                       </decoNote>
-
-                        </decoDesc>
+                           <decoNote type="miniature" xml:id="d39">
+                               <locus target="#27r"/>
+                               <desc>Jael drives a peg through the head of Sisera. <!--Pers names to be encoded? -->
+                                   <q xml:lang="gez">እግዚአብሔር።</q>
+                                   <q xml:lang="gez">እስራኤል፡</q>
+                                   <q xml:lang="gez">ዲቦራ፡</q><!--Pers name to be encoded? -->
+                                   <q xml:lang="gez">ሐይመት፡</q> <!--  spelling to be checked-->
+                                   <q xml:lang="gez">ሕዝበ፡ ሲሳራ፡</q>
+                                   <q xml:lang="gez">ኢያዔል፡</q>
+                                   <q xml:lang="gez">ሲሳራ፡</q>
+                               </desc>
+                           </decoNote>
+                           
+                           
+                           <decoNote type="miniature" xml:id="d40">
+                               <locus target="#27v"/>
+                               <desc>Three scenes showing military leaders: Jephthah sacrifices his daughter who had come out to meet him (upper left); Gideon defeats the Midianites (bottom left);
+                                   and <persName ref="PRS8469Samson">Samson</persName> defeats the Philistines brandishing the donkey jaw.  <!--Pers names to be encoded? -->
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ዮፍታሒ፡</q> <!--Pers name to be encoded? -->
+                                   <q xml:lang="gez">መንከሰ፡ ዓድግ፡</q>
+                                   <q xml:lang="gez">ጊዴዎን፡</q> <!--Pers name to be encoded? -->
+                                   <q xml:lang="gez">ሰብአ፡ ጊዴዎን፡</q>
+                                   <q xml:lang="gez">ሰብአ፡ ምድያም፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS8469Samson">ሳምሶን፡</persName></q>
+                                   <q xml:lang="gez">ሰብአ፡ ኢሎፍሊ፡</q>
+                               </desc>
+                           </decoNote>                           
+                           
+                           <decoNote type="miniature" xml:id="d41">
+                               <locus target="#28r"/>
+                               <desc>Four scenes: <persName ref="PRS8478Samuel">Samuel</persName> addresses the Israelites after the death of Eli (upper left); 
+                                   the five Philistine kings send the Ark of the Covenant back to Israel (bottom left); 
+                                   King <persName ref="PRS8567Saul">Saul</persName> addresses an armed man, probably his son (upper right); and the Israelites defeat the Philistines (bottom right).
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS8478Samuel"> ሳሙኤል፡</persName></q>
+                                   <q xml:lang="gez">እስራኤል፡</q>
+                                   <q xml:lang="gez">ኤሊ፡</q> <!--Pers name to be encoded? -->
+                                   <q xml:lang="gez">ሳኦል፡</q>
+                                   <q xml:lang="gez">ታቦት፡</q>
+                                   <q xml:lang="gez">አፍኒን፡ ፊንሐስ፡</q> <!--Pers name to be encoded? -->                                
+                                   <q xml:lang="gez">ሰብአ፡ ኢሎፍሊ፡</q>
+                               </desc>
+                           </decoNote>                           
+                           
+                           <decoNote type="miniature" xml:id="d42">
+                               <locus target="#28v"/>
+                               <desc>Three scenes: <persName ref="PRS3417David">David</persName> plays for King <persName ref="PRS8567Saul">Saul</persName> who hurls a spear at him (upper left);
+                                   <persName ref="PRS3417David">David</persName> defeats <persName ref="PRS11293Goliath">Goliath</persName> who is wearing a chainmail and pointed helmet and the
+                                   Philistines flee (bottom); Joab hurls his spear at Absalom who is hanging from a tree.                                   
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">በከመ፡ አድኃኖ፡ ለዳዊት፡ እምእደ፡ ሳኦል፡</q>
+                                   <q xml:lang="gez">እስራኤል፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS3417David">ዳዊት፡</persName></q>
+                                   <q xml:lang="gez">ኢሎፍሊ፡</q>
+                                   <q xml:lang="gez">ጎልያድ፡</q> <!--Pers name to be encoded? -->
+                                   <q xml:lang="gez">ኢዮአብ፡</q> <!--Pers name to be encoded? -->
+                                   <q xml:lang="gez">አቤሴሎም፡</q> <!--Pers name to be encoded? -->
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d43">
+                               <locus target="#29r"/>
+                               <desc>Five scenes: <persName ref="PRS3417David">David</persName> interacts with two unidentified men (his courtiers or soldiers); Uriah dies in battle; 
+                                   <persName ref="PRS3417David">David</persName> marries <persName ref="PRS2558Bathsheb">Batsheba</persName>; 
+                                   <persName ref="PRS13685Nathan">Nathan</persName> reproaches the King for his behaviour; 
+                                   and <persName ref="PRS3417David">David</persName> lays on the ground to seek forgiveness.                                 
+                                   <q xml:lang="gez"><persName ref="PRS3417David">ዳዊት፡</persName></q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ኦርዮ፡</q><!-- Encode Uriah? -->
+                                   <q xml:lang="gez"><persName ref="PRS2558Bathsheb">ቤርሳቤሕ፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS3417David">ዳዊት፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS3417David">ዳዊት፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS13685Nathan">ናታን፡</persName></q>
+                                   <q xml:lang="gez">ዘከመ፡ ወድቀ፡ ዳዊት፡</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d44">
+                               <locus target="#29v"/>
+                               <desc> Solomon is appointed king over the four kings of the world.
+                                   <q xml:lang="gez">እግዚአብሔር።</q>
+                                   <q xml:lang="gez"><persName ref="PRS8925Solomon">ሰሎሞን፡</persName></q>
+                                   <q xml:lang="gez">ነገሥተ፡ ምድር፡</q>                                   
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d45">
+                               <locus target="#30r"/>
+                               <desc>The Kings of Israel pray to God.
+                                   <q xml:lang="gez">እግዚአብሔር።</q>
+                                   <q xml:lang="gez">ነገሥታት።</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d46">
+                               <locus target="#30v"/>
+                               <desc>The Prophets of Israel have visions with the just in Paradise and the sinners in Hell.
+                                   <q xml:lang="gez">ነቢያት፡</q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ጻድቃን፡</q>
+                                   <q xml:lang="gez">ኃጥአን፡</q>
+                                   <q xml:lang="gez">ገሃነመ፡ እሳት፡</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d47">
+                               <locus target="#31r"/>
+                               <desc>Three scenes: King Ahab asks for Naboth’s vineyard; the latter is killed; and dogs devour the decapitated body of the king’s wife Jezebel. <!-- 3 Pers names to be encoded? -->
+                                   <q xml:lang="gez">እግዚአብሔር።</q>
+                                   <q xml:lang="gez">አከዓብ፡</q>
+                                   <q xml:lang="gez">ኤልዛቤል፡</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d48">
+                               <locus target="#31v"/>
+                               <desc>Three scenes: God instructs <persName ref="PRS3721Elijah">Elijah </persName>; the prophet confronts King Ahab; the king, who has now aged, sits afraid outside the city walls.
+                                   <!-- Pers name Ahab to be encoded? --> 
+                                   <q xml:lang="gez">እግዚአብሔር።</q>
+                                   <q xml:lang="gez"><persName ref="PRS3721Elijah">ኤልያስ፡</persName></q>
+                                   <q xml:lang="gez">አከዓብ፡ <gap reason="illegible"/> ኤልያስ፡</q> <!-- Pers name Ahab to be encoded? -->
+                                   <q xml:lang="gez">ዘከመ፡ ደንገፀ፡ ከዓብ።</q> <!-- Pers name Ahab to be encoded? --> 
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d49">
+                               <locus target="#32r"/>
+                               <desc>Three scenes: <persName ref="PRS3721Elijah">Elijah </persName> in the wilderness speaks to God and is aided by an Angel;
+                                   <persName ref="PRS3721Elijah">Elijah</persName> appoints <persName ref="PRS3723Elisha">Elisha</persName> as his disciple; the Arameans soldiers are unable to seize
+                                   <persName ref="PRS3723Elisha">Elisha</persName>.
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">መልአክ፡</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d50">
+                               <locus target="#32v"/>
+                               <desc>Three scenes: <persName ref="PRS5754Jonah">Jonah</persName> and the big fish; God instructs <persName ref="PRS5754Jonah">Jonah</persName>; 
+                                   and a naked <persName ref="PRS5754Jonah">Jonah</persName> confronts the Ninevites before the leafy plant.
+                                   <q xml:lang="gez">ሐመር፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS5754Jonah">ዮናስ፡</persName></q>
+                                   <q xml:lang="gez">አንበሪ፡</q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ሰብአ፡ ነነዌ፡</q>
+                                   <q xml:lang="gez">እሳት፡</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d51">
+                               <locus target="#33r"/>
+                               <desc>God addresses the Two Tribes of Israel that are left after the other Ten Tribes are deported by the Assyrian King Shalmaneser. <!-- Pers name to be encoded? -->
+                                   <q xml:lang="gez">፪ አንጋደ፡ እስራኤል።</q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ስልምናሶር፡</q><!-- Pers name to be encoded? -->
+                                   <q xml:lang="gez">ፄዋ፡ እስራኤል።</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d52">
+                               <locus target="#33v"/>
+                               <desc>King <persName ref="PRS5330Hezekiah">Hezekiah</persName>
+                                   prays to God who sends an angel to kill the men of the Assyrian ruler <persName ref=" PRS8762Sennache">Sennacherib</persName>
+                                   in their encampment who is later beheaded by two of his sons while praying to an idol.
+                                   <q xml:lang="gez">ዘከመ፡ ጸለየ፡ <persName ref="PRS5330Hezekiah">ሕዝቅያስ፡</persName>
+                                       ወኢሳይያስ፡</q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">መልአክ፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ ቀተልዎ፡ ደቂቁ፡ ለሰናክሬም<supplied reason="omitted">፡</supplied> ውስተ፡ ቤተ፡ ጣዖት፡</q>
+                                   <q xml:lang="gez">ሠራዊተ፡ <persName ref=" PRS8762Sennache">ሰናክሬም</persName></q>
+                               </desc>
+                           </decoNote>                           
+                           
+                           <decoNote type="miniature" xml:id="d53">
+                               <locus target="#34r"/>
+                               <desc><persName ref="PRS6644Manasseh">Manasseh</persName> prays to God and is restored to his Kingdom.                                   
+                                   <q xml:lang="gez">ዘከመ፡ ጸለየ፡ <persName ref="PRS6644Manasseh">ምናሴ።</persName></q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ ተሞቅሐ፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ ተመይጠ፡ ኀበ፡ መንግሥቱ።</q>
+                               </desc>
+                           </decoNote>                           
+                           
+                           <decoNote type="miniature" xml:id="d54">
+                               <locus target="#34v"/>
+                               <desc>An angel sent by God cleanses <persName ref="PRS5584Isaiah">Isaiah</persName> of leprosy by touching his mouth with a hot piece of coal held with thongs.                                  
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ጒጠት፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS5584Isaiah"> ኢሳይያስ፡</persName></q>
+                                   <q xml:lang="gez">መልአክ፡</q>
+                                   <q xml:lang="gez">መልአክ፡</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d55">
+                               <locus target="#35r"/>
+                               <desc><persName ref="PRS5774Josiah"> Josiah</persName> celebrates the Passover by having lambs and cattle skinned and by burning offerings to God.
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS5774Josiah">ኢዮሰያስ።</persName></q>
+                                   <q xml:lang="gez">እሳት፡</q>
+                                   <q xml:lang="gez">መሥዋዕተ፡ አባግዕ፡ ወዋልህምት።</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d56">
+                               <locus target="#35v"/>
+                               <desc>God saves <persName ref="PRS5680Jeremiah">Jeremiah</persName> from the mud cistern in which he was thrown by officials of King Zedekiah. <!-- encode king’s name? -->
+                                   <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS7049Michael">ሚካኤል፡</persName></q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS4377Gabriel">ገብርኤል፡</persName></q>
+                                   <q xml:lang="gez">ሴዴቅያስ።</q><!-- encode king’s name? -->
+                                   <q xml:lang="gez">ዘከመ፡ ወፅአ፡ እምዓዘቅት፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ ተወድየ፡ ውስተ፡ ዓዘቅት።</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d57">
+                               <locus target="#36r"/>
+                               <desc>Three scenes: the miraculous sleep of Ebed-Melech (Abimelech) the Ethiopian; God speaks to <persName ref="PRS2516Baruch">Baruch</persName> through 
+                                   <persName ref="PRS5680Jeremiah">Jeremiah</persName>; and the Israelites, along with their blind and shackled king, are taken captive by King 
+                                   <persName ref="PRS11373Nebuc">Nebuchadnezzar</persName> who rides among his armed men who are shown holding guns, shields, and spears.
+                                   <q xml:lang="gez">አቤሜሌክ፡</q> <!-- not sure if this is PRS1249Abimelec? -->
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">መላእክት፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS2516Baruch">ባሮክ<supplied reason="omitted">፡</supplied></persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS5680Jeremiah">ኤርምያስ፡</persName></q>
+                                   <q xml:lang="gez">እስራኤል፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS11373Nebuc">ናቡከደነ፡ ጻር፡</persName></q>
+                                   <q xml:lang="gez">ዘከመ፡ ተዓወረ፡ ሴዴቅያስ።</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d58">
+                               <locus target="#36v"/>
+                               <desc>A miniature showing the <ref type="authFile" corresp="AT1028HebrewsFurnace">Three Youths in the fiery Furnace</ref>.
+                                   <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS7049Michael">ሚካኤል፡</persName></q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS4377Gabriel">ገብርኤል፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS11373Nebuc">ናቡከደነ፡ ጻር፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS11288AnAzMi">፫ ደቂቅ፡</persName></q>
+                                   <q xml:lang="gez">እሳት፡</q>
+                                   <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS4377Gabriel">ገብርኤል፡</persName></q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d59">
+                               <locus target="#37r"/>
+                               <desc>God transforms King <persName ref="PRS11373Nebuc">Nebuchadnezzar</persName> into a wild boar.
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS11373Nebuc">ናቡከደነ፡ ጻር፡</persName></q>
+                                   <q xml:lang="gez">መልአክ።</q>
+                                   <q xml:lang="gez">ዘከመ፡ <gap reason="illegible"/></q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d60">
+                               <locus target="#37v"/>
+                               <desc>Two scenes: God turns King <persName ref="PRS11373Nebuc">Nebuchadnezzar</persName> back into a human being; and the king is crowned and enthroned and
+                                   attended by several courtiers including <persName ref="PRS3337Daniel">Daniel</persName> and the <persName ref="PRS11288AnAzMi">Three Youths</persName>.
+                                   <q xml:lang="gez"><persName ref="PRS11373Nebuc">ናቡከደነ፡ ጻር፡</persName> ዘይቤ፡ መንግሥቱ፡ ዘለዓም። ወምኵናኑኒ፡ ለትውልደ፡ ትውልድ።</q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS3337Daniel">ዳንኤል፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS11373Nebuc">ናቡከደነ፡ ጻር፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS11288AnAzMi"><supplied reason="lost">፫</supplied> ደ<supplied reason="lost">ቂቅ፡</supplied></persName></q>
+                               </desc>
+                           </decoNote>
+                           
+                           
+                           <decoNote type="miniature" xml:id="d61">
+                               <locus target="#38r"/>
+                               <desc>Two scenes: <persName ref="PRS3337Daniel">Daniel</persName> listenes to the accounts of <persName ref="PRS11599Susanna">Susanna</persName> and the two elders;
+                                   and the two elders are stoned to death for their lies.                                    
+                                   <q xml:lang="gez"><persName ref="PRS3337Daniel">ዳንኤል፡</persName></q>
+                                   <q xml:lang="gez">ረበናት፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS11599Susanna">ሶሰና፡</persName></q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ ወገርዎሙ፡ ለረበናት<supplied reason="omitted">፡</supplied></q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d62">
+                               <locus target="#38v"/>
+                               <desc><persName ref="PRS3337Daniel">Daniel</persName> in the lion’s den.                                   
+                                   <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS7049Michael">ሚካኤል፡</persName></q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS4377Gabriel">ገብርኤል፡</persName></q>
+                                   <q xml:lang="gez">ዘከመ፡ ወደይዎ፡ ለ<persName ref="PRS3337Daniel">ዳንኤል፡</persName> ውስተ፡ <add place="interlinear">ግበ፡</add> አናብከት።</q>
+                                   <q xml:lang="gez">መልአክ፡ ቅዱስ፡ <persName ref="PRS7049Michael">ሚካኤል።</persName></q>
+                                   <q xml:lang="gez">ግብ፡</q>
+                                   <q xml:lang="gez">አንብስት፡</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d63">
+                               <locus target="#39r"/>
+                               <desc><persName ref="PRS4914Habakkuk">Habakkuk</persName> brings bread in a basket to <persName ref="PRS3337Daniel">Daniel</persName>.
+                                   <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS7049Michael">ሚካኤል፡</persName></q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS4377Gabriel">ገብርኤል፡</persName></q>
+                                   <q xml:lang="gez">መልአክ፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS4914Habakkuk">ዕንባቆም፡</persName></q>
+                                   <q xml:lang="gez">ዘከመ፡ ቦአ፡ <persName ref="PRS3337Daniel">ዳንኤል፡</persName> ወስተ፡ ግበ፡ አናብስት፡</q>
+                                   <q xml:lang="gez">መሶብ፡ ወርቅ</q>
+                               </desc>
+                           </decoNote>                           
+                           
+                           <decoNote type="miniature" xml:id="d64">
+                               <locus target="#39v"/>
+                               <desc>Two scenes: <persName ref="PRS3942Ezekiel">Ezekiel</persName> has a vision of God surrounded by the tetramorph; 
+                                   and <persName ref="PRS3942Ezekiel">Ezekiel</persName> dreams of the Valley of Dry Bones.                                   
+                                   <q xml:lang="gez">ገጸ፡ ሰብእ።</q>
+                                   <q xml:lang="gez">ገጸ፡ ንስር፡</q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS3942Ezekiel">ሕዝቅኤል፡</persName></q>
+                                   <q xml:lang="gez">ገጸ፡ አንበሳ፡</q>
+                                   <q xml:lang="gez">ገጸ፡ ላህም፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS3942Ezekiel">ሕዝቅኤል፡</persName></q>
+                                   <q xml:lang="gez">ምውታን፡</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d65">
+                               <locus target="#40r"/>
+                               <desc>Two scenes: a group of three prophets, including <persName ref="PRS3814Enoch">Enoch</persName>, <persName ref="PRS3721Elijah">Elijah</persName>, 
+                                   and <persName ref="PRS3943Ezra">Ezra</persName>, converses before God; Ezra writes his book, an additional empty sheet of parchment at his side is represented 
+                                   as an empty rectangle.
+                                   <q xml:lang="gez"><persName ref="PRS7049Michael">ቅዱስ፡ ሚካኤል፡</persName></q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS4377Gabriel">ቅዱስ፡ ገብርኤል፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS3814Enoch">ሄኖክ፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS3721Elijah">ኤልያስ፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS3943Ezra">እዝራ፡</persName></q>
+                                   <q xml:lang="gez">ዘከመ፡ ጸሐፈ፡ <persName ref="PRS3943Ezra">እዝራ፡</persName> መጽሕፍተ፡ ነቢያት። እምድኅረ፡ አውዓይዎሙ በእሳት።</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d66">
+                               <locus target="#40v"/>
+                               <desc>Jeconiah is freed from prison during the reign of Amel-Marduk and after the death of the latter’s father.
+                                   <!-- encode names? Also, I am not sure if the scene in the lower right is the death of Nebuchadnezzar or some other figure, the caption is partially stained.
+                                       MV 18.05.2026: Yes, it is. Jacopo, do you want to add something to the description of the scene?  -->
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ሰብአ፡ ባቢሎን፡</q><!-- encode PLACE name? -->
+                                   <q xml:lang="gez">ኢኮንያን፡</q>
+                                   <q xml:lang="gez">ኤዎልማሮዴቅ፡</q><!-- encode PERSNAME? -->
+                                   <q xml:lang="gez">ዘከመ፡ ሞተ፡ <gap reason="illegible"/>ክደ<gap reason="illegible"/>ር፡</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d67">
+                               <locus target="#41r"/>
+                               <desc> <!-- Four of five scenes? Parts of this miniature are confusing to me, first we have the hand of the angel of god writing a prophecy about the imminent death of Belshazzar, next, I presume we see his beheaded body, as it’s mentioned in the main text (but what are the sources for this? It’s not in the Bible)  and someone bringing his head, to the middle left we have Daniel being made king? Cannot make out the inscriptions below, are these the servants bringing wine to the King? Are some extra biblical references included that it would be worth mentioning?
+                                   
+                               MV: Belshazzar’s death is described in Daniel 5, but there is no mention of his beheading; this detail probably comes from another source that I am not familiar with. Belshazzar organises a grand banquet for his dignitaries and his wives. During the banquet, cups are brought, among which God's holy cup (ጽዋዓ፡ እግዚአብሔር፡), from which the women drink. Mysterious words appear written by a hand on the wall (the words ማኔ፡ ቴቄል፡ ፉሬስ።). The king is afraid. Daniel, who could notoriously interpret dreams, is summoned to decipher the meaning of the mysterious writing on the wall, and he predicts the imminent end of Belshazzar’s reign. I can't find the biblical place in which Belshazzar's head is shown/given to the people of Israel.                                -->
+                                   <q xml:lang="gez">መልአክ፡</q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ ጸሐፈ፡ እደ፡ መልአክ፡ ወይቤ፡ ማኔ፡ ቴቄል፡ ፉሬስ።</q>
+                                   <q xml:lang="gez">ብላጣሶር።</q><!-- encode PERSNAME? -->
+                                   <q xml:lang="gez">ብእሲቱ፡ ዘከመ፡ አኅዘተ፡ ጽዋዓ፡ እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ ወሀቦሙ፡ ርእሶ፡ ለእስራኤል፡ ወዓለሁ፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ አምሰሐ፡ መኳንንቲሁ፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ መጠዋ፡ ጽዋዓ፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ ፈከረ፡ ሎቱ፡ ዳንኤል፡ ሕልማ፡</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d68">
+                               <locus target="#41v"/>
+                               <desc>King <persName ref="PRS3264CyrusII">Cyrus</persName> announces to the Israelites that they may return home, one of his officers plays a 
+                                   <!-- MV 18.05.2026: This description is incomplete -->
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">እስራኤል፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS3264CyrusII">ቂሮስ</persName></q>
+                                   <q xml:lang="gez">እስራኤል፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ ዜነወ፡ ቃለ፡ <!-- One word is missing here: HELP? --> ሚጠቶሙ፡ ለእስራኤል፡</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d69">
+                               <locus target="#42r"/>
+                               <desc>Zorobabel leads the Jews back from captivity.
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ትሩፋነ፡ ባቢሎን፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS5773Joshua">ዮሴዕ፡</persName> ወልደ፡ ዮሴዴቅ፡</q><!-- He's Joshua son of Jehozadak or Jozadak, cp. Ezra 3:2-->
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d70">
+                               <locus target="#42v"/>
+                               <desc>Two scenes: the Israelites return to Jerusalem led by Joshua, Zorobabel, and a third unidentified leader; and a battle between the Israelites and the people of Gog.
+                                   <q xml:lang="gez"><persName ref="PRS5773Joshua">ዮሴዕ፡</persName></q><!-- He's Joshua son of Jehozadak or Jozadak, cp. Ezra 3:2-->
+                                   <q xml:lang="gez">ዘሩባቤል፡</q>
+                                   <q xml:lang="gez">ሰብአ፡ ጎግ።</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d71">
+                               <locus target="#43r"/>
+                               <desc>Three scenes: Judith meets Holofernes in his camp; she beheads him; and her slave brings his head back to the town in the food bag.
+                                   <q xml:lang="gez">ዮዲት፡</q><!-- encode PERSNAME? -->
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ሆሎፎርኒስ፡</q><!-- encode PERSNAME? -->
+                                   <q xml:lang="gez">ዘከመ፡ ከተለቶ፡ ዮዲት፡ ለሆሎፎርኒስ፡</q><!-- encode PERSNAME? -->
+                                   <q xml:lang="gez">ሐይመት፡</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d72">
+                               <locus target="#43v"/>
+                               <desc>Three scenes: an unidentified man, possibly Haman, addresses two attendants; Mordecai tells Queen Esther about a plot to kill the Israelites; Haman is hung on a forked pole;
+                                   and King <persName ref="PRS10180Xerxes">Xerxes</persName> praises Mordechai. 
+                                   <!-- encode PERSNAME? No sure about the identification of the figure as Xerxes -->
+                                   <q xml:lang="gez">አስቴር።</q><!-- encode PERSNAMES? -->
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">መርዶክዮስ፡</q><!-- encode PERSNAME? -->
+                                   <q xml:lang="gez">እስራኤል።</q>
+                                   <q xml:lang="gez">ዘከመ፡ ተሰቅለ፡ ሐ<supplied reason="lost">ማ</supplied>፡</q><!-- encode PERSNAME? -->
+                                   <q xml:lang="gez">አርጤከስስ፡</q><!-- cannot read the lower portion, is this Xerxes? -->
+                                   <q xml:lang="gez">መርዶክዮስ፡</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d73">
+                               <locus target="#44r"/>
+                               <desc>The Israelites rebuild the walls of Jerusalem in spite of the opposition of Sanballat and his soldiers. <!-- encode PERSNAME? -->
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ሰንበላጥ[፡]</q><!-- encode PERSNAME? -->
+                                   <q xml:lang="gez">እስራኤል፡</q>
+                                   <q xml:lang="gez">ሠራዊተ፡ ሰንበላጥ፡</q>
+                               </desc>
+                           </decoNote>                           
+                           
+                           <decoNote type="miniature" xml:id="d74">
+                               <locus target="#44v"/>
+                               <desc>Two scenes: Alexander the Great has a vision of a sword-bearing angel; and he pays tribute to the high-priest and his entourage.
+                                   <q xml:lang="gez">መልአክ</q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">አስክንድር፡</q>
+                                   <q xml:lang="gez">ሠራዊተ፡ [???]</q>
+                                   <q xml:lang="gez">ዘከመ፡ ሰገደ፡ እስክንድር፡ ቃ?ና???</q>
+                                   <q xml:lang="gez">ካህናት፡</q>
+                                   <q xml:lang="gez">?አም?፡ [???]</q> <!-- would be interesting to translate word if it identifies the strange box held by Alexander the Great, I have not found this mentioned in Budge 1896 72-76, but on pp. 406-408 authors say he donates gold to the Temple and this could be it -->
+                               </desc>
+                           </decoNote>                           
+                           
+                           <decoNote type="miniature" xml:id="d75">
+                               <locus target="#45r"/>
+                               <desc>Two scenes: <persName ref="PRS7984Ptolemy">Ptolemy II</persName> is inspired by God to commission the translation of the Bible into Greek; an angel stops 
+                                   <persName ref="PRS8854Simeon">Simeon</persName> from changing the text of Isaiah that claims a Virgin will bear a son.
+                                   <q xml:lang="gez"><persName ref="PRS7984Ptolemy">በጥሊሞስ፡</persName></q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">መልአክ፡</q>
+                                   <q xml:lang="gez">ካልአኒሁጸሐፍት፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS8854Simeon">ስምዖን፡</persName></q>
+                                   <q xml:lang="gez">ሐይመት፡</q>
+                               </desc>
+                           </decoNote>                           
+                           
+                           <decoNote type="miniature" xml:id="d76">
+                               <locus target="#45v"/>
+                               <desc>Antiochus IV puts the Israelites to death and has a wild board sacrificed in the Temple to desecrate it. <!-- encode pers name of Antiochus? -->
+                                   <q xml:lang="gez">ሥዕለ፡ ፀሐይ፡</q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">አንጥያኮስ፡</q><!-- encode pers name of Antiochus? -->
+                                   <q xml:lang="gez"></q><!-- extensive caption above pig I cannot read -->
+                                   <q xml:lang="gez">እስራኤል፡</q>
+                               </desc>
+                           </decoNote>                           
+                           
+                           <decoNote type="miniature" xml:id="d77">
+                               <locus target="#46r"/>
+                               <desc>Antiochus IV puts Lazarus and his children to death. <!-- encode pers name of Antiochus and Lazarus? -->
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ደቂቀ፡ አልዓዛር፡</q>
+                                   <q xml:lang="gez">አልዓዛር፡</q>
+                               </desc>
+                           </decoNote>                           
+                           
+                           <decoNote type="miniature" xml:id="d78">
+                               <locus target="#46v"/>
+                               <desc>An angel brings heavenly bread to <persName ref="PRS6819Mary">Mary</persName> in a basket. 
+                                   <q xml:lang="gez">በተ፡ መቅደስ።</q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ ወሃበ፡ መልአክ፡ ልእግዝእትነ፡ ሃብስተ፡ ስማያት።</q>
+                               </desc>
+                           </decoNote>                           
+                           
+                           <decoNote type="miniature" xml:id="d79">
+                               <locus target="#47r"/>
+                               <desc>The Annunciation of <persName ref="PRS4377Gabriel">Gabriel</persName>to <persName ref="PRS6819Mary">Mary</persName> who is reading the  Book of Isaiah.
+                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም</persName>።</q>
+                                   <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS4377Gabriel">ገብርኤል።</persName></q>
+                                   <q xml:lang="gez">መጽሐፈ፡ ኢሳይያስ፡</q>
+                               </desc>
+                           </decoNote>                           
+                           
+                           <decoNote type="miniature" xml:id="d80">
+                               <locus target="#47v"/>
+                               <desc>A Nativity scene with shepherds playing Genna and a donor in proskynesis.
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ ተውልደ፡ መድኃኒነ፡ ውስተ፡ ገል፡</q>
+                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም</persName>።</q>
+                                   <q xml:lang="gez">ላህ[ም]</q>
+                                   <q xml:lang="gez">ዕድዓቅ፡</q>
+                                   <q xml:lang="gez">ኖሎት፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ ወለተ፡ ??? ጽዮን፡</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d81">
+                               <locus target="#48r"/>
+                               <desc>The circumcision of <persName ref="PRS5684JesusCh">Jesus</persName>.
+                                   <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS7049Michael">ሚካኤል፡</persName></q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS4377Gabriel">ገብርኤል።</persName></q>
+                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS8417Salome">ሳሎሜ</persName>።</q>
+                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም</persName>።</q>
+                                   <q xml:lang="gez"><persName ref="PRS5684JesusCh">መድኃኒነ፡</persName></q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d82">
+                               <locus target="#48v"/>
+                               <desc>The adoration of the Magi.
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም፡</persName></q>
+                                   <q xml:lang="gez">ዘከመ፡ ወሀብዎ፡ ለእቅዚእነ፡ አምኃ፡ ነግሥተ፡ ፍርስ። እንዘ፡ ይስቅዱ፡ ሎቱ</q>
+                               </desc>
+                           </decoNote>                           
+                           
+                           <decoNote type="miniature" xml:id="d83">
+                               <locus target="#49r"/>
+                               <desc>The Flight into Egypt.
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ ዜነዎ፡ መልአክ፡ በሕልም፡<persName ref="PRS5764Joseph">ዮሲፍ</persName></q>
+                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS8417Salome">ሳሎሜ፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS5764Joseph">ዮሲፍ፡</persName></q>
+                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም፡</persName> ምስለ፡ ፍቁር፡ <persName ref="PRS5684JesusCh">ወልደ።</persName></q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d84">
+                               <locus target="#49v"/>
+                               <desc><persName ref="PRS5299Herod">Herod</persName> commands the Massacre of the Innocents and the beheading of 
+                                   <persName ref="PRS10691Zechari">Zechariah</persName> in the Temple, while <persName ref="PRS3725Elizabet">Elizabeth</persName>is able to escape.
+                                   <q xml:lang="gez"><persName ref="PRS5299Herod">ሄሮድስ፡</persName></q>
+                                   <q xml:lang="gez">ዘከመ፡ ቀተልዎ፡ ለዘካርያስ፡ በቤተ፡ መቅደስ፡</q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS3725Elizabet">ኤልሳቤጥ፡</persName></q>
+                                   <q xml:lang="gez">ዘከመ፡ ተቀትሉ፡ ሕፃናት።</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d85">
+                               <locus target="#50r"/>
+                               <desc>The Baptism of <persName ref="PRS5684JesusCh">Jesus</persName> in the Jordan.
+                                   <q xml:lang="gez">ዘከመ፡ ወረደ፡ መንፈስ፡ ቅዱስ፡ በአምሳለ፡ ርግብ፡</q>
+                                   <q xml:lang="gez">ዘከመ<persName ref="PRS5684JesusCh">እግዚእነ</persName>፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS5741Johnthe">ዮሐንስ፡ መትምቅ፡</persName></q>
+                                   <q xml:lang="gez">ዮርዳኖስ፡</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d86">
+                               <locus target="#50v"/>
+                               <desc>The Temptation of <persName ref="PRS5684JesusCh">Jesus</persName>.
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ስይጣን፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS5684JesusCh">እግዚእነ፡</persName></q>
+                                   <q xml:lang="gez">ስይጣን።</q>
+                               </desc>
+                           </decoNote>                           
+                           
+                           <decoNote type="miniature" xml:id="d87">
+                               <locus target="#51r"/>
+                               <desc>The Last Supper.
+                                   <q xml:lang="gez"><persName ref="PRS5684JesusCh">እግዚእነ፡</persName></q>
+                                   <q xml:lang="gez">ሐዋርያት፡</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d88">
+                               <locus target="#51v"/>
+                               <desc>The Agony in the Garden.
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">መላክ፡ ዘወሀቦ፡ መስቀለ፡ ምስለ፡ ጽዋዕ።</q>
+                                   <q xml:lang="gez"><persName ref="PRS5684JesusCh">እግዚእነ</persName>፡</q>
+                                   <q xml:lang="gez">"><persName ref="PRS5695John">ዮሐንስ፡</persName> ፍቁረ፡ እግዚእነ፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS5662James">ያዕቆብ፡</persName> ወልደ፡ ዘብዴዎስ።</q>
+                                   <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS7805Peter">ጴጥሮስ፡</persName></q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d89">
+                               <locus target="#52r"/>
+                               <desc> A combination of the Anastasis and Resurrection of <persName ref="PRS5684JesusCh">Jesus</persName>.
+                                   <q xml:lang="gez">መላእክት፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS5684JesusCh">እግዚእነ</persName>፡</q>
+                                   <q xml:lang="gez">መላእክት፡</q>
+                                   <q xml:lang="gez">ዓቀብተ፡ መቃብር።</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d90">
+                               <locus target="#52v"/>
+                               <desc>The Ascension of <persName ref="PRS5684JesusCh">Jesus</persName>.
+                                   <q xml:lang="gez"><persName ref="PRS5684JesusCh">እግዚእነ</persName>፡</q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም፡</persName></q>
+                                   <q xml:lang="gez">ሐዋርያት። እለ፡ ነጸሩ፡ ዕርገተ፡ እግዚእነ፡</q>
+                               </desc>
+                           </decoNote>                           
+                           
+                           <decoNote type="miniature" xml:id="d91">
+                               <locus target="#53r"/>
+                               <desc>Pentecost.
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ርደተ፡ ጰራቅሊጦስ፡ በአ፡ ምስለ፡ እሳት፡ ላዕለ፡ ሐዋርያት፡</q>
+                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም፡</persName></q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d92">
+                               <locus target="#53v"/>
+                               <desc>The Second Coming of <persName ref="PRS5684JesusCh">Jesus</persName>
+                                   <q xml:lang="gez">ጸድቃን፡</q>
+                                   <q xml:lang="gez">ተእምርተ፡ ኵናት፡</q>
+                                   <q xml:lang="gez"><persName ref="PRS5684JesusCh">እግዚእነ፡</persName></q>
+                                   <q xml:lang="gez">ተእምርተ፡ መስቀል፡</q>
+                                   <q xml:lang="gez">ጸድቃን፡</q>
+                                   <q xml:lang="gez">ኃጥአን።</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d93">
+                               <locus target="#54r"/>
+                               <desc>The Last Judgment (in this miniature Christ is identified with the title that is elsewhere reserved for the Father).
+                                   <q xml:lang="gez">መላእክት፡</q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">መላእክት፡</q>
+                                   <q xml:lang="gez">ጸድቃን፡</q>
+                                   <q xml:lang="gez">ኃጥአን፡</q>
+                                   <q xml:lang="gez">ገሃነመ፡ እሳት፡</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d94">
+                               <locus target="#54v"/>
+                               <desc>The Trinity and a donor in proskynesis.
+                                   <q xml:lang="gez">ሥላሴ፡ ቅዱስ።</q>
+                                   <q xml:lang="gez">ገጸ፡ ሰብእ፡</q>
+                                   <q xml:lang="gez">ገጸ፡ ንስር</q>
+                                   <q xml:lang="gez">ገጸ፡ አንበሳ፡</q>
+                                   <q xml:lang="gez">ገጸ፡ ላህም፡</q>
+                                   <q xml:lang="gez">በ ??? ትክለ ??? ምርያም፡ ???</q><!-- extensive caption about donor I cannot read -->
+                               </desc>
+                           </decoNote>
+                                                      
+                           <decoNote type="miniature" xml:id="d95">
+                               <locus target="#55r"/>
+                               <desc>The Martyrdom of <persName ref="PRS7805Peter">Peter</persName> and <persName ref="PRS7743Paul">Paul</persName>.
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ ተስቅለ፡ <persName ref="PRS7805Peter">ጴጥሮስ፡</persName> ቊልቊሊተ፡</q>
+                                   <q xml:lang="gez">መልአክ</q>
+                                   <q xml:lang="gez">መልአክ፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ ተመትረበስያፍ፡ ቅዱስ፡ <persName ref="PRS7743Paul">ጳውሎስ</persName>።</q>
+                               </desc>
+                           </decoNote>
+                           
+                           <decoNote type="miniature" xml:id="d96">
+                               <locus target="#55v"/>
+                               <desc>A group of unidentified martyrs and saints with Gabra Manfas Qǝddus and St George.
+                                   <q xml:lang="gez">ጸድቃን፡</q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">አቡነ፡ ገብረ፡ መንፈስ፡ ቅዱስ፡</q>
+                                   <q xml:lang="gez">ስማዕታት፡</q>
+                                   <q xml:lang="gez">ቅዱስ፡ ጊዮርጊስ፡</q>
+                               </desc>
+                           </decoNote>                           
+                           
+                           <decoNote type="miniature" xml:id="d97">
+                               <locus target="#56r"/>
+                               <desc>God saves some a group of martyrs from lions and flames.
+                                   <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS7049Michael">ሚካኤል፡</persName></q>
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS4377Gabriel">ገብርኤል።</persName></q>
+                                   <q xml:lang="gez">አናብስት፡</q>
+                                   <q xml:lang="gez">ስማዕት፡ ወጸድቃን።</q>
+                                   <q xml:lang="gez">አሳት፡</q>
+                               </desc>
+                           </decoNote>                           
+                           
+                           <decoNote type="miniature" xml:id="d98">
+                               <locus target="#56v"/>
+                               <desc>God the Father flanked by a saint and enthroned above a donor in proskynesis. <!-- someone able to identify? -->
+                                   <q xml:lang="gez">እግዚአብሔር፡</q>
+                                   <q xml:lang="gez">ገጸ፡ ሰብእ፡</q>
+                                   <q xml:lang="gez">ገጸ፡ ንስር</q>
+                                   <q xml:lang="gez">ገጸ፡ አንበሳ፡</q>
+                                   <q xml:lang="gez">ገጸ፡ ላህም፡</q>
+                                   <q xml:lang="gez">?ከመ፡ ከሠተ?ቱ፡ ዘ?? ርስን ፡ ነ፡ መ??</q> <!-- extensive caption I cannot read -->
+                                   <q xml:lang="gez">በ ??? ትክ ??? ምርያም፡ ???</q><!-- extensive caption about donor I cannot read -->
+                               </desc>
+                           </decoNote>
+                       </decoDesc>
 
                         <additions>
                             <list>
@@ -810,6 +1618,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <change who="EDS" when="2023-01-24">Added condition, foliation, and binding description</change>
             <change who="DR" when="2025-07-21">Revisions by Dorothea Reule, Massimo Villa, Jonas
                 Karlsson, Eliana Dal Sasso and Jacopo Gnisci as part of the project ‘A Catalogue of the Manuscript Collection of Bent Juel-Jensen’</change>
+            <change who="MV" when="2026-05-18">Entered data by Jacopo Gnisci into DecoDesc</change>
         </revisionDesc>
 
     </teiHeader>

--- a/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
@@ -1147,7 +1147,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">ዮዲት፡</q><!-- encode PERSNAME? -->
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ሆሎፎርኒስ፡</q><!-- encode PERSNAME? -->
-                                   <q xml:lang="gez">ዘከመ፡ ከተለቶ፡ ዮዲት፡ ለሆሎፎርኒስ፡</q><!-- encode PERSNAME? -->
+                                   <q xml:lang="gez">ዘከመ፡ ቀተለቶ፡ ዮዲት፡ ለሆሎፎርኒስ፡</q><!-- encode PERSNAME? -->
                                    <q xml:lang="gez">ሐይመት፡</q>
                                </desc>
                            </decoNote>
@@ -1156,13 +1156,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#43v"/>
                                <desc>Three scenes: an unidentified man, possibly Haman, addresses two attendants; Mordecai tells Queen Esther about a plot to kill the Israelites; Haman is hung on a forked pole;
                                    and King <persName ref="PRS10180Xerxes">Xerxes</persName> praises Mordechai. 
-                                   <!-- encode PERSNAME? No sure about the identification of the figure as Xerxes -->
+                                   <!-- encode PERSNAME? No sure about the identification of the figure as Xerxes. 
+                                       MV (19.05.2026): The Persian king is Ashasuerus, cp. Esther 3. He's historically dientified with Xerxes -->
                                    <q xml:lang="gez">አስቴር።</q><!-- encode PERSNAMES? -->
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">መርዶክዮስ፡</q><!-- encode PERSNAME? -->
                                    <q xml:lang="gez">እስራኤል።</q>
                                    <q xml:lang="gez">ዘከመ፡ ተሰቅለ፡ ሐ<supplied reason="lost">ማ</supplied>፡</q><!-- encode PERSNAME? -->
-                                   <q xml:lang="gez">አርጤከስስ፡</q><!-- cannot read the lower portion, is this Xerxes? -->
+                                   <q xml:lang="gez">አርጤከስስ፡</q> <!-- encode PERSNAME? -->
                                    <q xml:lang="gez">መርዶክዮስ፡</q>
                                </desc>
                            </decoNote>
@@ -1171,7 +1172,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#44r"/>
                                <desc>The Israelites rebuild the walls of Jerusalem in spite of the opposition of Sanballat and his soldiers. <!-- encode PERSNAME? -->
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">ሰንበላጥ[፡]</q><!-- encode PERSNAME? -->
+                                   <q xml:lang="gez">ሰንበላጥ<supplied reason="omitted">፡</supplied></q><!-- encode PERSNAME? -->
                                    <q xml:lang="gez">እስራኤል፡</q>
                                    <q xml:lang="gez">ሠራዊተ፡ ሰንበላጥ፡</q>
                                </desc>
@@ -1180,13 +1181,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            <decoNote type="miniature" xml:id="d74">
                                <locus target="#44v"/>
                                <desc>Two scenes: Alexander the Great has a vision of a sword-bearing angel; and he pays tribute to the high-priest and his entourage.
-                                   <q xml:lang="gez">መልአክ</q>
+                                   <q xml:lang="gez">መልአክ<supplied reason="omitted">፡</supplied></q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">አስክንድር፡</q>
-                                   <q xml:lang="gez">ሠራዊተ፡ [???]</q>
-                                   <q xml:lang="gez">ዘከመ፡ ሰገደ፡ እስክንድር፡ ቃ?ና???</q>
+                                   <q xml:lang="gez">እስክንድር፡</q>
+                                   <q xml:lang="gez">ሠራዊተ፡ <gap reason="illegible"/></q>
+                                   <q xml:lang="gez">ዘከመ፡ ሰገደ፡ እስክ<supplied reason="omitted">ን</supplied>ድር፡ ለሊቀ፡ ካህና<gap reason="illegible"/></q>
                                    <q xml:lang="gez">ካህናት፡</q>
-                                   <q xml:lang="gez">?አም?፡ [???]</q> <!-- would be interesting to translate word if it identifies the strange box held by Alexander the Great, I have not found this mentioned in Budge 1896 72-76, but on pp. 406-408 authors say he donates gold to the Temple and this could be it -->
+                                   <q xml:lang="gez">ምስለ፡ አምኃ፡</q> <!-- would be interesting to translate word if it identifies the strange box held by Alexander the Great, I have not found this mentioned in Budge 1896 72-76, but on pp. 406-408 authors say he donates gold to the Temple and this could be it.
+                 MV (19.05.2026): Yes, the caption says "with a gift" (cp. also col. b, line 1). Jacopo do you want to add/change something in the description?
+                                   -->
                                </desc>
                            </decoNote>                           
                            
@@ -1197,7 +1200,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez"><persName ref="PRS7984Ptolemy">በጥሊሞስ፡</persName></q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">መልአክ፡</q>
-                                   <q xml:lang="gez">ካልአኒሁጸሐፍት፡</q>
+                                   <q xml:lang="gez">ካልአኒሁ<supplied reason="omitted">፡</supplied> ጸሐፍት፡</q>
                                    <q xml:lang="gez"><persName ref="PRS8854Simeon">ስምዖን፡</persName></q>
                                    <q xml:lang="gez">ሐይመት፡</q>
                                </desc>
@@ -1209,7 +1212,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">ሥዕለ፡ ፀሐይ፡</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">አንጥያኮስ፡</q><!-- encode pers name of Antiochus? -->
-                                   <q xml:lang="gez"></q><!-- extensive caption above pig I cannot read -->
+                                   <q xml:lang="gez">ዘከመ፡ አዘዞሙ፡ ይ<gap reason="illegible"/>ሥዋዕተ፡ ጣዖት፡</q><!-- I can't decipher the verb: HELP? -->
                                    <q xml:lang="gez">እስራኤል፡</q>
                                </desc>
                            </decoNote>                           
@@ -1226,16 +1229,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            <decoNote type="miniature" xml:id="d78">
                                <locus target="#46v"/>
                                <desc>An angel brings heavenly bread to <persName ref="PRS6819Mary">Mary</persName> in a basket. 
-                                   <q xml:lang="gez">በተ፡ መቅደስ።</q>
+                                   <q xml:lang="gez">ቤተ፡ መቅደስ።</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">ዘከመ፡ ወሃበ፡ መልአክ፡ ልእግዝእትነ፡ ሃብስተ፡ ስማያት።</q>
+                                   <q xml:lang="gez">ዘከመ፡ ወሀበ፡ መልአክ፡ ለእግዝእትነ፡ ኅብስተ፡ ሰማያዊ።</q>
                                </desc>
                            </decoNote>                           
                            
                            <decoNote type="miniature" xml:id="d79">
                                <locus target="#47r"/>
                                <desc>The Annunciation of <persName ref="PRS4377Gabriel">Gabriel</persName>to <persName ref="PRS6819Mary">Mary</persName> who is reading the  Book of Isaiah.
-                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም</persName>።</q>
+                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም።</persName></q>
                                    <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS4377Gabriel">ገብርኤል።</persName></q>
                                    <q xml:lang="gez">መጽሐፈ፡ ኢሳይያስ፡</q>
                                </desc>
@@ -1245,12 +1248,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#47v"/>
                                <desc>A Nativity scene with shepherds playing Genna and a donor in proskynesis.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">ዘከመ፡ ተውልደ፡ መድኃኒነ፡ ውስተ፡ ገል፡</q>
-                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም</persName>።</q>
-                                   <q xml:lang="gez">ላህ[ም]</q>
+                                   <q xml:lang="gez">ዘከመ፡ ተውልደ፡ መድኃኒነ፡ ውስተ፡ ጎል፡</q>
+                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም።</persName></q>
+                                   <q xml:lang="gez">በከመ፡ ተማኅፀነት፡ ወለተ፡ ጽዮን፡</q>
+                                   <q xml:lang="gez">ዮሴፍ፡</q>
+                                   <q xml:lang="gez">ላህ<supplied reason="lost">ም፡</supplied></q>
                                    <q xml:lang="gez">ዕድዓቅ፡</q>
                                    <q xml:lang="gez">ኖሎት፡</q>
-                                   <q xml:lang="gez">ዘከመ፡ ወለተ፡ ??? ጽዮን፡</q>
                                </desc>
                            </decoNote>
                            
@@ -1260,8 +1264,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS7049Michael">ሚካኤል፡</persName></q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS4377Gabriel">ገብርኤል።</persName></q>
-                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS8417Salome">ሳሎሜ</persName>።</q>
-                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም</persName>።</q>
+                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS8417Salome">ሳሎሜ።</persName></q>
+                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም።</persName></q>
                                    <q xml:lang="gez"><persName ref="PRS5684JesusCh">መድኃኒነ፡</persName></q>
                                </desc>
                            </decoNote>
@@ -1271,7 +1275,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <desc>The adoration of the Magi.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም፡</persName></q>
-                                   <q xml:lang="gez">ዘከመ፡ ወሀብዎ፡ ለእቅዚእነ፡ አምኃ፡ ነግሥተ፡ ፍርስ። እንዘ፡ ይስቅዱ፡ ሎቱ</q>
+                                   <q xml:lang="gez">ዘከመ፡ ወሀብዎ፡ ለእቅዚእነ፡ አምኃ፡ ነግሥተ፡ ፋርስ። እንዘ፡ ይሰግዱ፡ ሎቱ፡</q>
                                </desc>
                            </decoNote>                           
                            
@@ -1279,17 +1283,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#49r"/>
                                <desc>The Flight into Egypt.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">ዘከመ፡ ዜነዎ፡ መልአክ፡ በሕልም፡<persName ref="PRS5764Joseph">ዮሲፍ</persName></q>
+                                   <q xml:lang="gez">ዘከመ፡ ዜነዎ፡ መልአክ፡ በሕልም፡ ለ<persName ref="PRS5764Joseph">ዮሴፍ</persName></q>
                                    <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS8417Salome">ሳሎሜ፡</persName></q>
-                                   <q xml:lang="gez"><persName ref="PRS5764Joseph">ዮሲፍ፡</persName></q>
-                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም፡</persName> ምስለ፡ ፍቁር፡ <persName ref="PRS5684JesusCh">ወልደ።</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS5764Joseph">ዮሴፍ፡</persName></q>
+                                   <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም፡</persName> ምስለ፡ ፍቁር፡ <persName ref="PRS5684JesusCh">ወልዳ።</persName></q>
                                </desc>
                            </decoNote>
                            
                            <decoNote type="miniature" xml:id="d84">
                                <locus target="#49v"/>
                                <desc><persName ref="PRS5299Herod">Herod</persName> commands the Massacre of the Innocents and the beheading of 
-                                   <persName ref="PRS10691Zechari">Zechariah</persName> in the Temple, while <persName ref="PRS3725Elizabet">Elizabeth</persName>is able to escape.
+                                   <persName ref="PRS10691Zechari">Zechariah</persName> in the Temple, while <persName ref="PRS3725Elizabet">Elizabeth</persName> is able to escape.
                                    <q xml:lang="gez"><persName ref="PRS5299Herod">ሄሮድስ፡</persName></q>
                                    <q xml:lang="gez">ዘከመ፡ ቀተልዎ፡ ለዘካርያስ፡ በቤተ፡ መቅደስ፡</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
@@ -1302,8 +1306,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#50r"/>
                                <desc>The Baptism of <persName ref="PRS5684JesusCh">Jesus</persName> in the Jordan.
                                    <q xml:lang="gez">ዘከመ፡ ወረደ፡ መንፈስ፡ ቅዱስ፡ በአምሳለ፡ ርግብ፡</q>
-                                   <q xml:lang="gez">ዘከመ<persName ref="PRS5684JesusCh">እግዚእነ</persName>፡</q>
-                                   <q xml:lang="gez"><persName ref="PRS5741Johnthe">ዮሐንስ፡ መትምቅ፡</persName></q>
+                                   <q xml:lang="gez"><del rend="effaced">ዘከመ</del> <persName ref="PRS5684JesusCh">እግዚእነ፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS5741Johnthe">ዮሐንስ፡ መጥምቅ፡</persName></q>
                                    <q xml:lang="gez">ዮርዳኖስ፡</q>
                                </desc>
                            </decoNote>
@@ -1312,9 +1316,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#50v"/>
                                <desc>The Temptation of <persName ref="PRS5684JesusCh">Jesus</persName>.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">ስይጣን፡</q>
+                                   <q xml:lang="gez">ሰይጣን፡</q>
                                    <q xml:lang="gez"><persName ref="PRS5684JesusCh">እግዚእነ፡</persName></q>
-                                   <q xml:lang="gez">ስይጣን።</q>
+                                   <q xml:lang="gez">ሰይጣን።</q>
                                </desc>
                            </decoNote>                           
                            
@@ -1330,8 +1334,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#51v"/>
                                <desc>The Agony in the Garden.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">መላክ፡ ዘወሀቦ፡ መስቀለ፡ ምስለ፡ ጽዋዕ።</q>
-                                   <q xml:lang="gez"><persName ref="PRS5684JesusCh">እግዚእነ</persName>፡</q>
+                                   <q xml:lang="gez">መልአክ፡ ዘወሀቦ፡ መስቀለ፡ ምስለ፡ ጽዋዕ።</q>
+                                   <q xml:lang="gez"><persName ref="PRS5684JesusCh">እግዚእ፡ነ</persName></q>
                                    <q xml:lang="gez">"><persName ref="PRS5695John">ዮሐንስ፡</persName> ፍቁረ፡ እግዚእነ፡</q>
                                    <q xml:lang="gez"><persName ref="PRS5662James">ያዕቆብ፡</persName> ወልደ፡ ዘብዴዎስ።</q>
                                    <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS7805Peter">ጴጥሮስ፡</persName></q>
@@ -1362,7 +1366,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#53r"/>
                                <desc>Pentecost.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">ርደተ፡ ጰራቅሊጦስ፡ በአ፡ ምስለ፡ እሳት፡ ላዕለ፡ ሐዋርያት፡</q>
+                                   <q xml:lang="gez">ርደተ፡ ጰራቅሊጦስ፡ በአምሳለ፡ እሳት፡ ላዕለ፡ ሐዋርያት፡</q>
                                    <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም፡</persName></q>
                                </desc>
                            </decoNote>
@@ -1370,11 +1374,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            <decoNote type="miniature" xml:id="d92">
                                <locus target="#53v"/>
                                <desc>The Second Coming of <persName ref="PRS5684JesusCh">Jesus</persName>
-                                   <q xml:lang="gez">ጸድቃን፡</q>
+                                   <q xml:lang="gez">ጻድቃን፡</q>
                                    <q xml:lang="gez">ተእምርተ፡ ኵናት፡</q>
                                    <q xml:lang="gez"><persName ref="PRS5684JesusCh">እግዚእነ፡</persName></q>
                                    <q xml:lang="gez">ተእምርተ፡ መስቀል፡</q>
-                                   <q xml:lang="gez">ጸድቃን፡</q>
+                                   <q xml:lang="gez">ጻድቃን፡</q>
                                    <q xml:lang="gez">ኃጥአን።</q>
                                </desc>
                            </decoNote>
@@ -1385,7 +1389,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">መላእክት፡</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">መላእክት፡</q>
-                                   <q xml:lang="gez">ጸድቃን፡</q>
+                                   <q xml:lang="gez">ጻድቃን፡</q>
                                    <q xml:lang="gez">ኃጥአን፡</q>
                                    <q xml:lang="gez">ገሃነመ፡ እሳት፡</q>
                                </desc>
@@ -1399,7 +1403,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">ገጸ፡ ንስር</q>
                                    <q xml:lang="gez">ገጸ፡ አንበሳ፡</q>
                                    <q xml:lang="gez">ገጸ፡ ላህም፡</q>
-                                   <q xml:lang="gez">በ ??? ትክለ ??? ምርያም፡ ???</q><!-- extensive caption about donor I cannot read -->
+                                   <q xml:lang="gez">በ<gap reason="illegible"/> <persName ref="PRS13954TaklaMa" role="owner">ትክለ፡ ማርያም፡</persName> <gap reason="illegible"/></q><!-- extensive caption about donor I cannot read. HELP? -->
                                </desc>
                            </decoNote>
                                                       
@@ -1407,17 +1411,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#55r"/>
                                <desc>The Martyrdom of <persName ref="PRS7805Peter">Peter</persName> and <persName ref="PRS7743Paul">Paul</persName>.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">ዘከመ፡ ተስቅለ፡ <persName ref="PRS7805Peter">ጴጥሮስ፡</persName> ቊልቊሊተ፡</q>
-                                   <q xml:lang="gez">መልአክ</q>
+                                   <q xml:lang="gez">ዘከመ፡ ተሰቅለ፡ <persName ref="PRS7805Peter">ጴጥሮስ፡</persName> ቊልቊሊተ፡</q>
+                                   <q xml:lang="gez">መልአክ<supplied reason="omitted">፡</supplied></q>
                                    <q xml:lang="gez">መልአክ፡</q>
-                                   <q xml:lang="gez">ዘከመ፡ ተመትረበስያፍ፡ ቅዱስ፡ <persName ref="PRS7743Paul">ጳውሎስ</persName>።</q>
+                                   <q xml:lang="gez">ዘከመ፡ ተመትረ<supplied reason="omitted">፡</supplied> በሰይፍ፡ ቅዱስ፡ <persName ref="PRS7743Paul">ጳውሎስ።</persName></q>
                                </desc>
                            </decoNote>
                            
                            <decoNote type="miniature" xml:id="d96">
                                <locus target="#55v"/>
                                <desc>A group of unidentified martyrs and saints with Gabra Manfas Qǝddus and St George.
-                                   <q xml:lang="gez">ጸድቃን፡</q>
+                                   <q xml:lang="gez">ጻድቃን፡</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">አቡነ፡ ገብረ፡ መንፈስ፡ ቅዱስ፡</q>
                                    <q xml:lang="gez">ስማዕታት፡</q>
@@ -1427,26 +1431,28 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d97">
                                <locus target="#56r"/>
-                               <desc>God saves some a group of martyrs from lions and flames.
+                               <desc>God saves a group of martyrs from lions and flames.
                                    <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS7049Michael">ሚካኤል፡</persName></q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS4377Gabriel">ገብርኤል።</persName></q>
                                    <q xml:lang="gez">አናብስት፡</q>
-                                   <q xml:lang="gez">ስማዕት፡ ወጸድቃን።</q>
+                                   <q xml:lang="gez">ሰማዕት፡ ወጻድቃን።</q>
                                    <q xml:lang="gez">አሳት፡</q>
                                </desc>
                            </decoNote>                           
                            
                            <decoNote type="miniature" xml:id="d98">
                                <locus target="#56v"/>
-                               <desc>God the Father flanked by a saint and enthroned above a donor in proskynesis. <!-- someone able to identify? -->
+                               <desc>God the Father flanked by a saint and enthroned above a donor in proskynesis. 
+                                   <!-- someone able to identify?
+                                   MV 19.05.2026: the caption mentions a certain ʾAbuna Zamalakot, which is unmentioned elsewhere. The man in proskynesis is the donor Takla Māryām. -->
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ገጸ፡ ሰብእ፡</q>
                                    <q xml:lang="gez">ገጸ፡ ንስር</q>
                                    <q xml:lang="gez">ገጸ፡ አንበሳ፡</q>
                                    <q xml:lang="gez">ገጸ፡ ላህም፡</q>
-                                   <q xml:lang="gez">?ከመ፡ ከሠተ?ቱ፡ ዘ?? ርስን ፡ ነ፡ መ??</q> <!-- extensive caption I cannot read -->
-                                   <q xml:lang="gez">በ ??? ትክ ??? ምርያም፡ ???</q><!-- extensive caption about donor I cannot read -->
+                                   <q xml:lang="gez">በከመ፡ ከሠተ፡ ሎቱ፡ ዘንተ፡ ድርሳነ፡ ለአቡነ፡ ዘመለኮት።</q>
+                                   <q xml:lang="gez">በመ፡ <gap reason="illegible"/> <persName ref="PRS13954TaklaMa" role="owner">ትክለ፡ ማርያም፡</persName> <gap reason="illegible"/></q><!-- one word is illegible. HELP? -->
                                </desc>
                            </decoNote>
                        </decoDesc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
@@ -780,7 +780,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    the five Philistine kings send the Ark of the Covenant back to Israel (bottom left); 
                                    King <persName ref="PRS8567Saul">Saul</persName> addresses an armed man, probably his son (upper right); and the Israelites defeat the Philistines (bottom right).
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez"><persName ref="PRS8478Samuel"> ሳሙኤል፡</persName></q>
+                                   <q xml:lang="gez"><persName ref="PRS8478Samuel">ሳሙኤል፡</persName></q>
                                    <q xml:lang="gez">እስራኤል፡</q>
                                    <q xml:lang="gez">ኤሊ፡</q> <!--Pers name to be encoded? -->
                                    <q xml:lang="gez">ሳኦል፡</q>
@@ -1445,7 +1445,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#56v"/>
                                <desc>God the Father flanked by a saint and enthroned above a donor in proskynesis. 
                                    <!-- someone able to identify?
-                                   MV 19.05.2026: the caption mentions a certain ʾAbuna Zamalakot, which is unmentioned elsewhere. The man in proskynesis is the donor Takla Māryām. -->
+                                   MV 19.05.2026: the caption mentions a certain ʾAbuna Zamalakot, who is not mentioned elsewhere. The man in proskynesis is the donor Takla Māryām. -->
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ገጸ፡ ሰብእ፡</q>
                                    <q xml:lang="gez">ገጸ፡ ንስር</q>

--- a/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
@@ -1180,7 +1180,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#43v"/>
                                <desc>Three scenes: an unidentified man, possibly Haman, and two attendants, among whom possibly Mordecai refusing to bow before him; 
                                    Mordecai tells Queen Esther about a plot to kill the Israelites; Haman is hung on a forked pole;
-                                   and King Ashasuerus praises Mordecai. 
+                                   and King Ahasuerus praises Mordecai. 
                                    <q xml:lang="gez">አስቴር።</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">መርዶክዮስ፡</q>

--- a/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
@@ -1155,9 +1155,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            <decoNote type="miniature" xml:id="d72">
                                <locus target="#43v"/>
                                <desc>Three scenes: an unidentified man, possibly Haman, addresses two attendants; Mordecai tells Queen Esther about a plot to kill the Israelites; Haman is hung on a forked pole;
-                                   and King <persName ref="PRS10180Xerxes">Xerxes</persName> praises Mordechai. 
-                                   <!-- encode PERSNAME? No sure about the identification of the figure as Xerxes. 
-                                       MV (19.05.2026): The Persian king is Ashasuerus, cp. Esther 3. He's historically dientified with Xerxes -->
+                                   and King Ashasuerus praises Mordechai. 
                                    <q xml:lang="gez">አስቴር።</q><!-- encode PERSNAMES? -->
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">መርዶክዮስ፡</q><!-- encode PERSNAME? -->
@@ -1180,16 +1178,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d74">
                                <locus target="#44v"/>
-                               <desc>Two scenes: Alexander the Great has a vision of a sword-bearing angel; and he pays tribute to the high-priest and his entourage.
+                               <desc>Two scenes: Alexander the Great has a vision of a sword-bearing angel; and he pays tribute with a gift to the high priest and his entourage.
                                    <q xml:lang="gez">መልአክ<supplied reason="omitted">፡</supplied></q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">እስክንድር፡</q>
                                    <q xml:lang="gez">ሠራዊተ፡ <gap reason="illegible"/></q>
                                    <q xml:lang="gez">ዘከመ፡ ሰገደ፡ እስክ<supplied reason="omitted">ን</supplied>ድር፡ ለሊቀ፡ ካህና<gap reason="illegible"/></q>
                                    <q xml:lang="gez">ካህናት፡</q>
-                                   <q xml:lang="gez">ምስለ፡ አምኃ፡</q> <!-- would be interesting to translate word if it identifies the strange box held by Alexander the Great, I have not found this mentioned in Budge 1896 72-76, but on pp. 406-408 authors say he donates gold to the Temple and this could be it.
-                 MV (19.05.2026): Yes, the caption says "with a gift" (cp. also col. b, line 1). Jacopo do you want to add/change something in the description?
-                                   -->
+                                   <q xml:lang="gez">ምስለ፡ አምኃ፡</q> 
                                </desc>
                            </decoNote>                           
                            
@@ -1403,7 +1399,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">ገጸ፡ ንስር</q>
                                    <q xml:lang="gez">ገጸ፡ አንበሳ፡</q>
                                    <q xml:lang="gez">ገጸ፡ ላህም፡</q>
-                                   <q xml:lang="gez">በ<gap reason="illegible"/> <persName ref="PRS13954TaklaMa" role="owner">ትክለ፡ ማርያም፡</persName> <gap reason="illegible"/></q><!-- extensive caption about donor I cannot read. HELP? -->
+                                   <q xml:lang="gez">በ<del rend="effaced"/> <persName ref="PRS13954TaklaMa" role="owner">ትክለ፡ ማርያም፡</persName> <gap reason="illegible"/></q><!-- extensive caption about donor I cannot read. HELP? -->
                                </desc>
                            </decoNote>
                                                       
@@ -1452,7 +1448,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">ገጸ፡ አንበሳ፡</q>
                                    <q xml:lang="gez">ገጸ፡ ላህም፡</q>
                                    <q xml:lang="gez">በከመ፡ ከሠተ፡ ሎቱ፡ ዘንተ፡ ድርሳነ፡ ለአቡነ፡ ዘመለኮት።</q>
-                                   <q xml:lang="gez">በመ፡ <gap reason="illegible"/> <persName ref="PRS13954TaklaMa" role="owner">ትክለ፡ ማርያም፡</persName> <gap reason="illegible"/></q><!-- one word is illegible. HELP? -->
+                                   <q xml:lang="gez">በመ፡ <del rend="effaced"/> <persName ref="PRS13954TaklaMa" role="owner">ትክለ፡ ማርያም፡</persName> <del rend="effaced"/></q><!-- one word is illegible. HELP? -->
                                </desc>
                            </decoNote>
                        </decoDesc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
@@ -1467,7 +1467,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d98">
                                <locus target="#56v"/>
-                               <desc>God the Father flanked by an unknown ecclesiastic called <persName ref="PRS15405Zamalakot"><roleName type="title">ʾAbuna</roleName>
+                               <desc>God the Father flanked by <persName ref="PRS15405Zamalakot"><roleName type="title">ʾAbuna</roleName>
                                    Zamalakot</persName> and enthroned above the donor, <persName ref="PRS13954TaklaMa" role="owner">Takla Māryām</persName>, in proskynesis.
                                    The caption has been partially erased.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
@@ -1585,11 +1585,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                The manuscript was primarily owned or commissioned by a certain <persName ref="PRS13954TaklaMa"/>, whose name is inserted
                                in the main hand on <locus target="#8r #29rb #54vb"/>. It was then owned by a certain <persName ref="PRS13955WalattaS"/>, whose name
                                is written on <locus target="#2ra"/> on a previously erased name.
-                               The manuscript most likely comes from the area of <placeName ref="LOC3577Gondar">Gondar</placeName>. 
-                               It came into the possession of the church of <placeName ref="INS0101MadhaneAlam">Maqdala Madḫāne ʿĀlam</placeName> at a certain
-                               time in its history (see <ref target="#a1">Additional note 1</ref>).
-                               The manuscript was then brought to <placeName ref="wd:Q21">England</placeName> after the 1868 expedition by <persName ref="PRS7484Napier">Napier</persName>.
-                               The subsequent owners are unknown in detail.
+                               The involvement of a certain <persName ref="PRS15405Zamalakot"><roleName type="title">ʾAbuna</roleName>
+                                   Zamalakot</persName> is evidenced by the mention of his name, written in the main hand in the miniature on <locus target="#56v"/>. 
+                               The latter is possibly identical to the abbot of the monastery of <placeName ref="INS0329DE">Dāgā ʾƎsṭifānos</placeName>, who was in tenure in the early eighteenth century. This suggests that the manuscript has some connections to <placeName ref="INS0329DE">Dāgā ʾƎsṭifānos</placeName>. 
+                               At a certain time in its history, the manuscript came into the possession of the church of <placeName ref="INS0101MadhaneAlam">Maqdala Madḫāne ʿĀlam</placeName> (see <ref target="#a1">Additional note 1</ref>).
+                               The manuscript was then brought to <placeName ref="wd:Q21">England</placeName> after the 1868 expedition by <persName ref="PRS7484Napier">Napier</persName>. The subsequent owners are unknown in detail.
                                At some time the book entered <persName ref="PRS13956Kevork"/>’s private collection, as indicated on one of the white stickers glued
                                on the inner side of the front cover (‘H. Kevorkian collection 623’). The book was sold to the <placeName ref="INS0525Quaritch"/> and
                                eventually purchased by <persName ref="PRS5782JuelJen"/> at an auction at Sotheby’s on 20 March 1983, according to the auction catalogue.

--- a/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
@@ -598,7 +598,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="19r#"/>
                                <desc>The devil tests <persName ref="PRS5691Job">Job</persName>.
                                    <q xml:lang="gez">እግዚአብሔር።</q>
-                                   <q xml:lang="gez"><persName ref="PRS11330Devil">ሰይጣን፡</persName></q> <!-- twice -->
+                                   <q xml:lang="gez"><persName ref="PRS11330Devil">ሰይጣን፡</persName></q> (twice)
                                    <q xml:lang="gez">ብእሲቱ፡ ለኢዮብ፤</q>
                                    <q xml:lang="gez">ሕማሙ፡ ለኢዮብ፡</q>
                                    <q xml:lang="gez">ሳፍር፡ ኤልፋዝ፡ በልዳዶስ።</q>
@@ -622,7 +622,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#20r"/>
                                <desc>To the left God encounters <persName ref="PRS7181MosesM">Moses</persName> on a mountain with his flock of sheep. To the right the latter sets off towards Egypt.
                                    <q xml:lang="gez">እግዚአብሔር፤</q>
-                                   <q xml:lang="gez"><persName ref="PRS7181MosesM">ሙሴ፡</persName></q> <!-- twice -->
+                                   <q xml:lang="gez"><persName ref="PRS7181MosesM">ሙሴ፡</persName></q> (twice)
                                    <q xml:lang="gez">አባግዕ።</q>
                                </desc>
                            </decoNote>
@@ -880,7 +880,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <desc>Three scenes: King Ahab asks for Naboth’s vineyard; the latter is killed; and dogs devour the decapitated body of the king’s wife Jezebel. 
                                    <q xml:lang="gez">እግዚአብሔር።</q>
                                    <q xml:lang="gez">አክዓብ፡</q>
-                                   <q xml:lang="gez">ኤልዛቤል፡</q> <!-- twice -->
+                                   <q xml:lang="gez">ኤልዛቤል፡</q> (twice)
                                    <q xml:lang="gez">ናቡቴ፡</q>
                                </desc>
                            </decoNote>

--- a/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
@@ -322,13 +322,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <ptr target="bm:Mercier2000LArcheEthiopienne"/>
                                    <citedRange unit="page">174–177</citedRange>
                                </bibl>, 
-                               several images in these manuscripts were inspired by European prints or paintings. Many other details evoke local customs and material traditions, such as the prayer stick on <locus target="#17r"/>, the drum on <locus target="#22r"/>, the warriors wearing leopard skins and headbands on <locus target="#25v"/>, the king riding a caparisoned mule with bells on its bridle and accompanied by a page bearing an umbrella on <locus target="#26r"/>, the butchering of animals on <locus target="#35r"/>, the presence of what appears to be a mottled cow hide on a tent on <locus target="#43r"/>, and the bread basked on <locus target="#46v"/>.
-                               Particularly interesting is the representation of the miraculous sleep of Ebed-Melech (Abimelech) the Ethiopian on <locus target="#36r"/>, which offers a reference to 4Baruch that is only canonical in the Ethiopic tradition, since the episode is not mentioned in the text that the image accompanies and to Ethiopian Maccabees on <locus from="45v" to="46r"/>. This scene is absent in the British Library copy. On <locus target="#45r"/>, we see a reference to the translation of the Bible into Greek mentioned in the Ethiopian Synaxarium; the artist showcases his familiarity with the story and expands on the text of the Wisest of the Wise by including a reference to the angel that stops Simeon from changing the words of the Bible. 
+                               several images in these manuscripts were inspired by European prints or paintings. Many other details evoke local customs and material traditions, such as the prayer stick on <locus target="#17r"/>, the drum on <locus target="#22r"/>, the warriors wearing leopard skins and headbands on <locus target="#25v"/>, the king riding a caparisoned mule with bells on its bridle and accompanied by a page bearing an umbrella on <locus target="#26r"/>, the butchering of animals on <locus target="#35r"/>, the presence of what appears to be a mottled cow hide on a tent on <locus target="#43r"/>, and the bread basket on <locus target="#46v"/>.
+                               Particularly interesting is the representation of the miraculous sleep of Ebed-Melech (Abimelech) the Ethiopian on <locus target="#36r"/>, which offers a reference to 4Baruch that is only canonical in the Ethiopic tradition, since the episode is not mentioned in the text that the image accompanies and to Ethiopian Maccabees on <locus from="45v" to="46r"/>. This scene is absent in the British Library copy. On <locus target="#45r"/>, we see a reference to the translation of the Bible into Greek mentioned in the Ethiopian Synaxarion; the artist showcases his familiarity with the story and expands on the text of the Wisest of the Wise by including a reference to the angel that stops Simeon from changing the words of the Bible. 
                                In another instance, on  <locus target="#36r"/>, both text and image rely on non-biblical sources when they refer to Alexander the Great as presenting offerings to the High Priest of the Israelites. Alexander is shown presenting a chest, a detail possibly inspired by the Josippon (<bibl>
                                    <ptr target="bm:Budge1896AlexanderTranslation"/>
                                    <citedRange unit="page">409–410</citedRange>
                                </bibl>). Noteworthy is also the decision of the artists to represent King <persName ref="PRS11373Nebuc"> Nebuchadnezzar</persName> as a wild boar when is he transformed into a beast by God, a detail that is not mentioned in the Bible and recalls the transformation of Tiridates III of Armenia.
-                               Some motifs on the clothes of prominent figures in the illustrations may provide evidence of the circulation of particular patterns on textiles. The ones that appear on <locus target="#26r"/>, for example, seem to be inspired by contemporary Indian woven silks, as a sign of their prestige, whereas the fabric that covers the altar behind them could have been inspired by a block-printed Gujarati textile. Relatedly, the attire of Goliath on <locus target="#28v"/> may have been inspired by chainmail armour and a pointed helmet in use in the Islamicate world. Many scenes feature details inspired by the Biblical texts that inspired the verses.
+                               Some motifs on the clothes of prominent figures in the illustrations may provide evidence of the circulation of particular patterns on textiles. The ones that appear on <locus target="#26r"/>, for example, seem to be inspired by contemporary Indian woven silks, as a sign of their prestige, whereas the fabric that covers the altar behind them could have been inspired by a block-printed Gujarati textile. Relatedly, the attire of Goliath on <locus target="#28v"/> may have been inspired by chainmail armour and a pointed helmet in use in the Islamicate world. Many scenes feature details inspired by the biblical texts that inspired the verses.
                            </summary>
                            
                     <decoNote type="miniature" xml:id="d1">
@@ -394,8 +394,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                         <locus target="#11r"/>
                                         <desc>Two scenes:
                                           <persName ref="PRS3926Eve">Eve</persName> and
-                                          <persName ref="PRS1386Adam">Adam</persName> share the forbidden taken from a fig tree with the serpent coiled around it (left); the pair are cast out of Eden by an angel (right).
-                                            <!-- MV 18.05.2026 : Is something missing in the sentence "Eve and Adam share the forbidden taken from a fig tree" ? Is "forbidden" ok alone? -->
+                                          <persName ref="PRS1386Adam">Adam</persName> share the forbidden fruit taken from a fig tree with the serpent coiled around it (left); the pair are cast out of Eden by an angel (right).                                       
                                           <q xml:lang="gez">ከይሲ፡</q>
                                           <q xml:lang="gez"><persName ref="PRS1386Adam">አዳም።</persName></q>
                                           <q xml:lang="gez"><persName ref="PRS3926Eve">ሔዋን፡</persName></q>
@@ -523,7 +522,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    are guided away by the two angels (below).
                                    <q xml:lang="gez">እግዚአብሔር።</q>
                                    <q xml:lang="gez"><persName ref="PRS6357Lot">ሎት፡</persName></q>
-                                   <q xml:lang="gez">ዘከመ፡ ኮነት፡ ብእሲቱ፡ ሐውልት፡ ፄው፡ ሶበ፡ ተመይጠት፡ ድኅሬሃ፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ ኮነት፡ ብእሲቱ፡ ሐውልተ፡ ፄው፡ ሶበ፡ ተመይጠት፡ ድኅሬሃ፡</q>
                                    <q xml:lang="gez"><persName ref="PRS6357Lot">ሎት፡</persName></q>
                                    <q xml:lang="gez">፪ኤ፡ አዋልዲሁ፡</q>
                                    <q xml:lang="gez">ዘከመ፡ መርህዎ፡ መላእክት።</q>
@@ -704,17 +703,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <desc>The fall of <placeName ref="LOC3956Jerich">Jericho</placeName>.                                   
                                    <q xml:lang="gez">እግዚአብሔር።</q>
                                    <q xml:lang="gez">እስራኤል፡</q>
-                                   <q xml:lang="gez">ሰብአ <placeName ref="LOC3956Jerich">ኤሪኮ</placeName></q>
-                                   <!--There is an English Caption “Fall of Jericho, include?
-                                   MV: Jacopo, what do you mean with this comment?-->
+                                   <q xml:lang="gez">ሰብአ <placeName ref="LOC3956Jerich">ኤሪኮ፡</placeName></q>
+                                   <q xml:lang="en">Fall of <placeName ref="LOC3956Jerich">Jericho</placeName></q>
                                </desc>
                            </decoNote>
                            
                            <decoNote type="miniature" xml:id="d36">
                                <locus target="#25v"/>
-                               <desc>The prostitute Rahab <!--Pers name Rahab to be encoded? --> looks at the Israelites killing the men and rulers or Jericho.                                   
+                               <desc>The prostitute Rahab looks at the Israelites killing the men and rulers or Jericho.                                   
                                    <q xml:lang="gez">እግዚአብሔር።</q>
-                                   <q xml:lang="gez">ራአብ፡ ዘማ፡</q><!--Pers name Rahab to be encoded? -->
+                                   <q xml:lang="gez">ራአብ፡ ዘማ፡</q>
                                    <q xml:lang="gez">እስራኤል፡</q>
                                    <q xml:lang="gez">ሰብአ፡ <placeName ref="LOC3956Jerich">ኤሪኮ</placeName></q>
                                </desc>
@@ -738,8 +736,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez"><persName ref="PRS2394Balaam">በለዓም፡</persName></q>
                                    <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS7049Michael">ሚካኤል።</persName></q>
                                    <q xml:lang="gez">ዕድግት፡</q>
-                                   <q xml:lang="gez">ፊንሐስ፡ ዘምሪ</q> <!--Pers names to be encoded: Phinehas and Zimri, cf. Numbers 25:14 -->
-                                   <q xml:lang="gez">ከስቢ፡</q><!-- Pers name to be encoded: Kozbi, cf. Numbers 25:15-->
+                                   <q xml:lang="gez">ፊንሐስ፡ ዘምሪ፡</q>
+                                   <q xml:lang="gez">ከስቢ፡</q>
                                    <q xml:lang="gez">ጣዖት፡</q>	
                                    <q xml:lang="gez">መሥዋዕተ፡ ጣዖት፡</q>	
                                </desc>
@@ -747,11 +745,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                            <decoNote type="miniature" xml:id="d39">
                                <locus target="#27r"/>
-                               <desc>Jael drives a peg through the head of Sisera. <!--Pers names to be encoded? -->
+                               <desc>Jael drives a peg through the head of Sisera. 
                                    <q xml:lang="gez">እግዚአብሔር።</q>
                                    <q xml:lang="gez">እስራኤል፡</q>
-                                   <q xml:lang="gez">ዲቦራ፡</q><!--Pers name to be encoded? -->
-                                   <q xml:lang="gez">ሐይመት፡</q> <!--  spelling to be checked-->
+                                   <q xml:lang="gez">ዲቦራ፡</q>
+                                   <q xml:lang="gez">ሐይመት፡</q>
                                    <q xml:lang="gez">ሕዝበ፡ ሲሳራ፡</q>
                                    <q xml:lang="gez">ኢያዔል፡</q>
                                    <q xml:lang="gez">ሲሳራ፡</q>
@@ -762,11 +760,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            <decoNote type="miniature" xml:id="d40">
                                <locus target="#27v"/>
                                <desc>Three scenes showing military leaders: Jephthah sacrifices his daughter who had come out to meet him (upper left); Gideon defeats the Midianites (bottom left);
-                                   and <persName ref="PRS8469Samson">Samson</persName> defeats the Philistines brandishing the donkey jaw.  <!--Pers names to be encoded? -->
+                                   and <persName ref="PRS8469Samson">Samson</persName> defeats the Philistines brandishing the donkey jaw.  
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">ዮፍታሒ፡</q> <!--Pers name to be encoded? -->
+                                   <q xml:lang="gez">ዮፍታሒ፡</q> 
                                    <q xml:lang="gez">መንከሰ፡ ዓድግ፡</q>
-                                   <q xml:lang="gez">ጊዴዎን፡</q> <!--Pers name to be encoded? -->
+                                   <q xml:lang="gez">ጊዴዎን፡</q> 
                                    <q xml:lang="gez">ሰብአ፡ ጊዴዎን፡</q>
                                    <q xml:lang="gez">ሰብአ፡ ምድያም፡</q>
                                    <q xml:lang="gez"><persName ref="PRS8469Samson">ሳምሶን፡</persName></q>
@@ -782,10 +780,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez"><persName ref="PRS8478Samuel">ሳሙኤል፡</persName></q>
                                    <q xml:lang="gez">እስራኤል፡</q>
-                                   <q xml:lang="gez">ኤሊ፡</q> <!--Pers name to be encoded? -->
+                                   <q xml:lang="gez">ኤሊ፡</q> 
                                    <q xml:lang="gez">ሳኦል፡</q>
                                    <q xml:lang="gez">ታቦት፡</q>
-                                   <q xml:lang="gez">አፍኒን፡ ፊንሐስ፡</q> <!--Pers name to be encoded? -->                                
+                                   <q xml:lang="gez">አፍኒን፡ ፊንሐስ፡</q>                             
                                    <q xml:lang="gez">ሰብአ፡ ኢሎፍሊ፡</q>
                                </desc>
                            </decoNote>                           
@@ -800,9 +798,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">እስራኤል፡</q>
                                    <q xml:lang="gez"><persName ref="PRS3417David">ዳዊት፡</persName></q>
                                    <q xml:lang="gez">ኢሎፍሊ፡</q>
-                                   <q xml:lang="gez">ጎልያድ፡</q> <!--Pers name to be encoded? -->
-                                   <q xml:lang="gez">ኢዮአብ፡</q> <!--Pers name to be encoded? -->
-                                   <q xml:lang="gez">አቤሴሎም፡</q> <!--Pers name to be encoded? -->
+                                   <q xml:lang="gez">ጎልያድ፡</q> 
+                                   <q xml:lang="gez">ኢዮአብ፡</q> 
+                                   <q xml:lang="gez">አቤሴሎም፡</q> 
                                </desc>
                            </decoNote>
                            
@@ -814,7 +812,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    and <persName ref="PRS3417David">David</persName> lays on the ground to seek forgiveness.                                 
                                    <q xml:lang="gez"><persName ref="PRS3417David">ዳዊት፡</persName></q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">ኦርዮ፡</q><!-- Encode Uriah? -->
+                                   <q xml:lang="gez">ኦርዮ፡</q>
                                    <q xml:lang="gez"><persName ref="PRS2558Bathsheb">ቤርሳቤሕ፡</persName></q>
                                    <q xml:lang="gez"><persName ref="PRS3417David">ዳዊት፡</persName></q>
                                    <q xml:lang="gez"><persName ref="PRS3417David">ዳዊት፡</persName></q>
@@ -853,7 +851,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d47">
                                <locus target="#31r"/>
-                               <desc>Three scenes: King Ahab asks for Naboth’s vineyard; the latter is killed; and dogs devour the decapitated body of the king’s wife Jezebel. <!-- 3 Pers names to be encoded? -->
+                               <desc>Three scenes: King Ahab asks for Naboth’s vineyard; the latter is killed; and dogs devour the decapitated body of the king’s wife Jezebel. 
                                    <q xml:lang="gez">እግዚአብሔር።</q>
                                    <q xml:lang="gez">አከዓብ፡</q>
                                    <q xml:lang="gez">ኤልዛቤል፡</q>
@@ -863,11 +861,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            <decoNote type="miniature" xml:id="d48">
                                <locus target="#31v"/>
                                <desc>Three scenes: God instructs <persName ref="PRS3721Elijah">Elijah </persName>; the prophet confronts King Ahab; the king, who has now aged, sits afraid outside the city walls.
-                                   <!-- Pers name Ahab to be encoded? --> 
                                    <q xml:lang="gez">እግዚአብሔር።</q>
                                    <q xml:lang="gez"><persName ref="PRS3721Elijah">ኤልያስ፡</persName></q>
-                                   <q xml:lang="gez">አከዓብ፡ <gap reason="illegible"/> ኤልያስ፡</q> <!-- Pers name Ahab to be encoded? -->
-                                   <q xml:lang="gez">ዘከመ፡ ደንገፀ፡ ከዓብ።</q> <!-- Pers name Ahab to be encoded? --> 
+                                   <q xml:lang="gez">አከዓብ፡ <gap reason="illegible"/> ኤልያስ፡</q> 
+                                   <q xml:lang="gez">ዘከመ፡ ደንገፀ፡ ከዓብ።</q> 
                                </desc>
                            </decoNote>
                            
@@ -896,10 +893,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d51">
                                <locus target="#33r"/>
-                               <desc>God addresses the Two Tribes of Israel that are left after the other Ten Tribes are deported by the Assyrian King Shalmaneser. <!-- Pers name to be encoded? -->
+                               <desc>God addresses the Two Tribes of Israel that are left after the other Ten Tribes are deported by the Assyrian King Shalmaneser. 
                                    <q xml:lang="gez">፪ አንጋደ፡ እስራኤል።</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">ስልምናሶር፡</q><!-- Pers name to be encoded? -->
+                                   <q xml:lang="gez">ስልምናሶር፡</q>
                                    <q xml:lang="gez">ፄዋ፡ እስራኤል።</q>
                                </desc>
                            </decoNote>
@@ -951,11 +948,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d56">
                                <locus target="#35v"/>
-                               <desc>God saves <persName ref="PRS5680Jeremiah">Jeremiah</persName> from the mud cistern in which he was thrown by officials of King Zedekiah. <!-- encode king’s name? -->
+                               <desc>God saves <persName ref="PRS5680Jeremiah">Jeremiah</persName> from the mud cistern in which he was thrown by officials of King Zedekiah. 
                                    <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS7049Michael">ሚካኤል፡</persName></q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ቅዱስ፡ <persName ref="PRS4377Gabriel">ገብርኤል፡</persName></q>
-                                   <q xml:lang="gez">ሴዴቅያስ።</q><!-- encode king’s name? -->
+                                   <q xml:lang="gez">ሴዴቅያስ።</q>
                                    <q xml:lang="gez">ዘከመ፡ ወፅአ፡ እምዓዘቅት፡</q>
                                    <q xml:lang="gez">ዘከመ፡ ተወድየ፡ ውስተ፡ ዓዘቅት።</q>
                                </desc>
@@ -966,7 +963,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <desc>Three scenes: the miraculous sleep of Ebed-Melech (Abimelech) the Ethiopian; God speaks to <persName ref="PRS2516Baruch">Baruch</persName> through 
                                    <persName ref="PRS5680Jeremiah">Jeremiah</persName>; and the Israelites, along with their blind and shackled king, are taken captive by King 
                                    <persName ref="PRS11373Nebuc">Nebuchadnezzar</persName> who rides among his armed men who are shown holding guns, shields, and spears.
-                                   <q xml:lang="gez">አቤሜሌክ፡</q> <!-- not sure if this is PRS1249Abimelec? -->
+                                   <q xml:lang="gez">አቤሜሌክ፡</q> 
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">መላእክት፡</q>
                                    <q xml:lang="gez"><persName ref="PRS2516Baruch">ባሮክ<supplied reason="omitted">፡</supplied></persName></q>
@@ -1087,9 +1084,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <!-- encode names? Also, I am not sure if the scene in the lower right is the death of Nebuchadnezzar or some other figure, the caption is partially stained.
                                        MV 18.05.2026: Yes, it is. Jacopo, do you want to add something to the description of the scene?  -->
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">ሰብአ፡ ባቢሎን፡</q><!-- encode PLACE name? -->
+                                   <q xml:lang="gez">ሰብአ፡ ባቢሎን፡</q>
                                    <q xml:lang="gez">ኢኮንያን፡</q>
-                                   <q xml:lang="gez">ኤዎልማሮዴቅ፡</q><!-- encode PERSNAME? -->
+                                   <q xml:lang="gez">ኤዎልማሮዴቅ፡</q>
                                    <q xml:lang="gez">ዘከመ፡ ሞተ፡ <gap reason="illegible"/>ክደ<gap reason="illegible"/>ር፡</q>
                                </desc>
                            </decoNote>
@@ -1128,14 +1125,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <desc>Zorobabel leads the Jews back from captivity.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ትሩፋነ፡ ባቢሎን፡</q>
-                                   <q xml:lang="gez"><persName ref="PRS5773Joshua">ዮሴዕ፡</persName> ወልደ፡ ዮሴዴቅ፡</q><!-- He's Joshua son of Jehozadak or Jozadak, cp. Ezra 3:2-->
+                                   <q xml:lang="gez"><persName ref="PRS5773Joshua">ዮሴዕ፡</persName> ወልደ፡ ዮሴዴቅ፡</q>
                                </desc>
                            </decoNote>
                            
                            <decoNote type="miniature" xml:id="d70">
                                <locus target="#42v"/>
                                <desc>Two scenes: the Israelites return to Jerusalem led by Joshua, Zorobabel, and a third unidentified leader; and a battle between the Israelites and the people of Gog.
-                                   <q xml:lang="gez"><persName ref="PRS5773Joshua">ዮሴዕ፡</persName></q><!-- He's Joshua son of Jehozadak or Jozadak, cp. Ezra 3:2-->
+                                   <q xml:lang="gez"><persName ref="PRS5773Joshua">ዮሴዕ፡</persName></q>
                                    <q xml:lang="gez">ዘሩባቤል፡</q>
                                    <q xml:lang="gez">ሰብአ፡ ጎግ።</q>
                                </desc>
@@ -1144,10 +1141,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            <decoNote type="miniature" xml:id="d71">
                                <locus target="#43r"/>
                                <desc>Three scenes: Judith meets Holofernes in his camp; she beheads him; and her slave brings his head back to the town in the food bag.
-                                   <q xml:lang="gez">ዮዲት፡</q><!-- encode PERSNAME? -->
+                                   <q xml:lang="gez">ዮዲት፡</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">ሆሎፎርኒስ፡</q><!-- encode PERSNAME? -->
-                                   <q xml:lang="gez">ዘከመ፡ ቀተለቶ፡ ዮዲት፡ ለሆሎፎርኒስ፡</q><!-- encode PERSNAME? -->
+                                   <q xml:lang="gez">ሆሎፎርኒስ፡</q>
+                                   <q xml:lang="gez">ዘከመ፡ ቀተለቶ፡ ዮዲት፡ ለሆሎፎርኒስ፡</q>
                                    <q xml:lang="gez">ሐይመት፡</q>
                                </desc>
                            </decoNote>
@@ -1156,21 +1153,21 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#43v"/>
                                <desc>Three scenes: an unidentified man, possibly Haman, addresses two attendants; Mordecai tells Queen Esther about a plot to kill the Israelites; Haman is hung on a forked pole;
                                    and King Ashasuerus praises Mordechai. 
-                                   <q xml:lang="gez">አስቴር።</q><!-- encode PERSNAMES? -->
+                                   <q xml:lang="gez">አስቴር።</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">መርዶክዮስ፡</q><!-- encode PERSNAME? -->
+                                   <q xml:lang="gez">መርዶክዮስ፡</q>
                                    <q xml:lang="gez">እስራኤል።</q>
-                                   <q xml:lang="gez">ዘከመ፡ ተሰቅለ፡ ሐ<supplied reason="lost">ማ</supplied>፡</q><!-- encode PERSNAME? -->
-                                   <q xml:lang="gez">አርጤከስስ፡</q> <!-- encode PERSNAME? -->
+                                   <q xml:lang="gez">ዘከመ፡ ተሰቅለ፡ ሐ<supplied reason="lost">ማ</supplied>፡</q>
+                                   <q xml:lang="gez">አርጤከስስ፡</q> 
                                    <q xml:lang="gez">መርዶክዮስ፡</q>
                                </desc>
                            </decoNote>
                            
                            <decoNote type="miniature" xml:id="d73">
                                <locus target="#44r"/>
-                               <desc>The Israelites rebuild the walls of Jerusalem in spite of the opposition of Sanballat and his soldiers. <!-- encode PERSNAME? -->
+                               <desc>The Israelites rebuild the walls of Jerusalem in spite of the opposition of Sanballat and his soldiers. 
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">ሰንበላጥ<supplied reason="omitted">፡</supplied></q><!-- encode PERSNAME? -->
+                                   <q xml:lang="gez">ሰንበላጥ<supplied reason="omitted">፡</supplied></q>
                                    <q xml:lang="gez">እስራኤል፡</q>
                                    <q xml:lang="gez">ሠራዊተ፡ ሰንበላጥ፡</q>
                                </desc>
@@ -1204,10 +1201,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d76">
                                <locus target="#45v"/>
-                               <desc>Antiochus IV puts the Israelites to death and has a wild board sacrificed in the Temple to desecrate it. <!-- encode pers name of Antiochus? -->
+                               <desc>Antiochus IV puts the Israelites to death and has a wild board sacrificed in the Temple to desecrate it. 
                                    <q xml:lang="gez">ሥዕለ፡ ፀሐይ፡</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
-                                   <q xml:lang="gez">አንጥያኮስ፡</q><!-- encode pers name of Antiochus? -->
+                                   <q xml:lang="gez">አንጥያኮስ፡</q>
                                    <q xml:lang="gez">ዘከመ፡ አዘዞሙ፡ ይ<gap reason="illegible"/>ሥዋዕተ፡ ጣዖት፡</q><!-- I can't decipher the verb: HELP? -->
                                    <q xml:lang="gez">እስራኤል፡</q>
                                </desc>
@@ -1215,7 +1212,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d77">
                                <locus target="#46r"/>
-                               <desc>Antiochus IV puts Lazarus and his children to death. <!-- encode pers name of Antiochus and Lazarus? -->
+                               <desc>Antiochus IV puts Lazarus and his children to death. 
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ደቂቀ፡ አልዓዛር፡</q>
                                    <q xml:lang="gez">አልዓዛር፡</q>
@@ -1399,7 +1396,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                    <q xml:lang="gez">ገጸ፡ ንስር</q>
                                    <q xml:lang="gez">ገጸ፡ አንበሳ፡</q>
                                    <q xml:lang="gez">ገጸ፡ ላህም፡</q>
-                                   <q xml:lang="gez">በ<del rend="effaced"/> <persName ref="PRS13954TaklaMa" role="owner">ትክለ፡ ማርያም፡</persName> <gap reason="illegible"/></q><!-- extensive caption about donor I cannot read. HELP? -->
+                                   <q xml:lang="gez">በ<del rend="effaced"/> <persName ref="PRS13954TaklaMa" role="owner">ትክለ፡ ማርያም፡</persName> <gap reason="illegible"/></q>
                                </desc>
                            </decoNote>
                                                       
@@ -1441,13 +1438,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#56v"/>
                                <desc>God the Father flanked by a saint and enthroned above a donor in proskynesis. 
                                    <!-- someone able to identify?
-                                   MV 19.05.2026: the caption mentions a certain ʾAbuna Zamalakot, who is not mentioned elsewhere. The man in proskynesis is the donor Takla Māryām. -->
+                                   MV 19.05.2026: the caption mentions ʾAbuna Zamalakot (the record is now created, see caption). The man in proskynesis is the donor Takla Māryām. -->
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ገጸ፡ ሰብእ፡</q>
                                    <q xml:lang="gez">ገጸ፡ ንስር</q>
                                    <q xml:lang="gez">ገጸ፡ አንበሳ፡</q>
                                    <q xml:lang="gez">ገጸ፡ ላህም፡</q>
-                                   <q xml:lang="gez">በከመ፡ ከሠተ፡ ሎቱ፡ ዘንተ፡ ድርሳነ፡ ለአቡነ፡ ዘመለኮት።</q>
+                                   <q xml:lang="gez">በከመ፡ ከሠተ፡ ሎቱ፡ ዘንተ፡ ድርሳነ፡ ለአቡነ፡ <persName ref="PRS15405Zamalakot">ዘመለኮት።</persName></q>
                                    <q xml:lang="gez">በመ፡ <del rend="effaced"/> <persName ref="PRS13954TaklaMa" role="owner">ትክለ፡ ማርያም፡</persName> <del rend="effaced"/></q><!-- one word is illegible. HELP? -->
                                </desc>
                            </decoNote>

--- a/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
@@ -586,7 +586,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <desc>Three episodes: <persName ref="PRS5763Joseph">Joseph</persName> is sold by his brothers (above);
                                    his brothers depart with grain in their sacks as well as the objects placed there by his men and are chased by one of his stewards (bottom left);
                                    <persName ref="PRS5763Joseph">Joseph</persName> confronts his brothers.                                   
-                                   <q xml:lang="gez">ዘከመ፡ ሤጥዎ፡ለዮሴፍ፡ እኃዊሁ</q>	
+                                   <q xml:lang="gez">ዘከመ፡ ሤጥዎ፡ ለዮሴፍ፡ እኃዊሁ</q>	
                                    <q xml:lang="gez">እግዚአብሔር።</q>	
                                    <q xml:lang="gez">አግማል፡</q>		
                                    <q xml:lang="gez">ዕድግት፡</q>
@@ -710,7 +710,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d36">
                                <locus target="#25v"/>
-                               <desc>The prostitute Rahab looks at the Israelites killing the men and rulers or Jericho.                                   
+                               <desc>The prostitute Rahab looks at the Israelites killing the men and rulers of Jericho.                                   
                                    <q xml:lang="gez">እግዚአብሔር።</q>
                                    <q xml:lang="gez">ራአብ፡ ዘማ፡</q>
                                    <q xml:lang="gez">እስራኤል፡</q>
@@ -870,8 +870,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d49">
                                <locus target="#32r"/>
-                               <desc>Three scenes: <persName ref="PRS3721Elijah">Elijah </persName> in the wilderness speaks to God and is aided by an Angel;
-                                   <persName ref="PRS3721Elijah">Elijah</persName> appoints <persName ref="PRS3723Elisha">Elisha</persName> as his disciple; the Arameans soldiers are unable to seize
+                               <desc>Three scenes: <persName ref="PRS3721Elijah">Elijah </persName> in the wilderness speaks to God and is aided by an angel;
+                                   <persName ref="PRS3721Elijah">Elijah</persName> appoints <persName ref="PRS3723Elisha">Elisha</persName> as his disciple; the Aramean soldiers are unable to seize
                                    <persName ref="PRS3723Elisha">Elisha</persName>.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">መልአክ፡</q>
@@ -1012,7 +1012,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d61">
                                <locus target="#38r"/>
-                               <desc>Two scenes: <persName ref="PRS3337Daniel">Daniel</persName> listenes to the accounts of <persName ref="PRS11599Susanna">Susanna</persName> and the two elders;
+                               <desc>Two scenes: <persName ref="PRS3337Daniel">Daniel</persName> listens to the accounts of <persName ref="PRS11599Susanna">Susanna</persName> and the two elders;
                                    and the two elders are stoned to death for their lies.                                    
                                    <q xml:lang="gez"><persName ref="PRS3337Daniel">ዳንኤል፡</persName></q>
                                    <q xml:lang="gez">ረበናት፡</q>
@@ -1080,9 +1080,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d66">
                                <locus target="#40v"/>
-                               <desc>Jeconiah is freed from prison during the reign of Amel-Marduk and after the death of the latter’s father.
-                                   <!-- encode names? Also, I am not sure if the scene in the lower right is the death of Nebuchadnezzar or some other figure, the caption is partially stained.
-                                       MV 18.05.2026: Yes, it is. Jacopo, do you want to add something to the description of the scene?  -->
+                               <desc>Jeconiah is freed from prison during the reign of Amel-Marduk and after the death of the latter’s father, 
+                                   <persName ref="PRS11373Nebuc">Nebuchadnezzar</persName>.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ሰብአ፡ ባቢሎን፡</q>
                                    <q xml:lang="gez">ኢኮንያን፡</q>
@@ -1095,11 +1094,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                <locus target="#41r"/>
                                <desc> <!-- Four of five scenes? Parts of this miniature are confusing to me, first we have the hand of the angel of god writing a prophecy about the imminent death of Belshazzar, next, I presume we see his beheaded body, as it’s mentioned in the main text (but what are the sources for this? It’s not in the Bible)  and someone bringing his head, to the middle left we have Daniel being made king? Cannot make out the inscriptions below, are these the servants bringing wine to the King? Are some extra biblical references included that it would be worth mentioning?
                                    
-                               MV: Belshazzar’s death is described in Daniel 5, but there is no mention of his beheading; this detail probably comes from another source that I am not familiar with. Belshazzar organises a grand banquet for his dignitaries and his wives. During the banquet, cups are brought, among which God's holy cup (ጽዋዓ፡ እግዚአብሔር፡), from which the women drink. Mysterious words appear written by a hand on the wall (the words ማኔ፡ ቴቄል፡ ፉሬስ።). The king is afraid. Daniel, who could notoriously interpret dreams, is summoned to decipher the meaning of the mysterious writing on the wall, and he predicts the imminent end of Belshazzar’s reign. I can't find the biblical place in which Belshazzar's head is shown/given to the people of Israel.                                -->
+                               MV: Belshazzar’s death is described in Daniel 5, but there is no mention of his beheading; this detail probably comes from another source that I am not familiar with. Belshazzar organises a grand banquet for his dignitaries and his wives. During the banquet, cups are brought, among which God's holy cup (ጽዋዓ፡ እግዚአብሔር፡), from which the women drink. Mysterious words appear written by a hand on the wall (the words ማኔ፡ ቴቄል፡ ፉሬስ።). The king is afraid. Daniel, who could notoriously interpret dreams, is summoned to decipher the meaning of the mysterious writing on the wall, and he predicts the imminent end of Belshazzar’s reign. I can't find the biblical place in which Belshazzar's head is shown/given to the people of Israel.     -->
                                    <q xml:lang="gez">መልአክ፡</q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ዘከመ፡ ጸሐፈ፡ እደ፡ መልአክ፡ ወይቤ፡ ማኔ፡ ቴቄል፡ ፉሬስ።</q>
-                                   <q xml:lang="gez">ብላጣሶር።</q><!-- encode PERSNAME? -->
+                                   <q xml:lang="gez">ብላጣሶር።</q>
                                    <q xml:lang="gez">ብእሲቱ፡ ዘከመ፡ አኅዘተ፡ ጽዋዓ፡ እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ዘከመ፡ ወሀቦሙ፡ ርእሶ፡ ለእስራኤል፡ ወዓለሁ፡</q>
                                    <q xml:lang="gez">ዘከመ፡ አምሰሐ፡ መኳንንቲሁ፡</q>
@@ -1110,8 +1109,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d68">
                                <locus target="#41v"/>
-                               <desc>King <persName ref="PRS3264CyrusII">Cyrus</persName> announces to the Israelites that they may return home, one of his officers plays a 
-                                   <!-- MV 18.05.2026: This description is incomplete -->
+                               <desc>King <persName ref="PRS3264CyrusII">Cyrus</persName> announces to the Israelites that they may return home, one of his officers plays a drum.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">እስራኤል፡</q>
                                    <q xml:lang="gez"><persName ref="PRS3264CyrusII">ቂሮስ</persName></q>
@@ -1239,7 +1237,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d80">
                                <locus target="#47v"/>
-                               <desc>A Nativity scene with shepherds playing Genna and a donor in proskynesis.
+                               <desc>A Nativity scene with shepherds playing the Ethiopian game of Genna and a donor in proskynesis.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ዘከመ፡ ተውልደ፡ መድኃኒነ፡ ውስተ፡ ጎል፡</q>
                                    <q xml:lang="gez">እግዝእተነ፡ <persName ref="PRS6819Mary">ማርያም።</persName></q>
@@ -1390,7 +1388,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d94">
                                <locus target="#54v"/>
-                               <desc>The Trinity and a donor in proskynesis.
+                               <desc>The Trinity and a donor in proskynesis. The caption has been partially erased.
                                    <q xml:lang="gez">ሥላሴ፡ ቅዱስ።</q>
                                    <q xml:lang="gez">ገጸ፡ ሰብእ፡</q>
                                    <q xml:lang="gez">ገጸ፡ ንስር</q>
@@ -1436,16 +1434,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            
                            <decoNote type="miniature" xml:id="d98">
                                <locus target="#56v"/>
-                               <desc>God the Father flanked by a saint and enthroned above a donor in proskynesis. 
-                                   <!-- someone able to identify?
-                                   MV 19.05.2026: the caption mentions ʾAbuna Zamalakot (the record is now created, see caption). The man in proskynesis is the donor Takla Māryām. -->
+                               <desc>God the Father flanked by an unknown ecclesiastic called <persName ref="PRS15405Zamalakot"><roleName type="title">ʾAbuna</roleName>
+                                   Zamalakot</persName> and enthroned above the donor, <persName ref="PRS13954TaklaMa" role="owner">Takla Māryām</persName>, in proskynesis.
+                                   The caption has been partially erased.
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ገጸ፡ ሰብእ፡</q>
                                    <q xml:lang="gez">ገጸ፡ ንስር</q>
                                    <q xml:lang="gez">ገጸ፡ አንበሳ፡</q>
                                    <q xml:lang="gez">ገጸ፡ ላህም፡</q>
                                    <q xml:lang="gez">በከመ፡ ከሠተ፡ ሎቱ፡ ዘንተ፡ ድርሳነ፡ ለአቡነ፡ <persName ref="PRS15405Zamalakot">ዘመለኮት።</persName></q>
-                                   <q xml:lang="gez">በመ፡ <del rend="effaced"/> <persName ref="PRS13954TaklaMa" role="owner">ትክለ፡ ማርያም፡</persName> <del rend="effaced"/></q><!-- one word is illegible. HELP? -->
+                                   <q xml:lang="gez">በመ፡ <del rend="effaced"/> <persName ref="PRS13954TaklaMa" role="owner">ትክለ፡ ማርያም፡</persName> <del rend="effaced"/></q>
                                </desc>
                            </decoNote>
                        </decoDesc>

--- a/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
+++ b/OxfordBodleian/Juel-Jensen/BDLaethd16.xml
@@ -660,7 +660,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                            <decoNote type="miniature" xml:id="d31">
                                <locus target="#23r"/>
-                               <desc>The Israelites eat Manna and drink the water that miraculously pours out from two mountains.                                   
+                               <desc>The Israelites eat manna and drink the water that miraculously pours out from two mountains.                                   
                                    <q xml:lang="gez"><persName ref="PRS7181MosesM">ሙሴ፡</persName></q>
                                    <q xml:lang="gez">እግዚአብሔር፡</q>
                                    <q xml:lang="gez">ኰኵሐ፡</q>


### PR DESCRIPTION
Here comes the decoDesc of d.16 (= JJ36).

As Dorothea and Jacopo already known, all captions are now provided, with the exception perhaps of 2-3 that remain partially illegible. I’ve marked them as `<gap reason="illegible"/>` and commented them out, so if you want to try to decipher the missing words, please feel free. There are also some comments about the descriptions which might be enlarged in light of the restored captions. All changes can be directly made by editing the file here on GitHub.

Many personal names are not marked up, but we agreed that this will allow us to save time. The alternative would be to create a large number of records for all the minor biblical figures mentioned, and that would take some time, whereas we want to finalise the catalogue soon.