### PR TITLE
Create ANLcr67

### DIFF
--- a/EMIP/magicscrolls/EMIPms00533/EMIPms00533.xml
+++ b/EMIP/magicscrolls/EMIPms00533/EMIPms00533.xml
@@ -33,6 +33,29 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <msContents>
                   <summary/>
                   <msItem xml:id="ms_i1">
+                     <title ref="LIT5888AsmatPrayer">Ṣalot baʾǝnta ḥǝṣura Masqal</title>
+                     <textLang mainLang="gez"/>
+                  </msItem>
+                  <msItem xml:id="ms_i2">
+                     <title ref="LIT5888AsmatPrayer">Ṣalot baʾǝnta māʿśara ʾagānǝnt</title>
+                     <textLang mainLang="gez"/>
+                  </msItem>
+                  <msItem xml:id="ms_i3">
+                     <title ref="LIT5888AsmatPrayer">Ṣalot baʾǝnta maftǝḥe śǝrāy</title>
+                     <textLang mainLang="gez"/>
+                  </msItem>
+                  <msItem xml:id="ms_i4">
+                     <title ref="LIT5888AsmatPrayer">Ṣalot baʾǝnta maftǝḥe śǝrāy</title>
+                     <textLang mainLang="gez"/>
+                  </msItem>
+                  <msItem xml:id="ms_i5">
+                     <title ref="LIT4705MagicPr"/>
+                     <note>Contrary to other witnesses, this prayer is not only against wǝgʾat, but also against ʿAyna Ṭǝllā, Taṣārāri, ʿAyna Sabʾ, Zār
+                        and other demons.</note>
+                     <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ ዐይነ፡ ጥላ፡ ወተጸራሪ፡ ወዐይነ፡ ሰብእ፡ ተስሕቦ፡ ወጕርጉሆ፡ ዓገላ፡ ስቅስቃት፡ ዛር፡
+                        ወጋኔን፡ ወሕማመ፡ ውጋተ፡ ቀተፎን፡ ቀጠፎን፡ ቀተፎን፡ ቀቲፎን፡ ሰተፎን፡ ስተፎን፡ ስተፍን፡ ምጽምያስ፡ ምድምያስ፡ ምድምያሰ፡ የሐቂ፡ ናሐቂ፡ የሐዊ፡ አድኅና፡ እምሕማመ፡
+                        ባርያ፡ ወአይነት፡ ውጋት፡ ወቁርጥማት፡ ፍልጸት፡</incipit>
+                     <explicit xml:lang="gez">ወፈስ፡ ምትሐት፡ ለዓመትከ። አሚናት፡</explicit>
                      <textLang mainLang="gez"/>
                   </msItem>
                </msContents>
@@ -78,6 +101,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <change when="2022-07-13" who="RL">Edited idno to include images</change>
          <change when="2022-11-07" who="RL">Added include code to add Transkribus transcription</change>
          <change when="2024-09-02" who="RL">Formatted text and facsimile files</change>
+         <change when="2026-06-23" who="CH">Added msItems and LIT4705MagicPr</change>
 </revisionDesc>
    </teiHeader>
    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"

