### PR TITLE
Replaced doublet CAe

### DIFF
--- a/LondonBritishLibrary/orient/BLorient545.xml
+++ b/LondonBritishLibrary/orient/BLorient545.xml
@@ -88,7 +88,7 @@ children, and the peace of the Church.</title>
 
 <msItem xml:id="ms_i1.2.5.1">
 <locus from="12v"/>
-<title type="complete" xml:lang="en" ref="LIT1808Litonz">ሊጦን፡ ዘሰርክ፡ or <foreign xml:lang="grc">Λιτανεία</foreign> for Vespers</title>
+    <title type="complete" xml:lang="en" ref="LIT4271Prayer"/>
 <incipit xml:lang="gez">አምላክነ፡ ዘዲበ፡ ኩራቤል፡ ይነብር።</incipit>
 <textLang xml:lang="gez"/>
 </msItem>
@@ -435,11 +435,10 @@ as well as of <persName ref="PRS6906Matthew">Matthew</persName>, patriarch of Al
         </profileDesc>
         <revisionDesc>
             <change who="SG" when="2019-04-16">Created catalogue entry</change>
-
             <change who="MKr" when="2021-06-22">Completed description</change>
-
             <change when="2020-11-26" who="DR">Added link to images</change>
             <change when="2022-06-07" who="DR">Added layout</change>
+            <change when="2026-08-19" who="CH">Updated CAe ms_i1.2.5.1</change>
         </revisionDesc>
     </teiHeader>
     <facsimile>

--- a/VaticanBAV/et/BAVet21.xml
+++ b/VaticanBAV/et/BAVet21.xml
@@ -1328,7 +1328,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         </msItem>
                         <msItem xml:id="ms_i1.15.6">
                            <locus from="78r"/>
-                           <title ref="LIT4244Prayer">Prayer of John for the twilight</title>
+                           <title ref="LIT4271Prayer"/>
                            <incipit xml:lang="gez">
                            ጸሎተ፡ ሰርክ፡ ዘዮሐንስ፡ አምላክነ፡ ዘዲበ፡ ኪሩቤል፡ ይነብር፡ 
                                  <sic>ወእምኅበ፡</sic>
@@ -1971,6 +1971,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
       </profileDesc>
       <revisionDesc>
          <change who="MV" when="2016-11-22">Created catalogue entry</change>
+         <change when="2026-08-19" who="CH">Replaced doublet CAe in ms_i1.15.6</change>
       </revisionDesc>
   </teiHeader>
   <text xml:base="https://betamasaheft.eu/">

--- a/VaticanBAV/et/BAVet21.xml
+++ b/VaticanBAV/et/BAVet21.xml
@@ -1328,7 +1328,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"
                         </msItem>
                         <msItem xml:id="ms_i1.15.6">
                            <locus from="78r"/>
-                           <title ref="LIT4271Prayer"/>
+                           <title ref="LIT4244Prayer">Prayer of John for the twilight</title>
                            <incipit xml:lang="gez">
                            ጸሎተ፡ ሰርክ፡ ዘዮሐንስ፡ አምላክነ፡ ዘዲበ፡ ኪሩቤል፡ ይነብር፡ 
                                  <sic>ወእምኅበ፡</sic>
@@ -1971,7 +1971,6 @@ schematypens="http://relaxng.org/ns/structure/1.0"
       </profileDesc>
       <revisionDesc>
          <change who="MV" when="2016-11-22">Created catalogue entry</change>
-         <change when="2026-08-19" who="CH">Replaced doublet CAe in ms_i1.15.6</change>
       </revisionDesc>
   </teiHeader>
   <text xml:base="https://betamasaheft.eu/">


### PR DESCRIPTION
I found one manuscript (BAVet21) to replace the CAe according to the deletion of doublets in https://github.com/BetaMasaheft/Works/pull/2073.

I found another manuscript in BLorient545 with the same text, which I gave the more specific LIT4271Prayer instead of the liturgical collection LIT1808Litonz.