### PR TITLE
Update IVorlov34.xml

### DIFF
--- a/StPetersburg/IVorlov34.xml
+++ b/StPetersburg/IVorlov34.xml
@@ -112,7 +112,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
 
 
                        <item xml:id="a3">
-                          <desc type="CalendaricNote" xml:lang="am"/>
+                          <desc type="GuestText" xml:lang="am"><ref type="work" corresp="LIT7860HassSaatAmh"/>.</desc>
                           <locus target="#90v"/>
                           <q>
                               <foreign>ዘጊዜ፡ ቁርባን፡ የመስከረምና፡ የመጋቢት፡ ፲፡ ጫማ፡</foreign>
@@ -223,6 +223,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
       </profileDesc>
       <revisionDesc>
          <change who="DN" when="2019-06-11">Created catalogue entry</change>
+         <change when="2026-06-02" who="CH">Add LIT7860HassSaatAmh to #a3</change>
         </revisionDesc>
   </teiHeader>
   <text xml:base="https://betamasaheft.eu/">


### PR DESCRIPTION
According to our discussion in https://github.com/BetaMasaheft/Documentation/issues/3325#issuecomment-4604290680.

I think, I was mistaken about IVEf103. The text in ms_i5#coloph1 does not seem to me to have any astronomical content. Therefore, I limited myself in updating IVorlov34.