--- a/RomeALincei/ANLcr67.xml
+++ b/RomeALincei/ANLcr67.xml
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"
+?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+   schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="ANLcr67" type="mss">
+    <teiHeader xml:base="https://betamasaheft.eu/">
+        <fileDesc>
+            <titleStmt>
+                <title>Magic scroll</title>
+                <editor key="AB" role="generalEditor"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine
+                    multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc xml:id="ms">
+                    <msIdentifier>
+                        <repository ref="INS0335ANL"/>
+                        <idno>Conti Rossini 67</idno>
+                    </msIdentifier>
+                    <msContents>
+                        <summary>Protective Prayers</summary>
+                        <msItem xml:id="ms_i1">
+                            <title ref="LIT7321InfantsSus"/>
+                            <textLang mainLang="gez"/>                            
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> በስመ፡ እግዚአብሔር፡ ሕያው፡ ፈጣሪ፡ ወተናጋሪ፡ ነባቢ፡ ወመስተሣህል፡ ኄር፡ ወመሐሪ፡
+                                ጸሎት፡ ዘቅዱስ፡ ሱስንዮስ፡ በእንተ፡ አሰስሎ፡ ደዌ፡ እምሕፃናት፡ <surplus>እምሕፃናት፡</surplus> እለ፡ ይጠብው፡ ጥበ፡ እሞሙ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i2">
+                            <title ref="LIT7244PPBaha"/>
+                            <textLang mainLang="gez"/>                            
+                            <incipit xml:lang="gez">በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ ባርያ፡ ወሌጌዎን፡ ወዓየረ፡ አጋንንት፡ በስመ፡ እግዚአብሔር፡ ብርሃን፡
+                                በእንተ፡ ማዕሠሩ፡ ለሰይጣን፡ ለሥራይኛ፡ ወለቸነፈር፡ አስማተ፡ ኃይል፡ ዘስሙ፡ ሸዊራ፡ አሸዊራ፡</incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i3">
+                            <title ref="LIT5690MagicPrayer"/>
+                            <note>Containing the legend of the witch that was seen by the apostles on the coast of the lake Tiberias.</note>
+                            <textLang mainLang="gez"/>                            
+                            <incipit xml:lang="gez">ጸሎተ፡ ነድራ፡ ወእንዘ፡ የሐውር፡ እግዚእ፡ እየሱስ፡ ክርስቶስ፡ ውስተ፡ ባሕረ፡ ጥብርያደስ፡ ወመጽኡ፡ እሙንቱ፡ ፩ወ፪ ሐዋርያት፡ 
+                                አርዳእሁ፡ ወርእዩ፡ መልክዓ፡ ብእሲት፡ አረጊት፡ እንዘ፡ ትነብር፡ በባሕር፡</incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i4">
+                            <title ref="LIT7867MastemaYan"/>
+                            <note>In contrast to other attestations in <ref type="mss" corresp="BLorient4865"/> and 
+                                <ref type="mss" corresp="ANLcr63"/>, the demons Bāryā, Gānen, and ʾAyna Ṭǝlā are explicitly named here.</note>
+                            <textLang mainLang="gez"/>                            
+                            <incipit xml:lang="gez">መስጥም፡ ዘባርያ፡ ወጋኔን፡ ወዓይነ፡ ጥላ፡ ያናእላን፡ ያናእላን፡ ያናእላን፡</incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i5">
+                            <title ref="LIT7885BreathDem"/><!-- Issue #3357 -->
+                            <textLang mainLang="gez"/>                            
+                            <incipit xml:lang="gez">ለዑላፈይሂም፡ ቍረይሽን፡ እራህለተሽዒን፡ <gap reason="ellipsis"/> በዝቃለ፡ ዓረቢ፡ እምዓይነ፡ ባርያ፡ ወሌጌዎን፡ ወዓየረ፡
+                                አጋንንት፡ አድኅና፡ ለአመትከ፡ <gap reason="lost"/></incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i6">
+                            <title ref="LIT7884BarLegATel"/><!-- Issue #3356 -->
+                            <textLang mainLang="gez"/>                            
+                            <incipit xml:lang="gez">ጸሎት፡ በእንተ፡ ባርያ፡ ወሌጌዎን፡ ወዓይነ፡ ጥላ፡ ያሑሸባትያ፡ ተላቱን፡</incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i7">
+                            <title ref="LIT7883AyyaraAganent"/><!-- Issue #3355 -->
+                            <textLang mainLang="gez"/>                            
+                            <incipit xml:lang="gez">ስለኩ፡ ማያችከሊ፡ <gap reason="ellipsis"/> እምሥራየ፡ ባርያ፡ ወሌጌዎን፡ ወዓየረ፡ አጋንንት፡ አድኅና፡ ለአመትከ፡
+                                <gap reason="lost"/></incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i8"><!-- Issue#3354 -->
+                            <title ref="LIT7882BudaBarya"/>
+                            <textLang mainLang="gez"/>                            
+                            <incipit xml:lang="gez">እላሁማ፡ ወያኑራ፡ ሐኪም፡ በሐቅመ፡ ግኑን፡ <gap reason="ellipsis"/> በኃይለ፡ ዝንቱ፡ አስማቲከ፡ አድኅና፡ እምሕማመ፡
+                                ቡዳ፡ ወባርያ፡ ለአመትከ፡ <gap reason="lost"/></incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i9">
+                            <title>Prayers against vaginal haemorrhage</title>
+                            <textLang mainLang="gez"/>                            
+                            <msItem xml:id="ms_i9.1"><!-- Issue#3352 -->
+                                <title ref="LIT7881DamAflis"/> 
+                                <note>Directed only against vaginal haemorrhage here, but not against demons as in another witness 
+                                    in <ref type="mss" corresp="BLorient12053"/>.</note>
+                                <incipit xml:lang="gez">ጸሎት፡ በእንተ፡ ሕማመ፡ ደም፡ ሊስ፡ አፍሊስ፡</incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i9.2">
+                                <title ref="LIT5823MagicPrayer">Prayer against vaginal haemorrhage</title>
+                                <note>Magic prayer directed only against vaginal haemorrhage here, but not against the demon Šotalāy as in 
+                                    another witness in <ref type="mss" corresp="CJN001"/>. The prayer uses Psalm 1:1-5 as enforcement, contrary to
+                                    other witnesses, which recite only Psalm 1:1-4.</note>
+                                <incipit xml:lang="gez">ጸሎት፡ በእንተ፡ ሕማመ፡ ደም፡ ብፁዕ፡ ብእሲ፡ ዘኢሖረ፡ በምክረ፡ ረሲዓን፡</incipit>
+                            </msItem>
+                            <msItem xml:id="ms_i9.3">
+                                <title ref="LIT7880DamSatam"/><!-- #3351 -->                          
+                                <incipit xml:lang="gez">ጸሎት፡ በእንተ፡ ደም፡ ሰተም፡ ሰተም፡ ሰተም፡ ሰንተም፡ ሰንተም፡ ሰንተም፡ ሰንተረም፡ ሰንተረም፡ ሰንተረም፡</incipit>
+                            </msItem>
+                        </msItem>
+                        <msItem xml:id="ms_i10">
+                            <title ref="LIT7879GenGanen"/><!-- Issue #3350 -->
+                            <textLang mainLang="gez"/>                            
+                            <incipit xml:lang="gez">መስቀል፡ ኃይልነ፡ መስቀል፡ ጽንዕነ፡ <gap reason="ellipsis"/> በሐፁረ፡ መስቀል፡ ኅፅራ፡ ወአድኅና፡ እምሕማመ፡ ጅን፡
+                                ወጋኔን፡ ወዐይነ፡ ጥላ፡ ለአመትከ፡ <gap reason="lost"/></incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i11">
+                            <title ref="LIT7877EggaSab"/><!-- Issue #3347 -->
+                            <textLang mainLang="gez"/>                            
+                            <incipit xml:lang="gez">ጸሎት፡ በእንተ፡ መፍትሔ፡ ሥራይ፡ ወእጀ፡ ሰብእ፡ ሐበርደጀን፡ ሐበርደጀን፡ ሐበርደጀን፡</incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i12">
+                            <title ref="LIT4705MagicPr"/>
+                            <note>With slightly different ʾasmāt.</note>
+                            <textLang mainLang="gez"/>                            
+                            <incipit xml:lang="gez">ጸሎት፡ በእንተ፡ ሕማመ፡ ውግዓት፡ ቀተፎን፡ ሰተፎን፡</incipit>
+                        </msItem>
+                        <msItem xml:id="ms_i13">
+                            <title ref="LIT7878Qursat"/><!-- Issue #3348-->
+                            <textLang mainLang="gez"/>                            
+                            <incipit xml:lang="gez">ጸሎት፡ በእንተ፡ ሕማመ፡ ቁርፀት፡ ቄጼቤ፡ ቄጼቤ፡ ቄጼቤ፡ ቄፌኑ፡ ቄፌኑ፡ ቄፌኑ፡</incipit>
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <objectDesc form="Scroll">
+                            <supportDesc>
+                                <support><material key="parchment"/></support>
+                                <extent>
+                                    <measure unit="leaf" quantity="1">1</measure>
+                                    <measure unit="strips" quantity="3">3</measure>
+                                    <dimensions type="inner" unit="mm">
+                                        <height>1530</height>
+                                        <width>115</width>
+                                    </dimensions>
+                                </extent>
+                                <condition key="deficient">The top of the first strip has been torn off. The second strip is torn in three places.</condition>
+                            </supportDesc>
+                        </objectDesc>
+                        <handDesc><handNote xml:id="h1" script="Ethiopic">
+                            <seg type="script">Rather regular script.</seg>
+                            <seg type="ink">Black, red.</seg>
+                        </handNote>
+                        </handDesc>
+                        <decoDesc>
+                            <decoNote xml:id="d1" type="miniature">
+                                <desc><term key="MagicDrawing">Magic picture in black, red, blue and yellow</term> depicting 
+                                    <persName ref="PRS9038Susenyos"/>.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d2" type="miniature">
+                                <desc><term key="MagicDrawing">Magic picture in black, red, blue and yellow</term> depicting a magic face in
+                                    the center of a cruciform composition.</desc>
+                            </decoNote>
+                            <decoNote xml:id="d3" type="miniature">
+                                <desc><term key="MagicDrawing">Magic picture in black, red, blue and yellow</term> depicting a magic face in
+                                    the center of a cruciform composition.</desc>
+                            </decoNote>
+                        </decoDesc>
+                        
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origDate notBefore="1800" notAfter="1899">Nineteenth century</origDate>
+                        </origin>
+                        <provenance>
+                            The name of the original owner <persName ref="PRS15477WalattaKid" role="owner">Walatta Kidān</persName>
+                            was replaced in various places by the name <persName ref="PRS15476Laqac" role="owner">Walatta Masqal Lāqač</persName>.
+                        <!-- Possibly the same person as Lāqač, 'Queen of Goğğām' who owned EMDA321; Wayzaro Laqac who owned EMML504 or
+                       Wäyzäro Laqäč, who owned EMIP00138.Since Lāqač is a common Ethiopian and Eritrean name, it is not certain, whether 
+                       these four mentions refer to the same persons even though all of them are are indicated as personalities either from the
+                       nineteenth or twentieth century.--></provenance>
+                    </history>
+                    <additional>
+                        <adminInfo>
+                            <recordHist>
+                                <source>
+                                    <listBibl type="catalogue">
+                                        <bibl>
+                                            <ptr target="bm:Strelcyn1976Catalogue"/>
+                                            <citedRange unit="page">181–182</citedRange>
+                                        </bibl>
+                                    </listBibl>
+                                </source>
+                            </recordHist>
+                            <custodialHist>
+                                <custEvent type="restorations" subtype="none"/>
+                            </custodialHist>
+                        </adminInfo>
+                    </additional>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <projectDesc>
+                <p>Encoded according to TEI P5 Guidelines.</p>
+            </projectDesc>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+                <xi:fallback>
+                    <p>Definitions of prefixes used.</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
+        <profileDesc>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Magic"/>
+                    <term key="Prayers"/>
+                    <term key="demon"/>
+                    <term key="Disease"/>
+                    <term key="DiseasePain"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+                <language ident="it">Italian</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2026-06-18">Created record</change>
+            <!--  -->
+        </revisionDesc>
+    </teiHeader>
+    <text xml:base="https://betamasaheft.eu/">
+        <body>
+            <ab/>
+        </body>
+    </text>
+</TEI>

