### PR TITLE
Update ESmkl001 with LIT2807RepCh91

### DIFF
--- a/ES/ESath007.xml
+++ b/ES/ESath007.xml
@@ -465,14 +465,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                               because they have been erased. </note>
                         </item>
                         <item xml:id="a4">
-                           <locus target="#139r">f. 139rb-rc</locus>
-                           
-                           <desc type="GuestText"> salām-hymn for St Mary (<title ref="LIT2730RepCh14" type="incomplete"/>), incomplete.</desc>
+                           <locus from="139rb" to="139rc"/>
+                           <desc type="GuestText">Salām-hymn for St Mary (<ref type="work" corresp="LIT2730RepCh14"/>), incomplete.</desc>
                            <q xml:lang="gez">
-                              ሰላም፡ ለኪ፡ ማርያም፡ ስጣሕት፡
-                              ቀስተተ፡[sic] መሐላሁ፡ ለኖኅ፡…</q>
-                            Cp. the same text in <locus from="118rb" to="119rb">118rb-119rb</locus>
-                           <note>See also the same text in <ref type="mss" corresp="ESmkl001#ms_i1.2.2"/></note>
+                              ሰላም፡ ለኪ፡ ማርያም፡ ስጣሕት፡ <sic>ቀስተተ፡</sic> መሐላሁ፡ ለኖኅ፡ <gap reason="ellipsis"/></q>
                            <note>The note
                               contains rubrications. </note>
                         </item>
@@ -580,6 +576,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <change who="DN" when="2015-07-16">last edited</change>
          <change who="PL" when="2016-05-10">transformed from mycore to TEI P5</change>
          <change when="2019-11-18" who="ES">adjusting to schema</change>
+         <change when="2026-07-07" who="CH">Updated a4</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">

--- a/ES/ESmkl001.xml
+++ b/ES/ESmkl001.xml
@@ -104,21 +104,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      <locus from="117vc" to="119vb"/>
                      <title type="complete">Collection of Salām-Hymns</title>
                      
-                     <msItem xml:id="ms_i1.2.1">
-                        <locus from="117vc" to="118rb"/>
-                        <title type="complete" ref="LIT2807RepCh91">Salām-hymn for St Mary (ChRep 196, no. 91)</title>
+                     <msItem xml:id="ms_i2.2.1">
+                        <locus from="117vc" to="119rb"/>
+                        <title type="incomplete" ref="LIT2807RepCh91"/>
+                        <msItem xml:id="ms_i2.2.1.1">
+                           <locus from="117vc" to="118rb"/>
+                           <title type="complete" ref="LIT2807RepCh91#Morning"/>
+                        </msItem>
+                        <msItem xml:id="ms_i2.2.1.2">
+                           <locus from="118rb" to="119rb"/>
+                           <title type="complete" ref="LIT2807RepCh91#Midnight"/>
+                        </msItem>
                      </msItem>
-                     <msItem xml:id="ms_i1.2.2">
-                        <locus from="118rb" to="119rb"/>
-                        <title type="complete" ref="LIT2730RepCh14">Salām-hymn for St Mary (ChRep 191, no. 14)</title>
-                     </msItem>
-                     <msItem xml:id="ms_i1.2.3">
+                     <msItem xml:id="ms_i2.2.3">
                         <locus from="119rc" to="119va"/>
-                        <title type="complete" ref="LIT2780RepCh64">Salām-hymn for ʾEwosṭātewos (ChRep 164, no. 64)</title>
+                        <title type="complete" ref="LIT2780RepCh64"/>
                      </msItem>
-                     <msItem xml:id="ms_i1.2.4">
+                     <msItem xml:id="ms_i2.2.4">
                         <locus from="119va" to="119vb"/>
-                        <title type="complete" ref="LIT2757RepCh41">Salām-hymn for Mārqorewos (ChRep 192, no.  41)</title>
+                        <title type="complete" ref="LIT2757RepCh41"/>
                      </msItem>
                   </msItem>
                   
@@ -480,6 +484,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <change who="DN" when="2015-03-08">last edited</change>
          <change who="PL" when="2016-05-10">transformed from mycore to TEI P5</change>
          <change when="2019-11-19" who="ES">adjusted to schema</change>
+         <change when="2026-07-07" who="CH">Corrected ms_i2</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">


### PR DESCRIPTION
I updated ESmkl001, because I saw that ms_i2.2.1 and ms_i2.2.2 belong together and are equivalent to LIT2807RepCh91#Morning and LIT2807RepCh91#Midnight.

ESath007 contains another text. The reference to ESmkl001 is misleading. I will open an issue for the identification of ESath007#a7.