### PR TITLE
Update Hasura Masqal manuscript

### DIFF
--- a/EMIP/magicscrolls/EMIPms00484/EMIPms00484.xml
+++ b/EMIP/magicscrolls/EMIPms00484/EMIPms00484.xml
@@ -34,6 +34,31 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <msContents>
                   <summary/>
                   <msItem xml:id="ms_i1">
+                     <title ref="LIT5696MagicPrayer"/>
+                     <textLang mainLang="gez"/>
+                  </msItem>
+                  <msItem xml:id="ms_i2">
+                     <title ref="LIT5888AsmatPrayer"/>
+                     <textLang mainLang="gez"/>
+                  </msItem>
+                  <msItem xml:id="ms_i3">
+                     <title ref="LIT5888AsmatPrayer"/>
+                     <textLang mainLang="gez"/>
+                  </msItem>
+                  <msItem xml:id="ms_i4">
+                     <title ref="LIT5888AsmatPrayer"/>
+                     <textLang mainLang="gez"/>
+                  </msItem>
+                  <msItem xml:id="ms_i5">
+                     <title ref="LIT5888AsmatPrayer"/>
+                     <textLang mainLang="gez"/>
+                  </msItem>
+                  <msItem xml:id="ms_i6">
+                     <title ref="LIT5888AsmatPrayer"/>
+                     <textLang mainLang="gez"/>
+                  </msItem>
+                  <msItem xml:id="ms_i7">
+                     <title ref="LIT5888AsmatPrayer"/>
                      <textLang mainLang="gez"/>
                   </msItem>
                </msContents>
@@ -47,7 +72,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <extent>
                            <measure unit="strips">3</measure>
                            <dimensions type="outer" unit="mm">
-                              <height>186</height>
+                              <height>186</height><!-- these dimensions can not be correct -->
                               <width>8.7</width>
                               <depth/>
                            </dimensions>
@@ -88,6 +113,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <change when="2022-09-23" who="RL">Corrected include code errors</change>
          <change when="2022-09-26" who="RL">Removed text body code lines</change>
          <change when="2024-08-28" who="RL">formatted text and facsimile files</change>
+         <change when="2026-06-24" who="CH">Add msContents with LIT5696MagicPrayer</change>
       </revisionDesc>
    </teiHeader>
   

--- a/EMIP/magicscrolls/EMIPms00510/EMIPms00510.xml
+++ b/EMIP/magicscrolls/EMIPms00510/EMIPms00510.xml
@@ -31,9 +31,34 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <idno facs="EMIP/Scrolls/MS0510/" n="13">Tweed MS 42</idno>
                </msIdentifier>
                <msContents>
-                  <summary> </summary>
+                  <summary>Magic prayers</summary>
                   <msItem xml:id="ms_i1">
-                     <textLang mainLang="gez">Gǝ‘ǝz</textLang>
+                     <title ref="LIT5888AsmatPrayer"/>
+                     <textLang mainLang="gez"/>
+                  </msItem>
+                  <msItem xml:id="ms_i2">
+                     <title ref="LIT5888AsmatPrayer"/>
+                     <textLang mainLang="gez"/>
+                  </msItem>
+                  <msItem xml:id="ms_i3">
+                     <title ref="LIT5888AsmatPrayer"/>
+                     <textLang mainLang="gez"/>
+                  </msItem>
+                  <msItem xml:id="ms_i4"><!--  -->
+                     <title ref="LIT5696MagicPrayer"/>
+                     <textLang mainLang="gez"/>
+                  </msItem>
+                  <msItem xml:id="ms_i5">
+                     <title ref="LIT5888AsmatPrayer"/>
+                     <textLang mainLang="gez"/>
+                  </msItem>
+                  <msItem xml:id="ms_i6">
+                     <title ref="LIT5888AsmatPrayer"/>
+                     <textLang mainLang="gez"/>
+                  </msItem>
+                  <msItem xml:id="ms_i7">
+                     <title ref="LIT5888AsmatPrayer"/>
+                     <textLang mainLang="gez"/>
                   </msItem>
                </msContents>
                <physDesc>
@@ -46,7 +71,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <extent>
                            <measure unit="strips">3</measure>
                            <dimensions type="outer" unit="mm">
-                              <height>180</height>
+                              <height>180</height><!-- these dimensions can not be correct -->
                               <width>8.0</width>
                               <depth/>
                            </dimensions>
@@ -70,7 +95,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
       </encodingDesc>
       <profileDesc>
          
-         <langUsage><language ident="en">English</language></langUsage>
+         <langUsage><language ident="en">English</language><language ident="gez">Gǝʿǝz</language></langUsage>
       </profileDesc>
       <revisionDesc>
          <change who="PL" when="2018-01-18">Created XML record from EMIP Collection Metadata.xsls</change>
@@ -78,6 +103,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <change when="2022-07-08" who="RL">Edited idno to include images</change>
          <change when="2022-10-18" who="RL">Added include code to add Transkribus transcription</change>
          <change when="2024-08-29" who="RL">Formatted text and facsimile files</change>
+         <change when="2026-06-24" who="CH">Add msContents with LIT5696MagicPrayer</change>
          </revisionDesc>
    </teiHeader>
    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"

--- a/EMIP/magicscrolls/EMIPms00532/EMIPms00532.xml
+++ b/EMIP/magicscrolls/EMIPms00532/EMIPms00532.xml
@@ -32,8 +32,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <idno facs="EMIP/Scrolls/MS0532/" n="7">Tweed MS 64</idno>
                </msIdentifier>
                <msContents>
-                  <summary/>
+                  <summary>Magic prayers</summary>
                   <msItem xml:id="ms_i1">
+                     <title ref="LIT5888AsmatPrayer"/>
+                     <textLang mainLang="gez"/>
+                  </msItem>
+                  <msItem xml:id="ms_i2">
+                     <title ref="LIT5888AsmatPrayer"/>
+                     <textLang mainLang="gez"/>
+                  </msItem>
+                  <msItem xml:id="ms_i3">
+                     <title ref="LIT5888AsmatPrayer"/>
+                     <textLang mainLang="gez"/>
+                  </msItem>
+                  <msItem xml:id="ms_i4">
+                     <title ref="LIT5888AsmatPrayer"/>
+                     <textLang mainLang="gez"/>
+                  </msItem>
+                  <msItem xml:id="ms_i5">
+                     <title ref="LIT5696MagicPrayer"/>
                      <textLang mainLang="gez"/>
                   </msItem>
                </msContents>
@@ -47,7 +64,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <extent>
                            <measure unit="strips">2</measure>
                            <dimensions type="outer" unit="mm">
-                              <height>108</height>
+                              <height>108</height><!-- these dimensions can not be correct -->
                               <width>7.2</width>
                               <depth/>
                            </dimensions>
@@ -88,6 +105,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <change when="2022-09-23" who="RL">Corrected include code errors</change>
          <change when="2022-09-26" who="RL">Removed text body code lines</change>
          <change when="2024-09-02" who="RL">Formatted text and facsimile files</change>
+         <change when="2026-06-24" who="CH">Add msContents with LIT5696MagicPrayer</change>
       </revisionDesc>
    </teiHeader>
   


### PR DESCRIPTION
I updated three records with LIT5696MagicPrayer, which is a general record for Hasura masqal manuscripts according to my suggestion in https://github.com/BetaMasaheft/Documentation/issues/3350.

I found that the dimensions must be incorrect and I will open an issue for it in a minute.