--- a/RomeALincei/ANLcr67.xml
+++ b/RomeALincei/ANLcr67.xml
@@ -89,12 +89,12 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                             <msItem xml:id="ms_i9.2">
                                 <title ref="LIT5823MagicPrayer">Prayer against vaginal haemorrhage</title>
                                 <note>Magic prayer directed only against vaginal haemorrhage here, but not against the demon Šotalāy as in 
-                                    another witness in <ref type="mss" corresp="CJN001"/>. The prayer uses Psalm 1:1-5 as enforcement, contrary to
-                                    other witnesses, which recite only Psalm 1:1-4.</note>
+                                    another witness in <ref type="mss" corresp="CJN001"/>. The prayer uses Psalm 1:1-5, contrary to other witnesses, 
+                                    which provide slightly shorter Psalm 1:1-4.</note>
                                 <incipit xml:lang="gez">ጸሎት፡ በእንተ፡ ሕማመ፡ ደም፡ ብፁዕ፡ ብእሲ፡ ዘኢሖረ፡ በምክረ፡ ረሲዓን፡</incipit>
                             </msItem>
                             <msItem xml:id="ms_i9.3">
-                                <title ref="LIT7880DamSatam"/><!-- #3351 -->                          
+                                <title ref="LIT7880DamSatam"/><!-- Issue #3351 -->                          
                                 <incipit xml:lang="gez">ጸሎት፡ በእንተ፡ ደም፡ ሰተም፡ ሰተም፡ ሰተም፡ ሰንተም፡ ሰንተም፡ ሰንተም፡ ሰንተረም፡ ሰንተረም፡ ሰንተረም፡</incipit>
                             </msItem>
                         </msItem>
@@ -163,11 +163,8 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         </origin>
                         <provenance>
                             The name of the original owner <persName ref="PRS15477WalattaKid" role="owner">Walatta Kidān</persName>
-                            was replaced in various places by the name <persName ref="PRS15476Laqac" role="owner">Walatta Masqal Lāqač</persName>.
-                        <!-- Possibly the same person as Lāqač, 'Queen of Goğğām' who owned EMDA321; Wayzaro Laqac who owned EMML504 or
-                       Wäyzäro Laqäč, who owned EMIP00138.Since Lāqač is a common Ethiopian and Eritrean name, it is not certain, whether 
-                       these four mentions refer to the same persons even though all of them are are indicated as personalities either from the
-                       nineteenth or twentieth century.--></provenance>
+                            was replaced in various places by the name <persName ref="PRS15476Laqac" role="owner">Walatta Masqal Lāqačč</persName>.
+                        </provenance>
                     </history>
                     <additional>
                         <adminInfo>
@@ -218,7 +215,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2026-06-18">Created record</change>
-            <!--  -->
+            <change who="CH" when="2026-06-30">Updated after review of Magdalena Krzyżanowska</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">

--- a/VaticanBAV/et/BAVet101.xml
+++ b/VaticanBAV/et/BAVet101.xml
@@ -4,7 +4,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
   <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Magical prayers</title>
+            <title>Magic prayers</title>
             <editor key="MV"/>
             <editor role="generalEditor" key="AB"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -284,6 +284,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
       </profileDesc>
       <revisionDesc>
          <change who="MV" when="2017-08-09">Created catalogue entry</change>
+         <change who="CH" when="2026-06-23">Changed title to Magic Prayers</change>
       </revisionDesc>
   </teiHeader>
   <text xml:base="https://betamasaheft.eu/">

--- a/VaticanBAV/et/BAVet94.xml
+++ b/VaticanBAV/et/BAVet94.xml
@@ -33,10 +33,10 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                   <summary/>
             
                   <msItem xml:id="ms_i1">
-                     <title type="complete" ref="LIT1763Legend"/>
+                     <title type="complete" ref="LIT7321InfantsSus"/>
                      <incipit xml:lang="gez">
                         <supplied reason="lost">በ</supplied>ስመ፡ አብ፡ <gap reason="omitted" extent="unknown" resp="bm:GrebTiss1935Codices"/>  ጸሎት፡ 
-                        በእንተ፡ ሕማመ፡ ሾተላይ፡ ባርያ፡ ወደም፡ ዘቅዱስ፡ ሱስንዮስ፡ በስመ፡ እግዚአብሔር፡ ሕያው፡ ነባቢ፡ ወተናጋሪ፡ ጸሎት፡ ዘቅዱስ፡ ሱስንዮስ፡ በእንተ፡ <del rend="effaced">አ</del>ሰስሎ፡ ደቄ፡ 
+                        በእንተ፡ ሕማመ፡ ሾተላይ፡ ባርያ፡ ወደም፡ ዘቅዱስ፡ ሱስንዮስ፡ በስመ፡ እግዚአብሔር፡ ሕያው፡ ነባቢ፡ ወተናጋሪ፡ ጸሎት፡ ዘቅዱስ፡ ሱስንዮስ፡ በእንተ፡ <del rend="effaced">አ</del>ሰስሎ፡ ደዌ፡ 
                         እምሕፃና<del rend="effaced">ት</del>፡ እለ፡ 
                            <sic>ይጠብው፡</sic>
                          ጥበ፡ <supplied reason="lost">እ</supplied>ሞሙ፡ ይበቍዕ፡ 
@@ -230,6 +230,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
       </profileDesc>
       <revisionDesc>
          <change who="MV" when="2017-05-12">Created catalogue entry</change>
+         <change when="2026-06-29" who="CH">Updated ms_i1 with LIT7321InfantsSus</change>
       </revisionDesc>
   </teiHeader>
   <text xml:base="https://betamasaheft.eu/">


### PR DESCRIPTION
I created a record for ANLcr67 that is a magic scroll. A good number of new LIT ID were necessary to describe the contents, as I have proposed in https://github.com/BetaMasaheft/Documentation/issues/3347, https://github.com/BetaMasaheft/Documentation/issues/3348, https://github.com/BetaMasaheft/Documentation/issues/3350, https://github.com/BetaMasaheft/Documentation/issues/3351, https://github.com/BetaMasaheft/Documentation/issues/3352, https://github.com/BetaMasaheft/Documentation/issues/3354, https://github.com/BetaMasaheft/Documentation/issues/3355, https://github.com/BetaMasaheft/Documentation/issues/3356 and https://github.com/BetaMasaheft/Documentation/issues/3357 and which I have created after that. 

I was able to identify some of the CAe in ANLcr67 also in EMIPms00533 and BAVet94 and therefore corrected the msContents in these two records.

I created two PRS records in https://github.com/BetaMasaheft/Persons/pull/1398.
